### PR TITLE
Disable automatic currency switching and switcher widgets on pay_for_order page

### DIFF
--- a/changelog/fix-5031-disable-currency-switcher-on-pay-for-order
+++ b/changelog/fix-5031-disable-currency-switcher-on-pay-for-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable automatic currency switching and switcher widgets on pay_for_order page.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -87,12 +87,32 @@ class Compatibility extends BaseCompatibility {
 	}
 
 	/**
-	 * Checks to see if the widgets should be hidden.
+	 * Deprecated method, please use should_disable_currency_switching.
 	 *
 	 * @return bool False if it shouldn't be hidden, true if it should.
 	 */
 	public function should_hide_widgets(): bool {
-		return apply_filters( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets', false );
+		return $this->should_disable_currency_switching( apply_filters( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets', false ) );
+	}
+
+	/**
+	 * Checks to see if currency switching should be disabled, such as the widgets and the automatic geolocation switching.
+	 *
+	 * @return bool False if no, true if yes.
+	 */
+	public function should_disable_currency_switching(): bool {
+		/**
+		 * If the pay_for_order parameter is set, we disable currency switching.
+		 *
+		 * WooCommerce itself handles all the heavy lifting and verification on the Order Pay page, we just need to
+		 * make sure the currency switchers are not displayed. This is due to once the order is created, the currency
+		 * itself should remain static.
+		 */
+		if ( isset( $_GET['pay_for_order'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return apply_filters( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching', false );
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -92,7 +92,8 @@ class Compatibility extends BaseCompatibility {
 	 * @return bool False if it shouldn't be hidden, true if it should.
 	 */
 	public function should_hide_widgets(): bool {
-		return $this->should_disable_currency_switching( apply_filters( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets', false ) );
+		wc_deprecated_function( __FUNCTION__, '6.5.0', 'Compatibility::should_disable_currency_switching' );
+		return $this->should_disable_currency_switching();
 	}
 
 	/**
@@ -101,6 +102,8 @@ class Compatibility extends BaseCompatibility {
 	 * @return bool False if no, true if yes.
 	 */
 	public function should_disable_currency_switching(): bool {
+		$return = false;
+
 		/**
 		 * If the pay_for_order parameter is set, we disable currency switching.
 		 *
@@ -109,10 +112,16 @@ class Compatibility extends BaseCompatibility {
 		 * itself should remain static.
 		 */
 		if ( isset( $_GET['pay_for_order'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return true;
+			$return = true;
 		}
 
-		return apply_filters( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching', false );
+		// If someone has hooked into the deprecated filter, throw a notice and then apply the filtering.
+		if ( has_action( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets' ) ) {
+			wc_deprecated_hook( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets', '6.5.0', MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching' );
+			$return = apply_filters( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets', $return );
+		}
+
+		return apply_filters( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching', $return );
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
+++ b/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
@@ -51,7 +51,7 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 				add_filter( MultiCurrency::FILTER_PREFIX . 'override_selected_currency', [ $this, 'override_selected_currency' ], 50 );
 				add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ], 50, 2 );
 				add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_coupon_amount', [ $this, 'should_convert_coupon_amount' ], 50, 2 );
-				add_filter( MultiCurrency::FILTER_PREFIX . 'should_hide_widgets', [ $this, 'should_hide_widgets' ], 50 );
+				add_filter( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching', [ $this, 'should_disable_currency_switching' ], 50 );
 			}
 		}
 	}
@@ -254,13 +254,13 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 	}
 
 	/**
-	 * Checks to see if the widgets should be hidden.
+	 * Checks to see if currency switching should be disabled.
 	 *
 	 * @param bool $return Whether widgets should be hidden or not. Default is false.
 	 *
 	 * @return bool
 	 */
-	public function should_hide_widgets( bool $return ): bool {
+	public function should_disable_currency_switching( bool $return ): bool {
 		// If it's already true, return it.
 		if ( $return ) {
 			return $return;

--- a/includes/multi-currency/CurrencySwitcherBlock.php
+++ b/includes/multi-currency/CurrencySwitcherBlock.php
@@ -117,7 +117,13 @@ class CurrencySwitcherBlock {
 	 * @return string The content to be displayed inside the block widget.
 	 */
 	public function render_block_widget( $block_attributes, $content ): string {
-		if ( $this->compatibility->should_hide_widgets() ) {
+		if ( $this->compatibility->should_disable_currency_switching() ) {
+			return '';
+		}
+
+		$enabled_currencies = $this->multi_currency->get_enabled_currencies();
+
+		if ( 1 === count( $enabled_currencies ) ) {
 			return '';
 		}
 
@@ -133,7 +139,7 @@ class CurrencySwitcherBlock {
 		$widget_content .= '<div class="currency-switcher-holder" style="' . $div_styles . '">';
 		$widget_content .= '<select name="currency" onchange="this.form.submit()" style="' . $select_styles . '">';
 
-		foreach ( $this->multi_currency->get_enabled_currencies() as $currency ) {
+		foreach ( $enabled_currencies as $currency ) {
 			$widget_content .= $this->render_currency_option( $currency, $with_symbol, $with_flag );
 		}
 

--- a/includes/multi-currency/CurrencySwitcherWidget.php
+++ b/includes/multi-currency/CurrencySwitcherWidget.php
@@ -77,7 +77,7 @@ class CurrencySwitcherWidget extends WC_Widget {
 	 * @param array $instance Saved values from database.
 	 */
 	public function widget( $args, $instance ) {
-		if ( $this->compatibility->should_hide_widgets() ) {
+		if ( $this->compatibility->should_disable_currency_switching() ) {
 			return;
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -781,8 +781,8 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function update_selected_currency_by_geolocation() {
-		// We only want to automatically set the currency if this option is enabled.
-		if ( ! $this->is_using_auto_currency_switching() ) {
+		// We only want to automatically set the currency if the option is enabled and it shouldn't be disabled for any reason.
+		if ( ! $this->is_using_auto_currency_switching() || $this->compatibility->should_disable_currency_switching() ) {
 			return;
 		}
 

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-subscriptions.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-subscriptions.php
@@ -109,7 +109,7 @@ class WCPay_Multi_Currency_WooCommerceSubscriptions_Tests extends WCPAY_UnitTest
 			[ 'wcpay_multi_currency_override_selected_currency', 'override_selected_currency' ],
 			[ 'wcpay_multi_currency_should_convert_product_price', 'should_convert_product_price' ],
 			[ 'wcpay_multi_currency_should_convert_coupon_amount', 'should_convert_coupon_amount' ],
-			[ 'wcpay_multi_currency_should_hide_widgets', 'should_hide_widgets' ],
+			[ 'wcpay_multi_currency_should_disable_currency_switching', 'should_disable_currency_switching' ],
 		];
 	}
 
@@ -709,15 +709,15 @@ class WCPay_Multi_Currency_WooCommerceSubscriptions_Tests extends WCPAY_UnitTest
 	}
 
 	// If true is passed to the method, true should be returned immediately.
-	public function test_should_hide_widgets_return_true_if_true_passed() {
+	public function test_should_disable_currency_switching_return_true_if_true_passed() {
 		// Act/Assert: Confirm the result value is true.
-		$this->assertTrue( $this->woocommerce_subscriptions->should_hide_widgets( true ) );
+		$this->assertTrue( $this->woocommerce_subscriptions->should_disable_currency_switching( true ) );
 	}
 
 	// If false is passed to the method and none of the checks are true, false is returned.
-	public function test_should_hide_widgets_return_false() {
+	public function test_should_disable_currency_switching_return_false() {
 		// Act/Assert: Confirm the result value is false.
-		$this->assertFalse( $this->woocommerce_subscriptions->should_hide_widgets( false ) );
+		$this->assertFalse( $this->woocommerce_subscriptions->should_disable_currency_switching( false ) );
 	}
 
 	/**
@@ -725,16 +725,16 @@ class WCPay_Multi_Currency_WooCommerceSubscriptions_Tests extends WCPAY_UnitTest
 	 *
 	 * @dataProvider provider_sub_types_renewal_resubscribe_switch
 	 */
-	public function test_should_hide_widgets_return_true_when_sub_type_in_cart( $sub_type ) {
+	public function test_should_disable_currency_switching_return_true_when_sub_type_in_cart( $sub_type ) {
 		// Arrange: Create a subscription and cart_items to be used.
 		[ $mock_subscription, $cart_items ] = $this->get_mock_subscription_and_session_cart_items( $sub_type );
 
 		// Act/Assert: Confirm the result value is true.
-		$this->assertTrue( $this->woocommerce_subscriptions->should_hide_widgets( false ) );
+		$this->assertTrue( $this->woocommerce_subscriptions->should_disable_currency_switching( false ) );
 	}
 
 	// Should return true if switch found in GET, for when a customer is doing a subscription switch.
-	public function test_should_hide_widgets_return_true_when_starting_subscription_switch() {
+	public function test_should_disable_currency_switching_return_true_when_starting_subscription_switch() {
 		// Arrange: Create a mock subscription to use.
 		$mock_subscription = $this->create_mock_subscription();
 
@@ -743,11 +743,11 @@ class WCPay_Multi_Currency_WooCommerceSubscriptions_Tests extends WCPAY_UnitTest
 		$_GET['_wcsnonce']           = wp_create_nonce( 'wcs_switch_request' );
 
 		// Act/Assert: Confirm that true is returned.
-		$this->assertTrue( $this->woocommerce_subscriptions->should_hide_widgets( false ) );
+		$this->assertTrue( $this->woocommerce_subscriptions->should_disable_currency_switching( false ) );
 	}
 
 	// Should return false since users will not match.
-	public function test_should_hide_widgets_return_false_when_starting_subscrition_switch_and_no_user_match() {
+	public function test_should_disable_currency_switching_return_false_when_starting_subscrition_switch_and_no_user_match() {
 		// Arrange: Create a mock subscription and assign its user.
 		$mock_subscription = $this->create_mock_subscription();
 		$mock_subscription->set_customer_id( 42 );
@@ -757,7 +757,7 @@ class WCPay_Multi_Currency_WooCommerceSubscriptions_Tests extends WCPAY_UnitTest
 		$_GET['_wcsnonce']           = wp_create_nonce( 'wcs_switch_request' );
 
 		// Act/Assert: Confirm that false is returned.
-		$this->assertFalse( $this->woocommerce_subscriptions->should_hide_widgets( false ) );
+		$this->assertFalse( $this->woocommerce_subscriptions->should_disable_currency_switching( false ) );
 	}
 
 	public function provider_sub_types_renewal_resubscribe_switch() {

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -201,4 +201,31 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( $expected, $this->compatibility->convert_order_prices( $expected, [] ) );
 	}
+
+	// The should_disable_currency_switching should return false by default.
+	public function test_should_disable_currency_switching_return_false_by_default() {
+		// Act/Assert: Confirm false is returned by default.
+		$this->assertFalse( $this->compatibility->should_disable_currency_switching() );
+	}
+
+	// If on the pay_for_order page, then should_disable_currency_switching should return true.
+	public function test_should_disable_currency_switching_return_true_on_pay_for_order() {
+		// Arrange: Blatantly hack mock request params for the test.
+		$_GET['pay_for_order'] = true;
+
+		// Act/Assert: Confirm true is returned if on the pay_for_order page.
+		$this->assertTrue( $this->compatibility->should_disable_currency_switching() );
+	}
+
+	// If filtered to true, then should_disable_currency_switching should return true.
+	public function test_should_disable_currency_switching_return_true_on_filtered_true() {
+		// Arrange: Blatantly hack mock request params for the test.
+		add_filter( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching', '__return_true' );
+
+		// Act/Assert: Confirm true is returned if filtered to true.
+		$this->assertTrue( $this->compatibility->should_disable_currency_switching() );
+
+		// Arrange: Remove our filter.
+		remove_all_filters( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching' );
+	}
 }

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -219,7 +219,7 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 
 	// If filtered to true, then should_disable_currency_switching should return true.
 	public function test_should_disable_currency_switching_return_true_on_filtered_true() {
-		// Arrange: Blatantly hack mock request params for the test.
+		// Arrange: Add filter to return true.
 		add_filter( MultiCurrency::FILTER_PREFIX . 'should_disable_currency_switching', '__return_true' );
 
 		// Act/Assert: Confirm true is returned if filtered to true.

--- a/tests/unit/multi-currency/test-class-currency-switcher-block.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-block.php
@@ -62,7 +62,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 		$symbol = $attributes['symbol'] ?? true;
 
 		$this->mock_compatibility->expects( $this->once() )
-			->method( 'should_hide_widgets' )
+			->method( 'should_disable_currency_switching' )
 			->willReturn( false );
 
 		$this->mock_multi_currency->expects( $this->once() )
@@ -184,7 +184,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 		];
 
 		$this->mock_compatibility->expects( $this->once() )
-			->method( 'should_hide_widgets' )
+			->method( 'should_disable_currency_switching' )
 			->willReturn( false );
 
 		$this->mock_multi_currency->expects( $this->once() )
@@ -195,5 +195,38 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 		$this->assertStringContainsString( '<input type="hidden" name="test_name" value="test_value" />', $result );
 		$this->assertStringContainsString( '<input type="hidden" name="test_array[0][0]" value="test_array_value" />', $result );
 		$this->assertStringContainsString( '<input type="hidden" name="named_key[key]" value="value" />', $result );
+	}
+
+	/**
+	 * The widget should not be displayed if should_disable_currency_switching returns true.
+	 */
+	public function test_widget_does_not_render_on_hide() {
+		// Arrange: Set the expected call and return value for should_disable_currency_switching.
+		$this->mock_compatibility
+			->expects( $this->once() )
+			->method( 'should_disable_currency_switching' )
+			->willReturn( true );
+
+		// Act/Assert: Confirm that when calling the renger method nothing is returned.
+		$this->assertSame( '', $this->currency_switcher_block->render_block_widget( [], '' ) );
+	}
+
+	/**
+	 * The widget should not be displayed if there's only a single currency enabled.
+	 */
+	public function test_widget_does_not_render_on_single_currency() {
+		// Arrange: Set the expected call and return values for should_disable_currency_switching  and get_enabled_currencies.
+		$this->mock_compatibility
+			->expects( $this->once() )
+			->method( 'should_disable_currency_switching' )
+			->willReturn( false );
+
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'get_enabled_currencies' )
+			->willReturn( [ new Currency( 'USD' ) ] );
+
+		// Act/Assert: Confirm that when calling the renger method nothing is returned.
+		$this->assertSame( '', $this->currency_switcher_block->render_block_widget( [], '' ) );
 	}
 }

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -55,7 +55,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 	}
 
 	public function test_widget_renders_title_with_args() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$instance = [
 			'title' => 'Test Title',
 		];
@@ -64,13 +64,13 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 	}
 
 	public function test_widget_renders_enabled_currencies_with_symbol() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$this->expectOutputRegex( '/value="USD">&#36; USD.+value="CAD">&#36; CAD.+value="EUR">&euro; EUR.+value="CHF">CHF/s' );
 		$this->render_widget();
 	}
 
 	public function test_widget_renders_enabled_currencies_without_symbol() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$instance = [
 			'symbol' => 0,
 		];
@@ -79,7 +79,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 	}
 
 	public function test_widget_renders_enabled_currencies_with_symbol_and_flag() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$instance = [
 			'symbol' => 1,
 			'flag'   => 1,
@@ -99,20 +99,20 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 	}
 
 	public function test_widget_selects_selected_currency() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'CAD' ) );
 		$this->expectOutputRegex( '/<option value="CAD" selected>&#36; CAD/' );
 		$this->render_widget();
 	}
 
 	public function test_widget_submits_form_on_change() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$this->expectOutputRegex( '/onchange="this.form.submit\(\)"/' );
 		$this->render_widget();
 	}
 
 	public function test_widget_does_not_render_on_hide() {
-		$this->mock_compatibility->method( 'should_hide_widgets' )->willReturn( true );
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( true );
 		$this->expectOutputString( '' );
 		$this->render_widget();
 	}
@@ -121,7 +121,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 		$mock_compatibility  = $this->createMock( WCPay\MultiCurrency\Compatibility::class );
 		$mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
 
-		$mock_compatibility->method( 'should_hide_widgets' )->willReturn( false );
+		$mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$mock_multi_currency
 			->method( 'get_enabled_currencies' )
 			->willReturn(


### PR DESCRIPTION
Fixes #5031 #6937

#### Changes proposed in this Pull Request

If a manual order is created for any reason, then a customer is taken to a "Pay for Order" page. This page should not allow currency switching in any form since we cannot know if we are converting prices correctly that are set in the order. This PR disables the currency switcher widgets and the automatic currency switching based on geolocation for that page.

* Add new `should_disable_currency_switching` to replace `should_hide_widgets` method. The functionality is the same, however, it is now used to also confirm if the automatic location based currency switching should happen. It has an added check in the method to see if the `pay_for_order` parameter has been passed.
* Instances of `should_hide_widgets` were replaced with `should_disable_currency_switching`, which is a large part of the changes.
* The `render_block_widget` method did not have a check to make sure the widget was not displayed if there was only a single currency, so I've added that.
* Tests were update and/or added as needed.

#### Testing instructions

* Do not check out this branch yet.
* For testing purposes, you will need to add the below filter. Note that this will set all users' geolocation to Canada, so it is assuming your store is not based in Canada and does not have CAD as the default currency.
* Navigate to WooCommerce > Settings > Multi-Currency and:
  * Add CAD as a currency if not already added.
  * Scroll down to _Store settings_ and enable the _Automatically switch customers to their local currency if it has been enabled_ setting.
* The currency switcher widget/block will need to active on your site, this is under Appearance > Widgets for non-block themes. I am not sure how it works for block themes.
* Create a new Customer user under Users > Add new. Take note of the password created.
* Navigate to WooCommerce > Orders, then use the _Add new_ button at the top.
* Create a new order with:
  * A single simple product,
  * The new user as the Customer,
  * The status of Pending Payment.
* Once the order is created, there will be a _Customer payment page_ link near the Status, open that in an incognito window.
* Log in as the new user.
* Confirm that:
  * The currency switcher widget is showing,
  * The banner at the bottom reads something like, "We noticed you're visiting from Canada. We've updated our prices to Canadian dollar..."
* Now check out this branch.
* Refresh the Pay for Order page in your incognito window.
* Confirm that:
  * The currency switcher is no longer showing,
  * The banner at the bottom about updating the currency no longer shows.

Filter for geolocation:
```
	add_filter(
		'woocommerce_geolocate_ip',
		function() {
			return 'CA';
		}
	);
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
