### PR TITLE
Allow merchants to see dispute evidence

### DIFF
--- a/changelog/add-7173-dispute-evidence
+++ b/changelog/add-7173-dispute-evidence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Adding issuer evidence to dispute details. Hidden behind a feature flag

--- a/client/data/files/action-types.ts
+++ b/client/data/files/action-types.ts
@@ -1,0 +1,8 @@
+/** @format */
+
+enum TYPES {
+	SET_FILE = 'SET_FILE',
+	SET_ERROR_FOR_FILES = 'SET_ERROR_FOR_FILES',
+}
+
+export default TYPES;

--- a/client/data/files/actions.ts
+++ b/client/data/files/actions.ts
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import ACTION_TYPES from './action-types';
+import type {
+	File,
+	UpdateFilesAction,
+	UpdateErrorForFilesAction,
+} from './types';
+import { ApiError } from 'wcpay/types/errors';
+
+export function updateFiles( id: string, data: File ): UpdateFilesAction {
+	return {
+		type: ACTION_TYPES.SET_FILE,
+		id,
+		data,
+	};
+}
+
+export function updateErrorForFiles(
+	id: string,
+	error: ApiError
+): UpdateErrorForFilesAction {
+	return {
+		type: ACTION_TYPES.SET_ERROR_FOR_FILES,
+		id,
+		error,
+	};
+}

--- a/client/data/files/hooks.ts
+++ b/client/data/files/hooks.ts
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import type { File, FileResponse } from './types';
+import { STORE_NAME } from '../constants';
+
+export const useFiles = ( id: string ): FileResponse =>
+	useSelect(
+		( select ) => {
+			const selectors = select( STORE_NAME );
+
+			const {
+				getFile,
+				getFileError,
+				isResolving,
+				hasFinishedResolution,
+			} = selectors;
+
+			const file: File = getFile( id );
+
+			return {
+				data: file || ( {} as File ),
+				error: getFileError( id ),
+				isLoading:
+					isResolving( 'getFile', [ id ] ) ||
+					! hasFinishedResolution( 'getFile', [ id ] ),
+			};
+		},
+		[ id ]
+	);

