### PR TITLE
Add correct inquiry docs link to active dispute/inquiry notice in transactions screen

### DIFF
--- a/changelog/fix-7241-update-live-dispute-docs-links-in-transaction-detail
+++ b/changelog/fix-7241-update-live-dispute-docs-links-in-transaction-detail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update documentation links (new/changed docs content) when notifying merchant that a dispute needs response.

--- a/changelog/fix-7241-update-live-dispute-docs-links-in-transaction-detail
+++ b/changelog/fix-7241-update-live-dispute-docs-links-in-transaction-detail
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Update documentation links (new/changed docs content) when notifying merchant that a dispute needs response.
+Comment: Behind a feature flag: Update documentation links (new/changed docs content) when notifying merchant that a dispute needs response.

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -70,7 +70,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 				<CardBody className="transaction-details-dispute-details-body">
 					<DisputeNotice
 						dispute={ dispute }
-						urgent={ countdownDays <= 2 }
+						isUrgent={ countdownDays <= 2 }
 					/>
 					{ hasStagedEvidence && (
 						<InlineNotice icon={ edit } isDismissible={ false }>

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -26,11 +26,7 @@ import type { Dispute } from 'wcpay/types/disputes';
 import type { ChargeBillingDetails } from 'wcpay/types/charges';
 import wcpayTracks from 'tracks';
 import { useDisputeAccept } from 'wcpay/data';
-import {
-	getDisputeFeeFormatted,
-	isAwaitingResponse,
-	isInquiry,
-} from 'wcpay/disputes/utils';
+import { getDisputeFeeFormatted, isInquiry } from 'wcpay/disputes/utils';
 import { getAdminUrl } from 'wcpay/utils';
 import DisputeNotice from './dispute-notice';
 import IssuerEvidenceList from './evidence-list';

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -64,13 +64,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 			{ createInterpolateElement(
 				sprintf( noticeText, shopperDisputeReason ),
 				{
-					a: (
-						<ExternalLink
-							target="_blank"
-							rel="noopener noreferrer"
-							href={ learnMoreDocsUrl }
-						/>
-					),
+					a: <ExternalLink href={ learnMoreDocsUrl } />,
 					strong: <strong />,
 				}
 			) }

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -18,12 +18,12 @@ import { isInquiry } from 'wcpay/disputes/utils';
 
 interface DisputeNoticeProps {
 	dispute: Dispute;
-	urgent: boolean;
+	isUrgent: boolean;
 }
 
 const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 	dispute,
-	urgent,
+	isUrgent,
 } ) => {
 	const clientClaim =
 		reasons[ dispute.reason ]?.claim ??
@@ -33,7 +33,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 		);
 
 	const noticeText = isInquiry( dispute )
