### PR TITLE
Added valid dependencies check on plugin update hook

### DIFF
--- a/changelog/fix-add-dependencies-check-on-plugin-update-hook
+++ b/changelog/fix-add-dependencies-check-on-plugin-update-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent cache deletion during plugin update if minimum dependencies are not met.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1299,7 +1299,7 @@ class WC_Payments {
 		}
 
 		// Don't trigger any update plugin hook and don't bump current plugin version if there is a dependencies issues.
-		if ( version_compare( WCPAY_VERSION_NUMBER, get_option( 'woocommerce_woocommerce_payments_version' ), '>' ) && true === $dependency_service->has_valid_dependencies() ) {
+		if ( version_compare( WCPAY_VERSION_NUMBER, get_option( 'woocommerce_woocommerce_payments_version' ), '>' ) && empty( $dependency_service->get_invalid_dependencies() ) ) {
 			do_action( 'woocommerce_woocommerce_payments_updated' );
 			self::update_plugin_version();
 		}


### PR DESCRIPTION
Fixes #7147 #7110 

#### Changes proposed in this Pull Request

This PR enhances security in the post-plugin update hook by preventing the deletion or purging of the cache, as well as avoiding the increment of the plugin version in the options table, if the minimum dependencies are not satisfied.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Downgrade WooCommerce to the unsupported version. You can use a rollback `[plugin](https://wordpress.org/plugins/wp-rollback/)`.
2. Downgrade plugin version in database by setting this option name `woocommerce_woocommerce_payments_version` to` 1.0.0` for example (`update_option( 'woocommerce_woocommerce_payments_version', '1.0.0' );`)
3. Refresh the page and make sure that the `woocommerce_woocommerce_payments_version` has the latest plugin version as a value
4. Disable WCPayments plugin
5. No errors should be shown.

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
