### PR TITLE
Verify the migrated subscription has a valid WooPayments payment token before completing the migration

### DIFF
--- a/changelog/verify_payment_token_on_migration
+++ b/changelog/verify_payment_token_on_migration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This PR comes as part of the migration script which hasn't been released yet. No changelog needed
+
+

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -627,7 +627,7 @@ class WC_Payments {
 		// Load Stripe Billing subscription integration.
 		if ( self::should_load_stripe_billing_integration() ) {
 			include_once WCPAY_ABSPATH . '/includes/subscriptions/class-wc-payments-subscriptions.php';
-			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::$order_service, self::$account );
+			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::$order_service, self::$account, self::$token_service );
 		}
 
 		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '7.9.0', '<' ) ) {

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -389,6 +389,7 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 		if ( ! $token ) {
 			try {
 				$token = $this->token_service->add_payment_method_to_user( $wcpay_subscription['default_payment_method'], $user );
+				$this->logger->log( sprintf( '---- Created a new payment token (%1$s) for subscription #%2$d.', $token->get_token(), $subscription->get_id() ) );
 			} catch ( \Exception $e ) {
 				$this->logger->log( sprintf( '---- WARNING: Subscription #%1$d is missing a payment token and we failed to create one. Error: %2$s', $subscription->get_id(), $e->getMessage() ) );
 				return;

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -397,7 +397,13 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 			}
 		}
 
+		// Prevent the WC_Payments_Subscriptions class from attempting to update the Stripe Billing subscription's payment method while we set the token.
+		remove_action( 'woocommerce_payment_token_added_to_order', [ WC_Payments_Subscriptions::get_subscription_service(), 'update_wcpay_subscription_payment_method' ], 10 );
+
 		$subscription->add_payment_token( $token );
+
+		// Reattach.
+		add_action( 'woocommerce_payment_token_added_to_order', [ WC_Payments_Subscriptions::get_subscription_service(), 'update_wcpay_subscription_payment_method' ], 10, 3 );
 
 		return $token;
 	}

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -355,7 +355,7 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 		$new_token = $this->maybe_create_and_update_payment_token( $subscription, $wcpay_subscription );
 
 		if ( $new_token ) {
-			$this->logger->log( sprintf( '---- Payment token on subscription #%1$d has been updated (from #%2$s to #%3$s) to match the payment method on the Stripe Billing subscription.', $subscription->get_id(), $token ? $token->get_token() : 'missing', $wcpay_subscription['default_payment_method'] ) );
+			$this->logger->log( sprintf( '---- Payment token on subscription #%1$d has been updated (from %2$s to %3$s) to match the payment method on the Stripe Billing subscription.', $subscription->get_id(), $token ? $token->get_token() : 'missing', $wcpay_subscription['default_payment_method'] ) );
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -139,12 +139,12 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 				$this->logger->log( sprintf( '---- Next payment date updated to %1$s to ensure subscription #%2$d has a pending scheduled payment.', $new_next_payment, $subscription_id ) );
 			}
 
-			$this->update_wcpay_subscription_meta( $subscription );
-
 			// If the subscription is active or on-hold, verify the payment method is valid and set correctly that it continues to renew.
 			if ( $subscription->has_status( [ 'active', 'on-hold' ] ) ) {
 				$this->verify_subscription_payment_token( $subscription, $wcpay_subscription );
 			}
+
+			$this->update_wcpay_subscription_meta( $subscription );
 
 			$subscription->add_order_note( __( 'This subscription has been successfully migrated to a WooPayments tokenized subscription.', 'woocommerce-payments' ) );
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -337,8 +337,10 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 			return;
 		}
 
+		unset( $wcpay_subscription['default_payment_method'] );
+
 		if ( empty( $wcpay_subscription['default_payment_method'] ) ) {
-			$this->logger->log( sprintf( '---- Could not verify the payment method. Stripe Billing subscription (%2$s) does not have a default payment method.', $wcpay_subscription['id'] ?? 'unknown' ) );
+			$this->logger->log( sprintf( '---- Could not verify the payment method. Stripe Billing subscription (%1$s) does not have a default payment method.', $wcpay_subscription['id'] ?? 'unknown' ) );
 			return;
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -85,8 +85,8 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 	 */
 	public function __construct( $api_client = null, $token_service = null ) {
 		$this->api_client    = $api_client;
-		$this->logger        = new WC_Payments_Subscription_Migration_Log_Handler();
 		$this->token_service = $token_service;
+		$this->logger        = new WC_Payments_Subscription_Migration_Log_Handler();
 
 		// Don't copy migrated subscription meta keys to related orders.
 		add_filter( 'wc_subscriptions_object_data', [ $this, 'exclude_migrated_meta' ], 10, 1 );

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -63,8 +63,9 @@ class WC_Payments_Subscriptions {
 	 * @param WC_Payments_Customer_Service $customer_service WCPay Customer Service.
 	 * @param WC_Payments_Order_Service    $order_service    WCPay Order Service.
 	 * @param WC_Payments_Account          $account          WC_Payments_Account.
+	 * @param WC_Payments_Token_Service    $token_service    WC_Payments_Token_Service.
 	 */
-	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payments_Order_Service $order_service, WC_Payments_Account $account ) {
+	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payments_Order_Service $order_service, WC_Payments_Account $account, WC_Payments_Token_Service $token_service ) {
 		// Store dependencies.
 		self::$order_service = $order_service;
 
@@ -93,7 +94,7 @@ class WC_Payments_Subscriptions {
 
 		if ( class_exists( 'WCS_Background_Repairer' ) ) {
 			include_once __DIR__ . '/class-wc-payments-subscriptions-migrator.php';
-			self::$stripe_billing_migrator = new WC_Payments_Subscriptions_Migrator( $api_client );
+			self::$stripe_billing_migrator = new WC_Payments_Subscriptions_Migrator( $api_client, $token_service );
 		}
 
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'maybe_disable_wcpay_subscriptions_on_update' ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When migrating a Stripe Billing subscription to WooPayments tokenized, we want to ensure the next payment is going to go through smoothly. To achieve this, in this PR we are implementing a method to verify the payment token is set correctly on the subscription so that it matches the same payment method that was set on Stripe.

There are a couple of things happening with these changes but here's a rundown of the logic used to verify and update the payemnt tokens:
 - If the subscription is no longer using WooPayments as the payment method, don't update any payment tokens
 - If the subscription isn't active or on-hold, don't update any payment tokens
 - If the subscription already has a token set, confirm that it matches the payment method on the stripe subscription, if it doesn't, check that the payment token on the stripe billing subscription exists in the Woo tokens table, create one if it doesn't, and then update the subscriptions payment token.
 - If the subscription doesn't have a token set, check that the payment token on the stripe billing subscription exists in the Woo tokens table, create one if it doesn't, and then update the subscription's payment token.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- [x] Subscription without a token
   - [x] Token on Stripe subscription doesn't exist in Woo (create and update)
   - [x] Token on Stripe subscription does exist in Woo (update)
- [x] Subscription with a WooPayments token
   - [x] Token on Stripe subscription matches token (do nothing)
   - [x] Token on Stripe subscription doesn't match and exists in Woo (update)
   - [x] Token on Stripe subscription doesn't match and doesn't exists in Woo (create and update)
- [x] Subscription payment changed to another gateway (don't update payment tokens)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
