### PR TITLE
Payment request buttons - remove hooks from constructors

### DIFF
--- a/changelog/fix-7263-hooks-in-prb
+++ b/changelog/fix-7263-hooks-in-prb
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Removed hooks from payment request button classes
+
+

--- a/dev/phpcs/ruleset.xml
+++ b/dev/phpcs/ruleset.xml
@@ -15,10 +15,6 @@
 	<exclude-pattern>*/includes/woopay-user/*</exclude-pattern>
 	<exclude-pattern>*/includes/class-wc-payments-order-success-page.php</exclude-pattern>
 
-	<!-- https://github.com/Automattic/woocommerce-payments/issues/7263 -->
-	<exclude-pattern>*/includes/class-wc-payments-apple-pay-registration.php</exclude-pattern>
-	<exclude-pattern>*/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php</exclude-pattern>
-
 	<!-- https://github.com/Automattic/woocommerce-payments/issues/7264 -->
 	<exclude-pattern>*/includes/class-wc-payments-customer-service.php</exclude-pattern>
 	<exclude-pattern>*/includes/class-wc-payments-token-service.php</exclude-pattern>

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -440,6 +440,6 @@ class WC_Payments_Apple_Pay_Registration {
 <?php endif; ?>
 			<p><?php echo $check_log_text; /* @codingStandardsIgnoreLine */ ?></p>
 		</div>
-<?php
+		<?php
 	}
 }

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -71,7 +71,14 @@ class WC_Payments_Apple_Pay_Registration {
 		$this->payments_api_client     = $payments_api_client;
 		$this->account                 = $account;
 		$this->gateway                 = $gateway;
+	}
 
+	/**
+	 * Initializes this class's hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'init', [ $this, 'add_domain_association_rewrite_rule' ], 5 );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'verify_domain_on_update' ] );
 		add_action( 'init', [ $this, 'init' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -554,6 +554,7 @@ class WC_Payments {
 		self::maybe_register_woopay_hooks();
 
 		self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
+		self::$apple_pay_registration->init_hooks();
 
 		self::maybe_display_express_checkout_buttons();
 
@@ -1484,6 +1485,7 @@ class WC_Payments {
 			$payment_request_button_handler          = new WC_Payments_Payment_Request_Button_Handler( self::$account, self::get_gateway(), $express_checkout_helper );
 			$woopay_button_handler                   = new WC_Payments_WooPay_Button_Handler( self::$account, self::get_gateway(), self::$woopay_util, $express_checkout_helper );
 			$express_checkout_button_display_handler = new WC_Payments_Express_Checkout_Button_Display_Handler( self::get_gateway(), $payment_request_button_handler, $woopay_button_handler, $express_checkout_helper );
+			$express_checkout_button_display_handler->init();
 		}
 	}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -56,6 +56,12 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 		$this->platform_checkout_button_handler = $platform_checkout_button_handler;
 		$this->express_checkout_helper          = $express_checkout_helper;
 
+	/**
+	 * Initializes this class, its dependencies, and its hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
 		$this->platform_checkout_button_handler->init();
 		$this->payment_request_button_handler->init();
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -113,9 +113,9 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			?>
 			<div class='wcpay-payment-request-wrapper' >
 			<?php
-				if ( ! $this->express_checkout_helper->is_pay_for_order_page() || $this->is_pay_for_order_flow_supported() ) {
-					$this->platform_checkout_button_handler->display_woopay_button_html();
-				}
+			if ( ! $this->express_checkout_helper->is_pay_for_order_page() || $this->is_pay_for_order_flow_supported() ) {
+				$this->platform_checkout_button_handler->display_woopay_button_html();
+			}
 				$this->payment_request_button_handler->display_payment_request_button_html();
 			?>
 			</div >
@@ -155,7 +155,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 
 		$order = wc_get_order( $order_id );
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification
 		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) && current_user_can( 'pay_for_order', $order_id ) ) {
 			add_filter(
 				'wcpay_payment_fields_js_config',
@@ -169,7 +169,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 					}
 
 					// Silence the filter_input warning because we are sanitizing the input with sanitize_email().
-					// nosemgrep: audit.php.lang.misc.filter-input-no-filter
+					// nosemgrep: audit.php.lang.misc.filter-input-no-filter.
 					$user_email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( filter_input( INPUT_POST, 'email' ) ) ) : $session_email;
 
 					$js_config['order_id']      = $order->get_id();
@@ -184,6 +184,6 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 				}
 			);
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification
 	}
 }

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -55,6 +55,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 		$this->payment_request_button_handler   = $payment_request_button_handler;
 		$this->platform_checkout_button_handler = $platform_checkout_button_handler;
 		$this->express_checkout_helper          = $express_checkout_helper;
+	}
 
 	/**
 	 * Initializes this class, its dependencies, and its hooks.

--- a/tests/unit/test-class-wc-payments-apple-pay-registration.php
+++ b/tests/unit/test-class-wc-payments-apple-pay-registration.php
@@ -64,6 +64,7 @@ class WC_Payments_Apple_Pay_Registration_Test extends WCPAY_UnitTestCase {
 			->getMock();
 
 		$this->wc_apple_pay_registration = new WC_Payments_Apple_Pay_Registration( $this->mock_api_client, $this->mock_account, $mock_gateway );
+		$this->wc_apple_pay_registration->init_hooks();
 
 		$this->file_name             = 'apple-developer-merchantid-domain-association';
 		$this->initial_file_contents = file_get_contents( WCPAY_ABSPATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine

--- a/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
@@ -143,6 +143,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler_Test extends WCPAY_Uni
 			->getMock();
 
 			$this->express_checkout_button_display_handler = new WC_Payments_Express_Checkout_Button_Display_Handler( $this->mock_wcpay_gateway, $this->mock_payment_request_button_handler, $this->mock_woopay_button_handler, $this->mock_express_checkout_helper );
+			$this->express_checkout_button_display_handler->init();
 
 		add_filter(
 			'woocommerce_available_payment_gateways',


### PR DESCRIPTION
Fixes #7263 
Based on #7249

#### Changes proposed in this Pull Request

- Add `init_hooks` to the Express Checkout class and Apple Domain Registration
- Updated tests
- Removed the exceptions from the PHPCS ruleset

#### Testing instructions

- Unit tests should pass
- PHPCS should pass
- I did the following myself, so can skip it:
  - `npm run build:deps`
  - `npm run build:release`
  - Upload the resulting zip to an HTTPS enabled site (JN or WPCOM)
  - Enable the payment request buttons
  - Pay with Google Pay or Apple Pay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
