### PR TITLE
Notices for deferred UPE rollout

### DIFF
--- a/changelog/deferred-upe-rollout-notices
+++ b/changelog/deferred-upe-rollout-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add notice for legacy UPE users about deferred UPE upcoming, and adjust wording for non-UPE users

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -91,14 +91,14 @@ const UpeSetupBanner = () => {
 			>
 				<h3>
 					{ __(
-						'Boost your sales by accepting additional payment methods',
+						'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023',
 						'woocommerce-payments'
 					) }
 				</h3>
 				<p>
 					{ __(
 						/* eslint-disable-next-line max-len */
-						'Get access to additional payment methods and an improved checkout experience.',
+						'This will improve the checkout experience and boost sales with access to additional payment methods, which you’ll be able to manage from here in settings.',
 						'woocommerce-payments'
 					) }
 				</p>
@@ -107,7 +107,7 @@ const UpeSetupBanner = () => {
 					<span className="payment-methods__express-checkouts-get-started">
 						<Button isSecondary onClick={ handleEnableUpeClick }>
 							{ __(
-								'Enable in your store',
+								'Enable payment methods',
 								'woocommerce-payments'
 							) }
 						</Button>

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -294,7 +294,7 @@ const PaymentMethods = () => {
 								components: {
 									learnMoreLink: (
 										// eslint-disable-next-line max-len
-										<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/" />
+										<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#popular-payment-methods" />
 									),
 								},
 							} ) }

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Card,
-	CardDivider,
 	CardHeader,
 	DropdownMenu,
 	ExternalLink,
