### PR TITLE
Prevent WooPay from modifying non-WooPay Webhooks

### DIFF
--- a/changelog/fix-redundant-webhooks-modifications
+++ b/changelog/fix-redundant-webhooks-modifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WooPay-related implementation to modify non-WooPay-specific webhooks by changing their data.

--- a/includes/woopay/class-woopay-order-status-sync.php
+++ b/includes/woopay/class-woopay-order-status-sync.php
@@ -135,6 +135,12 @@ class WooPay_Order_Status_Sync {
 	 * @param integer $id          ID of the webhook.
 	 */
 	public static function create_payload( $payload, $resource, $resource_id, $id ) {
+		$webhook = wc_get_webhook( $id );
+		if ( 0 !== strpos( $webhook->get_delivery_url(), WooPay_Utilities::get_woopay_rest_url( 'merchant-notification' ) ) ) {
+			// This is not a WooPay webhook, so we don't need to modify the payload.
+			return $payload;
+		}
+
 		return [
 			'blog_id'      => \Jetpack_Options::get_option( 'id' ),
 			'order_id'     => $resource_id,


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7219

#### Changes proposed in this Pull Request
This PR introduces a change, that ensures only WooPay-related Webhooks are being processed by `WooPay_Order_Status_Sync`. We create [the custom topic](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/woopay/class-woopay-order-status-sync.php#L105) with [specific delivery URL](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/woopay/class-woopay-order-status-sync.php#L107) so that [order updates are further handled by WooPay](https://github.com/Automattic/woopay/blame/c0e260165f287c828c435a297b2bad0b9d65e6f8/src/Webhook/MerchantWebhookController.php#L78), and we need to make sure that every non-related Webhook coming from `woocommerce_deliver_webhook_async` is filtered out. 


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out `develop` 
2. Reproduce the issue following steps described in https://github.com/Automattic/woocommerce-payments/issues/7219
3. Check out from `fix/redundant-webhooks-modifications`, repeat the steps and confirm the issue is not reproducible anymore
4. Confirm that [the order status update on WooPay](https://github.com/Automattic/woopay/blob/c0e260165f287c828c435a297b2bad0b9d65e6f8/src/Webhook/MerchantWebhookController.php#L78) works as expected
5. Try out different environments to ensure, that regardless of the environment and changing WooPay destination URL, the feature works as expected

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.