### PR TITLE
Fix issues when the Stripe Billing `is_migrating()` function would return false if the one of the actions was actively running

### DIFF
--- a/changelog/fix-subscription-migration-in-progress-check
+++ b/changelog/fix-subscription-migration-in-progress-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This change fixes a bug in unreleased code. No changelog entry needed.
+
+

--- a/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-migrator.php
@@ -766,13 +766,13 @@ class WC_Payments_Subscriptions_Migrator extends WCS_Background_Repairer {
 	/**
 	 * Determines if a migration is currently in progress.
 	 *
-	 * A migration is considered to be in progress if either the initial migration action or an individual subscription
-	 * actions are scheduled.
+	 * A migration is considered to be in progress if the initial migration action or an individual subscription
+	 * action (or retry) is scheduled.
 	 *
 	 * @return bool True if a migration is in progress, false otherwise.
 	 */
 	public function is_migrating() {
-		return is_numeric( as_next_scheduled_action( $this->scheduled_hook ) ) || is_numeric( as_next_scheduled_action( $this->migrate_hook ) ) || is_numeric( as_next_scheduled_action( $this->migrate_hook . '_retry' ) );
+		return (bool) as_next_scheduled_action( $this->scheduled_hook ) || (bool) as_next_scheduled_action( $this->migrate_hook ) || (bool) as_next_scheduled_action( $this->migrate_hook . '_retry' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue I came across late last week after testing the Stripe Billing subscription migrator. 

After I pressed the **Begin migration** button on the WooPayments Settings screen. I hit refresh a couple of minutes later and even though the migration hadn't finished yet, the **Begin migration** notice had returned. 

After doing a deep dive I discovered it was because one of the `wcpay_migrate_subscription` actions had the `in-progress` status (ie was actively running at the time the check was made) which caused `as_next_scheduled_action()` return `true` rather than a timestamp which caused the `is_numeric()` checks in `is_migrating()` to return false. 

This PR fixes that by making sure we check for `true` (is running) or an int (is scheduled). 

#### Testing instructions

* Have at least 1 Stripe Billing subscription.
* Simulate a slow site by adding a `sleep( 120 )` into the `WC_Payments_Subscriptions_Migrator::get_items_to_repair()` function.  
* Go to the WooPayments settings screen and disable Stripe Billing. 
    * Note the migration in progress notice will show. 👍 
* Refresh the page. You may need to keep refreshing to wait for Action Scheduler to pick up the job. Running it manually via the list table might also work. 
* On `develop` you should see the **Begin migration** notice appear. Despite the migration is still technically running. 
* On this branch, the in-progress notice should continue to be shown as along as any migration related action is `pending` or `in-progress`.

Video showcasing the bug:
https://github.com/Automattic/woocommerce-payments/assets/8490476/e75188cb-c202-4e6c-8bdf-bca0d18580db

You can also use this code snippet to observe the bug. When the action is `in-progress`, this will echo `true` on this branch and `false` on develop.

```
$stripe_billing_migrator = WC_Payments_Subscriptions::get_stripe_billing_migrator();
var_export( $stripe_billing_migrator->is_migrating() );
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
