### PR TITLE
Update Transaction Details → HorizontalList label styles to uppercase

### DIFF
--- a/changelog/update-horizontal-list-label-style-uppercase
+++ b/changelog/update-horizontal-list-label-style-uppercase
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: No changelog required: a particularly insignificant UI change.
+
+

--- a/client/components/horizontal-list/style.scss
+++ b/client/components/horizontal-list/style.scss
@@ -45,7 +45,10 @@
 			@include font-size( 14 );
 		}
 		.woocommerce-list__item-title {
-			color: $studio-gray-60;
+			text-transform: uppercase;
+			color: $gray-700;
+			font-size: 11px;
+			font-weight: 600;
 		}
 		.woocommerce-list__item-content {
 			color: $studio-gray-80;

--- a/client/components/horizontal-list/style.scss
+++ b/client/components/horizontal-list/style.scss
@@ -52,6 +52,7 @@
 		}
 		.woocommerce-list__item-content {
 			color: $studio-gray-80;
+			display: flex;
 		}
 	}
 	.woocommerce-list__item:first-child {


### PR DESCRIPTION
Part of #6924 and #6974

Project thread: pdjTHR-2PC-p2


> **Warning**
> This PR is **not** behind a feature flag


#### Changes proposed in this Pull Request

This PR updates the styling of the `HorizontalList` labels to match the latest design. Note: this component is **only** used on the Transaction Details screen.

**This PR**
![implementation](https://github.com/Automattic/woocommerce-payments/assets/3147296/b8b67968-35d1-4e72-861b-44bd830c624d)

**Design**
<img width="1122" alt="design" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/67df3f27-a98b-448a-a374-1c4bd16bca6d">

**Before** (`develop`)
![develop](https://github.com/Automattic/woocommerce-payments/assets/3147296/7f98b5c7-0308-4644-91b3-771da2c30348)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to **Payments → Transactions** and click on a transaction to view the Transaction Details screen.
* Check that the styles match the design.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **Not required**
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.