### PR TITLE
Add documentation for create payment intent api endpoint

### DIFF
--- a/changelog/add-7381-add-documentation-for-create-payment-intent-api-endpoint
+++ b/changelog/add-7381-add-documentation-for-create-payment-intent-api-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added documentation for create payment intent API endpoint.

--- a/docs/rest-api/source/includes/wp-api-v3/intent.md
+++ b/docs/rest-api/source/includes/wp-api-v3/intent.md
@@ -1,0 +1,87 @@
+# Payment intents
+
+The Payment Intents API provides comprehensive functionality for managing payment intents. You can create and manage them seamlessly through its endpoints.
+
+
+## Create payment intenr
+
+_@since v6.6.0_
+
+Create new payment intent.
+
+### Error codes
+
+-   `rest_forbidden` - indicates that the user or application does not have the necessary permissions to perform the requested action.
+-   `wcpay_server_error` - Indicates that API had error processing the request. Usually occurs when request params are invalid like order is not found, and similar.
+
+### HTTP request
+
+<div class="api-endpoint">
+	<div class="endpoint-data">
+		<i class="label label-get">POST</i>
+		<h6>/wp-json/wc/v3/payments/payment_intents</h6>
+	</div>
+</div>
+
+```shell
+curl -X POST https://example.com/wp-json/wc/v3/payments/payment_intents \
+	-u consumer_key:consumer_secret \
+	-H "Content-Type: application/json" \
+	-d '{"payment_method":"<pm_id>","customer":"<customer_id>","order_id":"<order_id>"}'
+```
+
+> JSON response example:
+
+```json
+{
+  "id": "pi_4NxlPtR3eYmZSVZP0PPpwee8",
+  "amount": 1023,
+  "currency": "USD",
+  "created": 1696496578,
+  "customer": "cus_OUQoHGzJLw87Tk",
+  "payment_method": "pm_2NlT19R3eYmZSVZPRJEvxvwF",
+  "status": "succeeded",
+  "charge": {
+    "id": "ch_4NxlPtR3eYmZSVZP0ZLpKjfI",
+    "amount": 1023,
+    "application_fee_amount": 62,
+    "status": "succeeded",
+    "billing_details": {
+      "address": {
+        "city": "San Francisco",
+        "country": "US",
+        "line1": "123 Random St",
+        "line2": "-",
+        "postal_code": "94101",
+        "state": "CA"
+      },
+      "email": "random.email@example.com",
+      "name": "John Doe",
+      "phone": "5555555555"
+    },
+    "payment_method_details": {
+      "card": {
+        "amount_authorized": 1023,
+        "brand": "mastercard",
+        "capture_before": "",
+        "country": "US",
+        "exp_month": 5,
+        "exp_year": 2030,
+        "last4": "4321",
+        "three_d_secure": ""
+      }
+    }
+  }
+}
+
+```
+
+```json
+{
+  "code":"rest_forbidden",
+  "message":"Sorry, you are not allowed to do that.",
+  "data":{
+    "status":401
+  }
+}
+```


### PR DESCRIPTION
Fixes #7381 

#### Changes proposed in this Pull Request

Added documentation for create intent API endpoint-


#### Testing instructions

* After deployment, make sure that you can see the new endpoint in the documentation [link](https://automattic.github.io/woocommerce-payments).
* Make sure to test the endpoint and see does URL math and response example matches.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
