### PR TITLE
Migrate legacy UPE & legacy card users to deferred UPE with fallbacks

### DIFF
--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -71,13 +71,17 @@ const PaymentMethodsDropdownMenu = ( { setOpenModal } ) => {
 
 const UpeSetupBanner = () => {
 	const [ , setIsUpeEnabled ] = useIsUpeEnabled();
+	const { isUpeEnabled, upeType } = useContext( WcPayUpeContext );
 
 	const handleEnableUpeClick = () => {
+		console.log('while enabling, upe type is: ' + upeType);
 		setIsUpeEnabled( true ).then( () => {
-			window.location.href = getAdminUrl( {
-				page: 'wc-admin',
-				path: '/payments/additional-payment-methods',
-			} );
+			if ( upeType === '' ) {
+				window.location.href = getAdminUrl( {
+					page: 'wc-admin',
+					path: '/payments/additional-payment-methods',
+				} );
+			}
 		} );
 	};
 
@@ -89,27 +93,45 @@ const UpeSetupBanner = () => {
 				} ) }
 			>
 				<h3>
-					{ __(
+					{ upeType === 'legacy_after_deferred_intent' && __(
+						'Enable deferred UPE',
+						'woocommerce-payments'
+					)}
+
+					{ ! isUpeEnabled && __(
 						'Enable the new WooPayments checkout experience, which will become the default on November 1, 2023',
 						'woocommerce-payments'
-					) }
+					)}
+
+					{ upeType === 'split' && __(
+						'This is deferred UPE (this header will be removed after DEMO)',
+						'woocommerce-payments'
+					)}
 				</h3>
 				<p>
-					{ __(
+					{ upeType === 'legacy_after_deferred_intent' && __(
+						/* eslint-disable-next-line max-len */
+						'You previously disabled deferred UPE. Maybe it is time to give it another try?',
+						'woocommerce-payments'
+					)}
+
+					{ ! isUpeEnabled && __(
 						/* eslint-disable-next-line max-len */
 						'This will improve the checkout experience and boost sales with access to additional payment methods, which you’ll be able to manage from here in settings.',
 						'woocommerce-payments'
-					) }
+					)}
 				</p>
 
 				<div className="payment-methods__express-checkouts-actions">
 					<span className="payment-methods__express-checkouts-get-started">
-						<Button isSecondary onClick={ handleEnableUpeClick }>
-							{ __(
-								'Enable payment methods',
-								'woocommerce-payments'
-							) }
-						</Button>
+						{ upeType !== 'split' && (
+							<Button isSecondary onClick={ handleEnableUpeClick }>
+								{ __(
+									'Enable payment methods',
+									'woocommerce-payments'
+								) }
+							</Button>	
+						)}
 					</span>
 					<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/">
 						{ __( 'Learn more', 'woocommerce-payments' ) }
@@ -272,11 +294,25 @@ const PaymentMethods = () => {
 								</>
 							) }
 						</h4>
-						<PaymentMethodsDropdownMenu
-							setOpenModal={ setOpenModalIdentifier }
-						/>
+						{ upeType !== 'legacy_after_deferred_intent' && (
+							<PaymentMethodsDropdownMenu
+								setOpenModal={ setOpenModalIdentifier }
+							/>	
+						)}
 					</CardHeader>
 				) }
