### PR TITLE
Extract minimum supported PHP version from plugin file for GH actions

### DIFF
--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -10,12 +10,8 @@ runs:
       run: echo -e "machine github.com\n  login $E2E_GH_TOKEN" > ~/.netrc
 
     # PHP setup
-    - name: PHP Setup
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.4'
-        tools: composer
-        coverage: none
+    - name: "Set up PHP"
+      uses: ./.github/actions/setup-php
 
     # Composer setup
     - name: Setup Composer

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,4 +1,4 @@
-name: "Setup PHP"
+name: "Set up PHP"
 description: "Extracts the required PHP version from plugin file and uses it to build PHP."
 
 runs:

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,19 @@
+name: "Setup PHP"
+description: "Extracts the required PHP version from plugin file and uses it to build PHP."
+
+runs:
+  using: composite
+  steps:
+    - name: "Get minimum PHP version"
+      shell: bash
+      id: get_min_php_version
+      run: |
+        MIN_PHP_VERSION=$(sed -n 's/.*PHP: //p' woocommerce-payments.php)
+        echo "MIN_PHP_VERSION=$MIN_PHP_VERSION" >> $GITHUB_OUTPUT
+
+    - name: "Setup PHP"
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ steps.get_min_php_version.outputs.MIN_PHP_VERSION }}
+        tools: composer
+        coverage: none

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -21,16 +21,5 @@ runs:
         path: ~/.cache/composer/
         key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
-    - name: "Get minimum PHP version"
-      shell: bash
-      id: get_min_php_version
-      run: |
-        MIN_PHP_VERSION=$(sed -n 's/.*PHP: //p' woocommerce-payments.php)
-        echo "MIN_PHP_VERSION=$MIN_PHP_VERSION" >> $GITHUB_OUTPUT
-
-    - name: "Setup PHP"
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ steps.get_min_php_version.outputs.MIN_PHP_VERSION }}
-        tools: composer
-        coverage: none
+    - name: "Set up PHP"
+      uses: ./.github/actions/setup-php

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -30,9 +30,7 @@ runs:
 
     - name: "Setup PHP"
       uses: shivammathur/setup-php@v2
-      env:
-        MIN_PHP_VERSION: ${{ steps.get_min_php_version.outputs.MIN_PHP_VERSION }}
       with:
-        php-version: $MIN_PHP_VERSION
+        php-version: ${{ steps.get_min_php_version.outputs.MIN_PHP_VERSION }}
         tools: composer
         coverage: none

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -1,11 +1,6 @@
 name: "Setup WooCommerce Payments repository"
 description: "Handles the installation, building, and caching of the projects within the repository."
 
-inputs:
-  php-version:
-    description: "The version of PHP that the action should set up."
-    default: "7.4"
-
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -12,18 +12,26 @@ runs:
     - name: "Setup Node"
       uses: actions/setup-node@v3
       with:
-        node-version-file: '.nvmrc'
-        cache: 'npm'
+        node-version-file: ".nvmrc"
+        cache: "npm"
 
     - name: "Enable composer dependencies caching"
       uses: actions/cache@v3
       with:
         path: ~/.cache/composer/
         key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-    
+
+    - name: "Get minimum PHP version"
+      id: get_min_php_version
+      run: |
+        MIN_PHP_VERSION=$(sed -n 's/.*PHP: //p' woocommerce-payments.php)
+        echo "MIN_PHP_VERSION=$MIN_PHP_VERSION" >> $GITHUB_OUTPUT
+
     - name: "Setup PHP"
       uses: shivammathur/setup-php@v2
+      env:
+        MIN_PHP_VERSION: ${{ steps.get_min_php_version.outputs.MIN_PHP_VERSION }}
       with:
-        php-version: ${{ inputs.php-version }}
+        php-version: $MIN_PHP_VERSION
         tools: composer
         coverage: none

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -22,6 +22,7 @@ runs:
         key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
     - name: "Get minimum PHP version"
+      shell: bash
       id: get_min_php_version
       run: |
         MIN_PHP_VERSION=$(sed -n 's/.*PHP: //p' woocommerce-payments.php)

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -22,11 +22,8 @@ jobs:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools:    composer
-          coverage: none
+      - name: "Set up PHP"
+        uses: ./.github/actions/setup-php
       # Install composer packages.
       - run: composer self-update && composer install --no-progress
       # Fetch the target branch before running the check.

--- a/.github/workflows/i18n-weekly-release.yml
+++ b/.github/workflows/i18n-weekly-release.yml
@@ -27,12 +27,8 @@ jobs:
           path: ~/.npm/
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
       # setup PHP, but without debug extensions for reasonable performance
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools:       composer
-          coverage:    none
-
+      - name: "Set up PHP"
+        uses: ./.github/actions/setup-php
       - name: Build release
         run: |
           npm ci

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools: composer
-          coverage: none
+      - name: "Set up PHP"
+        uses: ./.github/actions/setup-php
       - run: bash bin/phpcs-compat.sh

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -27,11 +27,8 @@ jobs:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools: composer
-          coverage: none
+      - name: "Set up PHP"
+        uses: ./.github/actions/setup-php
       # install dependencies and run linter
       - run: composer self-update && composer install --no-progress && ./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep .php$) && ./vendor/bin/psalm
 

--- a/changelog/dev-update-workflows
+++ b/changelog/dev-update-workflows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update GH workflows to use PHP version from plugin file.

--- a/changelog/dev-update-workflows
+++ b/changelog/dev-update-workflows
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Update GH workflows to use PHP version from plugin file.
+Comment: Update GH workflows to use PHP version from plugin file.


### PR DESCRIPTION
Fixes #6815 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
- Create a new action to setup PHP that extracts the version from plugin file.
- Update usage to use new composite action.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Workflows on this branch should work as expected - [sample run](https://github.com/Automattic/woocommerce-payments/actions/runs/6158485079). 

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
