### PR TITLE
Enable deferred intent UPE for legacy UPE merchants

### DIFF
--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -39,7 +39,6 @@ import DisableUPEModal from '../settings/disable-upe-modal';
 import PaymentMethodsList from 'components/payment-methods-list';
 import PaymentMethod from 'components/payment-methods-list/payment-method';
 import WCPaySettingsContext from '../settings/wcpay-settings-context';
-import Pill from '../components/pill';
 import methodsConfiguration from '../payment-methods-map';
 import CardBody from '../settings/card-body';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
@@ -271,17 +270,6 @@ const PaymentMethods = () => {
 									'woocommerce-payments'
 								) }
 							</span>
-							{ upeType !== 'split' && (
-								<>
-									{ ' ' }
-									<Pill>
-										{ __(
-											'Early access',
-											'woocommerce-payments'
-										) }
-									</Pill>
-								</>
-							) }
 						</h4>
 						<PaymentMethodsDropdownMenu
 							setOpenModal={ setOpenModalIdentifier }

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -46,8 +46,6 @@ import ConfirmPaymentMethodActivationModal from './activation-modal';
 import ConfirmPaymentMethodDeleteModal from './delete-modal';
 import { getAdminUrl } from 'wcpay/utils';
 import { getPaymentMethodDescription } from 'wcpay/utils/payment-methods';
