### PR TITLE
revert changes to fix payment method title

### DIFF
--- a/changelog/fix-incorrect-payment-method-title
+++ b/changelog/fix-incorrect-payment-method-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix incorrect payment method title for non-WooPayments gateways

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1167,17 +1167,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * Sets the payment method title on the order for emails.
 	 *
 	 * @param WC_Order $order   WC Order object.
-	 *
-	 * @return void
 	 */
 	public function set_payment_method_title_for_email( $order ) {
-		$payment_method_id = $this->order_service->get_payment_method_id_for_order( $order );
-		if ( ! $payment_method_id ) {
-			$order->set_payment_method_title( $this->title );
-			$order->save();
-
-			return;
-		}
+		$payment_method_id      = $this->order_service->get_payment_method_id_for_order( $order );
 		$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
 		$payment_method_type    = $this->get_payment_method_type_from_payment_details( $payment_method_details );
 		$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );


### PR DESCRIPTION
This reverts commit f9d55c6b9ccafc74f3dd39d8033771b3370c8a6e.

Fixes https://github.com/Automattic/woocommerce-payments/issues/7273
Fixes https://github.com/Automattic/woocommerce-payments/issues/7272

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable Cash On Delivery and WooPayments
- As a customer, add any product to the cart
- Select Cash On Delivery as payment method
- Checkout
- On the Order Confirmation page, ensure the correct payment method title is set

Before:
![tJ9e4g.png](https://github.com/Automattic/woocommerce-payments/assets/273592/4faa1111-f837-4e8f-9831-b8a47daeaa67)

After:
![BXGgqI.png](https://github.com/Automattic/woocommerce-payments/assets/273592/5db92589-d9eb-4d5f-b640-72de3ab57eae)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.