### PR TITLE
Revert "Bump WC and PHP versions (#7134)"

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,10 +4,9 @@ on:
   pull_request
 
 env:
-  WC_MIN_SUPPORTED_VERSION: '7.7.0'
-  WP_MIN_SUPPORTED_VERSION: '6.1'
-  PHP_MIN_SUPPORTED_VERSION: '7.4'
-  GUTENBERG_VERSION_FOR_WP_MIN: '15.7.0'
+  WC_MIN_SUPPORTED_VERSION: '7.6.0'
+  WP_MIN_SUPPORTED_VERSION: '6.0'
+  PHP_MIN_SUPPORTED_VERSION: '7.3'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +23,7 @@ jobs:
         id: generate_matrix
         run: |
           WC_VERSIONS=$( echo "[\"$WC_MIN_SUPPORTED_VERSION\", \"latest\", \"beta\"]" )
-          MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_MIN_SUPPORTED_VERSION\",\"wordpress\":\"$WP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"$GUTENBERG_VERSION_FOR_WP_MIN\",\"php\":\"$PHP_MIN_SUPPORTED_VERSION\"}]" )
+          MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_MIN_SUPPORTED_VERSION\",\"wordpress\":\"$WP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"13.6.0\",\"php\":\"$PHP_MIN_SUPPORTED_VERSION\"}]" )
           echo "matrix={\"woocommerce\":$WC_VERSIONS,\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":[\"7.4\"], \"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
 
   woocommerce-compatibility:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_MIN_SUPPORTED_VERSION: '7.7.0'
+  WC_MIN_SUPPORTED_VERSION: '7.6.0'
   NODE_ENV: 'test'
   FORCE_E2E_DEPS_SETUP: true
 

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -6,9 +6,9 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_MIN_SUPPORTED_VERSION: '7.7.0'
+  WC_MIN_SUPPORTED_VERSION: '7.6.0'
   GUTENBERG_VERSION: latest
-  PHP_MIN_SUPPORTED_VERSION: '7.4'
+  PHP_MIN_SUPPORTED_VERSION: '7.3'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,7 +41,7 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          PHP_VERSIONS=$( echo "[\"$PHP_MIN_SUPPORTED_VERSION\", \"8.0\", \"8.1\"]" )
+          PHP_VERSIONS=$( echo "[\"$PHP_MIN_SUPPORTED_VERSION\", \"7.3\", \"7.4\"]" )
           echo "matrix={\"php\":$PHP_VERSIONS}" >> $GITHUB_OUTPUT
 
   test:

--- a/changelog/dev-bump-min-wc-8-1-php-7-4
+++ b/changelog/dev-bump-min-wc-8-1-php-7-4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump minimum required version of WooCommerce to 7.7 and PHP to 7.4.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "minimum-stability": "dev",
     "config": {
         "platform": {
-            "php": "7.4"
+            "php": "7.3"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.2",
         "ext-json": "*",
         "automattic/jetpack-connection": "1.51.7",
         "automattic/jetpack-config": "1.15.2",

--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -15,8 +15,8 @@
 	<exclude-pattern>tests/</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="6.1" />
-	<config name="testVersion" value="7.4-" />
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="7.3-" />
 
 	<rule ref="PHPCompatibility">
 		<!-- WP has sodium compatibility since https://wordpress.org/support/wordpress-version/version-5-2/ -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,8 +16,8 @@
 	<exclude-pattern>./lib/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="6.1" />
-	<config name="testVersion" value="7.4-" />
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="7.3-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WooPayments - Fully Integrated Solution Built and Supported by Woo ===
 Contributors: woocommerce, automattic
 Tags: payment gateway, payment, apple pay, credit card, google pay, woocommerce payments
-Requires at least: 6.1
-Tested up to: 6.3
-Requires PHP: 7.4
+Requires at least: 6.0
+Tested up to: 6.2
+Requires PHP: 7.3
 Stable tag: 6.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -38,9 +38,9 @@ Our global support team is available to answer questions you may have about WooP
 
 = Requirements =
 
-* WordPress 6.1 or newer.
-* WooCommerce 7.7 or newer.
-* PHP 7.4 or newer is recommended.
+* WordPress 6.0 or newer.
+* WooCommerce 7.6 or newer.
+* PHP 7.3 or newer is recommended.
 
 = Try it now =
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,10 +8,10 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 7.7
- * WC tested up to: 7.9.0
- * Requires at least: 6.1
- * Requires PHP: 7.4
+ * WC requires at least: 7.6
+ * WC tested up to: 7.8.0
+ * Requires at least: 6.0
+ * Requires PHP: 7.3
  * Version: 6.4.1
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This reverts #7134 based on https://github.com/Automattic/woocommerce-payments/pull/7134#issuecomment-1715270236.

#### Testing instructions

Make sure the diff in this PR matches #7134.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.