### PR TITLE
Use fallback methods for updating the next payment date after migrating a stripe billing subscription

### DIFF
--- a/changelog/update-subscription-next-payment-on-migrate
+++ b/changelog/update-subscription-next-payment-on-migrate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: The migrator is unreleased code and improvements to it pre-release don't need a changelog entry.
+
+

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -116,20 +116,17 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 
 			$this->maybe_cancel_wcpay_subscription( $wcpay_subscription );
 
-			/**
-			 * There's a scenario where a WCPay subscription is active but has no pending renewal scheduled action.
-			 * Once migrated, this results in an active subscription that will remain active forever, without processing a renewal order.
-			 *
-			 * To ensure that all migrated subscriptions have a pending scheduled action, we need to reschedule the next payment date by
-			 * updating the date on the subscription.
-			 */
-			if ( $subscription->has_status( 'active' ) ) {
-				$this->update_next_payment_date( $subscription, $wcpay_subscription );
+			if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $subscription->get_payment_method() ) {
+				if ( $subscription->has_status( 'active' ) ) {
+					$this->update_next_payment_date( $subscription, $wcpay_subscription );
+				}
 			}
 
 			$this->update_wcpay_subscription_meta( $subscription );
 
-			$subscription->add_order_note( __( 'This subscription has been successfully migrated to a WooPayments tokenized subscription.', 'woocommerce-payments' ) );
+			if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $subscription->get_payment_method() ) {
+				$subscription->add_order_note( __( 'This subscription has been successfully migrated to a WooPayments tokenized subscription.', 'woocommerce-payments' ) );
+			}
 
 			$this->logger->log( sprintf( '---- SUCCESS: Subscription #%d migrated.', $subscription_id ) );
 		} catch ( \Exception $e ) {

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -123,11 +123,8 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 			 * To ensure that all migrated subscriptions have a pending scheduled action, we need to reschedule the next payment date by
 			 * updating the date on the subscription.
 			 */
-			if ( $subscription->has_status( 'active' ) && $subscription->get_time( 'next_payment' ) > time() ) {
-				$new_next_payment = gmdate( 'Y-m-d H:i:s', $subscription->get_time( 'next_payment' ) + 1 );
-				$subscription->update_dates( [ 'next_payment' => $new_next_payment ] );
-
-				$this->logger->log( sprintf( '---- Next payment date updated to %1$s to ensure subscription #%2$d has a pending scheduled payment.', $new_next_payment, $subscription_id ) );
+			if ( $subscription->has_status( 'active' ) ) {
+				$this->update_next_payment_date( $subscription, $wcpay_subscription );
 			}
 
 			$this->update_wcpay_subscription_meta( $subscription );
@@ -279,6 +276,67 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 		if ( $updated ) {
 			$subscription->save();
 		}
+	}
+
+	/**
+	 * Updates the subscription's next payment date in WooCommerce to ensure a smooth transition to on-site billing.
+	 *
+	 * There's a scenario where a WCPay subscription is active but has no pending renewal scheduled action.
+	 * Once migrated, this results in an active subscription that will remain active forever, without processing a renewal order.
+	 *
+	 * To ensure that all migrated subscriptions have a pending scheduled action, we need to reschedule the next payment date by
+	 * updating the date on the subscription.
+	 *
+	 * In priority order the new next payment date will be:
+	 *  - The existing WooCommerce next payment date if it's in the future.
+	 *  - The Stripe subscription's current_period_end if it's in the future.
+	 *  - A newly calculated next payment date using the WC_Subscription::calculate_date() method.
+	 *
+	 * @param WC_Subscription $subscription       The WC Subscription being migrated.
+	 * @param array           $wcpay_subscription The subscription data from Stripe.
+	 */
+	private function update_next_payment_date( $subscription, $wcpay_subscription ) {
+
+		// Just update the existing WC Subscription's next payment date if it's in the future.
+		if ( $subscription->get_time( 'next_payment' ) > time() ) {
+			$new_next_payment = gmdate( 'Y-m-d H:i:s', $subscription->get_time( 'next_payment' ) + 1 );
+
+			$subscription->update_dates( [ 'next_payment' => $new_next_payment ] );
+			$this->logger->log( sprintf( '---- Next payment date updated to %1$s to ensure subscription #%2$d has a pending scheduled payment.', $new_next_payment, $subscription->get_id() ) );
+
+			return;
+		}
+
+		// Use the Stripe subscription's next payment time (current_period_end) if it's in the future.
+		if ( isset( $wcpay_subscription['current_period_end'] ) && absint( $wcpay_subscription['current_period_end'] ) > time() ) {
+			$new_next_payment = gmdate( 'Y-m-d H:i:s', absint( $wcpay_subscription['current_period_end'] ) );
+
+			$subscription->update_dates( [ 'next_payment' => $new_next_payment ] );
+			$this->logger->log( sprintf( '---- Next payment date updated to %1$s to match Stripe subscription record and to ensure subscription #%2$d has a pending scheduled payment.', $new_next_payment, $subscription->get_id() ) );
+
+			return;
+		}
+
+		// Lastly calculate the next payment date.
+		$new_next_payment = $subscription->calculate_date( 'next_payment' );
+
+		if ( wcs_date_to_time( $new_next_payment ) > time() ) {
+			$subscription->update_dates( [ 'next_payment' => $new_next_payment ] );
+			$this->logger->log( sprintf( '---- Calculated a new next payment date (%1$s) to ensure subscription #%2$d has a pending scheduled payment in the future.', $new_next_payment, $subscription->get_id() ) );
+
+			return;
+		}
+
+		// If we got here the next payment date is in the past, the Stripe subscription is missing a "current_period_end" or it's in the past, and calculating a new date also failed. Log an error.
+		$this->logger->log(
+			sprintf(
+				'---- ERROR: Failed to update subscription #%1$d next payment date. Current next payment date (%2$s) is in the past, Stripe "current_period_end" data is invalid (%3$s) and an attempt to calculate a new date also failed (%4$s).',
+				$subscription->get_id(),
+				gmdate( 'Y-m-d H:i:s', $subscription->get_time( 'next_payment' ) ),
+				isset( $wcpay_subscription['current_period_end'] ) ? gmdate( 'Y-m-d H:i:s', absint( $wcpay_subscription['current_period_end'] ) ) : 'no data',
+				$new_next_payment
+			)
+		);
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -116,10 +116,8 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 
 			$this->maybe_cancel_wcpay_subscription( $wcpay_subscription );
 
-			if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $subscription->get_payment_method() ) {
-				if ( $subscription->has_status( 'active' ) ) {
-					$this->update_next_payment_date( $subscription, $wcpay_subscription );
-				}
+			if ( $subscription->has_status( 'active' ) ) {
+				$this->update_next_payment_date( $subscription, $wcpay_subscription );
 			}
 
 			$this->update_wcpay_subscription_meta( $subscription );
@@ -304,8 +302,8 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 			return;
 		}
 
-		// Use the Stripe subscription's next payment time (current_period_end) if it's in the future.
-		if ( isset( $wcpay_subscription['current_period_end'] ) && absint( $wcpay_subscription['current_period_end'] ) > time() ) {
+		// If the subscription was still using WooPayments, use the Stripe subscription's next payment time (current_period_end) if it's in the future.
+		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $subscription->get_payment_method() && isset( $wcpay_subscription['current_period_end'] ) && absint( $wcpay_subscription['current_period_end'] ) > time() ) {
 			$new_next_payment = gmdate( 'Y-m-d H:i:s', absint( $wcpay_subscription['current_period_end'] ) );
 
 			$subscription->update_dates( [ 'next_payment' => $new_next_payment ] );

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -126,7 +126,7 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 				$subscription->add_order_note( __( 'This subscription has been successfully migrated to a WooPayments tokenized subscription.', 'woocommerce-payments' ) );
 			}
 
-			$this->logger->log( sprintf( '---- SUCCESS: Subscription #%d migrated.', $subscription_id ) );
+			$this->logger->log( sprintf( '---- Subscription #%d migration complete.', $subscription_id ) );
 		} catch ( \Exception $e ) {
 			$this->logger->log( $e->getMessage() );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces multiple fallback mechanisms for updating a subscription's next payment date when it's migrated from Stripe Billing to on-site billing via tokens. 

Prior to this PR it simply added 1 second to the current next payment date if it existed and it was in the future. 

This still remains the 1st approach, however there's now 2 additional mechanisms if that first check fails (current next payment date is in the past for some reason):

1. If the Stripe Billing subscription's `current_period_end` is in the future, use it.
2. If all previous checks fail, attempt to calculate a new date using the `$subscription->calculate_date()`. 

If all 3 fail, something has seriously gone wrong somewhere along the line and an error is logged to the migration log. 

### Testing

#### Setup
- Enable Stripe Billing.
- Purchase any number of subscriptions using Stripe Billing.
- You can use the following code snippet to start a migration for each test.

```php
do_action( 'wcpay_migrate_subscription', 2995 ); 
```

#### Testing scenarios

- **Standard test**
  1. Run the migration (see code example above). 
  2. Look at the `woopayments-subscription-migration` log file you should notice that the new next payment date is **updated by 1 sec**. 
  3. Check the admin subscription list table and confirm the subscription has a matching next payment date and scheduled action.

```
DEBUG Migrating subscription #2991.
DEBUG ---- Stripe subscription (sub_1NpN5KFyDQrVWdZ2xYQ3hGi7) has "active" status. Canceling the subscription.
DEBUG ---- Stripe subscription (sub_1NpN5KFyDQrVWdZ2xYQ3hGi7) successfully canceled.
DEBUG ---- Next payment date updated to 2023-12-12 03:16:18 to ensure subscription #2991 has a pending scheduled payment.
DEBUG ---- SUCCESS: Subscription #2991 migrated.
```

- **No next payment date.** 
  1. Delete the `_schedule_next_payment` meta. 
  3. Run the migration (see code example above). 
  4. Look at the `woopayments-subscription-migration` log file you should notice that the new next payment date is pulled from **Stripe**. 
  5. Check the admin subscription list table and confirm the subscription has a matching next payment date and scheduled action.

```
 DEBUG Migrating subscription #2982.
 DEBUG ---- Stripe subscription (sub_1NpMxJFyDQrVWdZ28kGOsxEd) has "active" status. Canceling the subscription.
 DEBUG ---- Stripe subscription (sub_1NpMxJFyDQrVWdZ28kGOsxEd) successfully canceled.
 DEBUG ---- Next payment date updated to 2023-10-13 04:28:55 to match Stripe subscription record and to ensure subscription #2982 has a pending scheduled payment.
 DEBUG ---- SUCCESS: Subscription #2982 migrated.
 DEBUG Migrating subscription #2983.
```

- **No next payment date and no Stripe data** 
  1. Delete the `_schedule_next_payment` meta.
  2. Edit the `update_next_payment_date()` code to simulate missing `current_period_end`. 
  3. Run the migration (see code example above). 
  4. Look at the `woopayments-subscription-migration` log file you should notice that the new next payment date is calculated. 
  5. Check the admin subscription list table and confirm the subscription has a matching next payment date and scheduled action.

```php
unset( $wcpay_subscription['current_period_end'] );
```

```
Migrating subscription #2993.
DEBUG ---- Stripe subscription (sub_1NpNIuFyDQrVWdZ2WoCweKMW) has "active" status. Canceling the subscription.
DEBUG ---- Stripe subscription (sub_1NpNIuFyDQrVWdZ2WoCweKMW) successfully canceled.
DEBUG ---- Calculated a new next payment date (2023-09-19 03:30:29) to ensure subscription #2993 has a pending scheduled payment in the future.
DEBUG ---- SUCCESS: Subscription #2993 migrated.
```

- **No next payment date, no Stripe data and a failed attempt to calculate a date** 
  1. Delete the `_schedule_next_payment` meta.
  2. Edit the `update_next_payment_date()` code to simulate missing `current_period_end`.
  3. Edit the `update_next_payment_date()` code to simulate `$subscription->calculate_date()` returning an invalid date.  
  4. Run the migration (see code example above). 
  5. Look at the `woopayments-subscription-migration` log file you should notice an error message.

```php
// Return a date that is in the past. 
$new_next_payment = gmdate( 'Y-m-d H:i:s', time() - ( HOUR_IN_SECONDS * 5 ) );
```

```
DEBUG Migrating subscription #2995.
DEBUG ---- Stripe subscription (sub_1NpNLkFyDQrVWdZ2dcwyvvZI) has "active" status. Canceling the subscription.
DEBUG ---- Stripe subscription (sub_1NpNLkFyDQrVWdZ2dcwyvvZI) successfully canceled.
DEBUG ---- ERROR: Failed to update subscription #2995 next payment date. Current next payment date (1970-01-01 00:00:00) is in the past, Stripe "current_period_end" data is invalid (1970-01-01 00:00:00) and an attempt to calculate a new date also failed (2023-09-12 02:36:46).
DEBUG Migrating subscription #2997.
DEBUG ---- Stripe subscription (sub_1NpOEMFyDQrVWdZ2RPC9XyqV) has "active" status. Canceling the subscription.
DEBUG ---- Stripe subscription (sub_1NpOEMFyDQrVWdZ2RPC9XyqV) successfully canceled.
DEBUG ---- ERROR: Failed to update subscription #2997 next payment date. Current next payment date (1970-01-01 00:00:00) is in the past, Stripe "current_period_end" data is invalid (no data) and an attempt to calculate a new date also failed (2023-09-11 23:30:14).
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
