### PR TITLE
Pass pay for order param to init WooPay session

### DIFF
--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -209,6 +209,27 @@ class WC_Payments_Checkout {
 	}
 
 	/**
+	 * Add the Pay for order params to the JS config.
+	 *
+	 * @param WC_Order $order The pay-for-order order.
+	 */
+	public function add_pay_for_order_params_to_js_config( $order ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['pay_for_order'] ) ) {
+			add_filter(
+				'wcpay_payment_fields_js_config',
+				function( $js_config ) use ( $order ) {
+					$js_config['order_id']      = $order->get_id();
+					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+
+					return $js_config;
+				}
+			);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -209,28 +209,6 @@ class WC_Payments_Checkout {
 	}
 
 	/**
-	 * Add the Pay for order params to the JS config.
-	 *
-	 * @param WC_Order $order The pay-for-order order.
-	 */
-	public function add_pay_for_order_params_to_js_config( $order ) {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
-			add_filter(
-				'wcpay_payment_fields_js_config',
-				function( $js_config ) use ( $order ) {
-					$js_config['order_id']      = $order->get_id();
-					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
-					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
-
-					return $js_config;
-				}
-			);
-		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-	}
-
-	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -215,12 +215,13 @@ class WC_Payments_Checkout {
 	 */
 	public function add_pay_for_order_params_to_js_config( $order ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['pay_for_order'] ) ) {
+		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
 			add_filter(
 				'wcpay_payment_fields_js_config',
 				function( $js_config ) use ( $order ) {
 					$js_config['order_id']      = $order->get_id();
 					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
 
 					return $js_config;
 				}

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -381,8 +381,8 @@ class WooPay_Session {
 			'email'                => '',
 			'store_data'           => [
 				'store_name'                     => get_bloginfo( 'name' ),
-				'store_logo'                     => ! empty( $store_logo ) ? get_rest_url( null, 'wc/v3/payments/file/' . $store_logo ) : '',
-				'custom_message'                 => WC_Payments::get_gateway()->get_option( 'platform_checkout_custom_message' ),
+				'store_logo'                     => $store_logo,
+				'custom_message'                 => self::get_formatted_custom_message(),
 				'blog_id'                        => Jetpack_Options::get_option( 'id' ),
 				'blog_url'                       => get_site_url(),
 				'blog_checkout_url'              => ! $is_pay_for_order ? wc_get_checkout_url() : $order->get_checkout_payment_url(),

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -358,7 +358,14 @@ class WooPay_Session {
 
 		$account_id = WC_Payments::get_account_service()->get_stripe_account_id();
 
-		$store_logo = WC_Payments::get_gateway()->get_option( 'platform_checkout_store_logo' );
+		$site_logo_id      = get_theme_mod( 'custom_logo' );
+		$site_logo_url     = $site_logo_id ? ( wp_get_attachment_image_src( $site_logo_id, 'full' )[0] ?? '' ) : '';
+		$woopay_store_logo = WC_Payments::get_gateway()->get_option( 'platform_checkout_store_logo' );
+
+		$store_logo = $site_logo_url;
+		if ( ! empty( $woopay_store_logo ) ) {
+			$store_logo = get_rest_url( null, 'wc/v3/payments/file/' . $woopay_store_logo );
+		}
 
 		include_once WCPAY_ABSPATH . 'includes/compat/blocks/class-blocks-data-extractor.php';
 		$blocks_data_extractor = new Blocks_Data_Extractor();


### PR DESCRIPTION
Fixes 2135-gh-Automattic/woopay

#### Changes proposed in this Pull Request
This PR passes `pay_for_order` param to init WooPay session and pass a fake `order_id` to checkout data as a workaround for the [checkout order error](https://github.com/woocommerce/woocommerce-blocks/blob/04f36065b34977f02079e6c2c8cb955200a783ff/assets/js/blocks/checkout/block.tsx#L81-L83.).  This is a quick fix and we can optimize it more later.

#### GIFs
|Before|After|
|--|--|
|![ezgif com-optimize](https://github.com/Automattic/woopay/assets/56378160/6ea9b813-9222-4a27-8b6b-259e52e78f87)|<img width="743" alt="Screen Shot 2023-09-01 at 11 48 20 AM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/9ca10f04-3b24-4b0b-a907-1ee1d5e16ae7">|
|<img width="727" alt="Screen Shot 2023-09-01 at 10 00 10 AM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/1b4ea02d-e24c-44cf-acca-91dd04193916">|




#### Testing instructions
1. Clone the latest WooCommerce Blocks `11.0.0-dev` and install WooCommerce (>=8.0.2) on your merchant and WooPay site. It should include the two [endpoints](https://github.com/woocommerce/woocommerce-blocks/blob/75c115e84262fee379e0a301fd0f58e1fc7772b8/src/StoreApi/RoutesController.php#L65-L68).
3. Test with this WooPay branch 2136-gh-Automattic/woopay
4. Create a pay-for-order flow order (ex. WC Bookings or Pre-orders)
5. Go through WooPay checkout process


-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)