### PR TITLE
Adds environment metadata to Stripe Billing subscription and invoice payment intents

### DIFF
--- a/changelog/fix-6529-add-stripe-billing-context
+++ b/changelog/fix-6529-add-stripe-billing-context
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Record the subscriptions environment context in transaction meta when Stripe Billing payments are handled.

--- a/changelog/fix-6529-add-stripe-billing-context-2
+++ b/changelog/fix-6529-add-stripe-billing-context-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Record the source (Woo Subscriptions or WCPay Subscriptions) when a Stripe Billing subscription is created.

--- a/changelog/fix-payment-intent-meta-for-recurring-transactions
+++ b/changelog/fix-payment-intent-meta-for-recurring-transactions
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Fix payment context and subscription payment metadata stored on subscription recurring transactions
+Fix payment context and subscription payment metadata stored on subscription recurring transactions.

--- a/changelog/fix-payment-intent-meta-for-recurring-transactions
+++ b/changelog/fix-payment-intent-meta-for-recurring-transactions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix payment context and subscription payment metadata stored on subscription recurring transactions

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1612,9 +1612,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'subscription_payment' => 'no',
 		];
 
-		if ( 'recurring' === (string) $payment_type && function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order ) ) {
+		if ( 'recurring' === (string) $payment_type && function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order, 'any' ) ) {
 			$metadata['subscription_payment'] = wcs_order_contains_renewal( $order ) ? 'renewal' : 'initial';
-			$metadata['payment_context']      = $this->is_subscriptions_plugin_active() ? 'regular_subscription' : 'wcpay_subscription';
+			$metadata['payment_context']      = WC_Payments_Features::should_use_stripe_billing() ? 'wcpay_subscription' : 'regular_subscription';
 		}
 		return apply_filters( 'wcpay_metadata_from_order', $metadata, $order, $payment_type );
 	}

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -314,7 +314,7 @@ class WC_Payments_Invoice_Service {
 	 *
 	 * @param string $invoice_id The subscription invoice ID.
 	 */
-	public function record_invoice_payment_context( string $invoice_id ) {
+	public function record_subscription_payment_context( string $invoice_id ) {
 		$this->payments_api_client->update_invoice(
 			$invoice_id,
 			[

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -310,6 +310,20 @@ class WC_Payments_Invoice_Service {
 	}
 
 	/**
+	 * Sends a request to server to record the store's context for an invoice payment.
+	 *
+	 * @param string $invoice_id The subscription invoice ID.
+	 */
+	public function record_invoice_payment_context( string $invoice_id ) {
+		$this->payments_api_client->update_invoice(
+			$invoice_id,
+			[
+				'subscription_context' => class_exists( 'WC_Subscriptions' ) && WC_Payments_Features::is_stripe_billing_enabled() ? 'stripe_billing' : 'legacy_wcpay_subscription',
+			]
+		);
+	}
+
+	/**
 	 * Sets the subscription last invoice ID meta for WC subscription.
 	 *
 	 * @param WC_Subscription $subscription The subscription.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -388,6 +388,8 @@ class WC_Payments_Subscription_Service {
 			$subscription_data = $this->prepare_wcpay_subscription_data( $wcpay_customer_id, $subscription );
 			$this->validate_subscription_data( $subscription_data );
 
+			$subscription_data['metadata']['source'] = $this->is_subscriptions_plugin_active() ? 'woo_subscriptions' : 'wcpay_subscriptions';
+
 			$response = $this->payments_api_client->create_subscription( $subscription_data );
 
 			$this->set_wcpay_subscription_id( $subscription, $response['id'] );

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -388,7 +388,7 @@ class WC_Payments_Subscription_Service {
 			$subscription_data = $this->prepare_wcpay_subscription_data( $wcpay_customer_id, $subscription );
 			$this->validate_subscription_data( $subscription_data );
 
-			$subscription_data['metadata']['source'] = $this->is_subscriptions_plugin_active() ? 'woo_subscriptions' : 'wcpay_subscriptions';
+			$subscription_data['metadata']['subscription_source'] = $this->is_subscriptions_plugin_active() ? 'woo_subscriptions' : 'wcpay_subscriptions';
 
 			$response = $this->payments_api_client->create_subscription( $subscription_data );
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -186,6 +186,9 @@ class WC_Payments_Subscriptions_Event_Handler {
 			$this->invoice_service->get_and_attach_intent_info_to_order( $order, $event_object['payment_intent'] );
 		}
 
+		// Record the store's Stripe Billing environment context on the payment intent.
+		$this->invoice_service->record_invoice_payment_context( $wcpay_invoice_id );
+
 		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
 		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );
 	}
@@ -248,6 +251,9 @@ class WC_Payments_Subscriptions_Event_Handler {
 
 		// Record invoice ID so we can trigger repayment on payment method update.
 		$this->invoice_service->mark_pending_invoice_for_subscription( $subscription, $wcpay_invoice_id );
+
+		// Record the store's Stripe Billing environment context on the payment intent.
+		$this->invoice_service->record_invoice_payment_context( $wcpay_invoice_id );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -186,11 +186,11 @@ class WC_Payments_Subscriptions_Event_Handler {
 			$this->invoice_service->get_and_attach_intent_info_to_order( $order, $event_object['payment_intent'] );
 		}
 
-		// Record the store's Stripe Billing environment context on the payment intent.
-		$this->invoice_service->record_invoice_payment_context( $wcpay_invoice_id );
-
 		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
 		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );
+
+		// Record the store's Stripe Billing environment context on the payment intent.
+		$this->invoice_service->record_subscription_payment_context( $wcpay_invoice_id );
 	}
 
 	/**
@@ -253,7 +253,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 		$this->invoice_service->mark_pending_invoice_for_subscription( $subscription, $wcpay_invoice_id );
 
 		// Record the store's Stripe Billing environment context on the payment intent.
-		$this->invoice_service->record_invoice_payment_context( $wcpay_invoice_id );
+		$this->invoice_service->record_subscription_payment_context( $wcpay_invoice_id );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1119,6 +1119,23 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Updates an invoice.
+	 *
+	 * @param string $invoice_id ID of the invoice to update.
+	 * @param array  $data       Parameters to send to the invoice endpoint. Optional. Default is an empty array.
+	 * @return array
+	 *
+	 * @throws API_Exception Error updating the invoice.
+	 */
+	public function update_invoice( string $invoice_id, array $data = [] ) {
+		return $this->request(
+			$data,
+			self::INVOICES_API . '/' . $invoice_id,
+			self::POST
+		);
+	}
+
+	/**
 	 * Fetch a WCPay subscription.
 	 *
 	 * @param string $wcpay_subscription_id Data used to create subscription.

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -172,7 +172,7 @@ class WC_Payments_Subscription_Service_Test extends WCPAY_UnitTestCase {
 				],
 			],
 			'metadata' => [
-				'source' => 'woo_subscriptions',
+				'subscription_source' => 'woo_subscriptions',
 			],
 		];
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -171,6 +171,9 @@ class WC_Payments_Subscription_Service_Test extends WCPAY_UnitTestCase {
 					],
 				],
 			],
+			'metadata' => [
+				'source' => 'woo_subscriptions',
+			],
 		];
 
 		$this->assertNotEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );


### PR DESCRIPTION
Fixes #6529

### Changes proposed in this Pull Request

This PR adds 2 pieces of meta data to Stripe Billing objects:

- Subscriptions when they are created to reference the store's subscription plugin environment. (see example below).
- Invoice (renewal) payment intents to refer to the store's setup at the time of processing the invoice. (see example below).

#### Subscription metadata

| Woo Subscriptions inactive | Woo Subscriptions active |
|--------|--------|
| <img width="500" alt="Screenshot 2023-09-12 at 8 04 45 pm" src="https://github.com/Automattic/woocommerce-payments/assets/8490476/9553818e-9a59-4cdd-9e4d-84a1ce699278"> | <img width="500" alt="Screenshot 2023-09-12 at 8 04 57 pm" src="https://github.com/Automattic/woocommerce-payments/assets/8490476/3e42a57e-b0ca-4786-9da3-9097adcd19c0"> |

**Rationale**
When a store has the Woo Subscriptions plugin active and a Stripe Billing subscription is created they must have had Stripe Billing enabled at the time. If the plugin isn't active and they are still creating Stripe Billing subscriptions. Then they are still using WCPay Subscriptions. This meta data can be used to identify how many merchants are actively using Stripe Billing subscriptions, or still using WCPay Subscriptions.  

#### Payment intent metadata

| Woo Subscriptions OR Stripe Billing inactive | Woo Subscriptions AND Stripe Billing active |
|--------|--------|
| <img width="385" alt="Screenshot 2023-09-12 at 4 54 26 pm" src="https://github.com/Automattic/woocommerce-payments/assets/8490476/deaca0f1-7663-4762-a5c8-678389807f71"> | <img width="431" alt="Screenshot 2023-09-12 at 4 52 52 pm" src="https://github.com/Automattic/woocommerce-payments/assets/8490476/83b31917-586e-461b-a120-e4f110e8952d">|

**Rationale**

When we receive a webhook for a Stripe Billing renewal order (paid of failed), we want to know under what context this payment is being processed. Have they actively opted into Stripe Billing, are still using WCPay subscriptions, or have installed Woo Subscriptions but haven't migrated their subscriptions. 

### Testing instructions

* ⚠️ Requires the `add/support_for_subscription_and_invoice_meta` server branch for these changes to work correctly. 
* Make sure you're listening to webhooks in your local Server repo. 

#### Subscriptions

**_With Woo Subscriptions inactive_**
1. Purchase a Subscription using WCPay Subscriptions.
2. View the subscription in the Stripe Billing dashboard.
3. You should see this metadata `wcpay_subscriptions` meta.

_**With Woo Subscriptions active**_
1. Purchase a Subscription using Stripe Billing enabled.
2. View the subscription in the Stripe Billing dashboard.
3. You should see this metadata `woo_subscription` meta.

#### Subscription Renewals

1. Activate Woo Subscriptions.
2. Enable Stripe Billing.
3. Enable billing clocks on at least 1 of your Stripe Billing Subscriptions
   - It doesn't matter if it was created with or with the Woo Subscriptions plugin active. 
4. Process a paid of failed renewal order. 
5. Go to the **Payments** list table in the Stripe dashboard.
6. View the latest payment with the `Subscription updated` description.
7. Scroll down to the meta data. 
8. Note that new meta (`subscription_context` `stripe_billing`) is added.
   - 📓 _Even if this subscription was previously a WCPay subscription. The merchant has opted into Stripe Billing and so this payment is effectively a Stripe Billing payment._ 
10. Disable Stripe Billing but prevent it from migrating. (Use snippet below).
11. Run the renewal flow again via the Billing Clocks UI.  
12. View the latest payment in the Stripe dashboard with the `Subscription updated` description.
13. Scroll down to the meta data. 
14. Note that new meta (`subscription_context` `legacy_wcpay_subscription`) is added.
   - 📓 _Even though the store has Woo Subscriptions, any Stripe Billing payments must have been legacy WCPay subscriptions that haven't been migrated._
16. Disable Woo Subscriptions. 
17. Enable WCPay Subscriptions. 
18. Run the renewal flow again via the Billing Clocks UI.  
19. View the latest payment in the Stripe dashboard with the `Subscription updated` description.
20. Scroll down to the meta data. 
21. Note that new meta (`subscription_context` `legacy_wcpay_subscription`) is added.

```
update_option( '_wcpay_feature_stripe_billing', '0' );
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
