### PR TITLE
Fix checkout error with Afterpay

### DIFF
--- a/changelog/fix-7187-checkout-error-with-afterpay
+++ b/changelog/fix-7187-checkout-error-with-afterpay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an error in the checkout when Afterpay is selected as payment method.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3763,7 +3763,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @return void
 	 */
-	protected function modify_create_intent_parameters_when_processing_payment( Create_And_Confirm_Intention $request, Payment_Information $payment_information, $order ): void {
+	protected function modify_create_intent_parameters_when_processing_payment( Create_And_Confirm_Intention $request, Payment_Information $payment_information, $order ) {
 		// Do nothing.
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1235,6 +1235,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$request->set_payment_methods( $payment_methods );
 				$request->set_cvc_confirmation( $payment_information->get_cvc_confirmation() );
 
+				if ( Payment_Method::AFTERPAY === $this->get_selected_stripe_payment_type_id() && $this instanceof UPE_Split_Payment_Gateway ) {
+					$request->set_shipping( $this->get_shipping_data_from_order( $order ) );
+				}
+
 				// The below if-statement ensures the support for UPE payment methods.
 				if ( $this->upe_needs_redirection( $payment_methods ) ) {
 					$request->set_return_url(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1235,9 +1235,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$request->set_payment_methods( $payment_methods );
 				$request->set_cvc_confirmation( $payment_information->get_cvc_confirmation() );
 
-				if ( Payment_Method::AFTERPAY === $this->get_selected_stripe_payment_type_id() && $this instanceof UPE_Split_Payment_Gateway ) {
-					$request->set_shipping( $this->get_shipping_data_from_order( $order ) );
-				}
+				// Add specific payment method parameters to the request.
+				$this->modify_create_intent_parameters_when_processing_payment( $request, $payment_information, $order );
 
 				// The below if-statement ensures the support for UPE payment methods.
 				if ( $this->upe_needs_redirection( $payment_methods ) ) {
@@ -3751,5 +3750,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	private function upe_needs_redirection( $payment_methods ) {
 		return 1 === count( $payment_methods ) && 'card' !== $payment_methods[0];
+	}
+
+	/**
+	 * Modifies the create intent parameters when processing a payment.
+	 *
+	 * Currently used by child UPE_Split_Payment_Gateway to add required shipping information for Afterpay.
+	 *
+	 * @param Create_And_Confirm_Intention $request               The request object for creating and confirming intention.
+	 * @param Payment_Information          $payment_information   The payment information object.
+	 * @param mixed                        $order                 The order object or data.
+	 *
+	 * @return void
+	 */
+	protected function modify_create_intent_parameters_when_processing_payment( Create_And_Confirm_Intention $request, Payment_Information $payment_information, $order ): void {
+		// Do nothing.
 	}
 }

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -45,7 +45,8 @@ use WC_Payments_Features;
 use WCPay\Duplicate_Payment_Prevention_Service;
 use WP_User;
 use WC_Payments_Localization_Service;
-
+use WCPay\Payment_Information;
+use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 
 /**
  * UPE Payment method extended from WCPay generic Gateway.

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -28,6 +28,8 @@ use WCPay\Constants\Payment_Method;
 use WCPay\Duplicate_Payment_Prevention_Service;
 use WP_User;
 use WC_Payments_Localization_Service;
+use WCPay\Payment_Information;
+use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 
 
 
@@ -528,5 +530,22 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 	 */
 	public function get_stripe_id() {
 		return $this->stripe_id;
+	}
+
+	/**
+	 * Modifies the create intent parameters when processing a payment.
+	 *
+	 * If the selected Stripe payment type is AFTERPAY, it updates the shipping data in the request.
+	 *
+	 * @param Create_And_Confirm_Intention $request               The request object for creating and confirming intention.
+	 * @param Payment_Information          $payment_information   The payment information object.
+	 * @param mixed                        $order                 The order object or data.
+	 *
+	 * @return void
+	 */
+	protected function modify_create_intent_parameters_when_processing_payment( Create_And_Confirm_Intention $request, Payment_Information $payment_information, $order ): void {
+		if ( Payment_Method::AFTERPAY === $this->get_selected_stripe_payment_type_id() ) {
+			$request->set_shipping( $this->get_shipping_data_from_order( $order ) );
+		}
 	}
 }

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -543,7 +543,7 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 	 *
 	 * @return void
 	 */
-	protected function modify_create_intent_parameters_when_processing_payment( Create_And_Confirm_Intention $request, Payment_Information $payment_information, $order ): void {
+	protected function modify_create_intent_parameters_when_processing_payment( Create_And_Confirm_Intention $request, Payment_Information $payment_information, $order ) {
 		if ( Payment_Method::AFTERPAY === $this->get_selected_stripe_payment_type_id() ) {
 			$request->set_shipping( $this->get_shipping_data_from_order( $order ) );
 		}


### PR DESCRIPTION
Fixes #7187

#### Changes proposed in this Pull Request

This PR fixes the error in the checkout due to missing shipping information in the request to create and confirm a payment intent.

I'm adding the shipping information to the request in the `process_payment_for_order` method based on two conditions:

1. The selected payment method is `AFTERPAY`, since no other payment methods require shipping information at the moment.
2. The request is being handled by an instance of `UPE_Split_Payment_Gateway`, to avoid any risks of adding the shipping information to Legacy card gateway.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
_Prerequisites_

You need to have Afterpay enabled in the test site. If testing locally, make sure that your local server instance has the latest changes from `trunk`.  You'll also need a merchant account that complies with Afterpay requirements (i.e. US based merchant with USD currency). If you are still not able to see Afterpay in the admin, please try to clear the account cache. And finally make sure to have shortcode and block based checkout pages available.

1. Make sure that Enable Split UPE checkout with deferred intent creation is enabled.
2. Add a product to the cart and proceed to shortcode checkout.
3. Fill in the details, select Afterpay and submit the form.
4. Check that there are no errors in the checkout.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
