### PR TITLE
hotfix: fallback to the checkout gateway in case main gateway isn't initialized

### DIFF
--- a/changelog/hotifix-non-initialized-gateway
+++ b/changelog/hotifix-non-initialized-gateway
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the gateway from the Checkout class in case the main registered gateway isn't initialized for some reason.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -161,6 +161,9 @@ class WC_Payments_Checkout {
 		// Needed to init the hooks.
 		WC_Checkout::instance();
 
+		// The registered card gateway is more reliable than $this->gateway, but if it isn't available for any reason, fall back to the gateway provided to this checkout class.
+		$gateway = WC_Payments::get_registered_card_gateway() ? WC_Payments::get_registered_card_gateway() : $this->gateway;
+
 		$js_config = [
 			'publishableKey'                 => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
 			'testMode'                       => WC_Payments::mode()->is_test(),
@@ -176,7 +179,7 @@ class WC_Payments_Checkout {
 			'genericErrorMessage'            => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),
 			'fraudServices'                  => $this->account->get_fraud_services_config(),
 			'features'                       => $this->gateway->supports,
-			'forceNetworkSavedCards'         => WC_Payments::is_network_saved_cards_enabled() || WC_Payments::get_registered_card_gateway()->should_use_stripe_platform_on_checkout_page(),
+			'forceNetworkSavedCards'         => WC_Payments::is_network_saved_cards_enabled() || $gateway->should_use_stripe_platform_on_checkout_page(),
 			'locale'                         => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
 			'isPreview'                      => is_preview(),
 			'isUPEEnabled'                   => WC_Payments_Features::is_upe_enabled(),

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -162,7 +162,7 @@ class WC_Payments_Checkout {
 		WC_Checkout::instance();
 
 		// The registered card gateway is more reliable than $this->gateway, but if it isn't available for any reason, fall back to the gateway provided to this checkout class.
-		$gateway = WC_Payments::get_registered_card_gateway() ? WC_Payments::get_registered_card_gateway() : $this->gateway;
+		$gateway = WC_Payments::get_registered_card_gateway() ?? $this->gateway;
 
 		$js_config = [
 			'publishableKey'                 => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2205,6 +2205,27 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		WC_Payments::set_registered_card_gateway( $registered_card_gateway );
 	}
 
+	public function test_registered_gateway_replaced_by_gateway_if_not_initialized() {
+		// Set the registered gateway to null to simulate the case where the gateway is not initialized and thus should be replaced by $mock_wcpay_gateway.
+		WC_Payments::set_registered_card_gateway( null );
+
+		$mock_wcpay_gateway = $this->get_partial_mock_for_gateway( [ 'should_use_stripe_platform_on_checkout_page' ] );
+
+		$mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'should_use_stripe_platform_on_checkout_page' )
+			->willReturn( true );
+
+		$payments_checkout = new WC_Payments_Checkout(
+			$mock_wcpay_gateway,
+			$this->woopay_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertTrue( $payments_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
+	}
+
 	public function test_force_network_saved_cards_is_returned_as_false_if_should_not_use_stripe_platform() {
 		$mock_wcpay_gateway = $this->get_partial_mock_for_gateway( [ 'should_use_stripe_platform_on_checkout_page' ] );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7128

#### Changes proposed in this Pull Request
This PR introduces the countermeasure against handling non-initialized registered card gateway. Some time ago, https://github.com/Automattic/woocommerce-payments/pull/6828 started to fetch `should_use_stripe_platform_on_checkout_page`'s value from the `WC_Payments::get_registered_card_gateway()`.  As per 6705304-zd-a8c, it turns out that this variable is not initialized under certain circumstances which are unknown at the moment. The change in this PR is just an additional prevention mechanism against fatal errors users might experience.

Prior to https://github.com/Automattic/woocommerce-payments/pull/6828, `$this->gateway` was used for checking if `should_use_stripe_platform_on_checkout_page()`. So this change shouldn't introduce any regression.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
Checkout `develop`
1. Modify [this line](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments.php#L773) to `return null;` to simulate the behavior. 
2. Navigate to the wp-admin -> Pages -> Add new
3. Confirm the error identical to the below appears

```
An error of type E_ERROR was caused in line 179 of the file /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-checkout.php](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-checkout.php). Error message: Uncaught Error: Call to a member function should_use_stripe_platform_on_checkout_page() on null in /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-checkout.php:179](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-checkout.php:179)
Stack trace:
0-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-upe-checkout.php(146)](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-upe-checkout.php(146)): WCPay\WC_Payments_Checkout->get_payment_fields_js_config()
1-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-blocks-payment-method.php(101)](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-blocks-payment-method.php(101)): WCPay\WC_Payments_UPE_Checkout->get_payment_fields_js_config()
2-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Payments/PaymentMethodRegistry.php(62)](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Payments/PaymentMethodRegistry.php(62)): WC_Payments_Blocks_Payment_Method->get_payment_method_data()
3-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Payments/Api.php(93)](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/Payments/Api.php(93)): Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry->get_all_registered_script_data()
4-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-includes/class-wp-hook.php(310)](http://ennetbody.ch/public_html/wp-includes/class-wp-hook.php(310)): Automattic\WooCommerce\Blocks\Payments\Api->add_payment_method_script_data()
5-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-includes/class-wp-hook.php(334)](http://ennetbody.ch/public_html/wp-includes/class-wp-hook.php(334)): WP_Hook->apply_filters()
6-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-includes/plugin.php(517)](http://ennetbody.ch/public_html/wp-includes/plugin.php(517)): WP_Hook->do_action()
7-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockTypes/MiniCart.php(200)](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockTypes/MiniCart.php(200)): do_action()
8-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockTypes/AbstractBlock.php(100)](http://ennetbody.ch/public_html/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockTypes/AbstractBlock.php(100)): Automattic\WooCommerce\Blocks\BlockTypes\MiniCart->enqueue_data()
9-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-includes/class-wp-hook.php(310)](http://ennetbody.ch/public_html/wp-includes/class-wp-hook.php(310)): Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock->enqueue_editor_assets()
10-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-includes/class-wp-hook.php(334)](http://ennetbody.ch/public_html/wp-includes/class-wp-hook.php(334)): WP_Hook->apply_filters()
11-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-includes/plugin.php(517)](http://ennetbody.ch/public_html/wp-includes/plugin.php(517)): WP_Hook->do_action()
12-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-admin/edit-form-blocks.php(272)](http://ennetbody.ch/public_html/wp-admin/edit-form-blocks.php(272)): do_action()
13-zd-a8c /home/u704187269/domains/[ennetbody.ch/public_html/wp-admin/post.php(187)](http://ennetbody.ch/public_html/wp-admin/post.php(187)): require('/home/u70418726...')
14-zd-a8c {main}
  thrown
```


4. Checkout `hotifix/non-initialized-gateway` branch
5. Refresh the page and confirm that the error is gone
6. Perform a payment through shortcode checkout & Blocks checkout as sanity check.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.