-		? /* translators: <a> link to dispute documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
+		? /* translators: <a> link to dispute inquiry documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
 		  __(
 				// eslint-disable-next-line max-len
 				'<strong>%s</strong> You can challenge their claim if you believe it’s invalid. Not responding will result in an automatic loss. <a>Learn more</a>',
@@ -49,7 +49,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 	return (
 		<InlineNotice
 			icon
-			status={ urgent ? 'error' : 'warning' }
+			status={ isUrgent ? 'error' : 'warning' }
 			className="dispute-notice"
 			isDismissible={ false }
 		>

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -25,26 +25,30 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 	dispute,
 	isUrgent,
 } ) => {
-	const clientClaim =
+	const shopperDisputeReason =
 		reasons[ dispute.reason ]?.claim ??
 		__(
 			'The cardholder claims this is an unrecognized charge.',
 			'woocommerce-payments'
 		);
 
-	const noticeText = isInquiry( dispute )
-		? /* translators: <a> link to dispute inquiry documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
-		  __(
-				// eslint-disable-next-line max-len
-				'<strong>%s</strong> You can challenge their claim if you believe it’s invalid. Not responding will result in an automatic loss. <a>Learn more</a>',
-				'woocommerce-payments'
-		  )
-		: /* translators: <a> link to dispute documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
-		  __(
-				// eslint-disable-next-line max-len
-				'<strong>%s</strong> Challenge the dispute if you believe the claim is invalid, or accept to forfeit the funds and pay the dispute fee. Non-response will result in an automatic loss. <a>Learn more about responding to disputes</a>',
-				'woocommerce-payments'
-		  );
+	/* translators: <a> link to dispute documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
+	let noticeText = __(
+		'<strong>%s</strong> Challenge the dispute if you believe the claim is invalid, ' +
+		'or accept to forfeit the funds and pay the dispute fee. ' +
+		'Non-response will result in an automatic loss. <a>Learn more about responding to disputes</a>',
+		'woocommerce-payments'
+	);
+	let learnMoreDocsUrl = 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#section-3';
+
+	if ( isInquiry( dispute ) ) {
+		/* translators: <a> link to dispute inquiry documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
+		noticeText = __(
+			'<strong>%s</strong> You can challenge their claim if you believe it’s invalid. ' +
+			'Not responding will result in an automatic loss. <a>Learn more</a>',
+			'woocommerce-payments'
+		)
+	}
 
 	return (
 		<InlineNotice
@@ -53,13 +57,13 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 			className="dispute-notice"
 			isDismissible={ false }
 		>
-			{ createInterpolateElement( sprintf( noticeText, clientClaim ), {
+			{ createInterpolateElement( sprintf( noticeText, shopperDisputeReason ), {
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#section-3"
+						href={ learnMoreDocsUrl }
 					/>
 				),
 				strong: <strong />,

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**
@@ -64,8 +65,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 				sprintf( noticeText, shopperDisputeReason ),
 				{
 					a: (
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						<a
+						<ExternalLink
 							target="_blank"
 							rel="noopener noreferrer"
 							href={ learnMoreDocsUrl }

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -35,19 +35,22 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 	/* translators: <a> link to dispute documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
 	let noticeText = __(
 		'<strong>%s</strong> Challenge the dispute if you believe the claim is invalid, ' +
-		'or accept to forfeit the funds and pay the dispute fee. ' +
-		'Non-response will result in an automatic loss. <a>Learn more about responding to disputes</a>',
+			'or accept to forfeit the funds and pay the dispute fee. ' +
+			'Non-response will result in an automatic loss. <a>Learn more about responding to disputes</a>',
 		'woocommerce-payments'
 	);
-	let learnMoreDocsUrl = 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#section-3';
+	let learnMoreDocsUrl =
+		'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding';
 
 	if ( isInquiry( dispute ) ) {
 		/* translators: <a> link to dispute inquiry documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
 		noticeText = __(
 			'<strong>%s</strong> You can challenge their claim if you believe it’s invalid. ' +
-			'Not responding will result in an automatic loss. <a>Learn more</a>',
+				'Not responding will result in an automatic loss. <a>Learn more about payment inquiries</a>',
 			'woocommerce-payments'
-		)
+		);
+		learnMoreDocsUrl =
+			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries';
 	}
 
 	return (
@@ -57,17 +60,20 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 			className="dispute-notice"
 			isDismissible={ false }
 		>
-			{ createInterpolateElement( sprintf( noticeText, shopperDisputeReason ), {
-				a: (
-					// eslint-disable-next-line jsx-a11y/anchor-has-content
-					<a
-						target="_blank"
-						rel="noopener noreferrer"
-						href={ learnMoreDocsUrl }
-					/>
-				),
-				strong: <strong />,
-			} ) }
+			{ createInterpolateElement(
+				sprintf( noticeText, shopperDisputeReason ),
+				{
+					a: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="noopener noreferrer"
+							href={ learnMoreDocsUrl }
+						/>
+					),
+					strong: <strong />,
+				}
+			) }
 		</InlineNotice>
 	);
 };


### PR DESCRIPTION
Fixes #7241

#### Changes proposed in this Pull Request
This PR updates the docs links in the "you have a dispute you need to respond to" notice displayed in the transaction detail screen.

There are two links, one for disputes and one for inquiries (aka pre-dispute inquiries).

- https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding
- https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries

This PR also adds the "external link" icon since these docs are not in a modal/popup or hosted on merhant's store. This also gives a clue that they will open in a new tab/window, which can be confusing (especially on mobile).

#### And some refactoring
I've done some light refactoring to clarify the code while here. Will add inline review comments to explain. Happy to revert if this is disruptive.

#### Testing instructions
1. As shopper, in WooPayments test mode, purchase a product with one of the [dispute test cards](https://stripe.com/docs/testing#disputes).
2. As merchant, go to `Dashboard > Transactions` and click on the relevant transaction row to view details. 
3. Ensure the notice is displayed as appropriate, with correct dispute reason/claim, urgency level, and docs link.

Example screenshots:
![Screenshot 2023-09-25 at 3 31 35 PM](https://github.com/Automattic/woocommerce-payments/assets/4167300/91e9d85c-5552-4024-b129-a1e71b80f1c1)


-------------------
![Screenshot 2023-09-25 at 3 31 28 PM](https://github.com/Automattic/woocommerce-payments/assets/4167300/d6b26db1-f13f-4d5d-acd3-cc020b157435)

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