@@ -83,7 +82,6 @@ const UpeSetupBanner = () => {
 
 	return (
 		<>
-			<CardDivider />
 			<CardBody
 				className={ classNames( 'payment-methods__express-checkouts', {
 					'background-local-payment-methods': ! wcpaySettings.isBnplAffirmAfterpayEnabled,
@@ -367,6 +365,13 @@ const PaymentMethods = () => {
 						) }
 					</PaymentMethodsList>
 				</CardBody>
+			</Card>
+			<br />
+			<Card
+				className={ classNames( 'payment-methods', {
+					'is-loading': status === 'pending',
+				} ) }
+			>
 				{ isUpeSettingsPreviewEnabled && ! isUpeEnabled && (
 					<UpeSetupBanner />
 				) }

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -48,6 +48,7 @@ import ConfirmPaymentMethodActivationModal from './activation-modal';
 import ConfirmPaymentMethodDeleteModal from './delete-modal';
 import { getAdminUrl } from 'wcpay/utils';
 import { getPaymentMethodDescription } from 'wcpay/utils/payment-methods';
+import InlineNotice from 'wcpay/components/inline-notice';
 
 const PaymentMethodsDropdownMenu = ( { setOpenModal } ) => {
 	return (
@@ -275,6 +276,31 @@ const PaymentMethods = () => {
 						<PaymentMethodsDropdownMenu
 							setOpenModal={ setOpenModalIdentifier }
 						/>
+					</CardHeader>
+				) }
+
+				{ isUpeEnabled && upeType === 'legacy' && (
+					<CardHeader className="payment-methods__header">
+						<InlineNotice
+							icon
+							status="warning"
+							isDismissible={ false }
+						>
+							<div>
+								{ __(
+									'The new WooPayments checkout experience will become the default on October 2, 2023.',
+									'woocommerce-payments'
+								) }
+								<br />
+								{ /* eslint-disable-next-line max-len */ }
+								<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/">
+									{ __(
+										'Learn more',
+										'woocommerce-payments'
+									) }
+								</ExternalLink>
+							</div>
+						</InlineNotice>
 					</CardHeader>
 				) }
 

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -366,16 +366,20 @@ const PaymentMethods = () => {
 					</PaymentMethodsList>
 				</CardBody>
 			</Card>
-			<br />
-			<Card
-				className={ classNames( 'payment-methods', {
-					'is-loading': status === 'pending',
-				} ) }
-			>
-				{ isUpeSettingsPreviewEnabled && ! isUpeEnabled && (
-					<UpeSetupBanner />
-				) }
-			</Card>
+
+			{ isUpeSettingsPreviewEnabled && ! isUpeEnabled && (
+				<>
+					<br />
+					<Card
+						className={ classNames( 'payment-methods', {
+							'is-loading': status === 'pending',
+						} ) }
+					>
+						<UpeSetupBanner />
+					</Card>
+				</>
+			) }
+
 			{ activationModalParams && (
 				<ConfirmPaymentMethodActivationModal
 					onClose={ () => {

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -48,6 +48,7 @@ import ConfirmPaymentMethodDeleteModal from './delete-modal';
 import { getAdminUrl } from 'wcpay/utils';
 import { getPaymentMethodDescription } from 'wcpay/utils/payment-methods';
 import InlineNotice from 'wcpay/components/inline-notice';
+import interpolateComponents from '@automattic/interpolate-components';
 
 const PaymentMethodsDropdownMenu = ( { setOpenModal } ) => {
 	return (
@@ -284,20 +285,19 @@ const PaymentMethods = () => {
 							status="warning"
 							isDismissible={ false }
 						>
-							<div>
-								{ __(
-									'The new WooPayments checkout experience will become the default on October 2, 2023.',
+							{ interpolateComponents( {
+								mixedString: __(
+									'The new WooPayments checkout experience will become the default on October 2, 2023.' +
+										' {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 									'woocommerce-payments'
-								) }
-								<br />
-								{ /* eslint-disable-next-line max-len */ }
-								<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/">
-									{ __(
-										'Learn more',
-										'woocommerce-payments'
-									) }
-								</ExternalLink>
-							</div>
+								),
+								components: {
+									learnMoreLink: (
+										// eslint-disable-next-line max-len
+										<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/" />
+									),
+								},
+							} ) }
 						</InlineNotice>
 					</CardHeader>
 				) }

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -90,7 +90,7 @@ const UpeSetupBanner = () => {
 			>
 				<h3>
 					{ __(
-						'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023',
+						'Enable the new WooPayments checkout experience, which will become the default on November 1, 2023',
 						'woocommerce-payments'
 					) }
 				</h3>
@@ -287,7 +287,7 @@ const PaymentMethods = () => {
 						>
 							{ interpolateComponents( {
 								mixedString: __(
-									'The new WooPayments checkout experience will become the default on October 2, 2023.' +
+									'The new WooPayments checkout experience will become the default on October 11, 2023.' +
 										' {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 									'woocommerce-payments'
 								),

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -227,7 +227,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableWooCommercePaymentText = screen.getByText(
-			'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
+			'Enable the new WooPayments checkout experience, which will become the default on November 1, 2023'
 		);
 
 		expect( enableWooCommercePaymentText ).toBeInTheDocument();
@@ -342,7 +342,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableWooCommercePaymentText = screen.getByText(
-			'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
+			'Enable the new WooPayments checkout experience, which will become the default on November 1, 2023'
 		);
 
 		expect( enableWooCommercePaymentText.parentElement ).not.toHaveClass(
@@ -371,7 +371,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableWooCommercePaymentText = screen.getByText(
-			'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
+			'Enable the new WooPayments checkout experience, which will become the default on November 1, 2023'
 		);
 
 		expect( enableWooCommercePaymentText.parentElement ).toHaveClass(
@@ -404,7 +404,7 @@ describe( 'PaymentMethods', () => {
 			);
 
 			const enableWooCommercePaymentText = screen.queryByText(
-				'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
+				'Enable the new WooPayments checkout experience, which will become the default on November 1, 2023'
 			);
 
 			expect( enableWooCommercePaymentText ).toBeNull();

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -227,7 +227,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableWooCommercePaymentText = screen.getByText(
-			'Boost your sales by accepting additional payment methods'
+			'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
 		);
 
 		expect( enableWooCommercePaymentText ).toBeInTheDocument();
@@ -342,7 +342,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableWooCommercePaymentText = screen.getByText(
-			'Boost your sales by accepting additional payment methods'
+			'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
 		);
 
 		expect( enableWooCommercePaymentText.parentElement ).not.toHaveClass(
@@ -371,7 +371,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableWooCommercePaymentText = screen.getByText(
-			'Boost your sales by accepting additional payment methods'
+			'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
 		);
 
 		expect( enableWooCommercePaymentText.parentElement ).toHaveClass(
@@ -404,7 +404,7 @@ describe( 'PaymentMethods', () => {
 			);
 
 			const enableWooCommercePaymentText = screen.queryByText(
-				'Boost your sales by accepting additional payment methods'
+				'Enable the new WooPayments checkout experience, which will become the default on October 23, 2023'
 			);
 
 			expect( enableWooCommercePaymentText ).toBeNull();
@@ -444,7 +444,7 @@ describe( 'PaymentMethods', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'clicking "Enable in your store" in express payments enable UPE and redirects', async () => {
+	test( 'clicking "Enable payment methods" in express payments enable UPE and redirects', async () => {
 		Object.defineProperty( window, 'location', {
 			value: {
 				href: 'example.com/',
@@ -471,7 +471,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const enableInYourStoreButton = screen.queryByRole( 'button', {
-			name: 'Enable in your store',
+			name: 'Enable payment methods',
 		} );
 
 		expect( enableInYourStoreButton ).toBeInTheDocument();


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7114

#### Changes proposed in this Pull Request
New notices for legacy UPE users as well as updated banners for non-UPE users were introduced in this PR according to the discussion started in paJDYF-9xf-p2#comment-20562. Main things considered in this PR:

1. New notice for legacy UPE users about deferred UPE upcoming (https://github.com/Automattic/woocommerce-payments/pull/7210/commits/2f298ce43bb57866a508e1f6d7847ac7b30babd1)
2. Adjust wording of the existing banner for non-UPE users to be in line with C1r0Vzxh1mhbDJJnbjHp5q-fi-2126_77381 (https://github.com/Automattic/woocommerce-payments/pull/7210/commits/ec3959938f61551e15af49fbd9d6084f8f75862a)
3. Mention Oct 2 and 23 for dUPE rollout for legacy UPE and non-UPE users accordingly to reflect the plans described in paJDYF-9xf-p2
4. Add distance between payment methods list and dUPE-upcoming banner for the non-UPE users (to be in line with C1r0Vzxh1mhbDJJnbjHp5q-fi-2585_20192)
5. No kebab menu for non-UPE users needed according to paJDYF-9xf-p2#comment-20757 so no changes were introduced on that front
6. No snackbar needed (according to paJDYF-9xf-p2#comment-20757 there is already one popping up and it's `Settings saved`)

### Non-UPE Settings
| Before  | After |
| ------------- | ------------- |
| <img width="594" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/22319444/eaf83db9-ac68-4622-9292-c2426d308c81">  |   <img width="594" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/22319444/e50666f6-1b51-41ca-a889-fe265995f13e">  |


### Legacy UPE settings
| Before  | After |
| ------------- | ------------- |
| <img width="594" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/22319444/a3c66ca5-6351-4c28-b470-03a9135fa9d0">  |   <img width="594" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/22319444/e4ea9ba7-b92d-41e0-9953-ca9ded53a180">  |

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Disable every UPE-related feature flag in WCPay DevTools
2. Navigate to _Payments -> Settings_ and confirm, that the banner is in line with C1r0Vzxh1mhbDJJnbjHp5q-fi-2126_77381
3. Double-check the rollout date mentioned on the banner is in line with release timing (paJDYF-9xf-p2)
4. Double-check the hyperlink on _Learn more_ refers to the valid source
5. Enable legacy UPE and confirm, that the notice created in C1r0Vzxh1mhbDJJnbjHp5q-fi-2585%3A23004 is correctly displayed
6. Double-check the rollout date mentioned on the notice is in line with release timing (paJDYF-9xf-p2)
8. Double-check the hyperlink on _Learn more_ refers to the valid source
9. Enable split UPE and confirm the notice doesn't appear
10. Enable deferred intent create UPE and confirm the notice doesn't appear




<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.