### PR TITLE
Add tests for set_payment_method_title_for_email function

### DIFF
--- a/changelog/dev-7285-test-payment-method-title
+++ b/changelog/dev-7285-test-payment-method-title
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Adding a few unit tests
+
+

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -1455,6 +1455,37 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_set_payment_method_title_for_email_updates_title() {
+		$mock_visa_details = [
+			'type' => 'card',
+			'card' => [
+				'network' => 'visa',
+				'funding' => 'debit',
+			],
+		];
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_payment_method_id_for_order' )
+			->will(
+				$this->returnValue( 'pm_XXXXXXX' )
+			);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_payment_method' )
+			->will(
+				$this->returnValue( $mock_visa_details )
+			);
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->set_payment_method_title( 'Popular Payment Methods' );
+
+		$this->mock_upe_gateway->set_payment_method_title_for_email( $order );
+		$this->assertEquals( 'Visa debit card', $order->get_payment_method_title() );
+	}
+
 	public function test_correct_payment_method_title_for_order_when_set_for_email() {
 		$payment_methods = [
 			'cheque' => 'Check payments',

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -93,11 +93,11 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	private $mock_rate_limiter;
 
 	/**
-	 * WC_Payments_Order_Service.
+	 * Mock WC_Payments_Order_Service.
 	 *
-	 * @var WC_Payments_Order_Service
+	 * @var WC_Payments_Order_Service|PHPUnit_Framework_MockObject_MockObject
 	 */
-	private $order_service;
+	private $mock_order_service;
 
 	/**
 	 * Array of mock UPE payment methods.
@@ -240,7 +240,18 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			$this->mock_payment_methods[ $mock_payment_method->get_id() ] = $mock_payment_method;
 		}
 
-		$this->order_service = new WC_Payments_Order_Service( $this->mock_api_client );
+		$this->mock_order_service = $this->getMockBuilder( WC_Payments_Order_Service::class )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+				]
+			)
+			->setMethods(
+				[
+					'get_payment_method_id_for_order',
+				]
+			)
+			->getMock();
 
 		// Arrange: Mock UPE_Payment_Gateway so that some of its methods can be
 		// mocked, and their return values can be used for testing.
@@ -254,7 +265,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_action_scheduler_service,
 					$this->mock_payment_methods,
 					$this->mock_rate_limiter,
-					$this->order_service,
+					$this->mock_order_service,
 					$this->mock_dpps,
 					$this->mock_localization_service,
 				]
@@ -1444,6 +1455,58 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_correct_payment_method_title_for_order_when_set_for_email() {
+		$payment_methods = [
+			'cheque' => 'Check payments',
+			'cod'    => 'Cash on delivery',
+			'bacs'   => 'Direct bank transfer',
+		];
+
+		// Emulates order creation which sets the payment method and title.
+		$order = WC_Helper_Order::create_order();
+
+		foreach ( $payment_methods as $method => $title ) {
+			$order->set_payment_method( $method );
+			$order->set_payment_method_title( $title );
+
+			$this->mock_upe_gateway->set_payment_method_title_for_email( $order );
+			$this->assertEquals( $title, $order->get_payment_method_title() );
+		}
+	}
+
+	public function test_set_payment_method_title_for_email_fallback() {
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_payment_method_id_for_order' )
+			->will(
+				$this->returnValue( '' )
+			);
+
+			$order = WC_Helper_Order::create_order();
+			$order->set_payment_method( 'woocommerce_payments' );
+			$order->set_payment_method_title( 'Popular Payment Methods' );
+
+			$this->mock_upe_gateway->set_payment_method_title_for_email( $order );
+			$this->assertEquals( 'WooPayments', $order->get_payment_method_title() );
+	}
+
+	public function test_set_payment_method_title_for_email_only_runs_for_legacy_upe() {
+		update_option( '_wcpay_feature_upe', '0' );
+		update_option( '_wcpay_feature_upe_split', '1' );
+
+		// set_payment_method_title_for_email should return before this functions runs.
+		$this->mock_order_service
+			->expects( $this->never() )
+			->method( 'get_payment_method_id_for_order' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->set_payment_method_title( 'Credit / Debit Card' );
+
+		$this->mock_upe_gateway->set_payment_method_title_for_email( $order );
+		$this->assertEquals( 'Credit / Debit Card', $order->get_payment_method_title() );
+	}
+
 	public function test_payment_methods_show_correct_default_outputs() {
 		$mock_token = WC_Helper_Token::create_token( 'pm_mock' );
 		$this->mock_token_service->expects( $this->any() )
@@ -1978,7 +2041,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_action_scheduler_service,
 					$this->mock_payment_methods,
 					$this->mock_rate_limiter,
-					$this->order_service,
+					$this->mock_order_service,
 					$this->mock_dpps,
 					$this->mock_localization_service,
 				]
@@ -2027,7 +2090,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_action_scheduler_service,
 					$this->mock_payment_methods,
 					$this->mock_rate_limiter,
-					$this->order_service,
+					$this->mock_order_service,
 					$this->mock_dpps,
 					$this->mock_localization_service,
 				]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds unit tests for the [`set_payment_method_title_for_email`](https://github.com/Automattic/woocommerce-payments/blob/ed2a18f74ab15ac1e0d7189f7904f8fc8c30d3ff/includes/payment-methods/class-upe-payment-gateway.php#L1178) function. A [recent issue](https://github.com/Automattic/woocommerce-payments/issues/7272) prompted some validation be added to the function and these tests cover those additions. These tests required mocking the `WC_Payments_Order_Service` class which was the only dependency of `UPE_Payment_Gateway` left to be mocked in the `UPE_Payment_Gateway_Test` tests.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that all tests are passing. Specifically, the `UPE_Payment_Gateway_Test` tests. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
