### PR TITLE
Fixed the version check regex to allow major versions > 9

### DIFF
--- a/.github/actions/version-check/action.yml
+++ b/.github/actions/version-check/action.yml
@@ -29,9 +29,9 @@ runs:
         TRIMMED_VERSION=$(echo "$VERSION" | xargs) 
 
         if ${{ env.IS_PRERELEASE == 'true' }}; then
-          VERSION_FORMAT="^[0-9]+\.[0-9]\.[0-9]-test-[1-9]$"
+          VERSION_FORMAT="^[0-9]+\.[0-9]\.[0-9]+-test-[1-9]$"
         else
-          VERSION_FORMAT="^[0-9]+\.[0-9]\.[0-9]$"
+          VERSION_FORMAT="^[0-9]+\.[0-9]\.[0-9]+$"
         fi
 
         if [[ $TRIMMED_VERSION =~ $VERSION_FORMAT ]]; then

--- a/.github/actions/version-check/action.yml
+++ b/.github/actions/version-check/action.yml
@@ -29,9 +29,9 @@ runs:
         TRIMMED_VERSION=$(echo "$VERSION" | xargs) 
 
         if ${{ env.IS_PRERELEASE == 'true' }}; then
-          VERSION_FORMAT="^[0-9]\.[0-9]\.[0-9]-test-[1-9]$"
+          VERSION_FORMAT="^[0-9]+\.[0-9]\.[0-9]-test-[1-9]$"
         else
-          VERSION_FORMAT="^[0-9]\.[0-9]\.[0-9]$"
+          VERSION_FORMAT="^[0-9]+\.[0-9]\.[0-9]$"
         fi
 
         if [[ $TRIMMED_VERSION =~ $VERSION_FORMAT ]]; then

--- a/changelog/fix-major-version-check
+++ b/changelog/fix-major-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixed version check regex

--- a/changelog/fix-major-version-check
+++ b/changelog/fix-major-version-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed version check regex

--- a/changelog/fix-major-version-check
+++ b/changelog/fix-major-version-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed version check regex


### PR DESCRIPTION
Fixes #5706

#### Changes proposed in this Pull Request
This PR fixes the Regex used to check the release version to allow major versions > 9

#### Testing instructions
The easiest way is to simply check the regexes match given versions. 
- Copy one of them and paste in https://regexr.com/
- Type 9.9.0
- Make sure it matches
- Type 10.0.0 make sure it matches
- Try other versions that you think might break the regex but should actually work like 123.0.0

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
