### PR TITLE
Fix Mix and Match Products on product WooPay Express Checkout Button

### DIFF
--- a/changelog/fix-add-woopay-woocommerce-mix-and-match-support
+++ b/changelog/fix-add-woopay-woocommerce-mix-and-match-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add Mix and Match Products support on WooPay.

--- a/client/checkout/woopay/express-button/use-express-checkout-product-handler.js
+++ b/client/checkout/woopay/express-button/use-express-checkout-product-handler.js
@@ -74,7 +74,7 @@ const useExpressCheckoutProductHandler = ( api, isProductPage = false ) => {
 
 		let data = {
 			product_id: productId,
-			qty: document.querySelector( '.quantity .qty' ).value,
+			quantity: document.querySelector( '.quantity .qty' ).value,
 		};
 
 		if ( variation && ! bundleForm ) {
@@ -169,6 +169,7 @@ const useExpressCheckoutProductHandler = ( api, isProductPage = false ) => {
 		};
 
 		const bundleForm = document.querySelector( '.bundle_form' );
+		const mixAndMatchForm = document.querySelector( '.mnm_form' );
 		const variationForm = document.querySelector( '.variations_form' );
 
 		if ( bundleForm ) {
@@ -179,6 +180,14 @@ const useExpressCheckoutProductHandler = ( api, isProductPage = false ) => {
 					'woocommerce-product-bundle-hide',
 					disableAddToCartButton
 				);
+		} else if ( mixAndMatchForm ) {
+			// eslint-disable-next-line no-undef
+			jQuery( mixAndMatchForm )
+				.on(
+					'wc-mnm-display-add-to-cart-button',
+					enableAddToCartButton
+				)
+				.on( 'wc-mnm-hide-add-to-cart-button', disableAddToCartButton );
 		} else if ( variationForm ) {
 			// eslint-disable-next-line no-undef
 			jQuery( variationForm )
@@ -196,6 +205,17 @@ const useExpressCheckoutProductHandler = ( api, isProductPage = false ) => {
 					)
 					.off(
 						'woocommerce-product-bundle-hide',
+						disableAddToCartButton
+					);
+			} else if ( mixAndMatchForm ) {
+				// eslint-disable-next-line no-undef
+				jQuery( mixAndMatchForm )
+					.off(
+						'wc-mnm-display-add-to-cart-button',
+						enableAddToCartButton
+					)
+					.off(
+						'wc-mnm-hide-add-to-cart-button',
 						disableAddToCartButton
 					);
 			} else if ( variationForm ) {

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -100,7 +100,11 @@ export const WoopayExpressCheckoutButton = ( {
 				if ( isAddToCartDisabled ) {
 					alert(
 						window.wc_add_to_cart_variation_params
-							.i18n_make_a_selection_text
+							?.i18n_make_a_selection_text ||
+							__(
+								'Please select all required options to continue.',
+								'woocommerce-payments'
+							)
 					);
 					return;
 				}

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -217,14 +217,14 @@ class WC_Payments_WooPay_Button_Handler {
 		WC()->shipping->reset_shipping();
 
 		$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : false;
-		$qty          = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
+		$quantity     = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
 		$product      = wc_get_product( $product_id );
 		$product_type = $product->get_type();
 
 		// First empty the cart to prevent wrong calculation.
 		WC()->cart->empty_cart();
 
-		$is_add_to_cart_valid = apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $qty );
+		$is_add_to_cart_valid = apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity );
 
 		if ( ! $is_add_to_cart_valid ) {
 			// Some extensions error messages needs to be
@@ -245,11 +245,11 @@ class WC_Payments_WooPay_Button_Handler {
 			$data_store   = WC_Data_Store::load( 'product' );
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
-			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
+			WC()->cart->add_to_cart( $product->get_id(), $quantity, $variation_id, $attributes );
 		}
 
-		if ( 'simple' === $product_type || 'subscription' === $product_type || 'bundle' === $product_type ) {
-			WC()->cart->add_to_cart( $product->get_id(), $qty );
+		if ( in_array( $product_type, [ 'simple', 'subscription', 'bundle', 'mix-and-match' ], true ) ) {
+			WC()->cart->add_to_cart( $product->get_id(), $quantity );
 		}
 
 		WC()->cart->calculate_totals();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Fix Mix and Match Products validation sync and empty page with WooPay Express Checkout Button on product page.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install Mix and Match Products.
* Create a Mix and Match product.
* On product page, fill out the options with invalid data (less than minimum or greater than maximum container size).
* Click the WooPay button.
* An alert with the message `Please select all required options to continue.` should be shown.
* Fill out the options with valid data.
* Click the WooPay button.
* You should be redirect to WooPay with the correct selection items.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
