### PR TITLE
Fix incorrect payment intent status check in cancel authorization API endpoint.

### DIFF
--- a/changelog/fix-7149-fix-cancel-authorization-flaky-error-response
+++ b/changelog/fix-7149-fix-cancel-authorization-flaky-error-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected an issue causing incorrect responses at the cancel authorization API endpoint.

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -499,7 +499,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 
 			$result = $this->gateway->cancel_authorization( $order );
 
-			if ( Intent_Status::SUCCEEDED !== $result['status'] ) {
+			if ( Intent_Status::CANCELED !== $result['status'] ) {
 				return new WP_Error(
 					'wcpay_cancel_error',
 					sprintf(


### PR DESCRIPTION
Fixes #7149

#### Changes proposed in this Pull Request

The incorrect payment intent status was utilized, leading to an error response rather than a successful one.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Make sure to have uncaptured authorization or payment intent.
2. Execute the following API endpoint: payments/orders/ORDER_ID/cancel_authorization and pass payment_intent_id in the body of request.
3. 200 status code is returned.
-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
