### PR TITLE
Fix multicurrency widget error on post/page edit screen

### DIFF
--- a/changelog/fix-7135-currency-switch-widget-on-edit-post
+++ b/changelog/fix-7135-currency-switch-widget-on-edit-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Multicurrency widget error on post/page edit screen

--- a/client/data/multi-currency/hooks.js
+++ b/client/data/multi-currency/hooks.js
@@ -10,13 +10,6 @@ export const useCurrencies = () =>
 	useSelect( ( select ) => {
 		const { getCurrencies, isResolving } = select( STORE_NAME );
 
-		if ( wcpaySettings.isMultiCurrencyEnabled !== '1' ) {
-			return {
-				currencies: {},
-				isLoading: false,
-			};
-		}
-
 		return {
 			currencies: getCurrencies(),
 			isLoading: isResolving( 'getCurrencies', [] ),


### PR DESCRIPTION
Fixes #7135

#### Changes proposed in this Pull Request

This removes the multi currency feature enabled/disabled check in the `useCurrencies` hook that was added for making the fraud protection level modals show the right text when multi currency is disabled on https://github.com/Automattic/woocommerce-payments/pull/5942, but now the modals are removed and we don't need that. So we can remove the check that's causing the Currency switcher widget to produce an error, because `wcpaySettings` global variable is not defined on the Post/Page edit screens, which makes the hook fail because it depends on it.

The components that use the `useCurrencies` hook are:
- UPE LPM enable/disable screen additional currency info box
- Multi currency settings page
- Multi currency single currency settings page
- Multi currency onboarding page
- Currency switcher widget

#### Testing instructions

##### Testing the widget

- Create a new post and add the currency switcher widget
- You should not get an error
- Preview the page
- You should see the working switcher
- Repeat this for a page

##### Testing other parts that touch the hook

#### UPE LPM enable/disable screen additional currency info box
- Remove all enabled currencies 
- Disable UPE from the three dots menu on the top right of the LPM selection box, you can click cancel on the feedback request.
- Enable it back by clicking "Enable on your store" button on the same box.
- You should be redirected to the LPM onboarding screen.
- Enable one LPM that requires EUR as an enabled currency.
- You should see the box stating that EUR will be enabled. 
- Try it with multi currency disabled.
- You shouldn't see the box, enabling the LPM's should work, but MC shouldn't get enabled.

#### Multi currency settings page
- Will work as usual, and when MC is disabled, it should be hidden. 

#### Multi currency single currency settings page
- Will work as usual, and when MC is disabled, it should be hidden. 

#### Multi currency onboarding page
- On WooCommerce > Home page, in the "Inbox" box, find the task which has the title "[Sell worldwide in multiple currencies](http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=/payments/multi-currency-setup)" (Or click to this link if you're using Docker)  
- When multi currency is enabled, you should see the currencies and can enable some
- When multi currency is disabled, you should get an error stating the currency retrieval has failed. (I don't know if we should fix this, as it looks like an edge case.)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
