### PR TITLE
fix: WooPay billing phone fallback

### DIFF
--- a/changelog/fix-woopay-billing-phone-fallback
+++ b/changelog/fix-woopay-billing-phone-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooPay save my info phone number fallback for virtual products

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -51,6 +51,8 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			phoneFieldValue =
 				document.getElementById( 'phone' )?.value ||
 				document.getElementById( 'shipping-phone' )?.value ||
+				// in case of virtual products, the shipping phone is not available. So we also need to check the billing phone.
+				document.getElementById( 'billing-phone' )?.value ||
 				'';
 		} else {
 			// for classic checkout.
@@ -97,7 +99,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		if ( isChecked ) {
 			setPhoneNumber( getPhoneFieldValue() );
 		} else {
-			setPhoneNumber( null );
+			setPhoneNumber( '' );
 			if ( isBlocksCheckout ) {
 				sendExtensionData( true );
 			}
@@ -287,11 +289,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							value={ `${ viewportWidth }x${ viewportHeight }` }
 						/>
 						<PhoneNumberInput
-							value={
-								phoneNumber === null
-									? getPhoneFieldValue()
-									: phoneNumber
-							}
+							value={ phoneNumber }
 							onValueChange={ setPhoneNumber }
 							onValidationChange={ onPhoneValidationChange }
 							inputProps={ {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that when virtual products are added to the cart (and thus the shipping address is not needed) on blocks checkout, and when the "save my info" for WooPay is checked, the phone number isn't autofilled.
This is best shown in the screen capture below:
![2023-09-21 15 08 37](https://github.com/Automattic/woocommerce-payments/assets/273592/30fadf6e-cc96-4174-a220-6fd8d81f5030)


Now, instead, it should be fixed:


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a virtual product to the cart
- Go to the blocks checkout
- Enter a new WooPay email address (i.e.: an email address that doesn't exist on the platform checkout)
- Enter a phone number in the billing section of the checkout
- Click "Save my info" on the WooPay section
- The phone should now be autofilled

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
