### PR TITLE
Add support for switching currencies when editing NYP price from cart

### DIFF
--- a/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
+++ b/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
@@ -96,16 +96,11 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 				$cart_item['nyp'] = $cart_item['nyp_original'];
 			} else {
 
-				$nyp_currency = $this->multi_currency->get_enabled_currencies()[ $cart_item['nyp_currency'] ] ?? null;
+				$from_currency = $cart_item['nyp_currency'];
+				$raw_price     = $cart_item['nyp_original'];
 
-				// Convert entered price back to default currency.
-				$converted_price = ( (float) $cart_item['nyp_original'] ) / $nyp_currency->get_rate();
-
-				if ( ! $selected_currency->get_is_default() ) {
-					$converted_price = $this->multi_currency->get_price( $converted_price, 'product' );
-				}
-
-				$cart_item['nyp'] = $converted_price;
+				$cart_item['nyp'] = $this->multi_currency->get_raw_conversion( $raw_price, $selected_currency->get_code(), $from_currency );
+	
 			}
 
 			$cart_item = WC_Name_Your_Price()->cart->set_cart_item( $cart_item );
@@ -177,18 +172,9 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
             $selected_currency = $this->multi_currency->get_selected_currency();
             
             if ( $from_currency !== $selected_currency->get_code() ) {
-                $nyp_currency = $this->multi_currency->get_enabled_currencies()[ $from_currency ] ?? null;
-                
-                // Convert entered price back to default currency.
-				$converted_price = ( (float) $raw_price ) / $nyp_currency->get_rate();
+				$initial_price = $this->multi_currency->get_raw_conversion( $raw_price, $selected_currency->get_code(), $from_currency );
+			}
 		
-				if ( ! $selected_currency->get_is_default() ) {
-					$converted_price = $this->multi_currency->get_price( $converted_price, 'product' );
-				}
-		
-				$initial_price = $converted_price;
-                
-            }
 		}
 
 		return $initial_price;


### PR DESCRIPTION
slight enhancement to NYP compatibility module

#### Changes proposed in this Pull Request

Adds param to the "Edit price" link for a NYP product in the cart. When clicked the user is redirected back to the product page with the current price pre-filled. If the user switches the currency at this point the pre-filled price will not change until this patch is implemented. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
Going to need a slight patch in NYP 3.5.6 before can be tested.

Create simple NYP product
Add it to the cart in one currency
Go to cart and click on edit link, should redirect to single product page with price pre-filled
use a currency switcher to change currencies...

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
