### PR TITLE
Add/5669 add further payment metadata

### DIFF
--- a/changelog/add-5669-add-further-payment-metadata
+++ b/changelog/add-5669-add-further-payment-metadata
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Added more metadata to order
+Added additional meta data to payment requests

--- a/changelog/add-5669-add-further-payment-metadata
+++ b/changelog/add-5669-add-further-payment-metadata
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added more metadata to order

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1509,15 +1509,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'subscription_payment' => 'no',
 		];
 
-		// If the order belongs to a WCPay Subscription, set the payment context to 'wcpay_subscription' (this helps with associating which fees belong to orders).
-		if ( 'recurring' === (string) $payment_type && ! $this->is_subscriptions_plugin_active() ) {
-			$subscriptions = wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
+		if ( 'recurring' === (string) $payment_type ) {
+			$subscriptions                    = wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
+			$metadata['subscription_payment'] = count( $subscriptions ) > 1 ? 'renewal' : 'initial';
+			$metadata['payment_context']      = 'regular_subscription';
 
-			foreach ( $subscriptions as $subscription ) {
-				if ( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ) {
-					$metadata['payment_context']      = 'wcpay_subscription';
-					$metadata['subscription_payment'] = count( $subscriptions ) > 1 ? 'renewal' : 'initial';
-					break;
+			// If the order belongs to a WCPay Subscription, set the payment context to 'wcpay_subscription' (this helps with associating which fees belong to orders).
+			if ( $this->is_subscriptions_plugin_active() ) {
+				foreach ( $subscriptions as $subscription ) {
+					if ( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ) {
+						$metadata['payment_context'] = 'wcpay_subscription';
+						break;
+					}
 				}
 			}
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1482,7 +1482,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return array Array of keyed metadata values.
 	 */
 	protected function get_metadata_from_order( $order, $payment_type ) {
-		switch ( static::class ) {
+		switch ( get_class( $this ) ) {
 			case UPE_Split_Payment_Gateway::class:
 				$gateway_type = 'split_upe';
 				break;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1493,17 +1493,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$gateway_type = 'classic';
 		}
 
-		switch ( $order->get_created_via() ) {
-			case 'checkout':
-				$checkout_type = 'shortcode';
-				break;
-			case 'store-api': // For block based orders, the created-via field is set to this value.
-				$checkout_type = 'block';
-				break;
-			default:
-				$checkout_type = 'unknown';
-		}
-
 		$name     = sanitize_text_field( $order->get_billing_first_name() ) . ' ' . sanitize_text_field( $order->get_billing_last_name() );
 		$email    = sanitize_email( $order->get_billing_email() );
 		$metadata = [
@@ -1515,7 +1504,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => $payment_type,
 			'gateway_type'         => $gateway_type,
-			'checkout_type'        => $checkout_type,
+			'checkout_type'        => $order->get_created_via(),
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
 		];

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1482,17 +1482,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return array Array of keyed metadata values.
 	 */
 	protected function get_metadata_from_order( $order, $payment_type ) {
-		switch ( get_class( $this ) ) {
-			case UPE_Split_Payment_Gateway::class:
-				$gateway_type = 'split_upe';
-				break;
-			case UPE_Payment_Gateway::class:
-				$gateway_type = 'upe';
-				break;
-			default:
-				$gateway_type = 'classic';
+		if ( $this instanceof UPE_Split_Payment_Gateway ) {
+			$gateway_type = 'split_upe';
+		} else if ( $this instanceof UPE_Payment_Gateway ) {
+			$gateway_type = 'upe';
+		} else {
+			$gateway_type = 'classic';
 		}
-
 		$name     = sanitize_text_field( $order->get_billing_first_name() ) . ' ' . sanitize_text_field( $order->get_billing_last_name() );
 		$email    = sanitize_email( $order->get_billing_email() );
 		$metadata = [

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -381,7 +381,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'order_number'         => $order_number,
 					'order_key'            => $order->get_order_key(),
 					'payment_type'         => Payment_Type::SINGLE(),
-					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
+					'gateway_type'         => 'upe',
 					'checkout_type'        => '',
 					'client_version'       => WCPAY_VERSION_NUMBER,
 					'subscription_payment' => 'no',
@@ -483,7 +483,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'order_number'         => $order_number,
 					'order_key'            => $order->get_order_key(),
 					'payment_type'         => Payment_Type::SINGLE(),
-					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
+					'gateway_type'         => 'upe',
 					'checkout_type'        => '',
 					'client_version'       => WCPAY_VERSION_NUMBER,
 					'subscription_payment' => 'no',
@@ -581,7 +581,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'order_number'         => $order_number,
 					'order_key'            => $order->get_order_key(),
 					'payment_type'         => Payment_Type::SINGLE(),
-					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
+					'gateway_type'         => 'upe',
 					'checkout_type'        => '',
 					'client_version'       => WCPAY_VERSION_NUMBER,
 					'subscription_payment' => 'no',

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -374,13 +374,17 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->method( 'set_metadata' )
 			->with(
 				[
-					'customer_name'  => 'Jeroen Sormani',
-					'customer_email' => 'admin@example.org',
-					'site_url'       => 'http://example.org',
-					'order_id'       => $order_id,
-					'order_number'   => $order_number,
-					'order_key'      => $order->get_order_key(),
-					'payment_type'   => Payment_Type::SINGLE(),
+					'customer_name'        => 'Jeroen Sormani',
+					'customer_email'       => 'admin@example.org',
+					'site_url'             => 'http://example.org',
+					'order_id'             => $order_id,
+					'order_number'         => $order_number,
+					'order_key'            => $order->get_order_key(),
+					'payment_type'         => Payment_Type::SINGLE(),
+					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
+					'checkout_type'        => 'unknown',
+					'client_version'       => WCPAY_VERSION_NUMBER,
+					'subscription_payment' => 'no',
 				]
 			);
 
@@ -472,13 +476,17 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->method( 'set_metadata' )
 			->with(
 				[
-					'customer_name'  => 'Jeroen Sormani',
-					'customer_email' => 'admin@example.org',
-					'site_url'       => 'http://example.org',
-					'order_id'       => $order_id,
-					'order_number'   => $order_number,
-					'order_key'      => $order->get_order_key(),
-					'payment_type'   => Payment_Type::SINGLE(),
+					'customer_name'        => 'Jeroen Sormani',
+					'customer_email'       => 'admin@example.org',
+					'site_url'             => 'http://example.org',
+					'order_id'             => $order_id,
+					'order_number'         => $order_number,
+					'order_key'            => $order->get_order_key(),
+					'payment_type'         => Payment_Type::SINGLE(),
+					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
+					'checkout_type'        => 'unknown',
+					'client_version'       => WCPAY_VERSION_NUMBER,
+					'subscription_payment' => 'no',
 				]
 			);
 
@@ -566,13 +574,17 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->method( 'set_metadata' )
 			->with(
 				[
-					'customer_name'  => 'Jeroen Sormani',
-					'customer_email' => 'admin@example.org',
-					'site_url'       => 'http://example.org',
-					'order_id'       => $order_id,
-					'order_number'   => $order_number,
-					'order_key'      => $order->get_order_key(),
-					'payment_type'   => Payment_Type::SINGLE(),
+					'customer_name'        => 'Jeroen Sormani',
+					'customer_email'       => 'admin@example.org',
+					'site_url'             => 'http://example.org',
+					'order_id'             => $order_id,
+					'order_number'         => $order_number,
+					'order_key'            => $order->get_order_key(),
+					'payment_type'         => Payment_Type::SINGLE(),
+					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
+					'checkout_type'        => 'unknown',
+					'client_version'       => WCPAY_VERSION_NUMBER,
+					'subscription_payment' => 'no',
 				]
 			);
 

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -382,7 +382,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'order_key'            => $order->get_order_key(),
 					'payment_type'         => Payment_Type::SINGLE(),
 					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
-					'checkout_type'        => 'unknown',
+					'checkout_type'        => '',
 					'client_version'       => WCPAY_VERSION_NUMBER,
 					'subscription_payment' => 'no',
 				]
@@ -484,7 +484,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'order_key'            => $order->get_order_key(),
 					'payment_type'         => Payment_Type::SINGLE(),
 					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
-					'checkout_type'        => 'unknown',
+					'checkout_type'        => '',
 					'client_version'       => WCPAY_VERSION_NUMBER,
 					'subscription_payment' => 'no',
 				]
@@ -582,7 +582,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'order_key'            => $order->get_order_key(),
 					'payment_type'         => Payment_Type::SINGLE(),
 					'gateway_type'         => 'classic', // This won't show UPE as gateway since the mocked class is used.
-					'checkout_type'        => 'unknown',
+					'checkout_type'        => '',
 					'client_version'       => WCPAY_VERSION_NUMBER,
 					'subscription_payment' => 'no',
 				]

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -415,7 +415,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'order_number'         => $order_number,
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
-			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
+			'gateway_type'         => 'split_upe',
 			'checkout_type'        => '',
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
@@ -490,7 +490,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'order_number'         => $order_number,
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
-			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
+			'gateway_type'         => 'split_upe',
 			'checkout_type'        => '',
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
@@ -569,7 +569,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'order_number'         => $order_number,
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
-			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
+			'gateway_type'         => 'split_upe',
 			'checkout_type'        => '',
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -408,13 +408,17 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->method( 'create_customer_for_user' );
 
 		$metadata = [
-			'customer_name'  => 'Jeroen Sormani',
-			'customer_email' => 'admin@example.org',
-			'site_url'       => 'http://example.org',
-			'order_id'       => $order_id,
-			'order_number'   => $order_number,
-			'order_key'      => $order->get_order_key(),
-			'payment_type'   => Payment_Type::SINGLE(),
+			'customer_name'        => 'Jeroen Sormani',
+			'customer_email'       => 'admin@example.org',
+			'site_url'             => 'http://example.org',
+			'order_id'             => $order_id,
+			'order_number'         => $order_number,
+			'order_key'            => $order->get_order_key(),
+			'payment_type'         => Payment_Type::SINGLE(),
+			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
+			'checkout_type'        => 'unknown',
+			'client_version'       => '6.3.2',
+			'subscription_payment' => 'no',
 		];
 
 		$level3 = [
@@ -479,13 +483,18 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->method( 'create_customer_for_user' );
 
 		$metadata = [
-			'customer_name'  => 'Jeroen Sormani',
-			'customer_email' => 'admin@example.org',
-			'site_url'       => 'http://example.org',
-			'order_id'       => $order_id,
-			'order_number'   => $order_number,
-			'order_key'      => $order->get_order_key(),
-			'payment_type'   => Payment_Type::SINGLE(),
+			'customer_name'        => 'Jeroen Sormani',
+			'customer_email'       => 'admin@example.org',
+			'site_url'             => 'http://example.org',
+			'order_id'             => $order_id,
+			'order_number'         => $order_number,
+			'order_key'            => $order->get_order_key(),
+			'payment_type'         => Payment_Type::SINGLE(),
+			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
+			'checkout_type'        => 'unknown',
+			'client_version'       => '6.3.2',
+			'subscription_payment' => 'no',
+
 		];
 
 		$level3 = [
@@ -553,13 +562,17 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->method( 'create_customer_for_user' );
 
 		$metadata = [
-			'customer_name'  => 'Jeroen Sormani',
-			'customer_email' => 'admin@example.org',
-			'site_url'       => 'http://example.org',
-			'order_id'       => $order_id,
-			'order_number'   => $order_number,
-			'order_key'      => $order->get_order_key(),
-			'payment_type'   => Payment_Type::SINGLE(),
+			'customer_name'        => 'Jeroen Sormani',
+			'customer_email'       => 'admin@example.org',
+			'site_url'             => 'http://example.org',
+			'order_id'             => $order_id,
+			'order_number'         => $order_number,
+			'order_key'            => $order->get_order_key(),
+			'payment_type'         => Payment_Type::SINGLE(),
+			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
+			'checkout_type'        => 'unknown',
+			'client_version'       => WCPAY_VERSION_NUMBER,
+			'subscription_payment' => 'no',
 		];
 
 		$level3 = [

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -417,7 +417,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'payment_type'         => Payment_Type::SINGLE(),
 			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
 			'checkout_type'        => 'unknown',
-			'client_version'       => '6.3.2',
+			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
 		];
 

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -416,7 +416,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
 			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
-			'checkout_type'        => 'unknown',
+			'checkout_type'        => '',
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
 		];
@@ -491,8 +491,8 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
 			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
-			'checkout_type'        => 'unknown',
-			'client_version'       => '6.3.2',
+			'checkout_type'        => '',
+			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
 
 		];
@@ -570,7 +570,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
 			'gateway_type'         => 'classic', // This won't show split UPE as gateway since the mocked class is used.
-			'checkout_type'        => 'unknown',
+			'checkout_type'        => '',
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
 		];

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -445,14 +445,17 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	}
 
 	public function test_saved_card_zero_dollar_subscription() {
-		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+		$order         = WC_Helper_Order::create_order( self::USER_ID, 0 );
+		$subscriptions = [ new WC_Subscription() ];
+		$subscriptions[0]->set_parent( $order );
+
+		$this->mock_wcs_order_contains_subscription( true );
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
 		$_POST = [
 			'payment_method'        => WC_Payment_Gateway_WCPay::GATEWAY_ID,
 			self::TOKEN_REQUEST_KEY => $this->token->get_id(),
 		];
-
-		$this->mock_wcs_order_contains_subscription( true );
 
 		// The card is already saved and there's no payment needed, so no Setup Intent needs to be created.
 		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class, 0 );
@@ -462,9 +465,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		$this->mock_token_service
 			->expects( $this->never() )
 			->method( 'add_payment_method_to_user' );
-
-		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
-		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1322,7 +1322,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			'order_key'            => $order->get_order_key(),
 			'payment_type'         => Payment_Type::SINGLE(),
 			'gateway_type'         => 'classic',
-			'checkout_type'        => 'unknown',
+			'checkout_type'        => '',
 			'client_version'       => WCPAY_VERSION_NUMBER,
 			'subscription_payment' => 'no',
 		];

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1314,13 +1314,17 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		);
 
 		$merged_metadata = [
-			'customer_name'  => 'Test',
-			'customer_email' => $order->get_billing_email(),
-			'site_url'       => esc_url( get_site_url() ),
-			'order_id'       => $order->get_id(),
-			'order_number'   => $order->get_order_number(),
-			'order_key'      => $order->get_order_key(),
-			'payment_type'   => Payment_Type::SINGLE(),
+			'customer_name'        => 'Test',
+			'customer_email'       => $order->get_billing_email(),
+			'site_url'             => esc_url( get_site_url() ),
+			'order_id'             => $order->get_id(),
+			'order_number'         => $order->get_order_number(),
+			'order_key'            => $order->get_order_key(),
+			'payment_type'         => Payment_Type::SINGLE(),
+			'gateway_type'         => 'classic',
+			'checkout_type'        => 'unknown',
+			'client_version'       => WCPAY_VERSION_NUMBER,
+			'subscription_payment' => 'no',
 		];
 
 		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );


### PR DESCRIPTION
Fixes #5669 

#### Changes proposed in this Pull Request

This PR adds more payment metadata for easier tracking, debugging, ... More info about what needs to be added can be found here: p1684514680519539-slack-C0208C3BXHP

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Test the following flow with on UPE, Split UPE and classic checkout**

* Add regular product to cart and checkout using the standard checkout form. After the order is processed, check the metadata on the Stripe. Make sure that the `checkout_type` field is set to `shortcode`, `subscription_payment` is set to 'no', `client_version` matches the current plugin version, and `gateway_type` matched with the current payment gateway.
* Add subscription to cart and checkout using the standard checkout form. After the order is processed, check the metadata on the Stripe. Make sure that the `checkout_type` field is set to `shortcode`, `subscription_payment` is set to 'initial' or 'renewal' (depends is subscription on renewal or brand new one), `client_version` matches the current plugin version, and `gateway_type` matched with the current payment gateway.
* Add regular product to cart and checkout using the block-based checkout form. After the order is processed, check the metadata on the Stripe. Make sure that the `checkout_type` field is set to `block`, `subscription_payment` is set to 'no', `client_version` matches the current plugin version, and `gateway_type` matched with the current payment gateway.
* Add subscription to cart and checkout using the block-based checkout form. After the order is processed, check the metadata on the Stripe. Make sure that the `checkout_type` field is set to `block`, `subscription_payment` is set to 'initial' or 'renewal' (depends is subscription on renewal or brand new one), `client_version` matches the current plugin version, and `gateway_type` matched with the current payment gateway.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.