### PR TITLE
Change ConvertedAmount component to use an updated Tooltip

### DIFF
--- a/changelog/update-6991-table-tooltip
+++ b/changelog/update-6991-table-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Tooltip component on ConvertedAmount.

--- a/client/transactions/list/converted-amount.tsx
+++ b/client/transactions/list/converted-amount.tsx
@@ -5,42 +5,54 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Tooltip } from '@wordpress/components';
+import { Tooltip as FallbackTooltip } from '@wordpress/components';
 import SyncIcon from 'gridicons/dist/sync';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { formatExplicitCurrency } from 'utils/currency';
 
+declare const window: any;
+
 interface ConversionIndicatorProps {
 	amount: number;
 	currency: string;
 	baseCurrency: string;
+	fallback?: boolean;
 }
 
 const ConversionIndicator = ( {
 	amount,
 	currency,
+	fallback,
 	baseCurrency,
-}: ConversionIndicatorProps ): React.ReactElement => (
-	<Tooltip
-		text={ sprintf(
-			/* translators: %s is a monetary amount */
-			__( 'Converted from %s', 'woocommerce-payments' ),
-			formatExplicitCurrency( amount, currency, false, baseCurrency )
-		) }
-		position="bottom center"
-	>
-		<span
-			className="conversion-indicator"
-			data-testid="conversion-indicator"
-			style={ { height: '18px', width: '18px' } }
+}: ConversionIndicatorProps ): React.ReactElement => {
+	// If it's available, use the component from WP, not the one within WCPay, as WP's uses an updated component.
+	const Tooltip = ! fallback
+		? window?.wp?.components?.Tooltip
+		: FallbackTooltip;
+
+	return (
+		<Tooltip
+			text={ sprintf(
+				/* translators: %s is a monetary amount */
+				__( 'Converted from %s', 'woocommerce-payments' ),
+				formatExplicitCurrency( amount, currency, false, baseCurrency )
+			) }
+			position="bottom center"
 		>
-			<SyncIcon size={ 18 } />
-		</span>
-	</Tooltip>
-);
+			<span
+				className="conversion-indicator"
+				data-testid="conversion-indicator"
+				style={ { height: '18px', width: '18px' } }
+			>
+				<SyncIcon size={ 18 } />
+			</span>
+		</Tooltip>
+	);
+};
 
 interface ConvertedAmountProps {
 	amount: number;
@@ -62,11 +74,19 @@ const ConvertedAmount = ( {
 		return <>{ formattedCurrency }</>;
 	}
 
+	const isUpdatedTooltipAvailable = !! window?.wp?.components?.Tooltip;
+
 	return (
-		<div className="converted-amount">
+		<div
+			className={ classNames(
+				'converted-amount',
+				! isUpdatedTooltipAvailable && 'converted-amount--fallback'
+			) }
+		>
 			<ConversionIndicator
 				amount={ fromAmount }
 				currency={ fromCurrency }
+				fallback={ ! isUpdatedTooltipAvailable }
 				baseCurrency={ currency }
 			/>
 			{ formattedCurrency }

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -16,9 +16,11 @@ $space-header-item: 12px;
 			fill: $studio-gray-30;
 		}
 
-		.components-popover__content {
-			position: relative;
-			top: -( $gap * 2 ); // Positioning the tooltip in a higher position to avoid having it cropped by the bottom of the table
+		&--fallback {
+			.components-popover__content {
+				position: relative;
+				top: -( $gap * 2 ); // Positioning the tooltip in a higher position to avoid having it cropped by the bottom of the table
+			}
 		}
 	}
 

--- a/client/transactions/list/test/__snapshots__/converted-amount.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/converted-amount.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ConvertedAmount renders an amount with conversion icon and tooltip 1`] = `
 <div>
   <div
-    class="converted-amount"
+    class="converted-amount converted-amount--fallback"
   >
     <span
       class="conversion-indicator"
@@ -32,7 +32,7 @@ exports[`ConvertedAmount renders an amount with conversion icon and tooltip 1`] 
 exports[`ConvertedAmount renders an amount with conversion icon and tooltip 2`] = `
 <div>
   <div
-    class="converted-amount"
+    class="converted-amount converted-amount--fallback"
   >
     <span
       class="conversion-indicator"

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -660,7 +660,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       tabindex="-1"
                     >
                       <div
-                        class="converted-amount"
+                        class="converted-amount converted-amount--fallback"
                       >
                         <span
                           class="conversion-indicator"
@@ -1593,7 +1593,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       tabindex="-1"
                     >
                       <div
-                        class="converted-amount"
+                        class="converted-amount converted-amount--fallback"
                       >
                         <span
                           class="conversion-indicator"
@@ -2378,7 +2378,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                       tabindex="-1"
                     >
                       <div
-                        class="converted-amount"
+                        class="converted-amount converted-amount--fallback"
                       >
                         <span
                           class="conversion-indicator"
@@ -3226,7 +3226,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       tabindex="-1"
                     >
                       <div
-                        class="converted-amount"
+                        class="converted-amount converted-amount--fallback"
                       >
                         <span
                           class="conversion-indicator"
@@ -4207,7 +4207,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       tabindex="-1"
                     >
                       <div
-                        class="converted-amount"
+                        class="converted-amount converted-amount--fallback"
                       >
                         <span
                           class="conversion-indicator"
@@ -5182,7 +5182,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       tabindex="-1"
                     >
                       <div
-                        class="converted-amount"
+                        class="converted-amount converted-amount--fallback"
                       >
                         <span
                           class="conversion-indicator"


### PR DESCRIPTION
Fixes #6991

#### Changes proposed in this Pull Request

This PR aims to replace the `Tooltip` component with the same component from `window.wp.components`, because the regular component from `@wordpress/components` is causing the tooltip to appear on top of the reference element. This change is important because we're using an old version of `@wordpress/components` that doesn't contain some improvements on the `Tooltip` component.

The solution was suggested by Taha at https://github.com/Automattic/woocommerce-payments/issues/6991#issuecomment-1706766490.

**Changes**
- Use `window.wp.components.Tooltip` by default instead of `@wordpress/components`' `Tooltip`
- Add a fallback in case `window.wp.components.Tooltip` is not available

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Before checking out to this branch:
- Apply the following diff:
```diff
diff --git a/client/data/transactions/hooks.ts b/client/data/transactions/hooks.ts
index be8386916..41d27f95e 100644
--- a/client/data/transactions/hooks.ts
+++ b/client/data/transactions/hooks.ts
@@ -198,10 +198,48 @@ export const useTransactions = (
 				search,
 			};
 
+			const transactions = [
+				{
+					transaction_id: 'txn_3NjufoR6n9ZbYYsJ1pLN8y6i',
+					type: 'charge',
+					date: '2023-08-28 01:55:24',
+					source: 'visa',
+					source_identifier: '4242',
+					customer_name: 'First Last',
+					customer_email: 'admin_example@example.com.ar',
+					customer_country: 'US',
+					amount: 2935,
+					net: 2789,
+					fees: 146,
+					currency: 'usd',
+					risk_level: 0,
+					charge_id: 'ch_3NjufoR6n9ZbYYsJ1FvCz2Zc',
+					deposit_id: 'wcpay_estimated_daily_usd_1693353600',
+					available_on: '2023-08-30',
+					exchange_rate: 0.20526,
+					customer_amount: 14300,
+					customer_currency: 'brl',
+					order_id: 288,
+					amount_in_usd: 2935,
+					source_device: null,
+					channel: null,
+					deposit_status: 'estimated',
+					order: {
+						number: '288',
+						url:
+							'http://localhost:8082/wp-admin/post.php?post=288&action=edit',
+						customer_url:
+							'admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=1',
+						subscriptions: [],
+					},
+					payment_intent_id: 'pi_3NjufoR6n9ZbYYsJ1oWxFAW5',
+				},
+			] as any;
+
 			return {
-				transactions: getTransactions( query ),
-				transactionsError: getTransactionsError( query ),
-				isLoading: isResolving( 'getTransactions', [ query ] ),
+				transactions,
+				transactionsError: undefined,
+				isLoading: false,
 			};
 		},
 		[
diff --git a/client/transactions/list/style.scss b/client/transactions/list/style.scss
index f5ee0405c..cbb6fcb35 100644
--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -16,10 +16,10 @@ $space-header-item: 12px;
 			fill: $studio-gray-30;
 		}
 
-		.components-popover__content {
-			position: relative;
-			top: -( $gap * 2 ); // Positioning the tooltip in a higher position to avoid having it cropped by the bottom of the table
-		}
+		// .components-popover__content {
+		// 	position: relative;
+		// 	top: -( $gap * 2 ); // Positioning the tooltip in a higher position to avoid having it cropped by the bottom of the table
+		// }
 	}
 
 	// slight adjustment to align header items with sorting button to account for icon width
