### PR TITLE
Add different PO congrats message when account is not complete

### DIFF
--- a/changelog/update-6569-customize-success-banner-message-account-status
+++ b/changelog/update-6569-customize-success-banner-message-account-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Adapt the PO congratulations card copy for pending account status.

--- a/client/overview/connection-sucess-notice.tsx
+++ b/client/overview/connection-sucess-notice.tsx
@@ -15,7 +15,11 @@ const ConnectionSuccessNotice: React.FC = () => {
 
 	const {
 		accountStatus: {
-			progressiveOnboarding: { isComplete, isEnabled },
+			progressiveOnboarding: {
+				isEnabled: isPoEnabled,
+				isComplete: isPoComplete,
+			},
+			status: accountStatus,
 		},
 		onboardingTestMode,
 	} = wcpaySettings;
@@ -41,9 +45,9 @@ const ConnectionSuccessNotice: React.FC = () => {
 		<Card className="wcpay-connection-success">
 			{ /* Show dismiss button only at the end of Progressive Onboarding //
 			or at the end of the full KYC flow. */ }
-			{ ! ( isEnabled && ! isComplete ) && <DismissMenu /> }
+			{ ! ( isPoEnabled && ! isPoComplete ) && <DismissMenu /> }
 			<img src={ ConfettiImage } alt="confetti" />
-			{ isEnabled && ! isComplete ? (
+			{ isPoEnabled && ! isPoComplete ? (
 				<>
 					<h2>
 						{ __(
@@ -60,12 +64,21 @@ const ConnectionSuccessNotice: React.FC = () => {
 				</>
 			) : (
 				<>
-					<h2>
-						{ __(
-							'Congratulations! Your store has been verified.',
-							'woocommerce-payments'
-						) }
-					</h2>
+					{ accountStatus !== 'complete' ? (
+						<h2>
+							{ __(
+								'Congratulations! Your store is being verified.',
+								'woocommerce-payments'
+							) }
+						</h2>
+					) : (
+						<h2>
+							{ __(
+								'Congratulations! Your store has been verified.',
+								'woocommerce-payments'
+							) }
+						</h2>
+					) }
 				</>
 			) }
 		</Card>


### PR DESCRIPTION
Fixes #6569 

#### Changes proposed in this Pull Request

When the account status is not yet `complete`, the copy of the PO congratulations card changes from `Congratulations! Your store has been verified.` to `Congratulations! Your store is being verified.`:

![Screenshot 2023-09-26 at 12 55 10](https://github.com/Automattic/woocommerce-payments/assets/8830539/00ffa708-a978-4ab6-8d14-f0e9ade6d663)

#### Testing instructions

* Checkout the PR branch on your local client installation
* Build the client by running `npm run build:client`
* Apply [this patch](https://gist.github.com/vladolaru/aeaa3d8116975eb190f75fa4d0c0b35d) with `curl https://gist.githubusercontent.com/vladolaru/aeaa3d8116975eb190f75fa4d0c0b35d/raw/8764a6df64864d9dac628df4afa3b2ffb3642f83/po_account_enabled_not_complete_no_dev_test_mode_complete_status.patch | git apply` to modify the data sent to JS to make your setup ready to display the congratulations card.
* Go to http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview&wcpay-connection-success=1 and you should see the regular congrats card:
![Screenshot 2023-09-26 at 13 03 29](https://github.com/Automattic/woocommerce-payments/assets/8830539/7c605248-0b48-492d-b330-ab5e31a5dda6)
* Reset your local client code with `git reset --hard HEAD`
* Apply [this patch](https://gist.github.com/vladolaru/2c3f0a4f8296b3891656b1cc79127f31) with `curl https://gist.githubusercontent.com/vladolaru/2c3f0a4f8296b3891656b1cc79127f31/raw/f2bbcd2a2d84ffe2a92a3b5e0611dad9a6d52819/po_account_enabled_not_complete_no_dev_test_mode_pending_status.patch | git apply` to modify the data sent to JS to make your setup display the modified congratulations card.
* Go to http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview&wcpay-connection-success=1 and you should see the modified congrats card:
![Screenshot 2023-09-26 at 12 55 10](https://github.com/Automattic/woocommerce-payments/assets/8830539/417abd4b-ec8b-4d8a-b20f-8dabe1bf3d47)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
