### PR TITLE
Check if account service is defined before checking if Stripe account is valid

### DIFF
--- a/changelog/fix-7109-fatal-on-wc-home-task
+++ b/changelog/fix-7109-fatal-on-wc-home-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Potential fatal error when viewing WooCommerce home because we try to check if store has been fully onboarded but account service is not yet initialized.

--- a/includes/class-wc-payments-tasks.php
+++ b/includes/class-wc-payments-tasks.php
@@ -30,7 +30,8 @@ class WC_Payments_Tasks {
 	 * Adds a task to the WC 'Things to do next' task list the if disputes awaiting response.
 	 */
 	public static function add_task_disputes_need_response() {
-		if ( ! WC_Payments::get_account_service()->is_stripe_account_valid() ) {
+		$account_service = WC_Payments::get_account_service();
+		if ( ! $account_service || ! $account_service->is_stripe_account_valid() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #7109

#### Changes proposed in this Pull Request

We add dispute-related task to WooCommerce home task list. In https://github.com/Automattic/woocommerce-payments/pull/7027, we check if Stripe account is valid before fetching dispute data.

I'm not sure in what condition the fatal error reported in https://github.com/Automattic/woocommerce-payments/issues/7109 can be reproduced because I have made sure that [account service is initialized](https://github.com/Automattic/woocommerce-payments/blob/4db41815253e4afdc5a86e9650db88624874f8ff/includes/class-wc-payments.php#L474) first before [we check if Stripe account is valid](https://github.com/Automattic/woocommerce-payments/blob/4db41815253e4afdc5a86e9650db88624874f8ff/includes/class-wc-payments-tasks.php#L33).

Anyway, this PR makes sure that account service is truthy before we're calling its `is_stripe_account_valid()`.

#### Testing instructions

I'm not sure how to reproduce the fatal error, so I can't provide specific testing instructions to make sure the fatal error is fixed. We have to make sure when Stripe account has not been onboarded (or half-boarded), we're not trying to fetch dispute data and we don't see a fatal error though. Also, when store is on-boarded and there is some disputes needing response, we should see the task.

To test half-boarded scenario:
- Start with an store that is not yet onboarded with Stripe.
- Install WooCommerce.
- Install WooPayments.
- Start the onboarding process but do not finish it.
- Go back to the store before finishing the onboarding process. Go to WooCommerce's home (/wp-admin/admin.php?page=wc-admin).
- Confirm that we're no longer fetching disputes data. It's hard to test this without doing any local modification to the code. I put some logging in [this line](https://github.com/Automattic/woocommerce-payments/blob/85c37066e1d2f4895c60cd60f8788fcb07e59aba/includes/class-database-cache.php#L106C1-L106C1) and remove option named wcpay_active_dispute_cache from wp_options table.

To test onboarded with disputes task:
- Purchase a product with the Stripe test card 4000000000000259. This will create a dispute.
- View the WooCommerce Home screen (/wp-admin/admin.php?page=wc-admin). Please read the 'Mocking dispute' section from https://github.com/Automattic/woocommerce-payments/pull/6548 because the dispute needs to be due within 7 days so it appears on WooCommerce home. Then, make sure the dispute task appears.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
