### PR TITLE
Disputes:  wording for disputes implying that fee has not yet been deducted

### DIFF
--- a/changelog/fix-7254-update-dispute-fee-text
+++ b/changelog/fix-7254-update-dispute-fee-text
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
+Comment: Minor wording change on unreleased feature.
 
-Minor wording change on unreleased feature.

--- a/changelog/fix-7254-update-dispute-fee-text
+++ b/changelog/fix-7254-update-dispute-fee-text
@@ -2,3 +2,4 @@ Significance: patch
 Type: fix
 Comment: Minor wording change on unreleased feature.
 
+

--- a/changelog/fix-7254-update-dispute-fee-text
+++ b/changelog/fix-7254-update-dispute-fee-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Minor wording change on unreleased feature.

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -127,7 +127,7 @@ function getAcceptDisputeProps( dispute: Dispute ): AcceptDisputeProps {
 					sprintf(
 						/* translators: %s: dispute fee, <em>: emphasis HTML element. */
 						__(
-							'Accepting the dispute marks it as <em>Lost</em>. The disputed amount and the %s dispute fee will not be returned to you..',
+							'Accepting the dispute marks it as <em>Lost</em>. The disputed amount and the %s dispute fee will not be returned to you.',
 							'woocommerce-payments'
 						),
 						getDisputeFeeFormatted( dispute, true ) ?? '-'

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -127,7 +127,7 @@ function getAcceptDisputeProps( dispute: Dispute ): AcceptDisputeProps {
 					sprintf(
 						/* translators: %s: dispute fee, <em>: emphasis HTML element. */
 						__(
-							'Accepting the dispute marks it as <em>Lost</em>. The disputed amount will be returned to the cardholder, with a %s dispute fee deducted from your account.',
+							'Accepting the dispute marks it as <em>Lost</em>. The disputed amount and the %s dispute fee will not be returned to you..',
 							'woocommerce-payments'
 						),
 						getDisputeFeeFormatted( dispute, true ) ?? '-'

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -151,7 +151,7 @@ const DisputeSteps: React.FC< Props > = ( {
 									content={ sprintf(
 										// Translators: %s is a formatted currency amount, eg $10.00.
 										__(
-											`Accepting this dispute will automatically close it. Your account will be charged a %s fee, and the disputed amount will be refunded to the cardholder.`,
+											`Accepting this dispute will automatically close it. The disputed amount and the %s dispute fee will not be returned to you.`,
 											'woocommerce-payments'
 										),
 										getDisputeFeeFormatted(


### PR DESCRIPTION
Fixes #7254 

### Changes proposed in this Pull Request

Update the wording in the `Accept dispute` modal and the tooltip in `Steps to resolve` to make it clear that the dispute fee has already been deducted.


Accept dispute modal:
```diff
-The disputed amount will be returned to the cardholder, with a %s dispute fee deducted from your account.
+The disputed amount and the %s dispute fee will not be returned to you.
```

Steps to resolve - accept tooltip:
```diff
-Accepting this dispute will automatically close it. The account will be charged a %s fee, and the disputed amount will be refunded to the cardholder.
+Accepting this dispute will automatically close it. The disputed amount and the %s dispute fee will not be returned to you.
```

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Screenshots

**Before:**

![Screenshot 2023-10-05 at 12 34 08 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/a2e11fd7-5535-41c8-8a3d-4c244547235c)
![Screenshot 2023-10-05 at 12 33 58 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/1eab7312-00b1-488c-823d-0b0a7c816039)


**After:**
![Screenshot 2023-10-05 at 1 42 23 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/042b4156-61ee-4d1a-b650-dbdfbf065f9d)
![Screenshot 2023-10-05 at 12 40 55 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/cca68f18-35f9-4981-a19d-7c7a3acc812e)

### Testing instructions

* Enable the feature flag by running `update_option( '_wcpay_feature_dispute_on_transaction_page', '1' );` in [WP Console](https://wordpress.org/plugins/wp-console/).
* Purchase a product with card `4000000000000259` to get disputed right away.
* Open the transaction details page of that new order by going to admin > Payments > Transactions > click on the top most transaction.
* Check the text in tool-tip next to 'accept' in steps to resolve (step 3).
* Check the text modal by clicking `Accept dispute` button.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
