### PR TITLE
Add the feature flag check for pay-for-order flow

### DIFF
--- a/changelog/add-feature-flag-check-for-pay-for-order-flow
+++ b/changelog/add-feature-flag-check-for-pay-for-order-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add the feature flag check for pay-for-order flow

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -58,11 +58,6 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 21 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}
-
-		if ( class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '10.8.0', '>=' ) ) {
-			add_action( 'wp_enqueue_scripts', [ $this, 'add_pay_for_order_params_to_js_config' ], 5 );
-			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
-		}
 	}
 
 	/**

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -58,6 +58,11 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 21 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}
+
+		if ( WC_Payments_Features::is_pay_for_order_flow_enabled() && class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '11.1.0', '>=' ) ) {
+			add_action( 'wp_enqueue_scripts', [ $this, 'add_pay_for_order_params_to_js_config' ], 5 );
+			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -22,6 +22,7 @@ class WC_Payments_Features {
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
 	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
 	const DISPUTE_ON_TRANSACTION_PAGE       = '_wcpay_feature_dispute_on_transaction_page';
+	const PAY_FOR_ORDER_FLOW                = '_wcpay_feature_pay_for_order_flow';
 
 	/**
 	 * Checks whether any UPE gateway is enabled.
@@ -363,6 +364,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the pay for order flow is enabled
+	 *
+	 * @return bool
+	 */
+	public static function is_pay_for_order_flow_enabled() {
+		return '1' === get_option( '_wcpay_feature_pay_for_order_flow', '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -382,6 +392,7 @@ class WC_Payments_Features {
 				'isAuthAndCaptureEnabled'           => self::is_auth_and_capture_enabled(),
 				'progressiveOnboarding'             => self::is_progressive_onboarding_enabled(),
 				'isDisputeOnTransactionPageEnabled' => self::is_dispute_on_transaction_page_enabled(),
+				'isPayForOrderFlowEnabled'          => self::is_pay_for_order_flow_enabled(),
 			]
 		);
 	}

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -369,7 +369,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_pay_for_order_flow_enabled() {
-		return '1' === get_option( '_wcpay_feature_pay_for_order_flow', '0' );
+		return '1' === get_option( self::PAY_FOR_ORDER_FLOW, '0' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the feature flag check for pay-for-order flow.  Due to WooCommerce `8.2` doesn't include the order and checkout order endpoints in WooCommerce Blocks.  When WooPay upgrades WooCommerce to `8.3`, which includes the two endpoints in WooCommerce Blocks `11.2.0`, we can remove the feature flag check.



#### Testing instructions
1. Test with [this PR](100-gh-Automattic/woocommerce-payments-dev-tools)
2. Test both enable and disable the pay-for-order flow for WooPay
3. Create a pay-for-order order (ex. WooCommerce Pre-Orders)
4. Go through the payment process

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.