### PR TITLE
Follow up of Warn about dev mode

### DIFF
--- a/changelog/fix-6429-follow-up-fix
+++ b/changelog/fix-6429-follow-up-fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Warn about dev mode roll back to inline notice
+
+

--- a/client/onboarding/steps/mode-choice.tsx
+++ b/client/onboarding/steps/mode-choice.tsx
@@ -13,12 +13,12 @@ import RadioCard from 'components/radio-card';
 import { useStepperContext } from 'components/stepper';
 import { trackModeSelected } from '../tracking';
 import strings from '../strings';
-import BannerNotice from 'components/banner-notice';
+import InlineNotice from 'components/inline-notice';
 
 const DevModeNotice = () => (
-	<BannerNotice icon status="warning" isDismissible={ false }>
+	<InlineNotice icon status="warning" isDismissible={ false }>
 		{ strings.steps.mode.devModeNotice }
-	</BannerNotice>
+	</InlineNotice>
 );
 
 const ModeChoice: React.FC = () => {


### PR DESCRIPTION
Related to #6429 

#### Changes proposed in this Pull Request
I haven't pushed at the last moment in #7029 changes related to choice onboarding step (roll back BannerNotice to InlineNotice)

#### Testing instructions
- Changes should make sense
- Bonus: test onboarding with Dev Mode and PO enabled, you should see inline Dev Mode notice

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
