### PR TITLE
fix: express checkouts links consistency

### DIFF
--- a/changelog/fix-express-checkouts-links-consistency
+++ b/changelog/fix-express-checkouts-links-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+express checkout links UI consistency & area increase

--- a/client/settings/express-checkout/apple-google-pay-item.tsx
+++ b/client/settings/express-checkout/apple-google-pay-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 import React from 'react';
 
@@ -150,13 +150,14 @@ const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
 						</div>
 					</div>
 					<div className="express-checkout__link">
-						<a
+						<Button
 							href={ getPaymentMethodSettingsUrl(
 								'payment_request'
 							) }
+							isSecondary
 						>
 							{ __( 'Customize', 'woocommerce-payments' ) }
-						</a>
+						</Button>
 					</div>
 				</div>
 			</div>

--- a/client/settings/express-checkout/link-item.tsx
+++ b/client/settings/express-checkout/link-item.tsx
@@ -19,8 +19,6 @@ import { HoverTooltip } from 'components/tooltip';
 import LinkIcon from 'assets/images/payment-methods/link.svg?asset';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import { EnabledMethodIdsHook } from './interfaces';
-import { getAdminUrl } from 'wcpay/utils';
-import { ProtectionLevel } from 'wcpay/settings/fraud-protection/advanced-settings/constants';
 
 const LinkExpressCheckoutItem = (): React.ReactElement => {
 	const availablePaymentMethodIds = useGetAvailablePaymentMethodIds() as Array<

--- a/client/settings/express-checkout/link-item.tsx
+++ b/client/settings/express-checkout/link-item.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
+import { Button, CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**
@@ -19,6 +19,8 @@ import { HoverTooltip } from 'components/tooltip';
 import LinkIcon from 'assets/images/payment-methods/link.svg?asset';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import { EnabledMethodIdsHook } from './interfaces';
+import { getAdminUrl } from 'wcpay/utils';
+import { ProtectionLevel } from 'wcpay/settings/fraud-protection/advanced-settings/constants';
 
 const LinkExpressCheckoutItem = (): React.ReactElement => {
 	const availablePaymentMethodIds = useGetAvailablePaymentMethodIds() as Array<
@@ -154,26 +156,18 @@ const LinkExpressCheckoutItem = (): React.ReactElement => {
 								</div>
 							</div>
 							<div className="express-checkout__link">
-								{
-									/* eslint-disable jsx-a11y/anchor-has-content */
-									interpolateComponents( {
-										mixedString: __(
-											'{{linkDocs}}Read more{{/linkDocs}}',
-											'woocommerce-payments'
-										),
-										components: {
-											linkDocs: (
-												<a
-													target="_blank"
-													rel="noreferrer"
-													/* eslint-disable-next-line max-len */
-													href="https://woocommerce.com/document/woopayments/payment-methods/link-by-stripe/"
-												/>
-											),
-										},
-									} )
-									/* eslint-enable jsx-a11y/anchor-has-content */
-								}
+								<Button
+									target="_blank"
+									rel="noreferrer"
+									/* eslint-disable-next-line max-len */
+									href="https://woocommerce.com/document/woopayments/payment-methods/link-by-stripe/"
+									isSecondary
+								>
+									{ __(
+										'Read more',
+										'woocommerce-payments'
+									) }
+								</Button>
 							</div>
 						</div>
 					</div>

--- a/client/settings/express-checkout/style.scss
+++ b/client/settings/express-checkout/style.scss
@@ -135,17 +135,7 @@
 			}
 
 			&__link {
-				padding: 12px;
-				border: 1px solid #007cba;
-				border-radius: 2px;
-				font-size: 12px;
-				height: 18px;
 				align-self: center;
-
-				a {
-					text-decoration: none;
-					white-space: nowrap;
-				}
 
 				@include breakpoint( '<660px' ) {
 					align-self: flex-start;

--- a/client/settings/express-checkout/woopay-item.tsx
+++ b/client/settings/express-checkout/woopay-item.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
+import { Button, CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import WooIcon from 'assets/images/payment-methods/woo.svg?asset';
 import interpolateComponents from '@automattic/interpolate-components';
 import { getPaymentMethodSettingsUrl } from '../../utils';
@@ -162,16 +162,17 @@ const WooPayExpressCheckoutItem = (): React.ReactElement => {
 							</div>
 
 							<div className="express-checkout__link">
-								<a
+								<Button
 									href={ getPaymentMethodSettingsUrl(
 										'woopay'
 									) }
+									isSecondary
 								>
 									{ __(
 										'Customize',
 										'woocommerce-payments'
 									) }
-								</a>
+								</Button>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/6365

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The links on the "Express checkouts" section are inconsistent with the ones in the "Fraud protection" section.
Moreover, their clickable area is small. They're not clickable within the blue border.
Improving.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Scroll down to "Express checkouts"
- The "Customize" and "Learn more" links are now fully clickable and consistent with the ones displayed in the "Fraud protection" section

Before:
![2023-09-13 13 52 13](https://github.com/Automattic/woocommerce-payments/assets/273592/9b5c27ff-df1b-44bc-a96a-cb6c38b8f8d2)

After:
![2023-09-13 13 51 19](https://github.com/Automattic/woocommerce-payments/assets/273592/23845ecd-9a87-4da4-96c2-20386c47888d)

![Screenshot 2023-09-13 at 1 48 23 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/5f81630d-5c77-44cd-b2fa-a34f3c83b8b1)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
