### PR TITLE
RPP -  Load payment methods through the request class

### DIFF
--- a/changelog/rpp-6685-load-payment-methods
+++ b/changelog/rpp-6685-load-payment-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Load payment methods through the request class (re-engineering payment process).

--- a/src/Internal/Payment/PaymentRequest.php
+++ b/src/Internal/Payment/PaymentRequest.php
@@ -142,6 +142,6 @@ class PaymentRequest {
 			return new SavedPaymentMethod( $token );
 		}
 
-		throw new PaymentRequestException( __( 'No valid payment method attached to the request.', 'woocommerce-payments' ) );
+		throw new PaymentRequestException( __( 'No valid payment method was selected.', 'woocommerce-payments' ) );
 	}
 }

--- a/src/Internal/Payment/PaymentRequest.php
+++ b/src/Internal/Payment/PaymentRequest.php
@@ -115,7 +115,7 @@ class PaymentRequest {
 	public function get_payment_method(): PaymentMethodInterface {
 		$request = $this->request;
 
-		$is_woopayment_selected = isset( $request['payment_method'] ) || WC_Payment_Gateway_WCPay::GATEWAY_ID === $request['payment_method'];
+		$is_woopayment_selected = isset( $request['payment_method'] ) && WC_Payment_Gateway_WCPay::GATEWAY_ID === $request['payment_method'];
 		if ( ! $is_woopayment_selected ) {
 			throw new PaymentRequestException( __( 'WooPayments is not used during checkout, cannot retrieve payment method.', 'woocommerce-payments' ) );
 		}

--- a/src/Internal/Payment/PaymentRequest.php
+++ b/src/Internal/Payment/PaymentRequest.php
@@ -117,7 +117,7 @@ class PaymentRequest {
 
 		$is_woopayment_selected = isset( $request['payment_method'] ) && WC_Payment_Gateway_WCPay::GATEWAY_ID === $request['payment_method'];
 		if ( ! $is_woopayment_selected ) {
-			throw new PaymentRequestException( __( 'WooPayments is not used during checkout, cannot retrieve payment method.', 'woocommerce-payments' ) );
+			throw new PaymentRequestException( __( 'WooPayments is not used during checkout.', 'woocommerce-payments' ) );
 		}
 
 		if ( ! empty( $request['wcpay-payment-method'] ) ) {
@@ -142,6 +142,6 @@ class PaymentRequest {
 			return new SavedPaymentMethod( $token );
 		}
 
-		throw new PaymentRequestException( __( 'Payment method not attached for the request.', 'woocommerce-payments' ) );
+		throw new PaymentRequestException( __( 'No valid payment method attached to the request.', 'woocommerce-payments' ) );
 	}
 }

--- a/src/Internal/Payment/PaymentRequest.php
+++ b/src/Internal/Payment/PaymentRequest.php
@@ -120,14 +120,9 @@ class PaymentRequest {
 			throw new PaymentRequestException( __( 'WooPayments is not used during checkout.', 'woocommerce-payments' ) );
 		}
 
-		if ( ! empty( $request['wcpay-payment-method'] ) ) {
-			$payment_method = sanitize_text_field( wp_unslash( $request['wcpay-payment-method'] ) );
-			return new NewPaymentMethod( $payment_method );
-		}
-
-		$token_param = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
-		if ( ! empty( $request[ $token_param ] ) ) {
-			$token_id = absint( wp_unslash( $request [ $token_param ] ) );
+		$token_request_key = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
+		if ( isset( $request[ $token_request_key ] ) && 'new' !== $request[ $token_request_key ] ) {
+			$token_id = absint( wp_unslash( $request [ $token_request_key ] ) );
 
 			/**
 			 * Retrieved token object.
@@ -137,9 +132,14 @@ class PaymentRequest {
 			$token = $this->legacy_proxy->call_static( WC_Payment_Tokens::class, 'get', $token_id );
 
 			if ( is_null( $token ) ) {
-				throw new PaymentRequestException( __( 'Invalid saved payment method (token) ID', 'woocommerce-payments' ) );
+				throw new PaymentRequestException( __( 'Invalid saved payment method (token) ID.', 'woocommerce-payments' ) );
 			}
 			return new SavedPaymentMethod( $token );
+		}
+
+		if ( ! empty( $request['wcpay-payment-method'] ) ) {
+			$payment_method = sanitize_text_field( wp_unslash( $request['wcpay-payment-method'] ) );
+			return new NewPaymentMethod( $payment_method );
 		}
 
 		throw new PaymentRequestException( __( 'No valid payment method was selected.', 'woocommerce-payments' ) );

--- a/src/Internal/Payment/PaymentRequestException.php
+++ b/src/Internal/Payment/PaymentRequestException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Class PaymentRequestException
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Internal\Payment;
+
+/**
+ * Exception thrown when a payment request is invalid.
+ */
+class PaymentRequestException extends \Exception {
+}

--- a/tests/unit/src/Internal/Payment/PaymentRequestTest.php
+++ b/tests/unit/src/Internal/Payment/PaymentRequestTest.php
@@ -160,19 +160,6 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 		];
 	}
 
-	public function test_get_payment_return_new_payment_method() {
-		$request   = [
-			'payment_method'       => 'woocommerce_payments',
-			'wcpay-payment-method' => 'pm_mock',
-		];
-		$this->sut = new PaymentRequest(
-			$this->mock_legacy_proxy,
-			$request
-		);
-
-		$this->assertInstanceOf( NewPaymentMethod::class, $this->sut->get_payment_method() );
-	}
-
 	public function test_get_payment_throw_exception_due_to_invalid_token_id() {
 		$request   = [
 			'payment_method'                        => 'woocommerce_payments',
@@ -211,6 +198,19 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( SavedPaymentMethod::class, $this->sut->get_payment_method() );
 	}
 
+	public function test_get_payment_return_new_payment_method() {
+		$request   = [
+			'payment_method'       => 'woocommerce_payments',
+			'wcpay-payment-method' => 'pm_mock',
+		];
+		$this->sut = new PaymentRequest(
+			$this->mock_legacy_proxy,
+			$request
+		);
+
+		$this->assertInstanceOf( NewPaymentMethod::class, $this->sut->get_payment_method() );
+	}
+
 	public function test_get_payment_method_throw_exception_due_to_no_payment_method_attached() {
 		$request   = [ 'payment_method' => 'woocommerce_payments' ];
 		$this->sut = new PaymentRequest(
@@ -219,7 +219,7 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 		);
 
 		$this->expectException( PaymentRequestException::class );
-		$this->expectExceptionMessage( 'No valid payment method attached to the request.' );
+		$this->expectExceptionMessage( 'No valid payment method was selected.' );
 
 		$this->sut->get_payment_method();
 	}

--- a/tests/unit/src/Internal/Payment/PaymentRequestTest.php
+++ b/tests/unit/src/Internal/Payment/PaymentRequestTest.php
@@ -7,6 +7,7 @@
 
 namespace WCPay\Tests\Internal\Payment;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use WC_Payment_Token;
 use WC_Payment_Tokens;
 use WCPay\Internal\Payment\PaymentMethod\NewPaymentMethod;
@@ -26,6 +27,13 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 * @var PaymentRequest
 	 */
 	private $sut;
+
+	/**
+	 * Mock legacy proxy.
+	 *
+	 * @var LegacyProxy|MockObject
+	 */
+	private $mock_legacy_proxy;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/unit/src/Internal/Payment/PaymentRequestTest.php
+++ b/tests/unit/src/Internal/Payment/PaymentRequestTest.php
@@ -8,6 +8,7 @@
 namespace WCPay\Tests\Internal\Payment;
 
 use WCPay\Internal\Payment\PaymentRequest;
+use WCPay\Internal\Proxy\LegacyProxy;
 use WCPAY_UnitTestCase;
 
 /**
@@ -21,12 +22,18 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 */
 	private $sut;
 
+	public function setUp(): void {
+		parent::setUp();
+		$this->mock_legacy_proxy = $this->createMock( LegacyProxy::class );
+
+	}
+
 	/**
 	 * @dataProvider provider_text_string_param
 	 */
 	public function test_get_fraud_prevention_token( ?string $value, ?string $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'wcpay-fraud-prevention-token' => $value ];
-		$this->sut = new PaymentRequest( $request );
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
 		$this->assertSame( $expected, $this->sut->get_fraud_prevention_token() );
 	}
 
@@ -35,7 +42,7 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 */
 	public function test_get_woopay_intent_id( ?string $value, ?string $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'platform-checkout-intent' => $value ];
-		$this->sut = new PaymentRequest( $request );
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
 		$this->assertSame( $expected, $this->sut->get_woopay_intent_id() );
 	}
 
@@ -44,7 +51,7 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 */
 	public function test_get_intent_id( ?string $value, ?string $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'intent_id' => $value ];
-		$this->sut = new PaymentRequest( $request );
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
 		$this->assertSame( $expected, $this->sut->get_intent_id() );
 	}
 
@@ -53,7 +60,7 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 */
 	public function test_get_payment_method_id( ?string $value, ?string $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'payment_method_id' => $value ];
-		$this->sut = new PaymentRequest( $request );
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
 		$this->assertSame( $expected, $this->sut->get_payment_method_id() );
 	}
 
@@ -100,7 +107,7 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 */
 	public function test_is_woopay_preflight_check( ?string $value, bool $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'is-woopay-preflight-check' => $value ];
-		$this->sut = new PaymentRequest( $request );
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
 		$this->assertSame( $expected, $this->sut->is_woopay_preflight_check() );
 	}
 
@@ -109,7 +116,7 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	 */
 	public function test_get_order_id( ?string $value, ?int $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'order_id' => $value ];
-		$this->sut = new PaymentRequest( $request );
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
 		$this->assertSame( $expected, $this->sut->get_order_id() );
 	}
 


### PR DESCRIPTION
Fixes #6685

#### Changes proposed in this Pull Request

- Add `get_payment_method` and its tests. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check tests and confirm they're all great.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
