### PR TITLE
Fix failing DisputeDetails test due to elapsed `due_by` date

### DIFF
--- a/changelog/fix-7164-dispute-details-failing-test-due_by
+++ b/changelog/fix-7164-dispute-details-failing-test-due_by
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: No changelog entry required: this PR fixes a failing JS test.
+
+

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import type { Dispute } from 'wcpay/types/disputes';
+import type { Dispute, EvidenceDetails } from 'wcpay/types/disputes';
 import type { Charge } from 'wcpay/types/charges';
 import DisputeDetails from '..';
 
@@ -52,11 +52,13 @@ global.wcpaySettings = {
 	},
 };
 
-interface ChargeWithDisputeRequired extends Charge {
-	dispute: Dispute;
+interface ChargeWithDisputeEvidenceDetails extends Charge {
+	dispute: Dispute & {
+		evidence_details: EvidenceDetails;
+	};
 }
 
-const getBaseCharge = (): ChargeWithDisputeRequired =>
+const getBaseCharge = (): ChargeWithDisputeEvidenceDetails =>
 	( {
 		id: 'ch_38jdHA39KKA',
 		/* Stripe data comes in seconds, instead of the default Date milliseconds */
@@ -150,12 +152,7 @@ describe( 'DisputeDetails', () => {
 
 	test( 'correctly renders dispute details for a dispute with staged evidence', () => {
 		const charge = getBaseCharge();
-		charge.dispute.evidence_details = {
-			has_evidence: true,
-			due_by: 1694303999,
-			past_due: false,
-			submission_count: 0,
-		};
+		charge.dispute.evidence_details.has_evidence = true;
 
 		render( <DisputeDetails dispute={ charge.dispute } /> );
 

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -86,7 +86,8 @@ const getBaseCharge = (): ChargeWithDisputeRequired =>
 				shipping_address: '123 test address',
 			},
 			evidence_details: {
-				due_by: 1694303999,
+				// Create a unix timestamp for 7 days from now.
+				due_by: Date.now() / 1000 + 604800,
 				has_evidence: false,
 				past_due: false,
 				submission_count: 0,


### PR DESCRIPTION
Fixes #7164

#### Changes proposed in this Pull Request

This PR fixes the failing JS test `DisputeDetails → correctly renders dispute details` by defining `dispute.evidence_details.due_by` as a future date relative to the time the test is conducted.


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run JS tests for `npm run test:js "client/payment-details/dispute-details"`.
3. Observe that the tests for `client/payment-details/dispute-details` pass.
4. Alternatively, ensure the GH checks for this PR pass.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. **No changelog entry required**
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **Not applicable**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
