### PR TITLE
Redirect back to the pay-for-order page when it's pay-for-order order

### DIFF
--- a/changelog/fix-2141
+++ b/changelog/fix-2141
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Redirect back to the pay-for-order page when it is pay-for-order order

--- a/changelog/fix-init-woopay-error
+++ b/changelog/fix-init-woopay-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix init WooPay and empty cart error

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -690,10 +690,14 @@ export default class WCPayAPI {
 	initWooPay( userEmail, woopayUserSession ) {
 		const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
 		const nonce = getConfig( 'initWooPayNonce' );
+		const urlParams = new URLSearchParams( window.location.search );
+		const isPayForOrder = urlParams.get( 'pay_for_order' );
+
 		return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 			_wpnonce: nonce,
 			email: userEmail,
 			user_session: woopayUserSession,
+			pay_for_order: isPayForOrder,
 		} );
 	}
 

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -695,9 +695,9 @@ export default class WCPayAPI {
 			_wpnonce: nonce,
 			email: userEmail,
 			user_session: woopayUserSession,
-			order_id: window.wcpayConfig.order_id,
-			key: window.wcpayConfig.key,
-			billing_email: window.wcpayConfig.billing_email,
+			order_id: getConfig( 'order_id' ),
+			key: getConfig( 'key' ),
+			billing_email: getConfig( 'billing_email' ),
 		} );
 	}
 

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -696,6 +696,8 @@ export default class WCPayAPI {
 			email: userEmail,
 			user_session: woopayUserSession,
 			order_id: window.wcpayConfig.order_id,
+			key: window.wcpayConfig.key,
+			billing_email: window.wcpayConfig.billing_email,
 		} );
 	}
 

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -690,14 +690,12 @@ export default class WCPayAPI {
 	initWooPay( userEmail, woopayUserSession ) {
 		const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
 		const nonce = getConfig( 'initWooPayNonce' );
-		const urlParams = new URLSearchParams( window.location.search );
-		const isPayForOrder = urlParams.get( 'pay_for_order' );
 
 		return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 			_wpnonce: nonce,
 			email: userEmail,
 			user_session: woopayUserSession,
-			pay_for_order: isPayForOrder,
+			order_id: window.wcpayConfig.order_id,
 		} );
 	}
 

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -27,6 +27,9 @@ describe( 'WCPayAPI', () => {
 			email: 'foo@bar.com',
 			user_session: 'qwerty123',
 			pay_for_order: null,
+			order_id: 1,
+			key: 'testkey',
+			billing_email: 'test@example.com',
 		} );
 	} );
 } );

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -26,6 +26,7 @@ describe( 'WCPayAPI', () => {
 			_wpnonce: 'foo',
 			email: 'foo@bar.com',
 			user_session: 'qwerty123',
+			pay_for_order: null,
 		} );
 	} );
 } );

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -17,7 +17,15 @@ jest.mock( 'wcpay/utils/checkout', () => ( {
 describe( 'WCPayAPI', () => {
 	test( 'initializes woopay using config params', () => {
 		buildAjaxURL.mockReturnValue( 'https://example.org/' );
-		getConfig.mockReturnValue( 'foo' );
+		getConfig.mockImplementation( ( key ) => {
+			const mockProperties = {
+				initWooPayNonce: 'foo',
+				order_id: 1,
+				key: 'testkey',
+				billing_email: 'test@example.com',
+			};
+			return mockProperties[ key ];
+		} );
 
 		const api = new WCPayAPI( {}, request );
 		api.initWooPay( 'foo@bar.com', 'qwerty123' );
@@ -26,7 +34,6 @@ describe( 'WCPayAPI', () => {
 			_wpnonce: 'foo',
 			email: 'foo@bar.com',
 			user_session: 'qwerty123',
-			pay_for_order: null,
 			order_id: 1,
 			key: 'testkey',
 			billing_email: 'test@example.com',

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -190,6 +190,9 @@ export const handleWooPayEmailInput = async (
 			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'get_woopay_session' ),
 			{
 				_ajax_nonce: getConfig( 'woopaySessionNonce' ),
+				order_id: getConfig( 'order_id' ),
+				key: getConfig( 'key' ),
+				billing_email: getConfig( 'billing_email' ),
 			}
 		).then( ( response ) => {
 			if ( response?.data?.session ) {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -96,6 +96,9 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'get_woopay_session' ),
 			{
 				_ajax_nonce: getConfig( 'woopaySessionNonce' ),
+				order_id: getConfig( 'order_id' ),
+				key: getConfig( 'key' ),
+				billing_email: getConfig( 'billing_email' ),
 			}
 		).then( ( response ) => {
 			if ( response?.data?.session ) {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -172,6 +172,23 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 	};
 
+	const appendParamsToWooPayUrl = ( woopayUrl ) => {
+		const isPayForOrder = window.wcpayConfig.pay_for_order;
+		const orderId = window.wcpayConfig.order_id;
+		const key = window.wcpayConfig.key;
+
+		if ( ! isPayForOrder || ! orderId || ! key ) {
+			return woopayUrl;
+		}
+
+		const url = new URL( woopayUrl );
+		url.searchParams.append( 'pay_for_order', isPayForOrder );
+		url.searchParams.append( 'order_id', orderId );
+		url.searchParams.append( 'key', key );
+
+		return url.href;
+	};
+
 	const closeIframe = () => {
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -172,23 +172,6 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 	};
 
-	const appendParamsToWooPayUrl = ( woopayUrl ) => {
-		const isPayForOrder = window.wcpayConfig.pay_for_order;
-		const orderId = window.wcpayConfig.order_id;
-		const key = window.wcpayConfig.key;
-
-		if ( ! isPayForOrder || ! orderId || ! key ) {
-			return woopayUrl;
-		}
-
-		const url = new URL( woopayUrl );
-		url.searchParams.append( 'pay_for_order', isPayForOrder );
-		url.searchParams.append( 'order_id', orderId );
-		url.searchParams.append( 'key', key );
-
-		return url.href;
-	};
-
 	const closeIframe = () => {
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -209,6 +209,27 @@ class WC_Payments_Checkout {
 	}
 
 	/**
+	 * Add the Pay for order params to the JS config.
+	 *
+	 * @param WC_Order $order The pay-for-order order.
+	 */
+	public function add_pay_for_order_params_to_js_config( $order ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['pay_for_order'] ) ) {
+			add_filter(
+				'wcpay_payment_fields_js_config',
+				function( $js_config ) use ( $order ) {
+					$js_config['order_id']      = $order->get_id();
+					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+
+					return $js_config;
+				}
+			);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -209,28 +209,6 @@ class WC_Payments_Checkout {
 	}
 
 	/**
-	 * Add the Pay for order params to the JS config.
-	 *
-	 * @param WC_Order $order The pay-for-order order.
-	 */
-	public function add_pay_for_order_params_to_js_config( $order ) {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
-			add_filter(
-				'wcpay_payment_fields_js_config',
-				function( $js_config ) use ( $order ) {
-					$js_config['order_id']      = $order->get_id();
-					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
-					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
-
-					return $js_config;
-				}
-			);
-		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-	}
-
-	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -215,12 +215,13 @@ class WC_Payments_Checkout {
 	 */
 	public function add_pay_for_order_params_to_js_config( $order ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['pay_for_order'] ) ) {
+		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
 			add_filter(
 				'wcpay_payment_fields_js_config',
 				function( $js_config ) use ( $order ) {
 					$js_config['order_id']      = $order->get_id();
 					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
 
 					return $js_config;
 				}

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -289,7 +289,13 @@ class WooPay_Session {
 			return [];
 		}
 
-		$session = self::get_init_session_request();
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		$order_id      = ! empty( $_POST['order_id'] ) ? absint( wp_unslash( $_POST['order_id'] ) ) : null;
+		$key           = ! empty( $_POST['key'] ) ? sanitize_text_field( wp_unslash( $_POST['key'] ) ) : null;
+		$billing_email = ! empty( $_POST['billing_email'] ) ? sanitize_text_field( wp_unslash( $_POST['billing_email'] ) ) : null;
+		// phpcs:enable
+
+		$session = self::get_init_session_request( $order_id, $key, $billing_email );
 
 		$store_blog_token = ( WooPay_Utilities::get_woopay_url() === WooPay_Utilities::DEFAULT_WOOPAY_URL ) ? Jetpack_Options::get_option( 'blog_token' ) : 'dev_mode';
 

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -416,7 +416,7 @@ class WooPay_Session {
 		}
 
 		$email            = ! empty( $_POST['email'] ) ? wc_clean( wp_unslash( $_POST['email'] ) ) : '';
-		$is_pay_for_order = ! empty( $_POST['pay_for_order'] ) ? wc_clean( wp_unslash( $_POST['pay_for_order'] ) ) : '';
+		$is_pay_for_order = ! empty( $_POST['pay_for_order'] ) ? filter_var( wp_unslash( $_POST['pay_for_order'] ), FILTER_VALIDATE_BOOLEAN ) : false;
 
 		$body                 = self::get_init_session_request( $is_pay_for_order );
 		$body['email']        = $email;

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -321,9 +321,10 @@ class WooPay_Session {
 	/**
 	 * Returns the initial session request data.
 	 *
+	 * @param boolean $is_pay_for_order Pay for order.
 	 * @return array The initial session request data without email and user_session.
 	 */
-	private static function get_init_session_request() {
+	private static function get_init_session_request( $is_pay_for_order = false ) {
 		$user        = wp_get_current_user();
 		$customer_id = WC_Payments::get_customer_service()->get_customer_id_by_user_id( $user->ID );
 		if ( null === $customer_id ) {
@@ -391,10 +392,10 @@ class WooPay_Session {
 				'checkout_schema_namespaces'     => $blocks_data_extractor->get_checkout_schema_namespaces(),
 			],
 			'user_session'         => null,
-			'preloaded_requests'   => [
+			'preloaded_requests'   => ! $is_pay_for_order ? [
 				'cart'     => $cart_data,
 				'checkout' => $checkout_data,
-			],
+			] : [],
 			'tracks_user_identity' => WC_Payments::woopay_tracker()->tracks_get_identity( $user->ID ),
 		];
 
@@ -416,9 +417,10 @@ class WooPay_Session {
 			);
 		}
 
-		$email = ! empty( $_POST['email'] ) ? wc_clean( wp_unslash( $_POST['email'] ) ) : '';
+		$email            = ! empty( $_POST['email'] ) ? wc_clean( wp_unslash( $_POST['email'] ) ) : '';
+		$is_pay_for_order = ! empty( $_POST['pay_for_order'] ) ? wc_clean( wp_unslash( $_POST['pay_for_order'] ) ) : '';
 
-		$body                 = self::get_init_session_request();
+		$body                 = self::get_init_session_request( $is_pay_for_order );
 		$body['email']        = $email;
 		$body['user_session'] = isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null;
 

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -337,6 +337,7 @@ class WooPay_Session {
 	private static function get_init_session_request( $order_id = null, $key = null, $billing_email = null ) {
 		$user             = wp_get_current_user();
 		$is_pay_for_order = null !== $order_id;
+		$order            = wc_get_order( $order_id );
 		$customer_id      = WC_Payments::get_customer_service()->get_customer_id_by_user_id( $user->ID );
 		if ( null === $customer_id ) {
 			// create customer.
@@ -384,7 +385,7 @@ class WooPay_Session {
 				'custom_message'                 => WC_Payments::get_gateway()->get_option( 'platform_checkout_custom_message' ),
 				'blog_id'                        => Jetpack_Options::get_option( 'id' ),
 				'blog_url'                       => get_site_url(),
-				'blog_checkout_url'              => wc_get_checkout_url(),
+				'blog_checkout_url'              => ! $is_pay_for_order ? wc_get_checkout_url() : $order->get_checkout_payment_url(),
 				'blog_shop_url'                  => get_permalink( wc_get_page_id( 'shop' ) ),
 				'store_api_url'                  => self::get_store_api_url(),
 				'account_id'                     => $account_id,
@@ -393,7 +394,7 @@ class WooPay_Session {
 				'is_subscriptions_plugin_active' => WC_Payments::get_gateway()->is_subscriptions_plugin_active(),
 				'woocommerce_tax_display_cart'   => get_option( 'woocommerce_tax_display_cart' ),
 				'ship_to_billing_address_only'   => wc_ship_to_billing_address_only(),
-				'return_url'                     => wc_get_cart_url(),
+				'return_url'                     => ! $is_pay_for_order ? wc_get_cart_url() : $order->get_checkout_payment_url(),
 				'blocks_data'                    => $blocks_data_extractor->get_data(),
 				'checkout_schema_namespaces'     => $blocks_data_extractor->get_checkout_schema_namespaces(),
 			],
@@ -404,7 +405,7 @@ class WooPay_Session {
 			] : [
 				'cart'     => $cart_data,
 				'checkout' => [
-					'order_id' => -1, // This is a workaround for the checkout order error. https://github.com/woocommerce/woocommerce-blocks/blob/04f36065b34977f02079e6c2c8cb955200a783ff/assets/js/blocks/checkout/block.tsx#L81-L83.
+					'order_id' => $order_id, // This is a workaround for the checkout order error. https://github.com/woocommerce/woocommerce-blocks/blob/04f36065b34977f02079e6c2c8cb955200a783ff/assets/js/blocks/checkout/block.tsx#L81-L83.
 				],
 			],
 			'tracks_user_identity' => WC_Payments::woopay_tracker()->tracks_get_identity( $user->ID ),

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -44,7 +44,9 @@ class WooPay_Session {
 		'@^\/wc\/store(\/v[\d]+)?\/cart\/update-customer$@',
 		'@^\/wc\/store(\/v[\d]+)?\/cart\/update-item$@',
 		'@^\/wc\/store(\/v[\d]+)?\/cart\/extensions$@',
+		'@^\/wc\/store(\/v[\d]+)?\/checkout\/(?P<id>[\d]+)@',
 		'@^\/wc\/store(\/v[\d]+)?\/checkout$@',
+		'@^\/wc\/store(\/v[\d]+)?\/order\/(?P<id>[\d]+)@',
 	];
 
 	/**


### PR DESCRIPTION
Fixes 2141-gh-Automattic/woopay

#### Changes proposed in this Pull Request
When it's a pay-for-order order, the cart and Checkout as a guest buttons should redirect shoppers back to the pay-for-order page not the merchant cart page.

This PR adds condition check on `return_url` and `blog_checkout_url`.


#### Testing instructions
1. Clone WooCommerce Blocks `>=11.2.0-dev` and install WooCommerce `>=8.0.2)` on your merchant and WooPay site. It should include the two [endpoints](https://github.com/woocommerce/woocommerce-blocks/blob/75c115e84262fee379e0a301fd0f58e1fc7772b8/src/StoreApi/RoutesController.php#L65-L68).
2. Test with the latest WooPay `trunk`
3. Create a pay-for-order flow order (ex. WC Bookings or Pre-orders)
4. Go through the pay-for-order checkout by WooPay express button
5. Test the cart button and the Checkout as guest button 
6. Both should go back to the pay-for-order page not merchant cart page

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.