### PR TITLE
Fall back to site logo when no custom WooPay logo defined

### DIFF
--- a/changelog/add-use-site-logo-when-no-woopay-logo-defined
+++ b/changelog/add-use-site-logo-when-no-woopay-logo-defined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Fall back to site logo when a custom WooPay logo has not been defined

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -340,7 +340,14 @@ class WooPay_Session {
 
 		$account_id = WC_Payments::get_account_service()->get_stripe_account_id();
 
-		$store_logo = WC_Payments::get_gateway()->get_option( 'platform_checkout_store_logo' );
+		$site_logo_id      = get_theme_mod( 'custom_logo' );
+		$site_logo_url     = $site_logo_id ? ( wp_get_attachment_image_src( $site_logo_id, 'full' )[0] ?? '' ) : '';
+		$woopay_store_logo = WC_Payments::get_gateway()->get_option( 'platform_checkout_store_logo' );
+
+		$store_logo = $site_logo_url;
+		if ( ! empty( $woopay_store_logo ) ) {
+			$store_logo = get_rest_url( null, 'wc/v3/payments/file/' . $woopay_store_logo );
+		}
 
 		include_once WCPAY_ABSPATH . 'includes/compat/blocks/class-blocks-data-extractor.php';
 		$blocks_data_extractor = new Blocks_Data_Extractor();
@@ -361,7 +368,7 @@ class WooPay_Session {
 			'email'                => '',
 			'store_data'           => [
 				'store_name'                     => get_bloginfo( 'name' ),
-				'store_logo'                     => ! empty( $store_logo ) ? get_rest_url( null, 'wc/v3/payments/file/' . $store_logo ) : '',
+				'store_logo'                     => $store_logo,
 				'custom_message'                 => self::get_formatted_custom_message(),
 				'blog_id'                        => Jetpack_Options::get_option( 'id' ),
 				'blog_url'                       => get_site_url(),


### PR DESCRIPTION
Fixes #6994 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

If a site logo is defined, but no custom WooPay logo has been uploaded, fall back to the site logo instead.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to **wp-admin &rarr; Appearance &rarr; Customize &rarr; Site Identity** and make sure there is no logo set.
2. Go to **wp-admin &rarr; Payments &rarr; Settings &rarr; WooPay &rarr Customize** and make sure there is no logo set.
3. Add a product to your cart, go to the **Checkout** or **Cart** page, and start a WooPay session.
4. Once you've been redirected to WooPay make sure there is no logo, and instead the store's title/name is displayed.
5. Go to **wp-admin &rarr; Appearance &rarr; Customize &rarr; Site Identity** and add a logo.
6. Add a product to your cart, go to the **Checkout** or **Cart** page, and start a WooPay session.
7. Once you've been redirected to WooPay make sure the logo you uploaded in step (5) is the one displayed at the top of the checkout.
8. Go to **wp-admin &rarr; Payments &rarr; Settings &rarr; WooPay &rarr Customize** and add a logo.
9. Add a product to your cart, go to the **Checkout** or **Cart** page, and start a WooPay session.
10. Once you've been redirected to WooPay make sure the logo you uploaded in step (8) is the one displayed at the top of the checkout.
11. Go to **wp-admin &rarr; Appearance &rarr; Customize &rarr; Site Identity** and **remove** the logo you added step (5).
12. Add a product to your cart, go to the **Checkout** or **Cart** page, and start a WooPay session.
13. Once you've been redirected to WooPay make sure the logo you uploaded in step (8) is the one displayed at the top of the checkout.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
