### PR TITLE
Added setup_future_usage parameter

### DIFF
--- a/changelog/add-7304-payment-intent-add-future-usage
+++ b/changelog/add-7304-payment-intent-add-future-usage
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added setup_future_usage to payment_intent

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2181,6 +2181,7 @@ class WC_Payments_API_Client {
 		$processing             = $intention_array[ Intent_Status::PROCESSING ] ?? [];
 		$payment_method_types   = $intention_array['payment_method_types'] ?? [];
 		$payment_method_options = $intention_array['payment_method_options'] ?? [];
+		$setup_future_usage     = $intention_array['setup_future_usage'] ?? null;
 
 		$charge = ! empty( $charge_array ) ? self::deserialize_charge_object_from_array( $charge_array ) : null;
 		$order  = $this->get_order_info_from_intention_object( $intention_array['id'] );
@@ -2201,7 +2202,8 @@ class WC_Payments_API_Client {
 			$processing,
 			$payment_method_types,
 			$payment_method_options,
-			$order
+			$order,
+			$setup_future_usage
 		);
 
 		return $intent;

--- a/includes/wc-payment-api/models/class-wc-payments-api-payment-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-payment-intention.php
@@ -47,6 +47,14 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 	 */
 	private $processing;
 
+
+	/**
+	 * The future setup usage of the payment method.
+	 *
+	 * @var string
+	 */
+	private $setup_future_usage;
+
 	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
@@ -66,6 +74,7 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 	 * @param array                  $payment_method_types - An array containing the possible payment methods for the intent.
 	 * @param array                  $payment_method_options - An array containing the payment method options for the intent.
 	 * @param array                  $order                - An array containing the order data associated with this intention.
+	 * @param string                 $setup_future_usage   - Indicates whether the associated payment method can be used to make future payments.
 	 */
 	public function __construct(
 		$id,
@@ -83,7 +92,8 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 		$processing = [],
 		$payment_method_types = [],
 		$payment_method_options = [],
-		$order = []
+		$order = [],
+		$setup_future_usage = null
 	) {
 		$this->id                     = $id;
 		$this->amount                 = $amount;
@@ -101,6 +111,7 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 		$this->payment_method_types   = $payment_method_types;
 		$this->payment_method_options = $payment_method_options;
 		$this->order                  = $order;
+		$this->setup_future_usage     = $setup_future_usage;
 	}
 
 	/**
@@ -149,6 +160,16 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 	}
 
 	/**
+	 * Returns the future setup usage of this intention
+	 *
+	 * @return string
+	 */
+	public function get_setup_future_usage() {
+		return $this->setup_future_usage;
+	}
+
+
+	/**
 	 * Defines which data will be serialized to JSON
 	 */
 	public function jsonSerialize(): array {
@@ -165,6 +186,7 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 			'processing'           => $this->get_processing(),
 			'status'               => $this->get_status(),
 			'order'                => $this->get_order(),
+			'setup_future_usage'   => $this->get_setup_future_usage(),
 		];
 	}
 }


### PR DESCRIPTION
Fixes #7304 

#### Changes proposed in this Pull Request

Adds  `setup_future_usage` parameter to payment_intents API.

#### Testing instructions
``curl https://<site>/wp-json/wc/v3/payments/payment_intents/<pi_> -u <customer_key>:<customer_secret>``

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] n/a - Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
