### PR TITLE
Improve the logging in the Stripe Billing migration of token data 

### DIFF
--- a/changelog/fix-migrate-subscription-tokens
+++ b/changelog/fix-migrate-subscription-tokens
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This migration code is unreleased and this change isn't noteworthy.
+
+

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -389,11 +389,9 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 	private function verify_subscription_payment_token( $subscription, $wcpay_subscription ) {
 		// If the subscription's payment method isn't set to WooPayments, we skip this token step.
 		if ( $subscription->get_payment_method() !== WC_Payment_Gateway_WCPay::GATEWAY_ID ) {
-			$this->logger->log( sprintf( '---- Skipped verifying the payment token. Subscription #%1$d is no longer set to "woocommerce_payments".', $subscription->get_id() ) );
+			$this->logger->log( sprintf( '---- Skipped verifying the payment token. Subscription #%1$d has "%2$s" as the payment method.', $subscription->get_id(), $subscription->get_payment_method() ) );
 			return;
 		}
-
-		unset( $wcpay_subscription['default_payment_method'] );
 
 		if ( empty( $wcpay_subscription['default_payment_method'] ) ) {
 			$this->logger->log( sprintf( '---- Could not verify the payment method. Stripe Billing subscription (%1$s) does not have a default payment method.', $wcpay_subscription['id'] ?? 'unknown' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR does 2 things:

1. Improve the log when the subscription's payment method isn't WooPayments.
2. Removed erroneous code that unset the subscriptions default payment method before attempting to migrate it.  

#### Testing instructions

* Purchase a subscription using Stripe billing.
* Migrate it using the following code snippet. 
* On `trunk` you'll notice that the migration log includes the `Skipped verifying the payment token....` line.
* On this branch it should successfully migrate the token. 

```php
do_action( 'wcpay_migrate_subscription', 4098 );
```

* Purchase a subscription using Stripe billing.
* Go into the database and change the subscription's `payment_method` meta to `stripe`
* Migrate it using the following code snippet. 
* On this branch you should see this line: 

```
---- Skipped verifying the payment token. Subscription #4098 has "stripe" as the payment method.
```

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
