### PR TITLE
Implement `BannerNotice` component

### DIFF
--- a/changelog/add-7048-banner-notice-component
+++ b/changelog/add-7048-banner-notice-component
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add BannerNotice component, with no major UI difference for merchants.
+
+

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -1,0 +1,197 @@
+/**
+ * Based on the @wordpress/components `Notice` component.
+ * Adjusted to meet WooCommerce Admin Design Library.
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+import { __ } from '@wordpress/i18n';
+import { useEffect, renderToString } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+import classNames from 'classnames';
+import { Icon, Button } from '@wordpress/components';
+import { check, info } from '@wordpress/icons';
+import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
+import CloseIcon from 'gridicons/dist/cross-small';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+const statusIconMap = {
+	success: check,
+	error: NoticeOutlineIcon,
+	warning: NoticeOutlineIcon,
+	info: info,
+};
+
+type Status = keyof typeof statusIconMap;
+
+/**
+ * Custom hook which announces the message with politeness based on status,
+ * if a valid message is provided.
+ */
+const useSpokenMessage = ( status?: string, message?: React.ReactNode ) => {
+	const spokenMessage =
+		typeof message === 'string' ? message : renderToString( message );
+	const politeness = status === 'error' ? 'assertive' : 'polite';
+
+	useEffect( () => {
+		if ( spokenMessage ) {
+			speak( spokenMessage, politeness );
+		}
+	}, [ spokenMessage, politeness ] );
+};
+
+interface Props {
+	/**
+	 * A CSS `class` to give to the wrapper element.
+	 */
+	className?: string;
+	/**
+	 * The displayed message of a notice. Also used as the spoken message for
+	 * assistive technology, unless `spokenMessage` is provided as an alternative message.
+	 */
+	children: React.ReactNode;
+	/**
+	 * Determines the color of the notice: `warning` (yellow),
+	 * `success` (green), `error` (red), or `'info'`.
+	 * By default `'info'` will be blue, but if there is a parent Theme component
+	 * with an accent color prop, the notice will take on that color instead.
+	 *
+	 * @default 'info'
+	 */
+	status?: Status;
+	/**
+	 * Whether to display the default icon based on status or the icon to display.
+	 * Supported values are: boolean, JSX.Element and `undefined`.
+	 *
+	 * @default undefined
+	 */
+	icon?: boolean | JSX.Element;
+	/**
+	 * Whether the notice should be dismissible or not.
+	 *
+	 * @default true
+	 */
+	isDismissible?: boolean;
+	/**
+	 * An array of action objects. Each member object should contain:
+	 *
+	 * - `label`: `string` containing the text of the button/link
+	 * - `url`: `string` OR `onClick`: `( event: SyntheticEvent ) => void` to specify
+	 *    what the action does.
+	 * - `className`: `string` (optional) to add custom classes to the button styles.
+	 * - `variant`: `'primary' | 'secondary' | 'link'` (optional) You can denote a
+	 *    primary button action for a notice by passing a value of `primary`.
+	 *
+	 * The default appearance of an action button is inferred based on whether
+	 * `url` or `onClick` are provided, rendering the button as a link if
+	 * appropriate. If both props are provided, `url` takes precedence, and the
+	 * action button will render as an anchor tag.
+	 *
+	 * @default []
+	 */
+	actions?: ReadonlyArray< {
+		label: string;
+		className?: string;
+		variant?: Button.Props[ 'variant' ];
+		url?: string;
+		onClick?: React.MouseEventHandler< HTMLAnchorElement >;
+	} >;
+	/**
+	 * Function called when dismissing the notice
+	 *
+	 * @default undefined
+	 */
+	onRemove?: () => void;
+}
+
+const BannerNotice: React.FC< Props > = ( {
+	icon,
+	children,
+	actions = [],
+	className,
+	status = 'info',
+	isDismissible = true,
+	onRemove,
+} ) => {
+	useSpokenMessage( status, children );
+
+	const iconToDisplay = icon === true ? statusIconMap[ status ] : icon;
+
+	const classes = classNames(
+		className,
+		'wcpay-banner-notice',
+		'is-' + status
+	);
+
+	const handleRemove = () => onRemove?.();
+
+	return (
+		<div className={ classes }>
+			{ iconToDisplay && (
+				<Icon
+					icon={ iconToDisplay }
+					className="wcpay-banner-notice__icon"
+				/>
+			) }
+			<div>
+				{ children }
+				{ actions.length > 0 && (
+					<div className="wcpay-banner-notice__actions">
+						{ actions.map(
+							(
+								{
+									className: buttonCustomClasses,
+									label,
+									variant,
+									onClick,
+									url,
+								},
+								index
+							) => {
+								let computedVariant = variant;
+								if ( variant !== 'primary' ) {
+									computedVariant = ! url
+										? 'secondary'
+										: 'link';
+								}
+
+								return (
+									<Button
+										key={ index }
+										href={ url }
+										variant={ computedVariant }
+										onClick={ url ? undefined : onClick }
+										className={ buttonCustomClasses }
+									>
+										{ label }
+									</Button>
+								);
+							}
+						) }
+					</div>
+				) }
+			</div>
+			{ isDismissible && (
+				<Button
+					className="wcpay-banner-notice__dismiss"
+					icon={ CloseIcon }
+					label={ __(
+						'Dismiss this notice',
+						'woocommerce-payments'
+					) }
+					onClick={ handleRemove }
+					showTooltip={ false }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default BannerNotice;

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -140,7 +140,7 @@ const BannerNotice: React.FC< Props > = ( {
 					className="wcpay-banner-notice__icon"
 				/>
 			) }
-			<div>
+			<div className="wcpay-banner-notice__content">
 				{ children }
 				{ actions.length > 0 && (
 					<div className="wcpay-banner-notice__actions">

--- a/client/components/banner-notice/style.scss
+++ b/client/components/banner-notice/style.scss
@@ -29,6 +29,10 @@
 		margin-right: $gap-small;
 	}
 
+	&__content {
+		flex-grow: 1;
+	}
+
 	&__actions {
 		display: grid;
 		grid-auto-flow: column;

--- a/client/components/banner-notice/style.scss
+++ b/client/components/banner-notice/style.scss
@@ -24,6 +24,11 @@
 		fill: $alert-red;
 	}
 
+	&.is-warning &__icon,
+	&.is-error &__icon {
+		height: 21px; // Adjust gridicon height to match other icons
+	}
+
 	&__icon {
 		flex-shrink: 0;
 		margin-right: $gap-small;

--- a/client/components/banner-notice/style.scss
+++ b/client/components/banner-notice/style.scss
@@ -1,0 +1,56 @@
+.wcpay-banner-notice {
+	display: flex;
+	font-family: $default-font;
+	font-size: $default-font-size;
+	background-color: $white;
+	border-left: $gap-smallest solid $components-color-accent;
+	fill: $components-color-accent;
+	margin: $gap-large 0;
+	padding: $gap-small;
+	box-shadow: 0 2px 6px 0 rgba( 0, 0, 0, 0.05 );
+
+	&.is-success {
+		border-left-color: $alert-green;
+		fill: $alert-green;
+	}
+
+	&.is-warning {
+		border-left-color: $alert-yellow;
+		fill: $alert-yellow;
+	}
+
+	&.is-error {
+		border-left-color: $alert-red;
+		fill: $alert-red;
+	}
+
+	&__icon {
+		flex-shrink: 0;
+		margin-right: $gap-small;
+	}
+
+	&__actions {
+		display: grid;
+		grid-auto-flow: column;
+		grid-auto-columns: min-content;
+		column-gap: $gap-small;
+		margin-top: $gap-small;
+	}
+
+	&__dismiss.components-button.has-icon {
+		flex-shrink: 0;
+		padding: 0;
+		min-width: 24px;
+		height: 24px;
+
+		svg {
+			width: 20px;
+		}
+	}
+
+	/* Margin exceptions */
+	& + &,
+	&:first-child {
+		margin-top: 0;
+	}
+}

--- a/client/components/banner-notice/tests/__snapshots__/index.test.tsx.snap
+++ b/client/components/banner-notice/tests/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BannerNotice should match snapshot 1`] = `
+<div>
+  <div
+    class="wcpay-banner-notice is-success"
+  >
+    <span
+      class="wcpay-banner-notice__icon"
+      size="24"
+    >
+      Custom Icon
+    </span>
+    <div>
+      Example
+      <div
+        class="wcpay-banner-notice__actions"
+      >
+        <a
+          class="components-button is-link"
+          href="https://example.com"
+        >
+          More information
+        </a>
+        <button
+          class="components-button is-secondary"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="components-button is-primary"
+          type="button"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+    <button
+      aria-label="Dismiss this notice"
+      class="components-button wcpay-banner-notice__dismiss has-icon"
+      type="button"
+    >
+      <svg
+        class="gridicon gridicons-cross-small"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/client/components/banner-notice/tests/__snapshots__/index.test.tsx.snap
+++ b/client/components/banner-notice/tests/__snapshots__/index.test.tsx.snap
@@ -11,7 +11,9 @@ exports[`BannerNotice should match snapshot 1`] = `
     >
       Custom Icon
     </span>
-    <div>
+    <div
+      class="wcpay-banner-notice__content"
+    >
       Example
       <div
         class="wcpay-banner-notice__actions"

--- a/client/components/banner-notice/tests/index.test.tsx
+++ b/client/components/banner-notice/tests/index.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { mocked } from 'ts-jest/utils';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import BannerNotice from '../';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+describe( 'BannerNotice', () => {
+	beforeEach( () => {
+		mocked( speak ).mockClear();
+	} );
+
+	it( 'should match snapshot', () => {
+		const onClick = jest.fn();
+		const { container } = render(
+			<BannerNotice
+				status="success"
+				icon={ <span>Custom Icon</span> }
+				actions={ [
+					{ label: 'More information', url: 'https://example.com' },
+					{ label: 'Cancel', onClick },
+					{ label: 'Submit', onClick, variant: 'primary' },
+				] }
+			>
+				Example
+			</BannerNotice>
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'should default to info status', () => {
+		const {
+			container: { firstChild },
+		} = render( <BannerNotice>FYI</BannerNotice> );
+
+		expect( firstChild ).toHaveClass( 'is-info' );
+	} );
+
+	/*****************	 */
+
+	it( 'calls action onClick when clicked', () => {
+		const onClick = jest.fn();
+		render(
+			<BannerNotice actions={ [ { label: 'Action', onClick } ] }>
+				Notice with Action
+			</BannerNotice>
+		);
+
+		user.click( screen.getByText( 'Action' ) );
+
+		expect( onClick ).toHaveBeenCalled();
+	} );
+
+	it( 'calls onRemove when dismiss button is clicked', () => {
+		const onRemove = jest.fn();
+		render(
+			<BannerNotice onRemove={ onRemove }>
+				Dismissible Notice
+			</BannerNotice>
+		);
+
+		user.click( screen.getByLabelText( 'Dismiss this notice' ) );
+
+		expect( onRemove ).toHaveBeenCalled();
+	} );
+
+	describe( 'useSpokenMessage', () => {
+		it( 'should speak the given message', () => {
+			render( <BannerNotice>FYI</BannerNotice> );
+
+			expect( speak ).toHaveBeenCalledWith( 'FYI', 'polite' );
+		} );
+
+		it( 'should speak the given message by implicit politeness by status', () => {
+			render( <BannerNotice status="error">Uh oh!</BannerNotice> );
+
+			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
+		} );
+
+		it( 'should coerce a message to a string', () => {
+			render(
+				<BannerNotice>
+					With <em>emphasis</em> this time.
+				</BannerNotice>
+			);
+
+			expect( speak ).toHaveBeenCalledWith(
+				'With <em>emphasis</em> this time.',
+				'polite'
+			);
+		} );
+
+		it( 'should not re-speak an effectively equivalent element message', () => {
+			const { rerender } = render(
+				<BannerNotice>Duplicated notice message.</BannerNotice>
+			);
+			rerender( <BannerNotice>Duplicated notice message.</BannerNotice> );
+
+			expect( speak ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/client/onboarding/restored-state-banner.tsx
+++ b/client/onboarding/restored-state-banner.tsx
@@ -7,21 +7,20 @@ import React from 'react';
  * Internal dependencies
  */
 import strings from './strings';
-import InlineNotice from 'components/inline-notice';
+import BannerNotice from 'components/banner-notice';
 
 const RestoredStateBanner: React.FC = () => {
 	const [ hidden, setHidden ] = React.useState( false );
 	if ( hidden || ! wcpaySettings.onboardingFlowState ) return null;
 	return (
-		<InlineNotice
-			className="restored-state-banner"
-			status="info"
+		<BannerNotice
 			icon
-			isDismissible={ true }
+			status="info"
+			className="restored-state-banner"
 			onRemove={ () => setHidden( true ) }
 		>
 			{ strings.restoredState }
-		</InlineNotice>
+		</BannerNotice>
 	);
 };
 

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -66,3 +66,12 @@ $wp-green-70: #005c12;
 $wp-green-80: #00450c;
 $wp-green-90: #003008;
 $wp-green-100: #001c05;
+
+// Missing from dependencies
+$gutenberg-blue: #007cba;
+
+// Accent color
+$components-color-accent: var(
+	--wp-components-color-accent,
+	var( --wp-admin-theme-color, $gutenberg-blue )
+);

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -9,6 +9,3 @@ $gap-smallest: 4px;
 
 // Modals
 $modal-max-width: 500px;
-
-// Colors (missing from dependencies)
-$gutenberg-blue: #007cba;


### PR DESCRIPTION
Fixes #7048 

#### Changes proposed in this Pull Request
Implement `BannerNotice` component based on @wordpress/components `Notice` component applying WooCommerce Admin design library guidelines (Kofpo8jj4zDWXDsVdlSz0f-fi-4260%3A47121).

#### Testing instructions
- Implemented component matches design guidelines.
- It's only used on the new PO flow, to inform about a restored session. You can trigger it finishing the first step (personal) and refreshing the page.

You can use the following code to get all the variations from the following screenshot.
<details>
<summary>Code snippet</summary>

```jsx
<>
	<BannerNotice status="info">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice icon status="info">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice
		status="info"
		actions={ [
			{ label: 'Label', onClick: () => {} },
			{ label: 'Label', url: '#' },
		] }
	>
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice status="error">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice icon status="error">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice
		status="error"
		actions={ [
			{ label: 'Label', onClick: () => {} },
			{ label: 'Label', url: '#' },
		] }
	>
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice status="warning">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice icon status="warning">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice
		status="warning"
		actions={ [
			{ label: 'Label', onClick: () => {} },
			{ label: 'Label', url: '#' },
		] }
	>
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice status="success">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice icon status="success">
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
	<BannerNotice
		status="success"
		actions={ [
			{ label: 'Label', onClick: () => {} },
			{ label: 'Label', url: '#' },
		] }
	>
		Don’t abuse the notice system, please; Use them sparingly.
	</BannerNotice>
</>
```

</details>

#### Screenshots

| Design guidelines | Implementation |
|-|-|
<img width="487" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/0af58803-00a4-41a5-a94d-39ed8568d75b">|<img width="457" alt="Screenshot 2023-08-30 at 11 19 11" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/52ccbda1-7726-48f9-b28f-3bdd482df0f4">|

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.