### PR TITLE
Bump minimum PHP version to 7.4 for WooCommerce beta matrix only.

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          PHP_VERSIONS=$( echo "[\"$PHP_MIN_SUPPORTED_VERSION\", \"8.0\", \"8.1\"]" )
+          PHP_VERSIONS=$( echo "[\"7.4\", \"8.0\", \"8.1\"]" )
           echo "matrix={\"woocommerce\":[\"beta\"],\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":$PHP_VERSIONS}" >> $GITHUB_OUTPUT
 
   # a dedicated job, as allowed to fail

--- a/changelog/fix-bump-min-php-wc-beta
+++ b/changelog/fix-bump-min-php-wc-beta
@@ -1,4 +1,3 @@
 Significance: patch
 Type: dev
-
-Update automated test matrix to remove PHP 7.3 tests against WooCommerce beta.
+Comment: Update automated test matrix to remove PHP 7.3 testing against WooCommerce beta.

--- a/changelog/fix-bump-min-php-wc-beta
+++ b/changelog/fix-bump-min-php-wc-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update automated test matrix to remove PHP 7.3 tests against WooCommerce beta.


### PR DESCRIPTION
Fixes failing GitHub actions for WooCommerce beta + PHP 7.3

#### Changes proposed in this Pull Request

Title: Remove PHP 7.3 from WooCommerce beta test matrix


Updates WooCommerce beta test matrix so minimum PHP version is 7.4 instead of 7.3. This will temporarily fix test failures, but a long term fix is needed right away because WooCommerce 8.2 releases October 10th which will re-break the tests against the latest WooCommerce.


#### Testing instructions


* Confirm that tests pass in GitHub actions
* Confirm that WooCommerce beta tests are still running

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