```
- Run `npm run start`
- Go to **Payments > Transactions** and hover the amount icon on the first row
<img width="596" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/4e6166ac-8266-48f2-9fc4-feca95634ad6">

- Note that the tooltip is cropped
- Clear the changes on the `.scss` file by running: `git checkout client/transactions/list/style.scss`
- Refresh the transactions page and hover the same icon
<img width="596" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/84158036-8be7-4f47-9f1a-3d6450a1bbf5">

- It should be on top of the row's content. For this issue's context, this is considered the fallback tooltip.

#### Checkout to this branch
- Refresh the transactions page and hover the same icon
<img width="596" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/d7747692-4595-401a-a03a-fed438ab903e">

- Note that the tooltip appears correctly below the row's content and doesn't get cropped by the table. It is using the updated Tooltip component from `window.wp.components`
- Apply the following diff:
```diff
diff --git a/client/transactions/list/converted-amount.tsx b/client/transactions/list/converted-amount.tsx
index 6a74b01a2..f6d26d7ec 100644
--- a/client/transactions/list/converted-amount.tsx
+++ b/client/transactions/list/converted-amount.tsx
@@ -74,7 +74,7 @@ const ConvertedAmount = ( {
 		return <>{ formattedCurrency }</>;
 	}
 
-	const isUpdatedTooltipAvailable = !! window?.wp?.components?.Tooltip;
+	const isUpdatedTooltipAvailable = false;
 
 	return (
 		<div
```
- Refresh the transactions page and hover the same icon
- Note that it behaves exactly as it was before checking out to this branch
<img width="596" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/19aebd76-5507-441b-8bdc-d8ab35e6adfd">

- Clear the changes by running `git checkout .`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.