--- a/client/data/files/hooks.ts
+++ b/client/data/files/hooks.ts
@@ -26,7 +26,7 @@ export const useFiles = ( id: string ): FileResponse =>
 			const file: File = getFile( id );
 
 			return {
-				data: file || ( {} as File ),
+				file: file || ( {} as File ),
 				error: getFileError( id ),
 				isLoading:
 					isResolving( 'getFile', [ id ] ) ||

--- a/client/data/files/index.ts
+++ b/client/data/files/index.ts
@@ -1,0 +1,12 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+import * as resolvers from './resolvers';
+
+export { reducer, selectors, actions, resolvers };
+export * from './hooks';

--- a/client/data/files/reducer.ts
+++ b/client/data/files/reducer.ts
@@ -1,0 +1,44 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import TYPES from './action-types';
+import {
+	UpdateErrorForFilesAction,
+	FilesState,
+	FilesActions,
+	UpdateFilesAction,
+} from './types';
+
+const defaultState = {};
+
+const receiveFiles = (
+	state: FilesState = defaultState,
+	action: FilesActions
+): FilesState => {
+	const { type, id } = action;
+
+	switch ( type ) {
+		case TYPES.SET_FILE:
+			return {
+				...state,
+				[ id ]: {
+					...state[ id ],
+					data: ( action as UpdateFilesAction ).data,
+				},
+			};
+		case TYPES.SET_ERROR_FOR_FILES:
+			return {
+				...state,
+				[ id ]: {
+					...state[ id ],
+					error: ( action as UpdateErrorForFilesAction ).error,
+				},
+			};
+		default:
+			return state;
+	}
+};
+
+export default receiveFiles;

--- a/client/data/files/resolvers.ts
+++ b/client/data/files/resolvers.ts
@@ -16,9 +16,9 @@ import { File } from './types';
 import { ApiError } from 'wcpay/types/errors';
 
 /**
- * Retrieve a single dispute from the disputes API.
+ * Retrieve a single file from the files API.
  *
- * @param {string} id Identifier for specified dispute to retrieve.
+ * @param {string} id Identifier for specified file to retrieve.
  */
 export function* getFile( id: string ): Generator< unknown > {
 	try {

--- a/client/data/files/resolvers.ts
+++ b/client/data/files/resolvers.ts
@@ -23,7 +23,7 @@ import { ApiError } from 'wcpay/types/errors';
 export function* getFile( id: string ): Generator< unknown > {
 	try {
 		const result = yield apiFetch( {
-			path: `${ NAMESPACE }/file/detail/${ id }`,
+			path: `${ NAMESPACE }/file/${ id }/details`,
 		} );
 		yield updateFiles( id, result as File );
 	} catch ( e ) {

--- a/client/data/files/resolvers.ts
+++ b/client/data/files/resolvers.ts
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { NAMESPACE } from '../constants';
+import { updateFiles, updateErrorForFiles } from './actions';
+import { File } from './types';
+import { ApiError } from 'wcpay/types/errors';
+
+/**
+ * Retrieve a single dispute from the disputes API.
+ *
+ * @param {string} id Identifier for specified dispute to retrieve.
+ */
+export function* getFile( id: string ): Generator< unknown > {
+	try {
+		const result = yield apiFetch( {
+			path: `${ NAMESPACE }/file/detail/${ id }`,
+		} );
+		yield updateFiles( id, result as File );
+	} catch ( e ) {
+		yield controls.dispatch(
+			'core/notices',
+			'createErrorNotice',
+			__( 'Error retrieving file.', 'woocommerce-payments' )
+		);
+		yield updateErrorForFiles( id, e as ApiError );
+	}
+}

--- a/client/data/files/selectors.ts
+++ b/client/data/files/selectors.ts
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { State } from 'wcpay/data/types';
+import { File } from './types';
+import { ApiError } from 'wcpay/types/errors';
+
+export const getFile = ( { files }: State, id: string ): File => {
+	const file = files?.[ id ];
+
+	return file?.data || ( {} as File );
+};
+
+export const getFileError = ( { files }: State, id: string ): ApiError => {
+	const file = files?.[ id ];
+
+	return file?.error || ( {} as ApiError );
+};

--- a/client/data/files/types.d.ts
+++ b/client/data/files/types.d.ts
@@ -33,6 +33,17 @@ export interface File {
 	title: string | null;
 }
 
+export interface FileContent {
+	/**
+	 * The file mime-type.
+	 */
+	content_type: string;
+	/**
+	 * The file content, base64 encoded.
+	 */
+	file_content: string;
+}
+
 export interface FileResponse {
 	isLoading: boolean;
 	file?: File;

--- a/client/data/files/types.d.ts
+++ b/client/data/files/types.d.ts
@@ -12,7 +12,7 @@ export interface File {
 	 */
 	id: string;
 	/**
-	 * 'dispute_evidence' is expected here, as this is the only type of file upload used by the API at this time.
+	 * The purpose for file. eg 'dispute_evidence'.
 	 */
 	purpose: string;
 	/**
@@ -33,7 +33,7 @@ export interface File {
 	title: string | null;
 }
 
-export interface FileContent {
+export interface FileDownload {
 	/**
 	 * The file mime-type.
 	 */

--- a/client/data/files/types.d.ts
+++ b/client/data/files/types.d.ts
@@ -1,0 +1,62 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { ApiError } from 'wcpay/types/errors';
+import ACTION_TYPES from './action-types';
+
+export interface File {
+	/**
+	 * Unique identifier for the file, expected to be prefixed by file_
+	 */
+	id: string;
+	/**
+	 * 'dispute_evidence' is expected here, as this is the only type of file upload used by the API at this time.
+	 */
+	purpose: string;
+	/**
+	 * The filetype 'pdf' 'csv' 'jpg' etc.
+	 */
+	type: string;
+	/**
+	 * A filename for the file, suitable for saving to a filesystem.
+	 */
+	filename: string;
+	/**
+	 * The size in bytes.
+	 */
+	size: number;
+	/**
+	 * A user friendly title for the file.
+	 */
+	title: string | null;
+}
+
+export interface FileResponse {
+	isLoading: boolean;
+	file?: File;
+	fileError?: ApiError;
+}
+
+export interface UpdateFilesAction {
+	type: ACTION_TYPES.SET_FILE;
+	id: string;
+	data: File;
+}
+
+export interface UpdateErrorForFilesAction {
+	type: ACTION_TYPES.SET_ERROR_FOR_FILES;
+	id: string;
+	error: ApiError;
+}
+
+export interface FilesState {
+	[ key: string ]: {
+		id: string;
+		data?: File;
+		error?: ApiError;
+	};
+}
+
+export type FilesActions = UpdateFilesAction | UpdateErrorForFilesAction;

--- a/client/data/index.ts
+++ b/client/data/index.ts
@@ -24,3 +24,4 @@ export * from './capital/hooks';
 export * from './documents/hooks';
 export * from './payment-intents/hooks';
 export * from './authorizations/hooks';
+export * from './files/hooks';

--- a/client/data/store.js
+++ b/client/data/store.js
@@ -20,6 +20,7 @@ import * as capital from './capital';
 import * as documents from './documents';
 import * as paymentIntents from './payment-intents';
 import * as authorizations from './authorizations';
+import * as files from './files';
 
 // Extracted into wrapper function to facilitate testing.
 export const initStore = () =>
@@ -37,6 +38,7 @@ export const initStore = () =>
 			documents: documents.reducer,
 			paymentIntents: paymentIntents.reducer,
 			authorizations: authorizations.reducer,
+			files: files.reducer,
 		} ),
 		actions: {
 			...deposits.actions,
@@ -51,6 +53,7 @@ export const initStore = () =>
 			...documents.actions,
 			...paymentIntents.actions,
 			...authorizations.actions,
+			...files.actions,
 		},
 		controls,
 		selectors: {
@@ -66,6 +69,7 @@ export const initStore = () =>
 			...documents.selectors,
 			...paymentIntents.selectors,
 			...authorizations.selectors,
+			...files.selectors,
 		},
 		resolvers: {
 			...deposits.resolvers,
@@ -80,5 +84,6 @@ export const initStore = () =>
 			...documents.resolvers,
 			...paymentIntents.resolvers,
 			...authorizations.resolvers,
+			...files.resolvers,
 		},
 	} );

--- a/client/data/types.d.ts
+++ b/client/data/types.d.ts
@@ -5,8 +5,10 @@
  */
 import { CapitalState } from './capital/types';
 import { PaymentIntentsState } from './payment-intents/types';
+import { FilesState } from './files/types';
 
 export interface State {
 	capital?: CapitalState;
 	paymentIntents?: PaymentIntentsState;
+	files?: FilesState;
 }

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { Button, PanelBody } from '@wordpress/components';
 import { Icon, page } from '@wordpress/icons';
 
 /**
@@ -114,10 +114,11 @@ const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 	}
 
 	return (
-		<div className="dispute-evidence">
-			<div className="dispute-evidence__title">
-				{ __( 'Issuer evidence', 'woocommerce' ) }
-			</div>
+		<PanelBody
+			className="dispute-evidence"
+			title={ __( 'Issuer evidence', 'woocommerce' ) }
+			initialOpen={ false }
+		>
 			<ul className="dispute-evidence__list">
 				{ issuerEvidence.text_evidence && (
 					<li className="dispute-evidence__list-item">
@@ -134,7 +135,7 @@ const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 					)
 				) }
 			</ul>
-		</div>
+		</PanelBody>
 	);
 };
 

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -96,7 +96,7 @@ const FileEvidence: React.FC< {
 	);
 };
 
-const EvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
+const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 	if (
 		! issuerEvidence ||
 		! issuerEvidence.file_evidence.length ||
@@ -130,4 +130,4 @@ const EvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 	);
 };
 
-export default EvidenceList;
+export default IssuerEvidenceList;

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -111,8 +111,8 @@ const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 
 	return (
 		<div className="dispute-evidence">
-			<div className="dispute-evidence__header">
-				{ __( 'Issuer Evidence:', 'woocommercts' ) }
+			<div className="dispute-evidence__title">
+				{ __( 'Issuer evidence', 'woocommerce' ) }
 			</div>
 			<ul className="dispute-evidence__list">
 				{ issuerEvidence.text_evidence && (

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -7,7 +7,8 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import classNames from 'classnames';
+import { Button } from '@wordpress/components';
+import { Icon, page } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -23,18 +24,26 @@ interface Props {
 }
 const TextEvidence: React.FC< {
 	evidence: string;
-} > = ( { evidence } ): JSX.Element => (
-	// eslint-disable-next-line jsx-a11y/anchor-is-valid
-	<a
-		href={ URL.createObjectURL(
+} > = ( { evidence } ) => {
+	const download = () => {
+		const link = document.createElement( 'a' );
+		link.href = URL.createObjectURL(
 			new Blob( [ evidence ], { type: 'text/plain' } )
-		) }
-		className="dispute-evidence-link"
-		download="evidence.txt"
-	>
-		{ __( 'Evidence.txt', 'woocommerce-payments' ) }
-	</a>
-);
+		);
+		link.download = 'evidence.txt';
+		link.click();
+	};
+
+	return (
+		<Button
+			variant="secondary"
+			onClick={ download }
+			icon={ <Icon icon={ page } /> }
+		>
+			{ __( 'Evidence.txt', 'woocommerce-payments' ) }
+		</Button>
+	);
+};
 
 const FileEvidence: React.FC< {
 	fileId: string;
@@ -43,8 +52,7 @@ const FileEvidence: React.FC< {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isDownloading, setIsDownloading ] = React.useState( false );
 
-	const onDownload = async ( e: React.MouseEvent< HTMLAnchorElement > ) => {
-		e.preventDefault();
+	const onDownload = async () => {
 		if ( ! file || ! file.id || isDownloading ) {
 			return;
 		}
@@ -75,23 +83,19 @@ const FileEvidence: React.FC< {
 			isLoading={ isLoading }
 			placeholder={ __( 'Loading', 'woocommerce-payments' ) }
 		>
-			{
-				/* eslint-disable jsx-a11y/anchor-is-valid */
-				file && file.id ? (
-					<a
-						href="#"
-						className={ classNames( {
-							'dispute-evidence-link': true,
-							'dispute-evidence-link--downloading': isDownloading,
-						} ) }
-						onClick={ onDownload }
-					>
-						{ file?.title || file.filename }
-					</a>
-				) : (
-					<></>
-				)
-			}
+			{ file && file.id ? (
+				<Button
+					variant="secondary"
+					isBusy={ isDownloading }
+					disabled={ isDownloading }
+					icon={ <Icon icon={ page } /> }
+					onClick={ onDownload }
+				>
+					{ file?.title || file.filename }
+				</Button>
+			) : (
+				<></>
+			) }
 		</Loadable>
 	);
 };

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -1,0 +1,85 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { download, Icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { IssuerEvidence } from 'wcpay/types/disputes';
+import { useFiles } from 'wcpay/data';
+import Loadable from 'wcpay/components/loadable';
+
+interface Props {
+	issuerEvidence: IssuerEvidence | null;
+}
+const TextEvidence: React.FC< {
+	evidence: string;
+} > = ( { evidence } ): JSX.Element => (
+	// eslint-disable-next-line jsx-a11y/anchor-is-valid
+	<a
+		href={ URL.createObjectURL(
+			new Blob( [ evidence ], { type: 'text/plain' } )
+		) }
+		className="wcpay-text-evidence"
+		download="evidence.txt"
+	>
+		<Icon icon={ download } size={ 16 } />
+		{ __( 'Evidence.txt', 'woocommerce-payments' ) }
+	</a>
+);
+
+const FileEvidence: React.FC< {
+	fileId: string;
+} > = ( { fileId } ) => {
+	const { file, isLoading } = useFiles( fileId );
+
+	return (
+		<Loadable
+			isLoading={ isLoading }
+			placeholder={ __( 'Loading', 'woocommerce-payments' ) }
+		>
+			{
+				/* eslint-disable jsx-a11y/anchor-is-valid */
+				file && (
+					<a href="#" className="wcpay-text-evidence">
+						<Icon icon={ download } size={ 16 } />
+						{ file?.title || file.filename } ({ file.type })
+					</a>
+				)
+			}
+		</Loadable>
+	);
+};
+
+const EvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
+	if (
+		! issuerEvidence ||
+		! issuerEvidence.file_evidence.length ||
+		! issuerEvidence.text_evidence
+	) {
+		return (
+			<span>
+				{ __( 'No evidence available', 'woocommerce-payments' ) }
+			</span>
+		);
+	}
+
+	return (
+		<>
+			{ issuerEvidence.file_evidence.map( ( fileId: string, i: any ) => (
+				// eslint-disable-next-line react/jsx-key
+				<FileEvidence fileId={ fileId } />
+			) ) }
+			{ issuerEvidence.text_evidence && (
+				<TextEvidence evidence={ issuerEvidence.text_evidence } />
+			) }
+		</>
+	);
+};
+
+export default EvidenceList;

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -35,6 +35,7 @@ const TextEvidence: React.FC< {
 		<Button
 			variant="secondary"
 			onClick={ onClick }
+			isSmall={ true }
 			icon={ <Icon icon={ page } /> }
 		>
 			{
@@ -88,6 +89,7 @@ const FileEvidence: React.FC< {
 					variant="secondary"
 					isBusy={ isDownloading }
 					disabled={ isDownloading }
+					isSmall={ true }
 					icon={ <Icon icon={ page } /> }
 					onClick={ onClick }
 				>

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -17,15 +17,12 @@ import type { IssuerEvidence } from 'wcpay/types/disputes';
 import { useFiles } from 'wcpay/data';
 import Loadable from 'wcpay/components/loadable';
 import { NAMESPACE } from 'wcpay/data/constants';
-import { FileContent } from 'wcpay/data/files/types';
+import { FileDownload } from 'wcpay/data/files/types';
 
-interface Props {
-	issuerEvidence: IssuerEvidence | null;
-}
 const TextEvidence: React.FC< {
 	evidence: string;
 } > = ( { evidence } ) => {
-	const download = () => {
+	const onClick = () => {
 		const link = document.createElement( 'a' );
 		link.href = URL.createObjectURL(
 			new Blob( [ evidence ], { type: 'text/plain' } )
@@ -37,10 +34,13 @@ const TextEvidence: React.FC< {
 	return (
 		<Button
 			variant="secondary"
-			onClick={ download }
+			onClick={ onClick }
 			icon={ <Icon icon={ page } /> }
 		>
-			{ __( 'Evidence.txt', 'woocommerce-payments' ) }
+			{
+				/* translators: Default filename for issuer evidence on a dispute */
+				__( 'Evidence.txt', 'woocommerce-payments' )
+			}
 		</Button>
 	);
 };
@@ -52,13 +52,13 @@ const FileEvidence: React.FC< {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isDownloading, setIsDownloading ] = React.useState( false );
 
-	const onDownload = async () => {
+	const onClick = async () => {
 		if ( ! file || ! file.id || isDownloading ) {
 			return;
 		}
 		try {
 			setIsDownloading( true );
-			const downloadRequest = await apiFetch< FileContent >( {
+			const downloadRequest = await apiFetch< FileDownload >( {
 				path: `${ NAMESPACE }/file/${ encodeURI( file.id ) }/content`,
 				method: 'GET',
 			} );
@@ -89,7 +89,7 @@ const FileEvidence: React.FC< {
 					isBusy={ isDownloading }
 					disabled={ isDownloading }
 					icon={ <Icon icon={ page } /> }
-					onClick={ onDownload }
+					onClick={ onClick }
 				>
 					{ file?.title || file.filename }
 				</Button>
@@ -99,6 +99,10 @@ const FileEvidence: React.FC< {
 		</Loadable>
 	);
 };
+
+interface Props {
+	issuerEvidence: IssuerEvidence | null;
+}
 
 const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 	if (

--- a/client/payment-details/dispute-details/index.tsx
+++ b/client/payment-details/dispute-details/index.tsx
@@ -15,6 +15,7 @@ import { edit } from '@wordpress/icons';
 import type { Dispute } from 'wcpay/types/disputes';
 import { isAwaitingResponse } from 'wcpay/disputes/utils';
 import DisputeNotice from './dispute-notice';
+import EvidenceList from './evidence-list';
 import DisputeSummaryRow from './dispute-summary-row';
 import InlineNotice from 'components/inline-notice';
 import './style.scss';
@@ -54,6 +55,9 @@ const DisputeDetails: React.FC< DisputeDetailsProps > = ( { dispute } ) => {
 								<DisputeSummaryRow
 									dispute={ dispute }
 									daysRemaining={ countdownDays }
+								/>
+								<EvidenceList
+									issuerEvidence={ dispute.issuer_evidence }
 								/>
 							</>
 						) }

--- a/client/payment-details/dispute-details/index.tsx
+++ b/client/payment-details/dispute-details/index.tsx
@@ -15,7 +15,7 @@ import { edit } from '@wordpress/icons';
 import type { Dispute } from 'wcpay/types/disputes';
 import { isAwaitingResponse } from 'wcpay/disputes/utils';
 import DisputeNotice from './dispute-notice';
-import EvidenceList from './evidence-list';
+import IssuerEvidenceList from './evidence-list';
 import DisputeSummaryRow from './dispute-summary-row';
 import InlineNotice from 'components/inline-notice';
 import './style.scss';
@@ -56,7 +56,7 @@ const DisputeDetails: React.FC< DisputeDetailsProps > = ( { dispute } ) => {
 									dispute={ dispute }
 									daysRemaining={ countdownDays }
 								/>
-								<EvidenceList
+								<IssuerEvidenceList
 									issuerEvidence={ dispute.issuer_evidence }
 								/>
 							</>

--- a/client/payment-details/dispute-details/index.tsx
+++ b/client/payment-details/dispute-details/index.tsx
@@ -12,7 +12,7 @@ import { edit } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import type { Dispute } from 'wcpay/types/disputes';
+import type {Dispute, IssuerEvidence} from 'wcpay/types/disputes';
 import { isAwaitingResponse } from 'wcpay/disputes/utils';
 import DisputeNotice from './dispute-notice';
 import IssuerEvidenceList from './evidence-list';

--- a/client/payment-details/dispute-details/index.tsx
+++ b/client/payment-details/dispute-details/index.tsx
@@ -12,7 +12,7 @@ import { edit } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import type {Dispute, IssuerEvidence} from 'wcpay/types/disputes';
+import type { Dispute } from 'wcpay/types/disputes';
 import { isAwaitingResponse } from 'wcpay/disputes/utils';
 import DisputeNotice from './dispute-notice';
 import IssuerEvidenceList from './evidence-list';

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -49,6 +49,23 @@
 	}
 }
 
-.dispute-evidence-link {
-	margin-right: .5em;
+.dispute-evidence {
+	&__header {
+		font-weight: 600;
+	}
+	&__list {
+		list-style: none;
+		margin: 0 0 8px;
+	}
+	&__list-item {
+		display: inline-block;
+		margin-right: 12px;
+	}
+
+	.dispute-evidence-link {
+		&--downloading {
+			cursor: progress;
+			opacity: 0.5;
+		}
+	}
 }

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -48,3 +48,7 @@
 		margin-bottom: 8px;
 	}
 }
+
+.dispute-evidence-link {
+	margin-right: .5em;
+}

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -50,12 +50,26 @@
 }
 
 .dispute-evidence {
-	&__header {
+	// Override WordPress core PanelBody boxy styles. Ours is more inline content.
+	&.components-panel__body {
+		border: none;
+	}
+	// Override WordPress core PanelBody title to align with other nearby headings.
+	.components-panel__body-title button {
 		// Copy of WooCommerce core list table header style.
 		text-transform: uppercase;
 		color: #757575;
 		font-size: 11px;
 		font-weight: 600;
+	}
+	// Override WordPress core PanelBody button/title – slim padding consistent with surrounding components.
+	.components-panel__body-toggle.components-button {
+		padding: 10px;
+	}
+	// Override WordPress core PanelBody focus/highlighting.
+	.components-panel__body-toggle.components-button:focus {
+		box-shadow: none;
+		outline: 0;
 	}
 	&__list {
 		list-style: none;

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -54,6 +54,10 @@
 	&.components-panel__body {
 		border: none;
 	}
+	// Override WordPress core PanelBody padding so fits snug in our container.
+	&.components-panel__body.is-opened {
+		padding-bottom: 0;
+	}
 	// Override WordPress core PanelBody title to align with other nearby headings.
 	.components-panel__body-title button {
 		// Copy of WooCommerce core list table header style.
@@ -73,10 +77,11 @@
 	}
 	&__list {
 		list-style: none;
-		margin: 8px 0;
+		margin: 8px 0 0;
 	}
 	&__list-item {
 		display: inline-block;
 		margin-right: 12px;
+		margin-bottom: 0;
 	}
 }

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -51,11 +51,15 @@
 
 .dispute-evidence {
 	&__header {
+		// Copy of WooCommerce core list table header style.
+		text-transform: uppercase;
+		color: #757575;
+		font-size: 11px;
 		font-weight: 600;
 	}
 	&__list {
 		list-style: none;
-		margin: 0 0 8px;
+		margin: 8px 0;
 	}
 	&__list-item {
 		display: inline-block;

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -73,7 +73,7 @@
 	}
 	&__list {
 		list-style: none;
-		margin: 4px 0 8px;
+		margin: 8px 0;
 	}
 	&__list-item {
 		display: inline-block;

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -50,7 +50,12 @@
 }
 
 .dispute-evidence {
-	&__title {
+	// Override WordPress core PanelBody boxy styles. Ours is more inline content.
+	&.components-panel__body {
+		border: none;
+	}
+	// Override WordPress core PanelBody title to align with other nearby headings.
+	.components-panel__body-title button {
 		// Copy of WooCommerce core list table header style.
 		text-transform: uppercase;
 		color: #757575;

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -61,11 +61,4 @@
 		display: inline-block;
 		margin-right: 12px;
 	}
-
-	.dispute-evidence-link {
-		&--downloading {
-			cursor: progress;
-			opacity: 0.5;
-		}
-	}
 }

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -50,7 +50,7 @@
 }
 
 .dispute-evidence {
-	&__header {
+	&__title {
 		// Copy of WooCommerce core list table header style.
 		text-transform: uppercase;
 		color: #757575;
@@ -59,7 +59,7 @@
 	}
 	&__list {
 		list-style: none;
-		margin: 8px 0;
+		margin: 4px 0 8px;
 	}
 	&__list-item {
 		display: inline-block;

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -85,6 +85,7 @@ const getBaseCharge = (): ChargeWithDisputeRequired =>
 				customer_name: 'Test customer',
 				shipping_address: '123 test address',
 			},
+			issuer_evidence: null,
 			evidence_details: {
 				due_by: 1694303999,
 				has_evidence: false,

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -29,6 +29,24 @@ interface EvidenceDetails {
 	submission_count: number;
 }
 
+/**
+ * See https://stripe.com/docs/api/disputes/object#dispute_object-issuer_evidence
+ */
+interface IssuerEvidence {
+	/**
+	 * Type of issuer evidence supplied.
+	 */
+	evidence_type: string; //'retrieval' | 'chargeback' | 'response';
+	/**
+	 * List of up to 5 (ID of a file upload) File-based issuer evidence.
+	 */
+	file_evidence: string[];
+	/**
+	 * Free-form, text-based issuer evidence.
+	 */
+	text_evidence: string | null;
+}
+
 export type DisputeReason =
 	| 'bank_cannot_process'
 	| 'check_returned'
@@ -62,6 +80,7 @@ export interface Dispute {
 	metadata: Record< string, any >;
 	order: null | OrderDetails;
 	evidence: Evidence;
+	issuer_evidence: IssuerEvidence | null;
 	fileSize?: Record< string, number >;
 	reason: DisputeReason;
 	charge: Charge | string;

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -36,7 +36,7 @@ interface IssuerEvidence {
 	/**
 	 * Type of issuer evidence supplied.
 	 */
-	evidence_type: string; //'retrieval' | 'chargeback' | 'response';
+	evidence_type: 'retrieval' | 'chargeback' | 'response';
 	/**
 	 * List of up to 5 (ID of a file upload) File-based issuer evidence.
 	 */

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -153,7 +153,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 	 *     "type": "png",
 	 * }
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return mixed|WP_Error
 	 */
@@ -173,8 +173,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 	 *     "file_content": "iVBORw.......",
 	 * }
 	 *
-	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return mixed|WP_Error
 	 */

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -35,6 +35,16 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/detail/(?P<file_id>\w+)',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_file_detail' ],
+				'permission_callback' => [],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/(?P<file_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
@@ -42,6 +52,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 				'permission_callback' => [],
 			]
 		);
+
 	}
 
 	/**
@@ -114,6 +125,21 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 			]
 		);
 
+	}
+
+	public function get_file_detail( WP_REST_Request $request ) {
+		$file_id    = $request->get_param( 'file_id' );
+		$as_account = (bool) $request->get_param( 'as_account' );
+
+		if ( ! $this->check_permission() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to do that.', 'woocommerce-payments' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+
+		return $this->forward_request( 'get_file', [ $file_id, $as_account ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -137,6 +137,26 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 
 	}
 
+	/**
+	 * Retrieve file details via the API.
+	 *
+	 * Example response:
+	 * {
+	 *     "id": "file_1Np1S5J5cIRIG92xknlr0iND",
+	 *     "object": "file",
+	 *     "created": 1694405421,
+	 *     "expires_at": 1717733421,
+	 *     "filename": "Screenshot 2023-09-04 at 5.08.31\u202fPM.png",
+	 *     "purpose": "dispute_evidence",
+	 *     "size": 21444,
+	 *     "title": null,
+	 *     "type": "png",
+	 * }
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return mixed|WP_Error
+	 */
 	public function get_file_detail( WP_REST_Request $request ) {
 		$file_id    = $request->get_param( 'file_id' );
 		$as_account = (bool) $request->get_param( 'as_account' );
@@ -144,6 +164,20 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 		return $this->forward_request( 'get_file', [ $file_id, $as_account ] );
 	}
 
+	/**
+	 * Retrieve file contents via the API as a base64 encoded string.
+	 *
+	 * Example response:
+	 * {
+	 *     "content_type": "image\/png",
+	 *     "file_content": "iVBORw.......",
+	 * }
+	 *
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return mixed|WP_Error
+	 */
 	public function get_file_content( WP_REST_Request $request ) {
 		$file_id    = $request->get_param( 'file_id' );
 		$as_account = (bool) $request->get_param( 'as_account' );

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -35,11 +35,21 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/detail/(?P<file_id>\w+)',
+			'/' . $this->rest_base . '/(?P<file_id>\w+)/details',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_file_detail' ],
-				'permission_callback' => [],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<file_id>\w+)/content',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_file_content' ],
+				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
 
@@ -130,16 +140,14 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 	public function get_file_detail( WP_REST_Request $request ) {
 		$file_id    = $request->get_param( 'file_id' );
 		$as_account = (bool) $request->get_param( 'as_account' );
-
-		if ( ! $this->check_permission() ) {
-			return new WP_Error(
-				'rest_forbidden',
-				__( 'Sorry, you are not allowed to do that.', 'woocommerce-payments' ),
-				[ 'status' => rest_authorization_required_code() ]
-			);
-		}
-
 		return $this->forward_request( 'get_file', [ $file_id, $as_account ] );
+	}
+
+	public function get_file_content( WP_REST_Request $request ) {
+		$file_id    = $request->get_param( 'file_id' );
+		$as_account = (bool) $request->get_param( 'as_account' );
+
+		return $this->forward_request( 'get_file_contents', [ $file_id, $as_account ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -140,6 +140,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 	public function get_file_detail( WP_REST_Request $request ) {
 		$file_id    = $request->get_param( 'file_id' );
 		$as_account = (bool) $request->get_param( 'as_account' );
+
 		return $this->forward_request( 'get_file', [ $file_id, $as_account ] );
 	}
 


### PR DESCRIPTION
Fixes #7173 

#### Changes proposed in this Pull Request

Add the ability for merchants to review any evidence that is included with a dispute. 

When a customer disputes an order via their bank or "issuer", evidence can be supplied to the merchant with more information. This can be text-based or a PDF/image. Currently, there is no way for a merchant to view this. This PR is the first step to making the evidence accessible.

Stripe doesn't provide a way for testing `issuer_evidence`, this field is only available on live accounts when provided by the issuer/bank. 

Due to the limitations of testing in development and staging environments. This feature will ship behind a feature flag. This will allow validation of the feature on production accounts.

### Implementation

The issuer_evidence data that is returned via the [API](https://stripe.com/docs/api/disputes/object#dispute_object-issuer_evidence) is structured as below. `text_evidence` is `string|null`, `file_evidence` is an array of up to 5 strings.

```js
{
	evidence_type: 'chargeback',
	file_evidence: [
		'file_xxxxxxxxxxxxx1',
		'file_xxxxxxxxxxxxx2',
	],
	text_evidence: 'Sample text evidence',
}
```

I opted to treat both file-based and text-based evidence as file downloads to standardize the UI and handling of both.
Text-based dispute evidence is able to be clicked and downloaded as a `.txt` file. Any other file-based evidence is downloaded, retaining the filename set on upload.

There are two server REST API's for accessing `file` information from a file_id. One returns file details such as filename, filesize etc. The other returns the file contents as a base64 encoded string. Rather than implement new API's, I opted to utilize the currently available ones for this feature. 

The process of downloading file-based evidence can be slow due to the REST API and the overhead of base64. This means there can be a considerable delay between the user clicking the link and seeing any response. 

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

![image](https://github.com/Automattic/woocommerce-payments/assets/57298/bb99145c-4db0-46d7-9c5a-422e3b8ff153)

#### Testing instructions

As this `issuer_evidence` is not available on test accounts. Any testing of this feature must be done using mocked data. Any string can be supplied for `text_evidence`. To generate valid `file_id`'s I've found the simplest way is to upload merchant evidence against any dispute. These `file_id`'s can be used as `file_evidence` to test the rendering and downloading of these files.

1. Enable the feature flag `_wcpay_feature_dispute_on_transaction_page`
2. On any dispute, upload a file and save (not submit) the evidence.
3. Get the associated file_id. This can be done by reviewing the logs or the dispute object in the developer console.
4. In `client/payment-details/dispute-details/index.tsx` add the following snippet and update `<EvidenceList>` to use this instead of `dispute.issuer_evidence`. 
5. Test varying combinations of `file_evidence` and `text_evidence`

```ts
	const issuerEvidence: IssuerEvidence = {
		evidence_type: 'chargeback',
		file_evidence: [ 'file_xxxxxxxxx' ],
		text_evidence: 'Sample text evidence',
	};
```

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
