### PR TITLE
Only request WooPay session once on Blocks pages

### DIFF
--- a/changelog/fix-7357-multiple-woopay-session-requests
+++ b/changelog/fix-7357-multiple-woopay-session-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only request WooPay session data once on blocks pages.

--- a/client/checkout/woopay/express-button/woopay-express-checkout-payment-method.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-payment-method.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import ReactDOM from 'react-dom';
+
+/**
  * Internal dependencies
  */
 import { PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT } from '../../constants';
@@ -18,15 +24,27 @@ const api = new WCPayAPI(
 	request
 );
 
+const WooPayExpressCheckoutButtonContainer = () => {
+	const onRefChange = useCallback( ( node ) => {
+		if ( node ) {
+			const root = ReactDOM.createRoot( node );
+
+			root.render(
+				<WoopayExpressCheckoutButton
+					buttonSettings={ getConfig( 'woopayButton' ) }
+					api={ api }
+					emailSelector="#email"
+				/>
+			);
+		}
+	}, [] );
+
+	return <span ref={ onRefChange } />;
+};
+
 const wooPayExpressCheckoutPaymentMethod = () => ( {
 	name: PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT,
-	content: (
-		<WoopayExpressCheckoutButton
-			buttonSettings={ getConfig( 'woopayButton' ) }
-			api={ api }
-			emailSelector="#email"
-		/>
-	),
+	content: <WooPayExpressCheckoutButtonContainer />,
 	edit: (
 		<WoopayExpressCheckoutButton
 			buttonSettings={ getConfig( 'woopayButton' ) }


### PR DESCRIPTION
Fixes #7357.

#### Changes proposed in this Pull Request

It changes the way the WooPay button is rendered in the Blocks cart and checkout pages. We're adopting a ReactDOM render approach instead of simply rendering the component to prevent the component re-rendering, that was how multiple requests were being made.

The new approach creates a raw HTML node, and a new root through ReactDOM, then the new root is rendered in the node a single time, and the request is made only once.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Pull the latest changes on WooPay.
2. On branch `develop`, run `npm start` to build the assets and try to reproduce the steps described on #7357.
3. Switch to this branch and run `npm start` to rebuild the assets.
4. Add a product to the cart.
5. Visit both the Blocks checkout page and the Blocks cart page.
5.1. Monitor the Network tab in dev tools to confirm the request `wcpay_get_woopay_session` is made only once in each page.
7. Confirm the first party auth flow works as expected.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
