### PR TITLE
Avoid empty fields in new onboarding flow

### DIFF
--- a/changelog/fix-6981-missing-onboarding-field-data
+++ b/changelog/fix-6981-missing-onboarding-field-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid empty fields in new onboarding flow

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -887,7 +887,11 @@ class WC_Payments_API_Client {
 		);
 
 		if ( ! is_array( $fields_data ) ) {
-			return [];
+			throw new API_Exception(
+				__( 'Onboarding field data could not be retrieved', 'woocommerce-payments' ),
+				'wcpay_onboarding_fields_data_error',
+				400
+			);
 		}
 
 		return $fields_data;


### PR DESCRIPTION
Fixes #6981

#### Changes proposed in this Pull Request
- At the moment, the cache was being saved with an empty array for unknown reasons after the original request failed. That would make the onboarding flow fields empty.
- With this change, we make sure that if the request fails, we mark the cache as errored throwing an exception and subsequent trials will refresh the cache (something that is not happening at the moment, making an occasional failed request to not be refreshed).

#### Testing instructions
Because we rely on the `get_or_add` function that manages the refresh lifecycle of a cache, this change should not have any visible change. When a value is stored in the cache, a next request should not request to the server the value but take it from the cache. As said, this behavior is not part of the modified function, so it shouldn't change this behavior.
* You can add a `$fields_data = 'Error';` in [this line](https://github.com/Automattic/woocommerce-payments/blob/667cef5433b1ed4b3d46e4aba75984462ba76aff/includes/wc-payment-api/class-wc-payments-api-client.php#L888)  to simulate a wrong response and force the erroring in the cache.
* Enable Progressive Onboarding
* Go to the new onboarding flow
* In the Country field, you shouldn't see any option
* After that, remove the added line and see the request being made again, this time with the right data.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
