### PR TITLE
Fix changing Stripe Billing payment method which wasn't cancelling at Stripe

### DIFF
--- a/changelog/fix-changing-stripe-billing-payment-method-doesnt-cancel
+++ b/changelog/fix-changing-stripe-billing-payment-method-doesnt-cancel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure the Stripe Billing subscription is cancelled when the subscription is changed from WooPayments to another payment method.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -157,6 +157,8 @@ class WC_Payments_Subscription_Service {
 
 		add_action( 'woocommerce_payments_changed_subscription_payment_method', [ $this, 'maybe_attempt_payment_for_subscription' ], 10, 2 );
 		add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'show_wcpay_subscription_id' ] );
+
+		add_action( 'woocommerce_subscription_payment_method_updated_from_' . WC_Payment_Gateway_WCPay::GATEWAY_ID, [ $this, 'maybe_cancel_subscription' ], 10, 2 );
 	}
 
 	/**
@@ -824,6 +826,18 @@ class WC_Payments_Subscription_Service {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Cancels a WCPay subscription when a customer changes their payment method
+	 *
+	 * @param WC_Subscription $subscription       The subscription that was updated.
+	 * @param string          $new_payment_method The subscription's new payment method ID.
+	 */
+	public function maybe_cancel_subscription( $subscription, $new_payment_method ) {
+		if ( (bool) self::get_wcpay_subscription_id( $subscription ) && WC_Payment_Gateway_WCPay::GATEWAY_ID !== $new_payment_method ) {
+			$this->cancel_subscription( $subscription );
+		}
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -833,8 +833,15 @@ class WC_Payments_Subscription_Service {
 	 * @param string          $new_payment_method The subscription's new payment method ID.
 	 */
 	public function maybe_cancel_subscription( $subscription, $new_payment_method ) {
-		if ( (bool) self::get_wcpay_subscription_id( $subscription ) && WC_Payment_Gateway_WCPay::GATEWAY_ID !== $new_payment_method ) {
+		$wcpay_subscription_id = self::get_wcpay_subscription_id( $subscription );
+
+		if ( (bool) $wcpay_subscription_id && WC_Payment_Gateway_WCPay::GATEWAY_ID !== $new_payment_method ) {
 			$this->cancel_subscription( $subscription );
+
+			// Delete the WCPay Subscription meta but keep a record of it.
+			$subscription->update_meta_data( '_cancelled' . self::SUBSCRIPTION_ID_META_KEY, $wcpay_subscription_id );
+			$subscription->delete_meta_data( self::SUBSCRIPTION_ID_META_KEY );
+			$subscription->save();
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -559,16 +559,14 @@ class WC_Payments_Subscription_Service {
 	 *
 	 * If the WCPay subscription's payment method was updated while there's a failed invoice, trigger a retry.
 	 *
-	 * @param int              $post_id  Post ID (WC subscription ID) that had its payment method updated.
-	 * @param int              $token_id Payment Token post ID stored in DB.
-	 * @param WC_Payment_Token $token    Payment Token object.
-	 *
-	 * @return void
+	 * @param int              $subscription_id Post ID (WC subscription ID) that had its payment method updated.
+	 * @param int              $token_id        Payment Token post ID stored in DB.
+	 * @param WC_Payment_Token $token           Payment Token object.
 	 */
-	public function update_wcpay_subscription_payment_method( int $post_id, int $token_id, WC_Payment_Token $token ) {
-		$subscription = wcs_get_subscription( $post_id );
+	public function update_wcpay_subscription_payment_method( int $subscription_id, int $token_id, WC_Payment_Token $token ) {
+		$subscription = wcs_get_subscription( $subscription_id );
 
-		if ( $subscription ) {
+		if ( $subscription && self::is_wcpay_subscription( $subscription ) ) {
 			$wcpay_subscription_id   = $this->get_wcpay_subscription_id( $subscription );
 			$wcpay_payment_method_id = $token->get_token();
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -400,6 +400,7 @@ class WC_Payments_Subscription_Service_Test extends WCPAY_UnitTestCase {
 		$token                      = WC_Helper_Token::create_token( $mock_wcpay_token_id, 1 );
 		$subscription->set_parent( $mock_order );
 
+		$subscription->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
 		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
 
 		WC_Subscriptions::set_wcs_get_subscription(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes 2 issues: 

1. When a customer changes a Stripe Billing subscription to another payment method. Previously we weren't cancelling the Stripe Billing subscription. This PR fixes that. 
2. If you had changed payment methods from WooPayments + Stripe Billing to another payment method, it would attempt to update the Stripe Billing payment method to that new token. This PR also fixes that.

#### Testing instructions

* Purchase a subscription using Stripe Billing. 
* Enable the Woo Subscriptions plugin.
* Change the subscription's payment method to Woo Payments but change it to a different card. eg `4000056655665556`.
* Log into the Stripe Dashboard and confirm the Stripe Billing's payment method has been updated.
* On your site, go to the My Account page and view the subscription.
* Change the subscriptions payment method to Stripe (for example). 
* View the Stripe Billing subscription in the Stripe Dashboard and confirm it has been cancelled (this isn't the case on `develop`)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
