### PR TITLE
Increase admin enqueue scripts priority

### DIFF
--- a/changelog/fix-7067-admin-enqueue-scripts-priority
+++ b/changelog/fix-7067-admin-enqueue-scripts-priority
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Increase admin enqueue scripts priority to avoid compatibility issues with WooCommerce Beta Tester plugin.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -145,8 +145,8 @@ class WC_Payments_Admin {
 		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 0 );
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
 		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_redirect_overview_to_connect' ], 1 ); // Run this late (after `admin_init`) but before any scripts are actually enqueued.
-		add_action( 'admin_enqueue_scripts', [ $this, 'register_payments_scripts' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ], 12 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_payments_scripts' ], 9 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ], 9 );
 		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'payment_gateways_container' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_woopay_payment_method_name_admin' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_wcpay_transaction_fee' ] );


### PR DESCRIPTION
Fixes #7067

#### Changes proposed in this Pull Request
Increase `admin_enqueue_scripts` for [WC_Payments_Admin](https://github.com/Automattic/woocommerce-payments/blob/316bba2350c78a0b7069dee324f78c12be5dff91/includes/admin/class-wc-payments-admin.php#L148-L149) scripts, to avoid compatibility issues with **WooCommerce Beta Tester** plugin.

#### Testing instructions
- Install and enable **WooCommerce Beta Tester** plugin.
- With an onboarded account, go to **Payments → Overview**.
- It should load correctly rather than showing `Sorry, you are not allowed to access this page` message.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
