### PR TITLE
Fix double indicators showing under Payments tab

### DIFF
--- a/changelog/fix-7042-double-payments-badge
+++ b/changelog/fix-7042-double-payments-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix double indicators showing under Payments tab

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -956,10 +956,7 @@ class WC_Payments_Admin {
 
 		$badge = self::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( false === strpos( $menu_item[0], $badge )
-				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2]
-					|| 'admin.php?page=wc-admin&path=/payments/connect' === $menu_item[2] )
-			) {
+			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -954,9 +954,15 @@ class WC_Payments_Admin {
 			return;
 		}
 
+		$badge = self::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) {
-				$menu[ $index ][0] .= self::MENU_NOTIFICATION_BADGE; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			if ( false === strpos( $menu_item[0], $badge )
+				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2]
+					|| 'admin.php?page=wc-admin&path=/payments/connect' === $menu_item[2] )
+			) {
+				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+				// One menu item with a badge is more than enough.
 				break;
 			}
 		}

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -48,9 +48,12 @@ class WC_Payments_Incentives_Service {
 			return;
 		}
 
+		$badge = WC_Payments_Admin::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) {
-				$menu[ $index ][0] .= WC_Payments_Admin::MENU_NOTIFICATION_BADGE; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
+				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+				// One menu item with a badge is more than enough.
 				break;
 			}
 		}


### PR DESCRIPTION
Fixes #7042 

#### Changes proposed in this Pull Request

This PR fixes double indicators (badges) under Payments menu when the store is more than three days old and has connect incentive.

<table>
<tbody>
<td>Before</td>
<td><img width="218" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/79862886/40aa9854-b08c-42e4-a0b5-04be69c40d9e">
</td>

<td>After</td>
<td>
<img width="218" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/79862886/9bf51638-bdc2-4896-9544-ae5a272eb030">
</td>
</tbody>
</table>

#### Testing instructions

**To reproduce**
* Checkout `develop`
* Remove your local WCPay account if you have one
* Apply [this patch](https://gist.github.com/oaratovskyi/05c21f3fcbadb9c471b8d1bede613489) to get connect incentive locally
* Observe double indicators issue

**To test fix**
* Checkout `fix/7042-double-payments-badge`
* Again apply the patch to get connect incentive locally 
* Observe no issue

**Bonus: To test on JN**
- Set up a new Jurassic Site
- Either complete or skip Store setup
- Change `wcpay_activation_timestamp` option value to be > than 3 days ago. I used [options view](https://wordpress.org/plugins/options-view/) plugin for that.
- Click on "Payments" tab to start onboarding WCPayments to see the issue
- Update WCPay plugin to one that built from this branch using `npm run build:release`
- Observe no issue

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _ 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
