### PR TITLE
Fix incorrect payment method title

### DIFF
--- a/changelog/fix-7272-incorrect-payment-method-title
+++ b/changelog/fix-7272-incorrect-payment-method-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix incorrect payment method title for non-WooPayments gateways

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1173,7 +1173,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	public function set_payment_method_title_for_email( $order ) {
 		$payment_gateway = wc_get_payment_gateway_by_order( $order );
 
-		if ( self::GATEWAY_ID !== $payment_gateway->id || ! WC_Payments_Features::is_upe_legacy_enabled() ) {
+		if ( ! empty( $payment_gateway ) && self::GATEWAY_ID !== $payment_gateway->id || ! WC_Payments_Features::is_upe_legacy_enabled() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1171,13 +1171,21 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return void
 	 */
 	public function set_payment_method_title_for_email( $order ) {
+		$payment_gateway = wc_get_payment_gateway_by_order( $order );
+
+		if ( self::GATEWAY_ID !== $payment_gateway->id || ! WC_Payments_Features::is_upe_legacy_enabled() ) {
+			return;
+		}
+
 		$payment_method_id = $this->order_service->get_payment_method_id_for_order( $order );
+
 		if ( ! $payment_method_id ) {
 			$order->set_payment_method_title( $this->title );
 			$order->save();
 
 			return;
 		}
+
 		$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
 		$payment_method_type    = $this->get_payment_method_type_from_payment_details( $payment_method_details );
 		$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );


### PR DESCRIPTION
Fixes #7272
Fixes #7273 

#### Changes proposed in this Pull Request

This prevents the payment method title from being updated for non-WooPayments gateways and limits those updates to the Legacy UPE gateway.

#### Testing instructions

- Enable Cash On Delivery and WooPayments
- As a customer, add any product to the cart
- Select Cash On Delivery as payment method
- Checkout
- On the Order Confirmation page, ensure the correct payment method title is set

Before:
<img src="https://github.com/Automattic/woocommerce-payments/assets/3473953/ba1836f2-6d2e-4358-a22c-710c8ff46854" width="400" />

After:
<img src="https://github.com/Automattic/woocommerce-payments/assets/3473953/22a6ff14-1734-445a-961d-fad8057823b3" width="400" />

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