+
+				{ upeType === 'legacy_after_deferred_intent' && (
+					<CardHeader className="payment-methods__header">
+							<UpeSetupBanner />
+					</CardHeader>
+				)}
+
+				{ upeType === 'split' && (
+					<CardHeader className="payment-methods__header">
+							<UpeSetupBanner />
+					</CardHeader>
+				)}
 
 				{ isUpeEnabled && upeType === 'legacy' && (
 					<CardHeader className="payment-methods__header">

--- a/client/settings/disable-upe-modal/index.js
+++ b/client/settings/disable-upe-modal/index.js
@@ -88,14 +88,22 @@ const DisableUpeModalBody = () => {
 
 const DisableUpeModal = ( { setOpenModal, triggerAfterDisable } ) => {
 	const [ isUpeEnabled, setIsUpeEnabled ] = useIsUpeEnabled();
-	const { status } = useContext( WcPayUpeContext );
+	const { status, upeType } = useContext( WcPayUpeContext );
 
 	useEffect( () => {
-		if ( ! isUpeEnabled ) {
+		console.log(' upe type is: ' + upeType );
+		if ( status === 'pending') {
 			setOpenModal( '' );
 			triggerAfterDisable();
 		}
-	}, [ isUpeEnabled, setOpenModal, triggerAfterDisable ] );
+// 
+		// if ( isUpeEnabled && upeType === 'legacy_after_deferred_intent' ) {
+		// 	setOpenModal( '' );
+		// 	triggerAfterDisable();
+		// }
+
+		
+	}, [ isUpeEnabled, setOpenModal, triggerAfterDisable, status, upeType ] );
 
 	useEffect( () => {
 		if ( status === 'error' ) {

--- a/client/settings/wcpay-upe-toggle/provider.js
+++ b/client/settings/wcpay-upe-toggle/provider.js
@@ -27,11 +27,6 @@ const WcPayUpeContextProvider = ( {
 	const [ , setEnabledPaymentMethods ] = useEnabledPaymentMethodIds();
 	const { updateAvailablePaymentMethodIds } = useDispatch( STORE_NAME );
 
-	useState( () => {
-		console.log( 'timka: ' + upeType );
-	}
-	, [ upeType ] );
-
 	const updateFlag = useCallback(
 		( value ) => {
 			setStatus( 'pending' );
@@ -54,8 +49,8 @@ const WcPayUpeContextProvider = ( {
 							setIsUpeEnabled( true );
 						}
 					}
-					
-					// down 
+
+					// down
 					if ( ! value ) {
 						if ( upeType === 'deferred_upe_from_legacy_card' ) {
 							// fallback to card
@@ -63,12 +58,12 @@ const WcPayUpeContextProvider = ( {
 							setIsUpeEnabled( false );
 							updateAvailablePaymentMethodIds( [ 'card' ] );
 							setEnabledPaymentMethods( [ 'card' ] );
-						} 
+						}
 
-						if ( upeType ==='deferred_upe_from_legacy_upe' ) {
+						if ( upeType === 'deferred_upe_from_legacy_upe' ) {
 							// fallback to upe
 							setUpeType( 'legacy_after_deferred_intent' );
-							setIsUpeEnabled( true ); 
+							setIsUpeEnabled( true );
 						}
 					}
 
@@ -92,7 +87,7 @@ const WcPayUpeContextProvider = ( {
 			setStatus,
 			setIsUpeEnabled,
 			setUpeType,
-			upeType, 
+			upeType,
 			setEnabledPaymentMethods,
 			updateAvailablePaymentMethodIds,
 		]

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -136,7 +136,7 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 		}
 
 		// If the legacy UPE flag has been enabled, we need to disable the legacy UPE flag.
-		if ( '1' === get_option( WC_Payments_Features::UPE_FLAG_NAME ) ) {
+		if ( '1' === get_option( WC_Payments_Features::UPE_FLAG_NAME ) && '0' === get_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME ) ) {
 			update_option( WC_Payments_Features::UPE_FLAG_NAME, 'disabled' );
 
 			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -73,6 +73,18 @@ class WC_Payments_Features {
 	 * Checks whether the Split UPE with deferred intent is enabled
 	 */
 	public static function is_upe_deferred_intent_enabled() {
+		$deferred_intent_creation_upe_flag_value = get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, 0 );
+
+		// legacy UPE users in past which were migrated to dUPE and then went back to legacy UPE. This group should not be forced back to dUPE.
+		if ( self::is_upe_legacy_enabled() && 'disabled' === $deferred_intent_creation_upe_flag_value ) {
+			return false;
+		}
+
+		// legacy UPE users who never used dUPE and thus should be forced to dUPE.
+		if ( self::is_upe_legacy_enabled() && 0 === $deferred_intent_creation_upe_flag_value ) {
+			return true;
+		}
+
 		return ( '1' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' ) ) || self::is_upe_split_enabled();
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/7220

A few more commits will follow to apply the feedback from paJDYF-9xf-p2#comment-20862 as well as clean up the code. 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.