### PR TITLE
Fraud Services - Remove hooks from constructor

### DIFF
--- a/changelog/dev-7261-remove-hooks-from-fraud-services-constructor
+++ b/changelog/dev-7261-remove-hooks-from-fraud-services-constructor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Move fraud related service hooks out of class constructors and into new init_hooks methods.

--- a/changelog/fix-7191-dispute-resolution-footer-inquiries
+++ b/changelog/fix-7191-dispute-resolution-footer-inquiries
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Behind feature flag: Show dispute resolution footer for inquiries under review or closed.
+
+

--- a/changelog/fix-woopay-billing-phone-fallback
+++ b/changelog/fix-woopay-billing-phone-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooPay save my info phone number fallback for virtual products

--- a/changelog/fix-woopay-multiple-redirects
+++ b/changelog/fix-woopay-multiple-redirects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WooPay multiple redirect requests.

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -26,6 +26,7 @@ export default class WCPayAPI {
 		this.stripe = null;
 		this.stripePlatform = null;
 		this.request = request;
+		this.isWooPayRequesting = false;
 	}
 
 	createStripe( publishableKey, locale, accountId = '', betas = [] ) {
@@ -688,13 +689,18 @@ export default class WCPayAPI {
 	}
 
 	initWooPay( userEmail, woopayUserSession ) {
-		const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
-		const nonce = getConfig( 'initWooPayNonce' );
-		return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
-			_wpnonce: nonce,
-			email: userEmail,
-			user_session: woopayUserSession,
-		} );
+		if ( ! this.isWooPayRequesting ) {
+			this.isWooPayRequesting = true;
+			const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
+			const nonce = getConfig( 'initWooPayNonce' );
+			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
+				_wpnonce: nonce,
+				email: userEmail,
+				user_session: woopayUserSession,
+			} ).finally( () => {
+				this.isWooPayRequesting = false;
+			} );
+		}
 	}
 
 	expressCheckoutAddToCart( productData ) {

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -6,7 +6,9 @@ import request from 'wcpay/checkout/utils/request';
 import { buildAjaxURL } from 'wcpay/payment-request/utils';
 import { getConfig } from 'wcpay/utils/checkout';
 
-jest.mock( 'wcpay/checkout/utils/request', () => jest.fn() );
+jest.mock( 'wcpay/checkout/utils/request', () =>
+	jest.fn( () => Promise.resolve( {} ).finally( () => {} ) )
+);
 jest.mock( 'wcpay/payment-request/utils', () => ( {
 	buildAjaxURL: jest.fn(),
 } ) );
@@ -15,17 +17,30 @@ jest.mock( 'wcpay/utils/checkout', () => ( {
 } ) );
 
 describe( 'WCPayAPI', () => {
-	test( 'initializes woopay using config params', () => {
+	test( 'does not initialize woopay if already requesting', async () => {
 		buildAjaxURL.mockReturnValue( 'https://example.org/' );
 		getConfig.mockReturnValue( 'foo' );
 
 		const api = new WCPayAPI( {}, request );
-		api.initWooPay( 'foo@bar.com', 'qwerty123' );
+		api.isWooPayRequesting = true;
+		await api.initWooPay( 'foo@bar.com', 'qwerty123' );
+
+		expect( request ).not.toHaveBeenCalled();
+		expect( api.isWooPayRequesting ).toBe( true );
+	} );
+
+	test( 'initializes woopay using config params', async () => {
+		buildAjaxURL.mockReturnValue( 'https://example.org/' );
+		getConfig.mockReturnValue( 'foo' );
+
+		const api = new WCPayAPI( {}, request );
+		await api.initWooPay( 'foo@bar.com', 'qwerty123' );
 
 		expect( request ).toHaveBeenLastCalledWith( 'https://example.org/', {
 			_wpnonce: 'foo',
 			email: 'foo@bar.com',
 			user_session: 'qwerty123',
 		} );
+		expect( api.isWooPayRequesting ).toBe( false );
 	} );
 } );

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -51,6 +51,8 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			phoneFieldValue =
 				document.getElementById( 'phone' )?.value ||
 				document.getElementById( 'shipping-phone' )?.value ||
+				// in case of virtual products, the shipping phone is not available. So we also need to check the billing phone.
+				document.getElementById( 'billing-phone' )?.value ||
 				'';
 		} else {
 			// for classic checkout.
@@ -97,7 +99,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		if ( isChecked ) {
 			setPhoneNumber( getPhoneFieldValue() );
 		} else {
-			setPhoneNumber( null );
+			setPhoneNumber( '' );
 			if ( isBlocksCheckout ) {
 				sendExtensionData( true );
 			}
@@ -287,11 +289,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							value={ `${ viewportWidth }x${ viewportHeight }` }
 						/>
 						<PhoneNumberInput
-							value={
-								phoneNumber === null
-									? getPhoneFieldValue()
-									: phoneNumber
-							}
+							value={ phoneNumber }
 							onValueChange={ setPhoneNumber }
 							onValidationChange={ onPhoneValidationChange }
 							inputProps={ {

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -67,7 +67,7 @@ export const isUnderReview = ( status: DisputeStatus | string ): boolean => {
 	return disputeUnderReviewStatuses.includes( status );
 };
 
-export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
+export const isInquiry = ( dispute: Pick< Dispute, 'status' > ): boolean => {
 	// Inquiry dispute statuses are one of `warning_needs_response`, `warning_under_review` or `warning_closed`.
 	return dispute.status.startsWith( 'warning' );
 };
@@ -77,7 +77,7 @@ export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
  * and the deduction has not been reversed.
  */
 const getDisputeDeductedBalanceTransaction = (
-	dispute: Dispute
+	dispute: Pick< Dispute, 'balance_transactions' >
 ): BalanceTransaction | undefined => {
 	// Note that there can only be, at most, two balance transactions for a given dispute:
 
@@ -103,7 +103,7 @@ const getDisputeDeductedBalanceTransaction = (
  * and the deduction has not been reversed.
  */
 export const getDisputeFeeFormatted = (
-	dispute: Dispute,
+	dispute: Pick< Dispute, 'balance_transactions' >,
 	appendCurrencyCode?: boolean
 ): string | undefined => {
 	const disputeFee = getDisputeDeductedBalanceTransaction( dispute );

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -634,7 +634,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 			renderCharge( charge );
 
-			screen.getByText( /reviewing the case/i, {
+			screen.getByText( /You submitted evidence for this dispute/i, {
 				ignore: '.a11y-speak-region',
 			} );
 			screen.getByRole( 'button', { name: /View submitted evidence/i } );
@@ -706,6 +706,61 @@ describe( 'PaymentDetailsSummary', () => {
 
 			// No actions or steps rendered
 			expect( screen.queryByText( /Steps to resolve/i ) ).toBeNull();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Challenge/i,
+				} )
+			).toBeNull();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Accept/i,
+				} )
+			).toBeNull();
+		} );
+
+		test( 'correctly renders dispute details for "warning_under_review" inquiry disputes', () => {
+			const charge = getBaseCharge();
+			charge.disputed = true;
+			charge.dispute = getBaseDispute();
+			charge.dispute.status = 'warning_under_review';
+			charge.dispute.metadata.__evidence_submitted_at = '1693400000';
+
+			renderCharge( charge );
+
+			screen.getByText( /You submitted evidence for this inquiry/i, {
+				ignore: '.a11y-speak-region',
+			} );
+			screen.getByRole( 'button', { name: /View submitted evidence/i } );
+
+			// No actions rendered
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Challenge/i,
+				} )
+			).toBeNull();
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Accept/i,
+				} )
+			).toBeNull();
+		} );
+
+		test( 'correctly renders dispute details for "warning_closed" inquiry disputes', () => {
+			const charge = getBaseCharge();
+			charge.disputed = true;
+			charge.dispute = getBaseDispute();
+			charge.dispute.status = 'warning_closed';
+			charge.dispute.metadata.__evidence_submitted_at = '1693400000';
+			charge.dispute.metadata.__dispute_closed_at = '1693453017';
+
+			renderCharge( charge );
+
+			screen.getByText( /This inquiry was closed/i, {
+				ignore: '.a11y-speak-region',
+			} );
+			screen.getByRole( 'button', { name: /View submitted evidence/i } );
+
+			// No actions rendered
 			expect(
 				screen.queryByRole( 'button', {
 					name: /Challenge/i,

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -50,7 +50,14 @@ class WC_Payments_Fraud_Service {
 		$this->payments_api_client = $payments_api_client;
 		$this->customer_service    = $customer_service;
 		$this->account             = $account;
+	}
 
+	/**
+	 * Initializes this class's hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_filter( 'wcpay_prepare_fraud_config', [ $this, 'prepare_fraud_config' ], 10, 2 );
 		add_action( 'init', [ $this, 'link_session_if_user_just_logged_in' ] );
 		add_action( 'admin_print_footer_scripts', [ $this, 'add_sift_js_tracker' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -491,6 +491,8 @@ class WC_Payments {
 
 		( new WooPay_Scheduler( self::$api_client ) )->init();
 
+		self::$fraud_service->init_hooks();
+
 		self::$legacy_card_gateway = new CC_Payment_Gateway( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, self::$failed_transaction_rate_limiter, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service );
 
 		$payment_method_classes = [
@@ -627,7 +629,8 @@ class WC_Payments {
 			$wcpay_status = new WC_Payments_Status( self::get_gateway(), self::get_wc_payments_http(), self::get_account_service() );
 			$wcpay_status->init_hooks();
 
-			new WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box( self::$order_service );
+			$wcpay_order_frt_meta_box = new WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box( self::$order_service );
+			$wcpay_order_frt_meta_box->init_hooks();
 		}
 
 		// Load Stripe Billing subscription integration.

--- a/includes/fraud-prevention/class-fraud-risk-tools.php
+++ b/includes/fraud-prevention/class-fraud-risk-tools.php
@@ -48,6 +48,7 @@ class Fraud_Risk_Tools {
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new self( WC_Payments::get_account_service() );
+			self::$instance->init_hooks();
 		}
 		return self::$instance;
 	}
@@ -66,6 +67,14 @@ class Fraud_Risk_Tools {
 	 */
 	public function __construct( WC_Payments_Account $payments_account ) {
 		$this->payments_account = $payments_account;
+	}
+
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_menu', [ $this, 'init_advanced_settings_page' ] );
 		}

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -30,9 +30,16 @@ class Order_Fraud_And_Risk_Meta_Box {
 	 * @param WC_Payments_Order_Service $order_service The order service.
 	 */
 	public function __construct( WC_Payments_Order_Service $order_service ) {
-		add_action( 'add_meta_boxes', [ $this, 'maybe_add_meta_box' ] );
-
 		$this->order_service = $order_service;
+	}
+
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_action( 'add_meta_boxes', [ $this, 'maybe_add_meta_box' ] );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-fraud-service.php
+++ b/tests/unit/test-class-wc-payments-fraud-service.php
@@ -51,6 +51,7 @@ class WC_Payments_Fraud_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_account          = $this->createMock( WC_Payments_Account::class );
 
 		$this->fraud_service = new WC_Payments_Fraud_Service( $this->mock_api_client, $this->mock_customer_service, $this->mock_account );
+		$this->fraud_service->init_hooks();
 	}
 
 	public function test_registers_filters_and_actions_properly() {


### PR DESCRIPTION
Fixes #7261 

Currently based on PR #7249 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Remove hooks from Fraud Services related constructors. Move hooks to new `init_hooks` methods.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR moves hooks from the Fraud Services related constructors to new `init_hooks` methods. This PR also updates all calls to call these method. The following classes were updated:

- `Fraud_Risk_Tools`
- `WC_Payments_Fraud_Service`
- `Order_Fraud_And_Risk_Meta_Box`

Calls to instantiate these classes as objects were updated to include calls to `init_hooks` in:

- `WC_Payments`
- `WC_Payments_Fraud_Service_Test`

All changes related to fraud services were made in commit https://github.com/Automattic/woocommerce-payments/pull/7283/commits/e6099210333cda47a2be1e3a2fb046510199d2bc.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* All tests should pass.
* Add this patch to include some helpful log lines that are written to your client's `debug.log` file while testing these changes: [pr7283.patch](https://github.com/Automattic/woocommerce-payments/files/12731267/pr7283.patch).

#### Testing `Fraud_Risk_Tools`

- The only hook that is moved is the one that initializes the advanced fraud rules page. So verify that you can reach that page on your local: http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ffraud-protection.
- You should also see the following entry in the `debug.log` file: Registering the Fraud & Risk Tools Advanced Settings Page.

#### Testing `WC_Payments_Fraud_Service`

- Three hooks' callbacks need to be verified:
  - `prepare_fraud_config`
  - `link_session_if_user_just_logged_in`
  - `add_sift_js_tracker`
- To test the first two, in a browser window login as one of your test customer accounts, add an item to the cart, then go to the checkout page. Then look at your debug log and you should see at least one instance of each of the following two lines (you will see more of the first one as it hooks into `init`):
  - `link_session_if_user_just_logged_in`
  - `prepare_fraud_config`
- To test `add_sift_js_tracker`, simply click around to admin pages that aren't WCPay admin pages. They should see a line logged each time they click to a new page. Also check the elements tab in your browser inspector to see that `WC_Payments_Fraud_Service->add_sift_js_tracker()` is present in a table row for the `print_admin_footer_scripts`.

#### Testing `Order_Fraud_And_Risk_Meta_Box`

- Only one hook is moved to init_hooks: `maybe_add_meta_box`
- To test, click into an order in the admin and they should see the fraud and risk meta box on the right sidebar and the line following line should log to `debug.log`: Adding wcpay_order_fraud_and_risk_meta_box.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.