-import InlineNotice from 'wcpay/components/inline-notice';
-import interpolateComponents from '@automattic/interpolate-components';
 
 const PaymentMethodsDropdownMenu = ( { setOpenModal } ) => {
 	const { isUpeEnabled, upeType } = useContext( WcPayUpeContext );
@@ -233,7 +231,7 @@ const PaymentMethods = () => {
 		featureFlags: { upeSettingsPreview: isUpeSettingsPreviewEnabled },
 	} = useContext( WCPaySettingsContext );
 
-	const { isUpeEnabled, status, upeType } = useContext( WcPayUpeContext );
+	const { isUpeEnabled, status } = useContext( WcPayUpeContext );
 	const [ openModalIdentifier, setOpenModalIdentifier ] = useState( '' );
 
 	return (
@@ -274,30 +272,6 @@ const PaymentMethods = () => {
 						<PaymentMethodsDropdownMenu
 							setOpenModal={ setOpenModalIdentifier }
 						/>
-					</CardHeader>
-				) }
-
-				{ isUpeEnabled && upeType === 'legacy' && (
-					<CardHeader className="payment-methods__header">
-						<InlineNotice
-							icon
-							status="warning"
-							isDismissible={ false }
-						>
-							{ interpolateComponents( {
-								mixedString: __(
-									'The new WooPayments checkout experience will become the default on October 11, 2023.' +
-										' {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-									'woocommerce-payments'
-								),
-								components: {
-									learnMoreLink: (
-										// eslint-disable-next-line max-len
-										<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#popular-payment-methods" />
-									),
-								},
-							} ) }
-						</InlineNotice>
 					</CardHeader>
 				) }
 

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -51,20 +51,31 @@ import InlineNotice from 'wcpay/components/inline-notice';
 import interpolateComponents from '@automattic/interpolate-components';
 
 const PaymentMethodsDropdownMenu = ( { setOpenModal } ) => {
+	const { isUpeEnabled, upeType } = useContext( WcPayUpeContext );
+	const isDisablePossible = isUpeEnabled && upeType !== 'deferred_intent_upe';
+	const label = isDisablePossible
+		? __( 'Add feedback or disable', 'woocommerce-payments' )
+		: __( 'Add feedback', 'woocommerce-payments' );
+
+	const buttons = [
+		{
+			title: __( 'Provide feedback', 'woocommerce-payments' ),
+			onClick: () => setOpenModal( 'survey' ),
+		},
+	];
+
+	if ( isDisablePossible ) {
+		buttons.push( {
+			title: 'Disable',
+			onClick: () => setOpenModal( 'disable' ),
+		} );
+	}
+
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
-			label={ __( 'Add feedback or disable', 'woocommerce-payments' ) }
-			controls={ [
-				{
-					title: __( 'Provide feedback', 'woocommerce-payments' ),
-					onClick: () => setOpenModal( 'survey' ),
-				},
-				{
-					title: 'Disable',
-					onClick: () => setOpenModal( 'disable' ),
-				},
-			] }
+			label={ label }
+			controls={ buttons }
 		/>
 	);
 };

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -424,7 +424,7 @@ describe( 'PaymentMethods', () => {
 		expect( disableUPEButton ).toBeInTheDocument();
 		expect(
 			screen.queryByText( 'Payment methods' ).parentElement
-		).toHaveTextContent( 'Payment methods Early access' );
+		).toHaveTextContent( 'Payment methods' );
 	} );
 
 	test( 'Does not render the feedback elements when UPE is disabled', () => {

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -484,6 +484,48 @@ describe( 'PaymentMethods', () => {
 		);
 	} );
 
+	it( 'should only be able to leave feedback when deferred upe is enabled', () => {
+		render(
+			<WcPayUpeContextProvider
+				defaultIsUpeEnabled={ true }
+				defaultUpeType={ 'deferred_intent_upe' }
+			>
+				<PaymentMethods />
+			</WcPayUpeContextProvider>
+		);
+		const kebabMenuWithFeedbackOnly = screen.queryByRole( 'button', {
+			name: 'Add feedback',
+		} );
+
+		const kebabMenuWithFeedbackAndDisable = screen.queryByRole( 'button', {
+			name: 'Add feedback or disable',
+		} );
+
+		expect( kebabMenuWithFeedbackOnly ).toBeInTheDocument();
+		expect( kebabMenuWithFeedbackAndDisable ).not.toBeInTheDocument();
+	} );
+
+	it( 'should be able to leave feedback and disable for non-deferred-upe', () => {
+		render(
+			<WcPayUpeContextProvider
+				defaultIsUpeEnabled={ true }
+				defaultUpeType={ 'legacy' }
+			>
+				<PaymentMethods />
+			</WcPayUpeContextProvider>
+		);
+		const kebabMenuWithFeedbackOnly = screen.queryByRole( 'button', {
+			name: 'Add feedback',
+		} );
+
+		const kebabMenuWithFeedbackAndDisable = screen.queryByRole( 'button', {
+			name: 'Add feedback or disable',
+		} );
+
+		expect( kebabMenuWithFeedbackAndDisable ).toBeInTheDocument();
+		expect( kebabMenuWithFeedbackOnly ).not.toBeInTheDocument();
+	} );
+
 	it( 'should render the activation modal when requirements exist for the payment method', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( [ [], jest.fn() ] );
 		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'bancontact' ] );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1600,11 +1600,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	protected function get_metadata_from_order( $order, $payment_type ) {
 		if ( $this instanceof UPE_Split_Payment_Gateway ) {
-			$gateway_type = 'split_upe';
+			$gateway_type = 'split_upe_with_deferred_intent_creation';
 		} elseif ( $this instanceof UPE_Payment_Gateway ) {
-			$gateway_type = 'upe';
+			$gateway_type = 'legacy_upe';
 		} else {
-			$gateway_type = 'classic';
+			$gateway_type = 'legacy_card';
 		}
 		$name     = sanitize_text_field( $order->get_billing_first_name() ) . ' ' . sanitize_text_field( $order->get_billing_last_name() );
 		$email    = sanitize_email( $order->get_billing_email() );

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -38,8 +38,12 @@ class WC_Payments_Features {
 	 * @return string
 	 */
 	public static function get_enabled_upe_type() {
-		if ( self::is_upe_split_enabled() || self::is_upe_deferred_intent_enabled() ) {
+		if ( self::is_upe_split_enabled() ) {
 			return 'split';
+		}
+
+		if ( self::is_upe_deferred_intent_enabled() ) {
+			return 'deferred_intent_upe';
 		}
 
 		if ( self::is_upe_legacy_enabled() ) {

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -55,8 +55,10 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_upe_legacy_enabled() {
-		$upe_flag_value = '1' === get_option( self::UPE_FLAG_NAME, '0' );
-		if ( $upe_flag_value ) {
+		$upe_flag_value           = '1' === get_option( self::UPE_FLAG_NAME, '0' );
+		$is_deferred_upe_disabled = 'disabled' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
+
+		if ( $upe_flag_value && $is_deferred_upe_disabled ) {
 			return true;
 		}
 		return false;
@@ -73,7 +75,10 @@ class WC_Payments_Features {
 	 * Checks whether the Split UPE with deferred intent is enabled
 	 */
 	public static function is_upe_deferred_intent_enabled() {
-		return ( '1' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' ) ) || self::is_upe_split_enabled();
+		$is_upe_legacy_enabled    = '1' === get_option( self::UPE_FLAG_NAME, '0' );
+		$is_deferred_upe_disabled = 'disabled' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
+
+		return ( '1' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' ) ) || self::is_upe_split_enabled() || ( $is_upe_legacy_enabled && ! $is_deferred_upe_disabled );
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/7220

#### Changes proposed in this Pull Request
This PR
* Enables deferred intent creation UPE for legacy UPE merchants
* Removes the _Disable_ button from the kebab menu with deferred intent UPE and ensures only feedback form is available
* `refactor`: removes redundant _Early access_ pill for the legacy UPE
* `refactor`: removes the text about the upcoming deferred UPE, which was previously shown in legacy UPE stores

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To disable deferred intent creation UPE, add the following code snippet.
1. Check out `develop`, navigate to WCPay Dev Tools, and enable `legacy UPE` only
2. Perform a payment, and in the payment details on Stripe, confirm that `gateway_type` equals `legacy_upe`
3. Without changing anything, check out `feat/legacy_upe_migration_to_deferred_upe`
4. Place an order and confirm that `gateway_type` in Stripe payment details equals to `split_upe_with_deferred_intent_creation`



#### Testing fallback scenario
In case anything wrong happens, we want to ensure merchants are able to roll back to their previous gateway setting fast. To achieve this, the following code needs to be added (possibly through `Code snippets`)

```php

add_filter( 'pre_option__wcpay_feature_upe_deferred_intent', function ( $v ) {
	// ensures that once the next version of WCPay is released, this filter can be automaically be ignored
	if ( version_compare( WCPAY_VERSION_NUMBER, '6.6.0', '<' ) ) {
		return 'disabled';
	}

	return $v;
}, 100 );
```


1. Apply the above code snippet
2. Perform a payment and confirm the `gateway_type` is `legacy_upe` now
3. On the Settings page, confirm you don't see the notice for legacy UPE users introduced in https://github.com/Automattic/woocommerce-payments/pull/7210, as it's not relevant anymore
4. On the Settings page, confirm the _Early access_ pill disappeared, as it's not relevant anymore

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
