### PR TITLE
Fix single currency settings saving manual rate

### DIFF
--- a/changelog/fix-6857-multi-currency-manual-exchange-rate-is-not-saved
+++ b/changelog/fix-6857-multi-currency-manual-exchange-rate-is-not-saved
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix single currency manual rate save producing error when no changes are made

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -82,7 +82,6 @@ const SingleCurrencySettings = () => {
 	const [ isSaving, setIsSaving ] = useState( false );
 
 	useEffect( () => {
-		console.log( currencySettings[ currency ] );
 		if ( currencySettings[ currency ] ) {
 			setExchangeRateType(
 				currencySettings[ currency ].exchange_rate_type ||

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -82,6 +82,7 @@ const SingleCurrencySettings = () => {
 	const [ isSaving, setIsSaving ] = useState( false );
 
 	useEffect( () => {
+		console.log( currencySettings[ currency ] );
 		if ( currencySettings[ currency ] ) {
 			setExchangeRateType(
 				currencySettings[ currency ].exchange_rate_type ||
@@ -279,11 +280,16 @@ const SingleCurrencySettings = () => {
 															exchangeRateType ===
 															'manual'
 														}
-														onChange={ () =>
+														onChange={ () => {
 															setExchangeRateType(
 																'manual'
-															)
-														}
+															);
+															setManualRate(
+																manualRate
+																	? manualRate
+																	: targetCurrency.rate
+															);
+														} }
 													/>
 													<h4>
 														{ __(

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -527,6 +527,8 @@ class MultiCurrency {
 			throw new InvalidCurrencyException( $message, 'wcpay_multi_currency_invalid_currency', 500 );
 		}
 
+		$currency_code = strtolower( $currency_code );
+
 		if ( 'manual' === $exchange_rate_type && ! is_null( $manual_rate ) ) {
 			if ( ! is_numeric( $manual_rate ) || 0 >= $manual_rate ) {
 				$message = 'Invalid manual currency rate passed to update_single_currency_settings: ' . $manual_rate;
@@ -536,7 +538,6 @@ class MultiCurrency {
 			update_option( 'wcpay_multi_currency_manual_rate_' . $currency_code, $manual_rate );
 		}
 
-		$currency_code = strtolower( $currency_code );
 		update_option( 'wcpay_multi_currency_price_rounding_' . $currency_code, $price_rounding );
 		update_option( 'wcpay_multi_currency_price_charm_' . $currency_code, $price_charm );
 		if ( in_array( $exchange_rate_type, [ 'automatic', 'manual' ], true ) ) {


### PR DESCRIPTION
Fixes #6857

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR fixes the single currency settings save producing errors when only the exchange rate toggle switches to "manual rate", without changing the manual rate. The `manualRate` state was kept at 0 because the switch didn't touch it before. This change ensures that the `manualRate` is either set to the user-defined manual rate, or the initial target currency rate when the switch happens. 

Also, there was a character case mismatch on saving and getting the modified currency rate from the DB, we were saving the appended currency code as uppercase, but fetching it with lowercase letters, this also fixes it. I don't know how it works with uppercase saved currency names in the option, but it also works when retrieving it with the lowercase currency. Thought that it'll be good to fix it.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Do not apply this fix yet.
- Open the MC settings screen
- Enable a different currency if not enabled before
- Save the changes
- Reload the page, and click `manage` on the newly added currency.
- Check the "manual rate" radio button without changing anything else, and save it. 
- You should get an error, because the manual rate was sent as 0 in the request. You can check the network logs to confirm it.

Apply the fix from this branch, and re-test this and see you don't get any errors.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
