### PR TITLE
Add correct TS interface for `charge.dispute`

### DIFF
--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -52,7 +52,7 @@ export const useDispute = (
  * Does not return or fetch the dispute object.
  */
 export const useDisputeAccept = (
-	dispute: Dispute
+	dispute: Pick< Dispute, 'id' | 'payment_intent' >
 ): {
 	doAccept: () => void;
 	isLoading: boolean;

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -22,8 +22,7 @@ import {
 /**
  * Internal dependencies
  */
-import type { Dispute } from 'wcpay/types/disputes';
-import type { ChargeBillingDetails } from 'wcpay/types/charges';
+import type { ChargeBillingDetails, ChargeDispute } from 'wcpay/types/charges';
 import wcpayTracks from 'tracks';
 import { useDisputeAccept } from 'wcpay/data';
 import { getDisputeFeeFormatted, isInquiry } from 'wcpay/disputes/utils';
@@ -36,7 +35,7 @@ import InlineNotice from 'components/inline-notice';
 import './style.scss';
 
 interface Props {
-	dispute: Dispute;
+	dispute: ChargeDispute;
 	customer: ChargeBillingDetails | null;
 	chargeCreated: number;
 }

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -14,11 +14,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import './style.scss';
 import InlineNotice from 'components/inline-notice';
 import { reasons } from 'wcpay/disputes/strings';
-import { Dispute } from 'wcpay/types/disputes';
+import type { Dispute } from 'wcpay/types/disputes';
 import { isInquiry } from 'wcpay/disputes/utils';
 
 interface DisputeNoticeProps {
-	dispute: Dispute;
+	dispute: Pick< Dispute, 'reason' | 'status' >;
 	isUrgent: boolean;
 }
 

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -15,14 +15,13 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import type { Dispute } from 'wcpay/types/disputes';
-import { ChargeBillingDetails } from 'wcpay/types/charges';
+import type { ChargeBillingDetails, ChargeDispute } from 'wcpay/types/charges';
 import { formatExplicitCurrency } from 'utils/currency';
 import { ClickTooltip } from 'wcpay/components/tooltip';
 import { getDisputeFeeFormatted } from 'wcpay/disputes/utils';
 
 interface Props {
-	dispute: Dispute;
+	dispute: ChargeDispute;
 	customer: ChargeBillingDetails | null;
 	chargeCreated: number;
 	daysRemaining: number;

--- a/client/payment-details/dispute-details/dispute-summary-row.tsx
+++ b/client/payment-details/dispute-details/dispute-summary-row.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import type { Dispute } from 'wcpay/types/disputes';
+import type { ChargeDispute } from 'wcpay/types/charges';
 import { HorizontalList } from 'wcpay/components/horizontal-list';
 import { formatCurrency } from 'wcpay/utils/currency';
 import { reasons } from 'wcpay/disputes/strings';
@@ -22,7 +22,7 @@ import { ClickTooltip } from 'wcpay/components/tooltip';
 import Paragraphs from 'wcpay/components/paragraphs';
 
 interface Props {
-	dispute: Dispute;
+	dispute: ChargeDispute;
 	daysRemaining: number;
 }
 

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -11,8 +11,7 @@ import '@wordpress/jest-console';
 /**
  * Internal dependencies
  */
-import type { Charge } from 'wcpay/types/charges';
-import type { Dispute } from 'wcpay/types/disputes';
+import type { Charge, ChargeDispute } from 'wcpay/types/charges';
 import PaymentDetailsSummary from '../';
 import { useAuthorization } from 'wcpay/data';
 import { paymentIntentMock } from 'wcpay/data/payment-intents/test/hooks';
@@ -96,7 +95,7 @@ const getBaseCharge = (): Charge =>
 		},
 	} as any );
 
-const getBaseDispute = (): Dispute =>
+const getBaseDispute = (): ChargeDispute =>
 	( {
 		id: 'dp_1',
 		amount: 2000,
@@ -129,7 +128,7 @@ const getBaseDispute = (): Dispute =>
 		payment_intent: 'pi_1',
 		reason: 'fraudulent',
 		status: 'needs_response',
-	} as Dispute );
+	} as ChargeDispute );
 
 const getBaseMetadata = () => ( {
 	platform: 'ios',
@@ -304,7 +303,7 @@ describe( 'PaymentDetailsSummary', () => {
 						reporting_category: 'dispute',
 					},
 				],
-			} as Dispute,
+			} as ChargeDispute,
 		};
 
 		renderCharge( charge );

--- a/client/types/charges.d.ts
+++ b/client/types/charges.d.ts
@@ -51,6 +51,10 @@ export type OutcomeRiskLevel =
 	| 'not_assessed'
 	| 'unknown';
 
+interface ChargeDispute extends Dispute {
+	charge: string;
+}
+
 export interface Charge {
 	id: string;
 	amount: number;
@@ -62,7 +66,7 @@ export interface Charge {
 	captured?: boolean;
 	created: number;
 	currency: string;
-	dispute?: null | Dispute;
+	dispute?: null | ChargeDispute;
 	disputed: boolean;
 	order: null | OrderDetails;
 	outcome: null | {

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -98,7 +98,7 @@ export interface Dispute {
 	issuer_evidence: IssuerEvidence | null;
 	fileSize?: Record< string, number >;
 	reason: DisputeReason;
-	charge: Charge | string;
+	charge: Charge;
 	amount: number;
 	currency: string;
 	created: number;

--- a/client/utils/charge/index.ts
+++ b/client/utils/charge/index.ts
@@ -17,7 +17,7 @@ const failedOutcomeTypes = [ 'issuer_declined', 'invalid' ];
 const blockedOutcomeTypes = [ 'blocked' ];
 
 export const getDisputeStatus = (
-	dispute: null | Dispute = <Dispute>{}
+	dispute: null | Pick< Dispute, 'status' > = <Dispute>{}
 ): string => dispute?.status || '';
 
 export const getChargeOutcomeType = ( charge: Charge = <Charge>{} ): string =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our interfaces for Disputes are not 100% accurate:

* When fetching a charge, `charge.dispute.charge: string` 
* When fetching a dispute, `dispute.charge: Charge`

Currently, we use `Dispute` as the interface for both of these response types.

This PR introduces a `ChargeDispute` interface for `charge.dispute` objects.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
