### PR TITLE
Disputes: Prevent errors crashing the payment details page

### DIFF
--- a/changelog/add-7371-dispute-details-error-boundary
+++ b/changelog/add-7371-dispute-details-error-boundary
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Part of a larger feature with separate changelog entry
+
+

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -51,6 +51,7 @@ import CancelAuthorizationButton from '../../components/cancel-authorization-but
 import { PaymentIntent } from '../../types/payment-intents';
 import DisputeAwaitingResponseDetails from '../dispute-details/dispute-awaiting-response-details';
 import DisputeResolutionFooter from '../dispute-details/dispute-resolution-footer';
+import ErrorBoundary from 'wcpay/components/error-boundary';
 
 declare const window: any;
 
@@ -461,7 +462,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 			</CardBody>
 
 			{ charge.dispute && (
-				<>
+				<ErrorBoundary>
 					{ isAwaitingResponse( charge.dispute.status ) ? (
 						<DisputeAwaitingResponseDetails
 							dispute={ charge.dispute }
@@ -472,7 +473,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 					) : (
 						<DisputeResolutionFooter dispute={ charge.dispute } />
 					) }
-				</>
+				</ErrorBoundary>
 			) }
 
 			{ isAuthAndCaptureEnabled &&

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -51,7 +51,7 @@ import CancelAuthorizationButton from '../../components/cancel-authorization-but
 import { PaymentIntent } from '../../types/payment-intents';
 import DisputeAwaitingResponseDetails from '../dispute-details/dispute-awaiting-response-details';
 import DisputeResolutionFooter from '../dispute-details/dispute-resolution-footer';
-import ErrorBoundary from 'wcpay/components/error-boundary';
+import ErrorBoundary from 'components/error-boundary';
 
 declare const window: any;
 


### PR DESCRIPTION
Fixes #7371 

#### Changes proposed in this Pull Request

If an unhandled error occurs with dispute details on the transaction details page, the entire transaction details header component fails to render.

This PR adds an `<ErrorBoundary />` around the new dispute section on the transaction details page to ensure that the transaction details render correctly in this case.


**Before:**
![Screenshot 2023-10-05 at 4 54 21 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/0f2d47a8-1afa-47ff-bc26-49d22d50461d)

**After:**
![Screenshot 2023-10-05 at 4 54 48 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/d8899678-2a57-48df-9e31-697fb2982767)

#### Testing instructions

* Alter the code so that an error is thrown. I added `throw new Error( 'This is a test error' );` inside `<DisputeSteps />`
* View the dispute details with and without this branch.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
