### PR TITLE
Update new onboarding flow components to use admin color schema

### DIFF
--- a/changelog/update-7098-onboarding-components
+++ b/changelog/update-7098-onboarding-components
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Ensure new onboarding components (behind an experiment) use admin color schema.
+
+

--- a/client/components/load-bar/style.scss
+++ b/client/components/load-bar/style.scss
@@ -8,7 +8,7 @@
 		display: block;
 		height: 100%;
 		width: 100%;
-		background-color: $blue-50;
+		background-color: var( --wp-admin-theme-color );
 		animation: wcpay-component-load-bar 3s ease-in-out infinite;
 		transform-origin: 0 0;
 	}

--- a/client/components/radio-card/index.tsx
+++ b/client/components/radio-card/index.tsx
@@ -28,17 +28,23 @@ const RadioCard: React.FC< Props > = ( {
 	onChange,
 	className,
 } ) => {
-	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) =>
-		onChange( event.target.value );
-
 	return (
 		<>
 			{ options.map( ( { label, icon, value, content } ) => {
+				const id = `radio-card-${ name }-${ value }`;
 				const checked = value === selected;
+				const handleChange = () => onChange( value );
 
 				return (
-					<label
+					<div
+						role="radio"
+						aria-checked={ checked }
+						tabIndex={ 0 }
 						key={ value }
+						onClick={ handleChange }
+						onKeyDown={ ( event ) => {
+							if ( event.key === 'Enter' ) handleChange();
+						} }
 						className={ classNames(
 							'wcpay-component-radio-card',
 							{ checked },
@@ -47,17 +53,19 @@ const RadioCard: React.FC< Props > = ( {
 					>
 						<div className="wcpay-component-radio-card__label">
 							<input
+								id={ id }
 								type="radio"
 								name={ name }
 								value={ value }
 								checked={ !! checked }
 								onChange={ handleChange }
+								tabIndex={ -1 }
 							/>
-							{ label }
+							<label htmlFor={ id }>{ label }</label>
 							{ icon }
 						</div>
 						{ checked && content }
-					</label>
+					</div>
 				);
 			} ) }
 		</>

--- a/client/components/radio-card/style.scss
+++ b/client/components/radio-card/style.scss
@@ -11,8 +11,9 @@
 	}
 
 	&:hover,
-	&.checked {
-		box-shadow: 0 0 0 1px #007cba;
+	&.checked,
+	&:focus-visible {
+		box-shadow: 0 0 0 1.5px var( --wp-admin-theme-color );
 	}
 
 	&__label {
@@ -37,10 +38,15 @@
 			height: 20px;
 			border-color: $gray-700;
 
+			&:checked {
+				border-color: var( --wp-admin-theme-color );
+			}
+
 			&::before {
 				width: 12px;
 				height: 12px;
 				margin: 3px;
+				background: var( --wp-admin-theme-color );
 			}
 
 			&:focus {

--- a/client/components/radio-card/test/__snapshots__/index.tsx.snap
+++ b/client/components/radio-card/test/__snapshots__/index.tsx.snap
@@ -2,39 +2,57 @@
 
 exports[`RadioCard Component renders RadioCard component with provided props 1`] = `
 <div>
-  <label
+  <div
+    aria-checked="true"
     class="wcpay-component-radio-card checked"
+    role="radio"
+    tabindex="0"
   >
     <div
       class="wcpay-component-radio-card__label"
     >
       <input
         checked=""
+        id="radio-card-pizzas-pineapple"
         name="pizzas"
+        tabindex="-1"
         type="radio"
         value="pineapple"
       />
-      Pineapple pizza
+      <label
+        for="radio-card-pizzas-pineapple"
+      >
+        Pineapple pizza
+      </label>
       <svg />
     </div>
     <p>
       Sweet pizza
     </p>
-  </label>
-  <label
+  </div>
+  <div
+    aria-checked="false"
     class="wcpay-component-radio-card"
+    role="radio"
+    tabindex="0"
   >
     <div
       class="wcpay-component-radio-card__label"
     >
       <input
+        id="radio-card-pizzas-pizza"
         name="pizzas"
+        tabindex="-1"
         type="radio"
         value="pizza"
       />
-      Pizza
+      <label
+        for="radio-card-pizzas-pizza"
+      >
+        Pizza
+      </label>
       <svg />
     </div>
-  </label>
+  </div>
 </div>
 `;

--- a/client/components/radio-card/test/index.tsx
+++ b/client/components/radio-card/test/index.tsx
@@ -49,7 +49,7 @@ describe( 'RadioCard Component', () => {
 			/>
 		);
 
-		user.click( screen.getByRole( 'radio', { name: /Pineapple/i } ) );
+		user.click( screen.getByLabelText( /Pineapple/i ) );
 		expect( mockOnChange ).toHaveBeenCalledWith( 'pineapple' );
 	} );
 } );

--- a/client/onboarding/style.scss
+++ b/client/onboarding/style.scss
@@ -12,7 +12,7 @@ body.wcpay-onboarding__body {
 				top: 0;
 				left: 0;
 				height: 8px;
-				background-color: $gutenberg-blue;
+				background-color: var( --wp-admin-theme-color );
 				z-index: 11;
 				transition: width 250ms;
 			}


### PR DESCRIPTION
Fixes #7098 

#### Changes proposed in this Pull Request
- Update the following components to use admin schema colors:
  - `RadioCard` – make it also usable by keyboard.
  - `LoadBar`
  - The onboarding stepper progress bar at the top.

I've also checked if it was possible to replace any of those components with `@wordpress/components` or `@woocommerce/components`, but unfortunately the only matching ones are experimental or not externally usable for now. We could check it again in the future, or contribute to make them usable from WP/WC.

#### Testing instructions
- Go to **Users → Profile** and pick a different admin color schema. (e.g. Midnight)
- Go to the new onboarding flow.
- Ensure that the mentioned components use the admin color schema. You can check the following screenshots for reference.

#### Before vs After
<img src="https://github.com/Automattic/woocommerce-payments/assets/7670276/fe4d0b10-566a-41f3-bff5-3474a81f7b76" width="507" />
<img src="https://github.com/Automattic/woocommerce-payments/assets/7670276/f3908168-d2e7-49db-b402-99ec30403f5b" width="750" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**
- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
