### PR TITLE
Update the links used in the migrate option and automatically notice

### DIFF
--- a/changelog/update-stripe-billing-notice-links
+++ b/changelog/update-stripe-billing-notice-links
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: No changelog is needed given these notices are unreleased.
+
+

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
@@ -85,7 +85,7 @@ const MigrateAutomaticallyNotice: React.FC< Props > = ( {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" />
+						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
@@ -134,7 +134,7 @@ const MigrateOptionNotice: React.FC< Props > = ( {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" />
+						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/" />
 					),
 				},
 			} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR simply updates the two links shown at the end of the notice shown to merchants given them the option to migrate their Stripe Billing subscriptions, or warning them that disabling the setting will automatically migrate their existing subscriptions. 

The new link points them to this guide: https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/

#### Testing instructions

* Checkout this branch.
* Build with `npm run build`.
* Create at least 1 Stripe Billing subscription.
* Go to the WooPayments Settings.
* **If Stripe Billing is enabled**. Disable it.
* You should see the following notice: 

<p align="center">
<img width="500" alt="Screenshot 2023-09-13 at 9 55 55 am" src="https://github.com/Automattic/woocommerce-payments/assets/8490476/f88dc583-c2a3-4c7e-b885-fc94709f5123">
</p>

* The learn more link should point to: https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/
* **If Stripe Billing was already disabled**.
* You should see this notice: 

<p align="center">
<img width="500" alt="Screenshot 2023-09-13 at 9 53 55 am" src="https://github.com/Automattic/woocommerce-payments/assets/8490476/23d4ad12-d5ca-473a-a4ff-6bcb1b06346f">
</p>

* The learn more link should point to: https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/

If you need to switch between the two settings to test both notices, use the following snippet to prevent a migration being automatically scheduled.

```php
update_option( '_wcpay_feature_stripe_billing', '0' );
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
