### PR TITLE
Add component test for Transaction Details → Dispute Details

### DIFF
--- a/changelog/dev-add-dispute-summary-row-tests
+++ b/changelog/dev-add-dispute-summary-row-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not user-facing: updates tests for DisputeDetails component only.
+
+

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -170,7 +170,7 @@ describe( 'DisputeDetails', () => {
 			{ ignore: '.a11y-speak-region' }
 		);
 
-    // Render the staged evidence message
+		// Render the staged evidence message
 		screen.getByText(
 			/You initiated a dispute a challenge to this dispute/,
 			{ ignore: '.a11y-speak-region' }

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -1,0 +1,162 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { Dispute } from 'wcpay/types/disputes';
+import type { Charge } from 'wcpay/types/charges';
+import DisputeDetails from '..';
+
+declare const global: {
+	wcSettings: {
+		locale: {
+			siteLocale: string;
+		};
+	};
+	wcpaySettings: {
+		isSubscriptionsActive: boolean;
+		zeroDecimalCurrencies: string[];
+		currencyData: Record< string, any >;
+		connect: {
+			country: string;
+		};
+		featureFlags: {
+			isAuthAndCaptureEnabled: boolean;
+		};
+	};
+};
+
+global.wcpaySettings = {
+	isSubscriptionsActive: false,
+	zeroDecimalCurrencies: [],
+	connect: {
+		country: 'US',
+	},
+	featureFlags: {
+		isAuthAndCaptureEnabled: true,
+	},
+	currencyData: {
+		US: {
+			code: 'USD',
+			symbol: '$',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		},
+	},
+};
+
+interface ChargeWithDisputeRequired extends Charge {
+	dispute: Dispute;
+}
+
+const getBaseCharge = (): ChargeWithDisputeRequired =>
+	( {
+		id: 'ch_38jdHA39KKA',
+		/* Stripe data comes in seconds, instead of the default Date milliseconds */
+		created: Date.parse( 'Sep 19, 2019, 5:24 pm' ) / 1000,
+		amount: 2000,
+		amount_refunded: 0,
+		application_fee_amount: 70,
+		disputed: true,
+		dispute: {
+			id: 'dp_1',
+			amount: 6800,
+			charge: 'ch_38jdHA39KKA',
+			order: null,
+			balance_transactions: [
+				{
+					amount: -2000,
+					currency: 'usd',
+					fee: 1500,
+				},
+			],
+			created: 1693453017,
+			currency: 'usd',
+			evidence: {
+				billing_address: '123 test address',
+				customer_email_address: 'test@email.com',
+				customer_name: 'Test customer',
+				shipping_address: '123 test address',
+			},
+			evidence_details: {
+				due_by: 1694303999,
+				has_evidence: false,
+				past_due: false,
+				submission_count: 0,
+			},
+			// issuer_evidence: null,
+			metadata: [],
+			payment_intent: 'pi_1',
+			reason: 'fraudulent',
+			status: 'needs_response',
+		} as Dispute,
+		currency: 'usd',
+		type: 'charge',
+		status: 'succeeded',
+		paid: true,
+		captured: true,
+		balance_transaction: {
+			amount: 2000,
+			currency: 'usd',
+			fee: 70,
+		},
+		refunds: {
+			data: [],
+		},
+		order: {
+			number: 45981,
+			url: 'https://somerandomorderurl.com/?edit_order=45981',
+		},
+		billing_details: {
+			name: 'Customer name',
+		},
+		payment_method_details: {
+			card: {
+				brand: 'visa',
+				last4: '4242',
+			},
+			type: 'card',
+		},
+		outcome: {
+			risk_level: 'normal',
+		},
+	} as any );
+
+describe( 'DisputeDetails', () => {
+	test( 'correctly renders dispute details', () => {
+		const charge = getBaseCharge();
+		render( <DisputeDetails dispute={ charge.dispute } /> );
+
+		// Expect this warning to be logged to the console
+		expect( console ).toHaveWarnedWith(
+			'List with items prop is deprecated is deprecated and will be removed in version 9.0.0. Note: See ExperimentalList / ExperimentalListItem for the new API that will replace this component in future versions.'
+		);
+
+		// Dispute Notice
+		screen.getByText(
+			/The cardholder claims this is an unauthorized transaction/,
+			{ ignore: '.a11y-speak-region' }
+		);
+
+		// Dispute Summary Row
+		expect(
+			screen.getByText( /Dispute Amount/i ).nextSibling
+		).toHaveTextContent( /\$68.00/ );
+		expect(
+			screen.getByText( /Disputed On/i ).nextSibling
+		).toHaveTextContent( /Aug 30, 2023/ );
+		expect( screen.getByText( /Reason/i ).nextSibling ).toHaveTextContent(
+			/Transaction unauthorized/
+		);
+		expect(
+			screen.getByText( /Respond By/i ).nextSibling
+		).toHaveTextContent( /Sep 9, 2023/ );
+	} );
+} );

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -152,10 +152,6 @@ describe( 'DisputeDetails', () => {
 				{ ignore: '.a11y-speak-region' }
 			)
 		).toBeNull();
-		expect( console ).toHaveWarnedWith(
-			// eslint-disable-next-line max-len
-			'List with items prop is deprecated is deprecated and will be removed in version 9.0.0. Note: See ExperimentalList / ExperimentalListItem for the new API that will replace this component in future versions.'
-		);
 	} );
 
 	test( 'correctly renders dispute details for a dispute with staged evidence', () => {

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -11,8 +11,21 @@ interface Evidence {
 }
 
 interface EvidenceDetails {
+	/**
+	 * Whether evidence has been staged for this dispute.
+	 */
 	has_evidence: boolean;
+	/**
+	 * Date by which evidence must be submitted in order to successfully challenge dispute.
+	 */
 	due_by: number;
+	/**
+	 * Whether the last evidence submission was submitted past the due date. Defaults to false if no evidence submissions have occurred. If true, then delivery of the latest evidence is not guaranteed.
+	 */
+	past_due: boolean;
+	/**
+	 * The number of times evidence has been submitted. Typically, the merchant may only submit evidence once.
+	 */
 	submission_count: number;
 }
 
@@ -51,7 +64,7 @@ export interface Dispute {
 	evidence: Evidence;
 	fileSize?: Record< string, number >;
 	reason: DisputeReason;
-	charge: Charge;
+	charge: Charge | string;
 	amount: number;
 	currency: string;
 	created: number;


### PR DESCRIPTION
Based on the PR #7077

#### Changes proposed in this Pull Request

This PR adds a basic component test for PR #7077.

#### Testing instructions

* Ensure GH checks pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
