### PR TITLE
fix: remove max width on WooPay checkout appearance

### DIFF
--- a/changelog/fix-woopay-appearance-width
+++ b/changelog/fix-woopay-appearance-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix checkout appearance width

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -61,7 +61,6 @@
 
 .woopay-settings {
 	&__custom-message-wrapper {
-		max-width: 500px;
 		position: relative;
 
 		.components-base-control__field .components-text-control__input {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The new designs show the "checkout appearance" without a max width of 500px.
Updating.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=woopay
- The "Checkout appearance" section is now full width of the container.

Before:
![Screenshot 2023-09-12 at 2 59 54 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/33a7d863-43ad-4652-a345-2cd9d640c33f)

After:
![Screenshot 2023-09-12 at 3 00 06 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/2aefec38-ddfa-476e-aa70-ebcc17346b4c)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
