### PR TITLE
Transaction Details → fix typo in staged dispute challenge notice

### DIFF
--- a/changelog/fix-dispute-staged-evidence-notice-typo
+++ b/changelog/fix-dispute-staged-evidence-notice-typo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Behind feature flag: fix for typo in staged dispute challenge notice.
+
+

--- a/client/payment-details/dispute-details/index.tsx
+++ b/client/payment-details/dispute-details/index.tsx
@@ -46,7 +46,7 @@ const DisputeDetails: React.FC< DisputeDetailsProps > = ( { dispute } ) => {
 										isDismissible={ false }
 									>
 										{ __(
-											`You initiated a dispute a challenge to this dispute. Click 'Continue with challenge' to proceed with your drafted response.`,
+											`You initiated a challenge to this dispute. Click 'Continue with challenge' to proceed with your draft response.`,
 											'woocommerce-payments'
 										) }
 									</InlineNotice>

--- a/client/payment-details/dispute-details/test/index.test.tsx
+++ b/client/payment-details/dispute-details/test/index.test.tsx
@@ -195,9 +195,8 @@ describe( 'DisputeDetails', () => {
 		);
 
 		// Render the staged evidence message
-		screen.getByText(
-			/You initiated a dispute a challenge to this dispute/,
-			{ ignore: '.a11y-speak-region' }
-		);
+		screen.getByText( /You initiated a challenge to this dispute/, {
+			ignore: '.a11y-speak-region',
+		} );
 	} );
 } );


### PR DESCRIPTION
> **Note**
> This PR is behind feature flag `_wcpay_feature_dispute_on_transaction_page`


#### Changes proposed in this Pull Request

This PR corrects the text within the Transaction Details → staged dispute challenge notice, removing the strikethrough text below: 

_You initiated ~a dispute~ a challenge to this dispute. Click 'Continue with challenge' to proceed with your draft~ed~ response._

**Before**
<img width="817" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/77cf8d1d-11a9-4c75-bbd3-8661aed8fb35">


**After**
<img width="759" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/ab541754-5c64-484a-80b5-0830c391a56a">



#### Testing instructions

1. Create a disputed transaction with a staged evidence submission:
	* Enable feature flag by running `update_option( '_wcpay_feature_dispute_on_transaction_page', '1' );` in [WP Console](https://wordpress.org/plugins/wp-console/) or by modifying your database table `wp_options` directly.
	* Create a disputed transaction using the card `4000000000000259` at checkout.
	* Find the dispute in Payments → Disputes and click it to view the dispute details screen.
	* Click **Challenge**.
	* Make a small change to this form and click "Save for Later" to stage the dispute evidence submission.
* Navigate to the Transaction Details screen associated with this dispute.
* You should see the staged dispute evidence notice with the corrected text.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
