### PR TITLE
Fix the way request constants are traversed

### DIFF
--- a/changelog/fix-request-constant-traversing
+++ b/changelog/fix-request-constant-traversing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the way request params are loaded between parent and child classes.

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -537,24 +537,18 @@ abstract class Request {
 	 * @return string[] The unique combined values from the arrays.
 	 */
 	public static function traverse_class_constants( string $constant_name, bool $unique = false ) {
-		// Generate a class tree first, in order to reverse it later.
-		$class_tree = [];
+		$keys       = [];
 		$class_name = static::class;
-		do {
-			$class_tree[] = $class_name;
-			$class_name   = get_parent_class( $class_name );
-		} while ( $class_name );
-		$class_tree = array_reverse( $class_tree );
 
-		// Go from parent to child class, and load the constants.
-		$keys = [];
-		foreach ( $class_tree as $class_name ) {
+		do {
 			$constant = "$class_name::$constant_name";
 
 			if ( defined( $constant ) ) {
-				$keys = array_merge( $keys, constant( $constant ) );
+				$keys = array_merge( constant( $constant ), $keys );
 			}
-		}
+
+			$class_name = get_parent_class( $class_name );
+		} while ( $class_name );
 
 		if ( $unique ) {
 			$keys = array_unique( $keys );

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -537,18 +537,24 @@ abstract class Request {
 	 * @return string[] The unique combined values from the arrays.
 	 */
 	public static function traverse_class_constants( string $constant_name, bool $unique = false ) {
-		$keys       = [];
+		// Generate a class tree first, in order to reverse it later.
+		$class_tree = [];
 		$class_name = static::class;
-
 		do {
+			$class_tree[] = $class_name;
+			$class_name   = get_parent_class( $class_name );
+		} while ( $class_name );
+		$class_tree = array_reverse( $class_tree );
+
+		// Go from parent to child class, and load the constants.
+		$keys = [];
+		foreach ( $class_tree as $class_name ) {
 			$constant = "$class_name::$constant_name";
 
 			if ( defined( $constant ) ) {
 				$keys = array_merge( $keys, constant( $constant ) );
 			}
-
-			$class_name = get_parent_class( $class_name );
-		} while ( $class_name );
+		}
 
 		if ( $unique ) {
 			$keys = array_unique( $keys );

--- a/tests/unit/core/server/request/test-class-core-request.php
+++ b/tests/unit/core/server/request/test-class-core-request.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Class WCPay_Core_Request_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Core\Server\Request;
+use WCPay\Core\Server\Request\Paginated;
+use WCPay\Core\Server\Request\List_Transactions;
+
+/**
+ * WCPay\Core\Server\Capture_Intention_Test unit tests.
+ */
+class WCPay_Core_Request_Test extends WCPAY_UnitTestCase {
+	/**
+	 * Tests the most basic function of `traverse_class_constants`,
+	 * which is to go though all classes in the tree, and return a constant in the right order.
+	 */
+	public function test_traverse_class_constants() {
+		$expected = [];
+		$tree     = [
+			Request::class,
+			Paginated::class,
+			List_Transactions::class,
+		];
+		foreach ( $tree as $class_name ) {
+			$expected = array_merge( $expected, constant( $class_name . '::DEFAULT_PARAMS' ) );
+		}
+
+		$result = List_Transactions::traverse_class_constants( 'DEFAULT_PARAMS' );
+		$this->assertSame( $expected, $result );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`Request::traverse_class_constants` is used to combine the constants of multiple classes, which inherit each-other, like `DEFAULT_PARAMS`. The way the method was initially coded, it started with the current class, and while traversing through parent classes, it added to the array. However, that turns out to be an issue, as properties of parent classes end up overwriting the properties of child classes, instead of the other way around.

Example:

```php
class Request {
	const DEFAULT_PARAMS = [];
}

class Paginated extends Request {
	const DEFAULT_PARAMS = [
		'sort' => 'created',
	];
}

class List_Transactions extends Paginated {
	const DEFAULT_PARAMS = [
		'sort' => 'date',
	];
}

$defaults = List_Transactions::traverse_class_constants( 'DEFAULT_PARAMS' );
var_dump( $defaults );

array(1) {
	["sort"]=>
	string(1) "created"
}
```

As you can see, instead of `date`, `sort` remains `created`.

**With this PR, the order of traversing classes is reversed,** and the result above would be `date`.

#### Testing instructions

You could tinker with loading transactions in the admin, but the unit test is the best way to make sure this works.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
