### PR TITLE
Fix deprecated string interpolation in Analytics.php

### DIFF
--- a/changelog/fix-7169-deprecated-string-interpolation
+++ b/changelog/fix-7169-deprecated-string-interpolation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix deprecated string interpolation of ${var} with {$var}
+
+

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -316,9 +316,9 @@ class Analytics {
 				$clauses[] = "LEFT JOIN {$meta_table} {$currency_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$currency_tbl}.{$id_field} AND {$currency_tbl}.meta_key = '_order_currency'";
 
 			}
-			$clauses[] = "LEFT JOIN {$meta_table} {$default_currency_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$default_currency_tbl}.{$id_field} AND ${default_currency_tbl}.meta_key = '_wcpay_multi_currency_order_default_currency'";
-			$clauses[] = "LEFT JOIN {$meta_table} {$exchange_rate_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$exchange_rate_tbl}.{$id_field} AND ${exchange_rate_tbl}.meta_key = '_wcpay_multi_currency_order_exchange_rate'";
-			$clauses[] = "LEFT JOIN {$meta_table} {$stripe_exchange_rate_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$stripe_exchange_rate_tbl}.{$id_field} AND ${stripe_exchange_rate_tbl}.meta_key = '_wcpay_multi_currency_stripe_exchange_rate'";
+			$clauses[] = "LEFT JOIN {$meta_table} {$default_currency_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$default_currency_tbl}.{$id_field} AND {$default_currency_tbl}.meta_key = '_wcpay_multi_currency_order_default_currency'";
+			$clauses[] = "LEFT JOIN {$meta_table} {$exchange_rate_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$exchange_rate_tbl}.{$id_field} AND {$exchange_rate_tbl}.meta_key = '_wcpay_multi_currency_order_exchange_rate'";
+			$clauses[] = "LEFT JOIN {$meta_table} {$stripe_exchange_rate_tbl} ON {$wpdb->prefix}wc_order_stats.order_id = {$stripe_exchange_rate_tbl}.{$id_field} AND {$stripe_exchange_rate_tbl}.meta_key = '_wcpay_multi_currency_stripe_exchange_rate'";
 		}
 
 		return apply_filters( MultiCurrency::FILTER_PREFIX . 'filter_join_clauses', $clauses );


### PR DESCRIPTION
Fixes #7169 

#### Changes proposed in this Pull Request

**Title:** Fix deprecated string interpolation in Analytics.php

**Description:**
This PR addresses a deprecation issue in `/var/www/html/web/app/plugins/woocommerce-payments/includes/multi-currency/Analytics.php`. The problem involves the use of `${var}` for string interpolation, which is deprecated. This change replaces `${var}` with the correct `{$var}` format, resolving the following warnings:

- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /plugins/woocommerce-payments/includes/multi-currency/Analytics.php on line 330
- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /plugins/woocommerce-payments/includes/multi-currency/Analytics.php on line 331
- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /plugins/woocommerce-payments/includes/multi-currency/Analytics.php on line 332

**Testing instructions:**
To test this change, follow these steps:

No tests are required because the code changes involve straightforward syntax updates to resolve deprecation warnings. These changes are low-risk and don't introduce new functionality. Visual inspection and basic validation confirm the correctness of the fix. If further testing is required:

1. *Clone the repository and switch to the branch with this fix:*
   ```bash
   git clone https://github.com/your-username/your-repo.git
   cd your-repo
   git checkout bug-fix
2. *Ensure you have the necessary development environment set up for WooCommerce Payments.*
3. *Locate the Analytics.php file in the multi-currency folder within the WooCommerce Payments plugin.*
4. *Check lines 330-332 and the suggested fix*
5. *Identify test cases that previously triggered the deprecation warnings related to string interpolation using ${var}.*
6. *Execute the identified test cases and confirm that the deprecation warnings no longer appear.*
7. *Verify that the correct {$var} interpolation is now in place and that the affected code still functions as expected.*


-------------------

- [x] Run `npm run changelog` to add a changelog file (is `patch`).
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios): _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos, etc.) to the release announcement post, if applicable.
