### PR TITLE
Transaction Details → Show resolution status footer for inquiries

### DIFF
--- a/changelog/fix-7191-dispute-resolution-footer-inquiries
+++ b/changelog/fix-7191-dispute-resolution-footer-inquiries
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Behind feature flag: Show dispute resolution footer for inquiries under review or closed.
+
+

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -67,7 +67,7 @@ export const isUnderReview = ( status: DisputeStatus | string ): boolean => {
 	return disputeUnderReviewStatuses.includes( status );
 };
 
-export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
+export const isInquiry = ( dispute: Pick< Dispute, 'status' > ): boolean => {
 	// Inquiry dispute statuses are one of `warning_needs_response`, `warning_under_review` or `warning_closed`.
 	return dispute.status.startsWith( 'warning' );
 };
@@ -77,7 +77,7 @@ export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
  * and the deduction has not been reversed.
  */
 const getDisputeDeductedBalanceTransaction = (
-	dispute: Dispute
+	dispute: Pick< Dispute, 'balance_transactions' >
 ): BalanceTransaction | undefined => {
 	// Note that there can only be, at most, two balance transactions for a given dispute:
 
@@ -103,7 +103,7 @@ const getDisputeDeductedBalanceTransaction = (
  * and the deduction has not been reversed.
  */
 export const getDisputeFeeFormatted = (
-	dispute: Dispute,
+	dispute: Pick< Dispute, 'balance_transactions' >,
 	appendCurrencyCode?: boolean
 ): string | undefined => {
 	const disputeFee = getDisputeDeductedBalanceTransaction( dispute );

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -89,121 +89,6 @@ const DisputeUnderReviewFooter: React.FC< {
 	);
 };
 
-const InquiryUnderReviewFooter: React.FC< {
-	dispute: Dispute;
-} > = ( { dispute } ) => {
-	const submissionDateFormatted = dispute.metadata.__evidence_submitted_at
-		? dateI18n(
-				'M j, Y',
-				moment
-					.unix(
-						parseInt( dispute.metadata.__evidence_submitted_at, 10 )
-					)
-					.toISOString()
-		  )
-		: '-';
-
-	return (
-		<CardFooter className="transaction-details-dispute-footer transaction-details-dispute-footer--primary">
-			<Flex justify="space-between">
-				<FlexItem>
-					{ createInterpolateElement(
-						sprintf(
-							/* Translators: %s - formatted date, <a> - link to documentation page */
-							__(
-								'You submitted evidence for this inquiry on %s. The cardholder’s bank is reviewing the case, which can take 120 days or more. You will be alerted when they make their final decision. <a>Learn more</a>.',
-								'woocommerce-payments'
-							),
-							submissionDateFormatted
-						),
-						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Link content is provided by createInterpolateElement
-								<a
-									target="_blank"
-									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries"
-								/>
-							),
-						}
-					) }
-				</FlexItem>
-				<FlexItem className="transaction-details-dispute-footer__actions">
-					<Link
-						href={ getAdminUrl( {
-							page: 'wc-admin',
-							path: '/payments/disputes/challenge',
-							id: dispute?.id,
-						} ) }
-					>
-						<Button
-							variant="secondary"
-							onClick={ () => {
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
-									{
-										dispute_status: dispute.status,
-									}
-								);
-							} }
-						>
-							{ __(
-								'View submitted evidence',
-								'woocommerce-payments'
-							) }
-						</Button>
-					</Link>
-				</FlexItem>
-			</Flex>
-		</CardFooter>
-	);
-};
-
-const InquiryClosedFooter: React.FC< {
-	dispute: Dispute;
-} > = ( { dispute } ) => {
-	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
-		? dateI18n(
-				'M j, Y',
-				moment
-					.unix(
-						parseInt( dispute.metadata.__dispute_closed_at, 10 )
-					)
-					.toISOString()
-		  )
-		: '-';
-
-	return (
-		<CardFooter className="transaction-details-dispute-footer">
-			<Flex justify="space-between">
-				<FlexItem>
-					{ createInterpolateElement(
-						sprintf(
-							/* Translators: %s - formatted date, <a> - link to documentation page */
-							__(
-								'This inquiry was closed on %s. <a>Learn more about preventing disputes</a>.',
-								'woocommerce-payments'
-							),
-							closedDateFormatted
-						),
-						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Link content is provided by createInterpolateElement
-								<a
-									target="_blank"
-									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
-								/>
-							),
-						}
-					) }
-				</FlexItem>
-			</Flex>
-		</CardFooter>
-	);
-};
-
 const DisputeWonFooter: React.FC< {
 	dispute: Dispute;
 } > = ( { dispute } ) => {
@@ -377,6 +262,121 @@ const DisputeLostFooter: React.FC< {
 						</Link>
 					</FlexItem>
 				) }
