### PR TITLE
Revert "Update Subscriptions with WooPayments eligibility as we move to deprecate this functionality"

### DIFF
--- a/changelog/issue-6510-deprecate-wcpay-subscriptions
+++ b/changelog/issue-6510-deprecate-wcpay-subscriptions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Only display the WCPay Subscriptions setting to existing users as part of deprecating this feature.

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -30,8 +30,11 @@ const WCPaySubscriptionsToggle = () => {
 		updateIsWCPaySubscriptionsEnabled( value );
 	};
 
-	return ! wcpaySettings.isSubscriptionsActive &&
-		isWCPaySubscriptionsEligible ? (
+	/**
+	 * Only show the toggle if the site is eligible for wcpay subscriptions or
+	 * if wcpay subscriptions are already enabled.
+	 */
+	return isWCPaySubscriptionsEligible || isWCPaySubscriptionsEnabled ? (
 		<CheckboxControl
 			label={ sprintf(
 				/* translators: %s: WooPayments */

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -31,10 +31,11 @@ const WCPaySubscriptionsToggle = () => {
 	};
 
 	/**
-	 * Only show the toggle if the site is eligible for wcpay subscriptions or
-	 * if wcpay subscriptions are already enabled.
+	 * Only show the toggle if the site doesn't have WC Subscriptions active and is eligible
+	 * for wcpay subscriptions or if wcpay subscriptions are already enabled.
 	 */
-	return isWCPaySubscriptionsEligible || isWCPaySubscriptionsEnabled ? (
+	return ! wcpaySettings.isSubscriptionsActive &&
+		( isWCPaySubscriptionsEligible || isWCPaySubscriptionsEnabled ) ? (
 		<CheckboxControl
 			label={ sprintf(
 				/* translators: %s: WooPayments */

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -188,72 +188,17 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Returns whether the store is eligible to use WCPay Subscriptions (the free subscriptions bundled in WooPayments)
-	 *
-	 * Stores are eligible for the WCPay Subscriptions feature if:
-	 * 1. The store has existing WCPay Subscriptions, or
-	 * 2. The store has Stripe Billing product metadata on at least 1 product subscription product.
+	 * Returns whether WCPay Subscriptions is eligible, based on the stores base country.
 	 *
 	 * @return bool
 	 */
 	public static function is_wcpay_subscriptions_eligible() {
-		/**
-		 * Check if they have at least 1 WCPay Subscription.
-		 *
-		 * Note: this is only possible if WCPay Subscriptions is enabled, otherwise the wcs_get_subscriptions function wouldn't exist.
-		 */
-		if ( function_exists( 'wcs_get_subscriptions' ) ) {
-			$wcpay_subscriptions = wcs_get_subscriptions(
-				[
-					'subscriptions_per_page' => 1,
-					'subscription_status'    => 'any',
-					'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-						[
-							'key'     => '_wcpay_subscription_id',
-							'compare' => 'EXISTS',
-						],
-					],
-				]
-			);
-
-			if ( count( $wcpay_subscriptions ) > 0 ) {
-				return true;
-			}
+		if ( ! function_exists( 'wc_get_base_location' ) ) {
+			return false;
 		}
 
-		/**
-		 * Check if they have at least 1 Stripe Billing enabled product.
-		 */
-		$stripe_billing_meta_query_handler = function ( $query, $query_vars ) {
-			if ( ! empty( $query_vars['stripe_billing_product'] ) ) {
-				$query['meta_query'][] = [
-					'key'     => '_wcpay_product_hash',
-					'compare' => 'EXISTS',
-				];
-			}
-
-			return $query;
-		};
-
-		add_filter( 'woocommerce_product_data_store_cpt_get_products_query', $stripe_billing_meta_query_handler, 10, 2 );
-
-		$subscription_products = wc_get_products(
-			[
-				'limit'                  => 1,
-				'type'                   => [ 'subscription', 'variable-subscription' ],
-				'status'                 => 'publish',
-				'return'                 => 'ids',
-				'stripe_billing_product' => 'true',
-			]
-		);
-
-		remove_filter( 'woocommerce_product_data_store_cpt_get_products_query', $stripe_billing_meta_query_handler, 10, 2 );
-
-		if ( count( $subscription_products ) > 0 ) {
-			return true;
-		}
-
-		return false;
+		$store_base_location = wc_get_base_location();
+		return ! empty( $store_base_location['country'] ) && 'US' === $store_base_location['country'];
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -95,8 +95,6 @@ class WC_Payments_Subscriptions {
 			include_once __DIR__ . '/class-wc-payments-subscriptions-migrator.php';
 			self::$stripe_billing_migrator = new WC_Payments_Subscriptions_Migrator( $api_client );
 		}
-
-		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'maybe_disable_wcpay_subscriptions_on_update' ] );
 	}
 
 	/**
@@ -157,16 +155,5 @@ class WC_Payments_Subscriptions {
 		}
 
 		return class_exists( 'WCS_Staging' ) && WCS_Staging::is_duplicate_site();
-	}
-
-	/**
-	 * Disable the WCPay Subscriptions feature on WooPayments plugin update if it's enabled and the store is no longer eligible.
-	 *
-	 * @see WC_Payments_Features::is_wcpay_subscriptions_eligible() for eligibility criteria.
-	 */
-	public static function maybe_disable_wcpay_subscriptions_on_update() {
-		if ( WC_Payments_Features::is_wcpay_subscriptions_enabled() && ! WC_Payments_Features::is_wcpay_subscriptions_eligible() ) {
-			update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '0' );
-		}
 	}
 }


### PR DESCRIPTION
Reverts Automattic/woocommerce-payments#7117

After discussing this internally (peNR48-2u-p2#comment-148) we're going to revert this PR for the September 20 release and will reapply it for the October 11.

