### PR TITLE
Disable tracking on Stripe disconnected accounts

### DIFF
--- a/changelog/fix-enable-tracking-on-connected-accounts
+++ b/changelog/fix-enable-tracking-on-connected-accounts
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: dev
 
-Tracks conditions
+Fix Tracks conditions

--- a/changelog/fix-enable-tracking-on-connected-accounts
+++ b/changelog/fix-enable-tracking-on-connected-accounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tracks conditions

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -161,7 +161,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	}
 
 	/**
-	 * Override parent method to omit the jetpack TOS check.
+	 * Override parent method to omit the jetpack TOS check and include custom tracking conditions.
 	 *
 	 * @param bool $is_admin_event Indicate whether the event is emitted from admin area.
 	 * @param bool $track_on_all_stores Indicate whether the event is tracked on all WCPay stores.
@@ -169,6 +169,13 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @return bool
 	 */
 	public function should_enable_tracking( $is_admin_event = false, $track_on_all_stores = false ) {
+
+		// Don't track if the account is not connected.
+		$account = WC_Payments::get_account_service();
+		if ( is_null( $account ) || ! $account->is_stripe_connected() ) {
+			return false;
+		}
+
 		// Always respect the user specific opt-out cookie.
 		if ( ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -25,6 +25,11 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	private $http_client_stub;
 
 	/**
+	 * @var WC_Payments_Account|MockObject
+	 */
+	private $mock_account;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -37,6 +42,10 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->_cache     = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
 		WC_Payments::set_database_cache( $this->mock_cache );
+
+		$this->mock_account = $this->getMockBuilder( WC_Payments_Account::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function tear_down() {
@@ -74,6 +83,15 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_does_not_track_when_account_not_connected() {
+		wp_set_current_user( 1 );
+		$this->set_is_woopay_eligible( true );
+		$this->set_account_connected( false );
+		$is_admin_event      = false;
+		$track_on_all_stores = true;
+		$this->assertFalse( $this->tracker->should_enable_tracking( $is_admin_event, $track_on_all_stores ) );
+	}
+
 	/**
 	 * @param bool $is_admin
 	 */
@@ -100,5 +118,11 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	 */
 	private function set_is_woopay_eligible( $is_woopay_eligible ) {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => $is_woopay_eligible ] );
+	}
+
+	private function set_account_connected( $is_stripe_connected ) {
+		$this->mock_account
+			->method( 'is_stripe_connected' )
+			->willReturn( $is_stripe_connected );
 	}
 }

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\WooPay_Tracker;
 
 /**
@@ -56,6 +57,8 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_tracks_obeys_woopay_flag() {
+		$this->set_account_connected( true );
+		WC_Payments::set_account_service( $this->mock_account );
 		$this->set_is_woopay_eligible( false );
 		$this->assertFalse( $this->tracker->should_enable_tracking( null, null ) );
 	}
@@ -63,6 +66,8 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	public function test_does_not_track_admin_pages() {
 		wp_set_current_user( 1 );
 		$this->set_is_woopay_eligible( true );
+		$this->set_account_connected( true );
+		WC_Payments::set_account_service( $this->mock_account );
 		$this->set_is_admin( true );
 		$this->assertFalse( $this->tracker->should_enable_tracking( null, null ) );
 	}
@@ -70,7 +75,9 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	public function test_does_track_non_admins() {
 		global $wp_roles;
 		$this->set_is_woopay_eligible( true );
+		$this->set_account_connected( true );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
+		WC_Payments::set_account_service( $this->mock_account );
 		wp_set_current_user( 1 );
 		$this->set_is_admin( false );
 
@@ -87,6 +94,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		wp_set_current_user( 1 );
 		$this->set_is_woopay_eligible( true );
 		$this->set_account_connected( false );
+		WC_Payments::set_account_service( $this->mock_account );
 		$is_admin_event      = false;
 		$track_on_all_stores = true;
 		$this->assertFalse( $this->tracker->should_enable_tracking( $is_admin_event, $track_on_all_stores ) );
@@ -114,12 +122,17 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	/**
 	 * Cache account details.
 	 *
-	 * @param $account
+	 * @param $is_woopay_eligible
 	 */
 	private function set_is_woopay_eligible( $is_woopay_eligible ) {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => $is_woopay_eligible ] );
 	}
 
+	/**
+	 * Set Stripe Account connections status.
+	 *
+	 * @param $is_stripe_connected
+	 */
 	private function set_account_connected( $is_stripe_connected ) {
 		$this->mock_account
 			->method( 'is_stripe_connected' )


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This fixes a bug in Tracks class where the module is too early. We add a new condition so Tracks is only called when the account is fully onboarded.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log the Tracks request [here](https://github.com/Automattic/woocommerce-payments/blob/e74fcdcd4f5a69c29de0e1f2230840eb030160f4/includes/class-woopay-tracker.php#L250) by adding an entry like `Logger::debug( 'Tracks Pixel URL: ' . $pixel );`
* Go to WCPay Dev plugin and check the "Force the WCPay plugin to act as disconnected from the WCPay Server" option.
* As a non-admin shopper, add a product to the cart and go to the checkout page.
* As an admin, go to WooCommerce -> Status -> Logs and open WCpay logs.
* Make sure the log entry added above is not recorded.
* Uncheck the  "Force the WCPay plugin to act as disconnected from the WCPay Server" option from WCPay Dev plugin.
* Repeat the above test and make sure the log entry is recorded.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