+			</Flex>
+		</CardFooter>
+	);
+};
+
+const InquiryUnderReviewFooter: React.FC< {
+	dispute: Dispute;
+} > = ( { dispute } ) => {
+	const submissionDateFormatted = dispute.metadata.__evidence_submitted_at
+		? dateI18n(
+				'M j, Y',
+				moment
+					.unix(
+						parseInt( dispute.metadata.__evidence_submitted_at, 10 )
+					)
+					.toISOString()
+		  )
+		: '-';
+
+	return (
+		<CardFooter className="transaction-details-dispute-footer transaction-details-dispute-footer--primary">
+			<Flex justify="space-between">
+				<FlexItem>
+					{ createInterpolateElement(
+						sprintf(
+							/* Translators: %s - formatted date, <a> - link to documentation page */
+							__(
+								'You submitted evidence for this inquiry on %s. The cardholder’s bank is reviewing the case, which can take 120 days or more. You will be alerted when they make their final decision. <a>Learn more</a>.',
+								'woocommerce-payments'
+							),
+							submissionDateFormatted
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Link content is provided by createInterpolateElement
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries"
+								/>
+							),
+						}
+					) }
+				</FlexItem>
+				<FlexItem className="transaction-details-dispute-footer__actions">
+					<Link
+						href={ getAdminUrl( {
+							page: 'wc-admin',
+							path: '/payments/disputes/challenge',
+							id: dispute?.id,
+						} ) }
+					>
+						<Button
+							variant="secondary"
+							onClick={ () => {
+								wcpayTracks.recordEvent(
+									wcpayTracks.events
+										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+									{
+										dispute_status: dispute.status,
+									}
+								);
+							} }
+						>
+							{ __(
+								'View submitted evidence',
+								'woocommerce-payments'
+							) }
+						</Button>
+					</Link>
+				</FlexItem>
+			</Flex>
+		</CardFooter>
+	);
+};
+
+const InquiryClosedFooter: React.FC< {
+	dispute: Dispute;
+} > = ( { dispute } ) => {
+	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
+		? dateI18n(
+				'M j, Y',
+				moment
+					.unix(
+						parseInt( dispute.metadata.__dispute_closed_at, 10 )
+					)
+					.toISOString()
+		  )
+		: '-';
+
+	return (
+		<CardFooter className="transaction-details-dispute-footer">
+			<Flex justify="space-between">
+				<FlexItem>
+					{ createInterpolateElement(
+						sprintf(
+							/* Translators: %s - formatted date, <a> - link to documentation page */
+							__(
+								'This inquiry was closed on %s. <a>Learn more about preventing disputes</a>.',
+								'woocommerce-payments'
+							),
+							closedDateFormatted
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Link content is provided by createInterpolateElement
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+								/>
+							),
+						}
+					) }
+				</FlexItem>
 			</Flex>
 		</CardFooter>
 	);

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -62,7 +62,7 @@ const DisputeUnderReviewFooter: React.FC< {
 						href={ getAdminUrl( {
 							page: 'wc-admin',
 							path: '/payments/disputes/challenge',
-							id: dispute?.id,
+							id: dispute.id,
 						} ) }
 					>
 						<Button
@@ -92,7 +92,7 @@ const DisputeUnderReviewFooter: React.FC< {
 const DisputeWonFooter: React.FC< {
 	dispute: Dispute;
 } > = ( { dispute } ) => {
-	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
+	const closedDateFormatted = dispute.metadata.__dispute_closed_at
 		? dateI18n(
 				'M j, Y',
 				moment
@@ -133,7 +133,7 @@ const DisputeWonFooter: React.FC< {
 						href={ getAdminUrl( {
 							page: 'wc-admin',
 							path: '/payments/disputes/challenge',
-							id: dispute?.id,
+							id: dispute.id,
 						} ) }
 					>
 						<Button
@@ -163,11 +163,11 @@ const DisputeWonFooter: React.FC< {
 const DisputeLostFooter: React.FC< {
 	dispute: Dispute;
 } > = ( { dispute } ) => {
-	const isSubmitted = !! dispute?.metadata.__evidence_submitted_at;
-	const isAccepted = dispute?.metadata.__closed_by_merchant === '1';
+	const isSubmitted = !! dispute.metadata.__evidence_submitted_at;
+	const isAccepted = dispute.metadata.__closed_by_merchant === '1';
 	const disputeFeeFormatted = getDisputeFeeFormatted( dispute, true ) ?? '-';
 
-	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
+	const closedDateFormatted = dispute.metadata.__dispute_closed_at
 		? dateI18n(
 				'M j, Y',
 				moment
@@ -239,7 +239,7 @@ const DisputeLostFooter: React.FC< {
 							href={ getAdminUrl( {
 								page: 'wc-admin',
 								path: '/payments/disputes/challenge',
-								id: dispute?.id,
+								id: dispute.id,
 							} ) }
 						>
 							<Button
@@ -311,7 +311,7 @@ const InquiryUnderReviewFooter: React.FC< {
 						href={ getAdminUrl( {
 							page: 'wc-admin',
 							path: '/payments/disputes/challenge',
-							id: dispute?.id,
+							id: dispute.id,
 						} ) }
 					>
 						<Button
@@ -341,8 +341,8 @@ const InquiryUnderReviewFooter: React.FC< {
 const InquiryClosedFooter: React.FC< {
 	dispute: Dispute;
 } > = ( { dispute } ) => {
-	const isSubmitted = !! dispute?.metadata.__evidence_submitted_at;
-	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
+	const isSubmitted = !! dispute.metadata.__evidence_submitted_at;
+	const closedDateFormatted = dispute.metadata.__dispute_closed_at
 		? dateI18n(
 				'M j, Y',
 				moment
@@ -385,7 +385,7 @@ const InquiryClosedFooter: React.FC< {
 						href={ getAdminUrl( {
 							page: 'wc-admin',
 							path: '/payments/disputes/challenge',
-							id: dispute?.id,
+							id: dispute.id,
 						} ) }
 					>
 						<Button

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -381,36 +381,37 @@ const InquiryClosedFooter: React.FC< {
 						}
 					) }
 				</FlexItem>
-			</Flex>
-			{ isSubmitted && (
-				<FlexItem className="transaction-details-dispute-footer__actions">
-					<Link
-						href={ getAdminUrl( {
-							page: 'wc-admin',
-							path: '/payments/disputes/challenge',
-							id: dispute.id,
-						} ) }
-					>
-						<Button
-							variant="secondary"
-							onClick={ () => {
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
-									{
-										dispute_status: dispute.status,
-									}
-								);
-							} }
+
+				{ isSubmitted && (
+					<FlexItem className="transaction-details-dispute-footer__actions">
+						<Link
+							href={ getAdminUrl( {
+								page: 'wc-admin',
+								path: '/payments/disputes/challenge',
+								id: dispute.id,
+							} ) }
 						>
-							{ __(
-								'View submitted evidence',
-								'woocommerce-payments'
-							) }
-						</Button>
-					</Link>
-				</FlexItem>
-			) }
+							<Button
+								variant="secondary"
+								onClick={ () => {
+									wcpayTracks.recordEvent(
+										wcpayTracks.events
+											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+										{
+											dispute_status: dispute.status,
+										}
+									);
+								} }
+							>
+								{ __(
+									'View submitted evidence',
+									'woocommerce-payments'
+								) }
+							</Button>
+						</Link>
+					</FlexItem>
+				) }
+			</Flex>
 		</CardFooter>
 	);
 };

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -160,6 +160,50 @@ const InquiryUnderReviewFooter: React.FC< {
 	);
 };
 
+const InquiryClosedFooter: React.FC< {
+	dispute: Dispute;
+} > = ( { dispute } ) => {
+	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
+		? dateI18n(
+				'M j, Y',
+				moment
+					.unix(
+						parseInt( dispute.metadata.__dispute_closed_at, 10 )
+					)
+					.toISOString()
+		  )
+		: '-';
+
+	return (
+		<CardFooter className="transaction-details-dispute-footer">
+			<Flex justify="space-between">
+				<FlexItem>
+					{ createInterpolateElement(
+						sprintf(
+							/* Translators: %s - formatted date, <a> - link to documentation page */
+							__(
+								'This inquiry was closed on %s. <a>Learn more about preventing disputes</a>.',
+								'woocommerce-payments'
+							),
+							closedDateFormatted
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content -- Link content is provided by createInterpolateElement
+								<a
+									target="_blank"
+									rel="noopener noreferrer"
+									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+								/>
+							),
+						}
+					) }
+				</FlexItem>
+			</Flex>
+		</CardFooter>
+	);
+};
+
 const DisputeWonFooter: React.FC< {
 	dispute: Dispute;
 } > = ( { dispute } ) => {
@@ -352,6 +396,9 @@ const DisputeResolutionFooter: React.FC< {
 	}
 	if ( dispute.status === 'warning_under_review' ) {
 		return <InquiryUnderReviewFooter dispute={ dispute } />;
+	}
+	if ( dispute.status === 'warning_closed' ) {
+		return <InquiryClosedFooter dispute={ dispute } />;
 	}
 
 	return null;

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -19,7 +19,7 @@ import { getDisputeFeeFormatted } from 'wcpay/disputes/utils';
 import './style.scss';
 
 const DisputeUnderReviewFooter: React.FC< {
-	dispute: Dispute;
+	dispute: Pick< Dispute, 'id' | 'metadata' | 'status' >;
 } > = ( { dispute } ) => {
 	const submissionDateFormatted = dispute.metadata.__evidence_submitted_at
 		? dateI18n(
@@ -90,7 +90,7 @@ const DisputeUnderReviewFooter: React.FC< {
 };
 
 const DisputeWonFooter: React.FC< {
-	dispute: Dispute;
+	dispute: Pick< Dispute, 'id' | 'metadata' | 'status' >;
 } > = ( { dispute } ) => {
 	const closedDateFormatted = dispute.metadata.__dispute_closed_at
 		? dateI18n(
@@ -161,7 +161,10 @@ const DisputeWonFooter: React.FC< {
 };
 
 const DisputeLostFooter: React.FC< {
-	dispute: Dispute;
+	dispute: Pick<
+		Dispute,
+		'id' | 'metadata' | 'status' | 'balance_transactions'
+	>;
 } > = ( { dispute } ) => {
 	const isSubmitted = !! dispute.metadata.__evidence_submitted_at;
 	const isAccepted = dispute.metadata.__closed_by_merchant === '1';
@@ -268,7 +271,7 @@ const DisputeLostFooter: React.FC< {
 };
 
 const InquiryUnderReviewFooter: React.FC< {
-	dispute: Dispute;
+	dispute: Pick< Dispute, 'id' | 'metadata' | 'status' >;
 } > = ( { dispute } ) => {
 	const submissionDateFormatted = dispute.metadata.__evidence_submitted_at
 		? dateI18n(
@@ -339,7 +342,7 @@ const InquiryUnderReviewFooter: React.FC< {
 };
 
 const InquiryClosedFooter: React.FC< {
-	dispute: Dispute;
+	dispute: Pick< Dispute, 'id' | 'metadata' | 'status' >;
 } > = ( { dispute } ) => {
 	const isSubmitted = !! dispute.metadata.__evidence_submitted_at;
 	const closedDateFormatted = dispute.metadata.__dispute_closed_at
@@ -413,7 +416,10 @@ const InquiryClosedFooter: React.FC< {
 };
 
 const DisputeResolutionFooter: React.FC< {
-	dispute: Dispute;
+	dispute: Pick<
+		Dispute,
+		'id' | 'metadata' | 'status' | 'balance_transactions'
+	>;
 } > = ( { dispute } ) => {
 	if ( dispute.status === 'under_review' ) {
 		return <DisputeUnderReviewFooter dispute={ dispute } />;

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -341,6 +341,7 @@ const InquiryUnderReviewFooter: React.FC< {
 const InquiryClosedFooter: React.FC< {
 	dispute: Dispute;
 } > = ( { dispute } ) => {
+	const isSubmitted = !! dispute?.metadata.__evidence_submitted_at;
 	const closedDateFormatted = dispute?.metadata.__dispute_closed_at
 		? dateI18n(
 				'M j, Y',
@@ -378,6 +379,35 @@ const InquiryClosedFooter: React.FC< {
 					) }
 				</FlexItem>
 			</Flex>
+			{ isSubmitted && (
+				<FlexItem className="transaction-details-dispute-footer__actions">
+					<Link
+						href={ getAdminUrl( {
+							page: 'wc-admin',
+							path: '/payments/disputes/challenge',
+							id: dispute?.id,
+						} ) }
+					>
+						<Button
+							variant="secondary"
+							onClick={ () => {
+								wcpayTracks.recordEvent(
+									wcpayTracks.events
+										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+									{
+										dispute_status: dispute.status,
+									}
+								);
+							} }
+						>
+							{ __(
+								'View submitted evidence',
+								'woocommerce-payments'
+							) }
+						</Button>
+					</Link>
+				</FlexItem>
+			) }
 		</CardFooter>
 	);
 };

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -641,13 +641,15 @@ describe( 'PaymentDetailsSummary', () => {
 			charge.disputed = true;
 			charge.dispute = getBaseDispute();
 			charge.dispute.status = 'warning_closed';
-			charge.dispute.metadata.__dispute_closed_at = '1693400000';
+			charge.dispute.metadata.__evidence_submitted_at = '1693400000';
+			charge.dispute.metadata.__dispute_closed_at = '1693453017';
 
 			renderCharge( charge );
 
 			screen.getByText( /This inquiry was closed/i, {
 				ignore: '.a11y-speak-region',
 			} );
+			screen.getByRole( 'button', { name: /View submitted evidence/i } );
 
 			// No actions rendered
 			expect(

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -528,7 +528,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 			renderCharge( charge );
 
-			screen.getByText( /reviewing the case/i, {
+			screen.getByText( /You submitted evidence for this dispute/i, {
 				ignore: '.a11y-speak-region',
 			} );
 			screen.getByRole( 'button', { name: /View submitted evidence/i } );
@@ -595,6 +595,33 @@ describe( 'PaymentDetailsSummary', () => {
 				ignore: '.a11y-speak-region',
 			} );
 			screen.getByRole( 'button', { name: /View dispute details/i } );
+
+			// No actions rendered
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Challenge/i,
+				} )
+			).toBeNull();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Accept/i,
+				} )
+			).toBeNull();
+		} );
+
+		test( 'correctly renders dispute details for "warning_under_review" inquiry disputes', () => {
+			const charge = getBaseCharge();
+			charge.disputed = true;
+			charge.dispute = getBaseDispute();
+			charge.dispute.status = 'warning_under_review';
+			charge.dispute.metadata.__evidence_submitted_at = '1693400000';
+
+			renderCharge( charge );
+
+			screen.getByText( /You submitted evidence for this inquiry/i, {
+				ignore: '.a11y-speak-region',
+			} );
+			screen.getByRole( 'button', { name: /View submitted evidence/i } );
 
 			// No actions rendered
 			expect(

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -635,5 +635,31 @@ describe( 'PaymentDetailsSummary', () => {
 				} )
 			).toBeNull();
 		} );
+
+		test( 'correctly renders dispute details for "warning_closed" inquiry disputes', () => {
+			const charge = getBaseCharge();
+			charge.disputed = true;
+			charge.dispute = getBaseDispute();
+			charge.dispute.status = 'warning_closed';
+			charge.dispute.metadata.__dispute_closed_at = '1693400000';
+
+			renderCharge( charge );
+
+			screen.getByText( /This inquiry was closed/i, {
+				ignore: '.a11y-speak-region',
+			} );
+
+			// No actions rendered
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Challenge/i,
+				} )
+			).toBeNull();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Accept/i,
+				} )
+			).toBeNull();
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #7191 

#### Changes proposed in this Pull Request

This PR adds dispute information to the Transaction Details screen for closed or under review **inquiries**, with a link to the submitted evidence if available.


**Inquiry: Under review**
![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/3e10e1c9-4f08-4162-bdd6-5bd77ca88c27)

**Inquiry: Closed** (challenged)
![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/d6b6c0c8-c53d-4cd0-bc90-2e99f3c3e20d)

**Inquiry: Closed** (accepted)
![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/1e2739d2-2f5e-4921-93d0-de7b4fee5fc4)

**Mobile viewport**
<img width="375" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/090d750c-22a0-46cc-a4a1-f9485880f44d">


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Enable feature flag by running `update_option( '_wcpay_feature_dispute_on_transaction_page', '1' );` in [WP Console](https://wordpress.org/plugins/wp-console/) or by modifying your database table `wp_options` directly.

* **Inquiry: Under review**
	* Create a disputed inquiry transaction using the card `4000000000001976` at checkout.
	* Find the inquiry in Payments → Disputes and click it to view the dispute details screen.
	* Click Challenge and submit the challenge form with arbitrary evidence. This will change the dispute's status from `warning_needs_response` to `warning_under_review`.
	* Navigate to the transaction details screen for this dispute.
	* Notice the dispute resolution footer that matches the screenshot above.
* **Inquiry: Closed** (challenged)
	* Create a disputed inquiry transaction using the card `4000000000001976` at checkout.
	* Find the inquiry in Payments → Disputes and click it to view the dispute details screen.
	* Click Challenge and submit the challenge form **with `winning_evidence` in the “Additional details” field**. This will change the dispute's status from `warning_needs_response` to `warning_closed`.
	* Navigate to the transaction details screen for this dispute.
	* Notice the dispute resolution footer that matches the screenshot above.
* **Inquiry: Closed** (accepted)
	* Create a disputed inquiry transaction using the card `4000000000001976` at checkout.
	* Find the inquiry in Payments → Disputes and click it to view the dispute details screen.
	* Click Accept. This will change the dispute's status from `warning_needs_response` to `warning_closed`.
	* Navigate to the transaction details screen for this dispute.
	* Notice the dispute resolution footer that matches the screenshot above.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
