### PR TITLE
Now the setup intents ids are no more a link to the transaction page

### DIFF
--- a/changelog/fix-setup-intent-link
+++ b/changelog/fix-setup-intent-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removed link to setup intent

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -660,6 +660,10 @@ class WC_Payments_Utils {
 			return '';
 		}
 
+		if ( strpos( $primary_id, 'seti_' ) !== false ) {
+			return '';
+		}
+
 		return add_query_arg( // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 			array_merge(
 				[


### PR DESCRIPTION
Fixes #6577

#### Changes proposed in this Pull Request
This PR removes the link to setup intents because the transaction page does not support setup intents

#### Testing instructions
- Use WCPay Subscription and create a subscription product with free trial.
- Purchase this product, and check out with a new card.
- Check the setup intent (starting with prefix seti_) attached to the edit page of this order.
- Click the link for the setup intent ID, which is similar to this http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=seti_1NM5QOR67tFB8u4VSbAIJoyW
- Make sure the setup intent `seti_` id is not a link

![Markup on 2023-06-23 at 16:24:49](https://github.com/Automattic/woocommerce-payments/assets/10045087/d33aea59-c3bd-4608-bce9-aff8b6f55fc7)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
