### PR TITLE
chore: add checkout appearance documentation link

### DIFF
--- a/changelog/feat-add-checkout-appearance-learn-more-link
+++ b/changelog/feat-add-checkout-appearance-learn-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+add WooPay checkout appearance documentation link

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -4,7 +4,12 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CheckboxControl, TextareaControl } from '@wordpress/components';
+import {
+	Card,
+	CheckboxControl,
+	TextareaControl,
+	ExternalLink,
+} from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 
@@ -213,19 +218,24 @@ const WooPaySettings = ( { section } ) => {
 							help={ interpolateComponents( {
 								mixedString: __(
 									'Override the default {{privacyLink}}privacy policy{{/privacyLink}}' +
-										' and {{termsLink}}terms of service{{/termsLink}}, or add custom text to WooPay checkout.',
+										' and {{termsLink}}terms of service{{/termsLink}},' +
+										' or add custom text to WooPay checkout. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 									'woocommerce-payments'
 								),
 								// prettier-ignore
 								components: {
 									/* eslint-disable prettier/prettier */
 									privacyLink: window.wcSettings?.storePages?.privacy?.permalink ?
-										<Link href={ window.wcSettings?.storePages?.privacy?.permalink } type="external" /> :
+										<Link href={ window.wcSettings.storePages.privacy.permalink } type="external" /> :
 										<span />,
 									termsLink: window.wcSettings?.storePages?.terms?.permalink ?
-										<Link href={ window.wcSettings?.storePages?.terms?.permalink } type="external" /> :
+										<Link href={ window.wcSettings.storePages.terms.permalink } type="external" /> :
 										<span />,
 									/* eslint-enable prettier/prettier */
+									learnMoreLink: (
+										// eslint-disable-next-line max-len
+										<ExternalLink href="https://woocommerce.com/document/woopay-merchant-documentation/#checkout-appearance" />
+									),
 								}
 							} ) }
 							value={ woopayCustomMessage }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Added a "learn more" link, as discussed in https://github.com/Automattic/woocommerce-payments/issues/6993#issuecomment-1711102965 (as a first step)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=woopay
- The "learn more" link should be added to the help text

![Markup 2023-09-12 at 15 32 54](https://github.com/Automattic/woocommerce-payments/assets/273592/456cd194-b768-4b5c-af8f-a006975f1d67)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
