### PR TITLE
fix: checkout processing when fields are hidden

### DIFF
--- a/changelog/fix-7121-null-coalescing
+++ b/changelog/fix-7121-null-coalescing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+checkout processing when fields are hidden via customizer

--- a/client/checkout/classic/upe-deferred-intent-creation/payment-processing.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/payment-processing.js
@@ -112,21 +112,25 @@ function createStripePaymentMethod(
 				name: document.querySelector( '#billing_first_name' )
 					? (
 							document.querySelector( '#billing_first_name' )
-								.value +
+								?.value +
 							' ' +
-							document.querySelector( '#billing_last_name' ).value
+							document.querySelector( '#billing_last_name' )
+								?.value
 					  ).trim()
 					: undefined,
-				email: document.querySelector( '#billing_email' ).value,
-				phone: document.querySelector( '#billing_phone' ).value,
+				email: document.querySelector( '#billing_email' )?.value,
+				phone: document.querySelector( '#billing_phone' )?.value,
 				address: {
-					city: document.querySelector( '#billing_city' ).value,
-					country: document.querySelector( '#billing_country' ).value,
-					line1: document.querySelector( '#billing_address_1' ).value,
-					line2: document.querySelector( '#billing_address_2' ).value,
+					city: document.querySelector( '#billing_city' )?.value,
+					country: document.querySelector( '#billing_country' )
+						?.value,
+					line1: document.querySelector( '#billing_address_1' )
+						?.value,
+					line2: document.querySelector( '#billing_address_2' )
+						?.value,
 					postal_code: document.querySelector( '#billing_postcode' )
-						.value,
-					state: document.querySelector( '#billing_state' ).value,
+						?.value,
+					state: document.querySelector( '#billing_state' )?.value,
 				},
 			},
 		};

--- a/client/checkout/classic/upe-deferred-intent-creation/test/payment-processing.test.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/test/payment-processing.test.js
@@ -336,13 +336,12 @@ describe( 'Payment processing', () => {
 
 		const mockJqueryForm = {
 			submit: jest.fn(),
-			addClass: jest.fn( () => {
-				return {
-					block: jest.fn(),
-				};
-			} ),
-			removeClass: jest.fn(),
-			unblock: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+			} ) ),
 			attr: jest.fn().mockReturnValue( 'checkout' ),
 		};
 
@@ -377,13 +376,46 @@ describe( 'Payment processing', () => {
 
 		const checkoutForm = {
 			submit: jest.fn(),
-			addClass: jest.fn( () => {
-				return {
-					block: jest.fn(),
-				};
-			} ),
-			removeClass: jest.fn(),
-			unblock: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+			} ) ),
+			attr: jest.fn().mockReturnValue( 'checkout' ),
+		};
+
+		await processPayment( apiMock, checkoutForm, 'card' );
+
+		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
+			elements: expect.any( Object ),
+			params: {
+				billing_details: expect.any( Object ),
+			},
+		} );
+	} );
+
+	test( 'Payment processing does not create error when some fields are hidden via customizer', async () => {
+		setupBillingDetailsFields();
+		// pretending that the customizer removed the billing phone field
+		document.body.removeChild( document.getElementById( 'billing_phone' ) );
+		getFingerprint.mockImplementation( () => {
+			return 'fingerprint';
+		} );
+
+		const mockDomElement = document.createElement( 'div' );
+		mockDomElement.dataset.paymentMethodType = 'card';
+
+		await mountStripePaymentElement( apiMock, mockDomElement );
+
+		const checkoutForm = {
+			submit: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+			} ) ),
 			attr: jest.fn().mockReturnValue( 'checkout' ),
 		};
 
@@ -410,13 +442,12 @@ describe( 'Payment processing', () => {
 
 		const addPaymentMethodForm = {
 			submit: jest.fn(),
-			addClass: jest.fn( () => {
-				return {
-					block: jest.fn(),
-				};
-			} ),
-			removeClass: jest.fn(),
-			unblock: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+			} ) ),
 			attr: jest.fn().mockReturnValue( 'add_payment_method' ),
 		};
 


### PR DESCRIPTION
Fixes #7121 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Ensuring that the checkout fields are present in the UI before processing the checkout.
Sometimes, checkout fields can be hidden via the customizer.
Adding null-coalescing to ensure the checkout form doesn't break.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have "Enable Split UPE checkout with deferred intent creation" enabled via WCPay dev tools
- Ensure you are using the **shortcode** checkout page
- Hide the "phone" field via the customizer
- Try to checkout
- The issue shouldn't present itself anymore
- Testable at https://sound-fungus.jurassic.ninja/

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
