### PR TITLE
Exit the scheduled_subscription_payment function if the order is a Stripe Billing Subscription

### DIFF
--- a/changelog/issue-7123
+++ b/changelog/issue-7123
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue with WCPay Subscription orders being set to failed during payment processing when Woo Subscriptions plugin is active.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -308,16 +308,17 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	 * @param WC_Order $renewal_order A WC_Order object created to record the renewal payment.
 	 */
 	public function scheduled_subscription_payment( $amount, $renewal_order ) {
+
+		// Exit early if the order belongs to a WCPay Subscription. The payment will be processed by the subscription via webhooks.
+		if ( $this->is_wcpay_subscription_renewal_order( $renewal_order ) ) {
+			return;
+		}
+
 		$token = $this->get_payment_token( $renewal_order );
 		if ( is_null( $token ) && ! WC_Payments::is_network_saved_cards_enabled() ) {
 			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );
 			// TODO: Update to use Order_Service->mark_payment_failed.
 			$renewal_order->update_status( 'failed' );
-			return;
-		}
-
-		// Exit early if the order belongs to a WCPay Subscription. The payment will be processed by the subscription via webhooks.
-		if ( $this->is_wcpay_subscription_renewal_order( $renewal_order ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #7123 

#### Changes proposed in this Pull Request

This PR moves the existing logic to exit the `scheduled_subscription_payment` function if the renewal order is a Stripe Billing subscription to the top of the function. 

Having the logic where it was could lead to a situation where a renewal order is set to `failed` if the token is missing from the order. FWIW I don't know what cuases the token to be missing, but this function shouldn't be involved in WCPay subscriptions anyway so is a safe change.

#### Testing instructions

1. Purchase a subscription using Stripe Billing.
2. Process a renewal order using the billing clock
3. Install the WooCommerce Subscriptions plugin.
4. Go in and delete the token meta from the renewal order. (idk why this site has the token missing).
5. Run the scheduled subscription payment action.
   - On `develop` note the last renewal order is set to "failed".
   - On this branch the function should exit early and prevent the renewal order being failed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
