### PR TITLE
Modify title in task to continue with onboarding

### DIFF
--- a/changelog/fix-title-task-continue-onboarding
+++ b/changelog/fix-title-task-continue-onboarding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Modify title in task to continue with onboarding

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -123,7 +123,7 @@ export const getUpdateBusinessDetailsTask = (
 		title: ! detailsSubmitted
 			? sprintf(
 					/* translators: %s: WooPayments */
-					__( 'Set up %s', 'woocommerce-payments' ),
+					__( 'Finish setting up %s', 'woocommerce-payments' ),
 					'WooPayments'
 			  )
 			: sprintf(

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -173,7 +173,7 @@ describe( 'getTasks()', () => {
 				expect.objectContaining( {
 					key: 'complete-setup',
 					completed: false,
-					title: 'Set up WooPayments',
+					title: 'Finish setting up WooPayments',
 					actionLabel: 'Finish setup',
 				} ),
 			] )


### PR DESCRIPTION
This is a follow-up of #7009, because of the tight timeline we were not able to review the copy in time. Addressing the changes from here p1693054711225209/1692964719.857729-slack-C03KTTK2YMA

#### Changes proposed in this Pull Request

Before
![image](https://github.com/Automattic/woocommerce-payments/assets/2612426/c60ade4f-ad28-406f-b42f-96bbef5154c9)


After
<img width="693" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/7949447d-2ccc-4516-bc8c-b256be505504">


#### Testing instructions

Taking into account the change, I'd say just check for the tests passing.

If in need of a deeper test, follow #7009 instructions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.