### PR TITLE
Gate dispute issuer evidence behind a feature flag.

### DIFF
--- a/changelog/update-7372-issuer-evidence
+++ b/changelog/update-7372-issuer-evidence
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Just putting a feature (dispute issuer evidence) that was never public to real users behind a feature flag.
+
+

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -15,6 +15,7 @@ declare global {
 			customSearch: boolean;
 			isAuthAndCaptureEnabled: boolean;
 			paymentTimeline: boolean;
+			isDisputeIssuerEvidenceEnabled: boolean;
 		};
 		fraudServices: unknown[];
 		testMode: boolean;

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -34,7 +34,7 @@ import IssuerEvidenceList from './evidence-list';
 import DisputeSummaryRow from './dispute-summary-row';
 import { DisputeSteps, InquirySteps } from './dispute-steps';
 import InlineNotice from 'components/inline-notice';
-import WCPaySettingsContext from '../../settings/wcpay-settings-context';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
 import './style.scss';
 
 interface Props {

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import moment from 'moment';
 import { __, sprintf } from '@wordpress/i18n';
 import { backup, edit, lock, arrowRight } from '@wordpress/icons';
@@ -34,6 +34,7 @@ import IssuerEvidenceList from './evidence-list';
 import DisputeSummaryRow from './dispute-summary-row';
 import { DisputeSteps, InquirySteps } from './dispute-steps';
 import InlineNotice from 'components/inline-notice';
+import WCPaySettingsContext from '../../settings/wcpay-settings-context';
 import './style.scss';
 
 interface Props {
@@ -165,6 +166,10 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 	const hasStagedEvidence = dispute.evidence_details?.has_evidence;
 	const { createErrorNotice } = useDispatch( 'core/notices' );
 
+	const {
+		featureFlags: { isDisputeIssuerEvidenceEnabled },
+	} = useContext( WCPaySettingsContext );
+
 	const onModalClose = () => {
 		setModalOpen( false );
 	};
@@ -222,9 +227,11 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 						/>
 					) }
 
-					<IssuerEvidenceList
-						issuerEvidence={ dispute.issuer_evidence }
-					/>
+					{ isDisputeIssuerEvidenceEnabled && (
+						<IssuerEvidenceList
+							issuerEvidence={ dispute.issuer_evidence }
+						/>
+					) }
 
 					{ /* Dispute Actions */ }
 					{

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -103,14 +103,15 @@ const FileEvidence: React.FC< {
 };
 
 interface Props {
-	issuerEvidence: IssuerEvidence | null;
+	issuerEvidence: IssuerEvidence[] | null;
 }
 
 const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 	if (
-		! issuerEvidence ||
-		! issuerEvidence.file_evidence.length ||
-		! issuerEvidence.text_evidence
+		! issuerEvidence?.some(
+			( evidence ) =>
+				evidence.file_evidence.length || evidence.text_evidence
+		)
 	) {
 		return <></>;
 	}
@@ -122,20 +123,19 @@ const IssuerEvidenceList: React.FC< Props > = ( { issuerEvidence } ) => {
 			initialOpen={ false }
 		>
 			<ul className="dispute-evidence__list">
-				{ issuerEvidence.text_evidence && (
-					<li className="dispute-evidence__list-item">
-						<TextEvidence
-							evidence={ issuerEvidence.text_evidence }
-						/>
+				{ issuerEvidence.map( ( evidence, i ) => (
+					<li
+						className="dispute-evidence__list-item"
+						key={ `evidence_${ i }` }
+					>
+						{ evidence.text_evidence && (
+							<TextEvidence evidence={ evidence.text_evidence } />
+						) }
+						{ evidence.file_evidence.map( ( fileId ) => (
+							<FileEvidence fileId={ fileId } key={ fileId } />
+						) ) }
 					</li>
-				) }
-				{ issuerEvidence.file_evidence.map(
-					( fileId: string, i: any ) => (
-						<li className="dispute-evidence__list-item" key={ i }>
-							<FileEvidence fileId={ fileId } />
-						</li>
-					)
-				) }
+				) ) }
 			</ul>
 		</PanelBody>
 	);

--- a/client/settings/wcpay-settings-context.js
+++ b/client/settings/wcpay-settings-context.js
@@ -9,6 +9,7 @@ const WCPaySettingsContext = createContext( {
 	accountStatus: {},
 	featureFlags: {
 		isAuthAndCaptureEnabled: false,
+		isDisputeIssuerEvidenceEnabled: false,
 		woopay: false,
 	},
 } );

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -95,7 +95,7 @@ export interface Dispute {
 	};
 	order: null | OrderDetails;
 	evidence: Evidence;
-	issuer_evidence: IssuerEvidence | null;
+	issuer_evidence: IssuerEvidence[] | null;
 	fileSize?: Record< string, number >;
 	reason: DisputeReason;
 	charge: Charge | string;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -24,6 +24,7 @@ class WC_Payments_Features {
 	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
 	const PAY_FOR_ORDER_FLOW                = '_wcpay_feature_pay_for_order_flow';
 	const DEFERRED_UPE_SERVER_FLAG_NAME     = 'is_deferred_intent_creation_upe_enabled';
+	const DISPUTE_ISSUER_EVIDENCE           = '_wcpay_feature_dispute_issuer_evidence';
 
 	/**
 	 * Checks whether any UPE gateway is enabled.
@@ -423,6 +424,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Dispute issuer evidence feature should be enabled. Disabled by default.
+	 *
+	 * @return bool
+	 */
+	public static function is_dispute_issuer_evidence_enabled(): bool {
+		return '1' === get_option( self::DISPUTE_ISSUER_EVIDENCE, '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -430,18 +440,19 @@ class WC_Payments_Features {
 	public static function to_array() {
 		return array_filter(
 			[
-				'upe'                      => self::is_upe_enabled(),
-				'upeSplit'                 => self::is_upe_split_enabled(),
-				'upeDeferred'              => self::is_upe_deferred_intent_enabled(),
-				'upeSettingsPreview'       => self::is_upe_settings_preview_enabled(),
-				'multiCurrency'            => self::is_customer_multi_currency_enabled(),
-				'woopay'                   => self::is_woopay_eligible(),
-				'documents'                => self::is_documents_section_enabled(),
-				'clientSecretEncryption'   => self::is_client_secret_encryption_enabled(),
-				'woopayExpressCheckout'    => self::is_woopay_express_checkout_enabled(),
-				'isAuthAndCaptureEnabled'  => self::is_auth_and_capture_enabled(),
-				'progressiveOnboarding'    => self::is_progressive_onboarding_enabled(),
-				'isPayForOrderFlowEnabled' => self::is_pay_for_order_flow_enabled(),
+				'upe'                            => self::is_upe_enabled(),
+				'upeSplit'                       => self::is_upe_split_enabled(),
+				'upeDeferred'                    => self::is_upe_deferred_intent_enabled(),
+				'upeSettingsPreview'             => self::is_upe_settings_preview_enabled(),
+				'multiCurrency'                  => self::is_customer_multi_currency_enabled(),
+				'woopay'                         => self::is_woopay_eligible(),
+				'documents'                      => self::is_documents_section_enabled(),
+				'clientSecretEncryption'         => self::is_client_secret_encryption_enabled(),
+				'woopayExpressCheckout'          => self::is_woopay_express_checkout_enabled(),
+				'isAuthAndCaptureEnabled'        => self::is_auth_and_capture_enabled(),
+				'progressiveOnboarding'          => self::is_progressive_onboarding_enabled(),
+				'isPayForOrderFlowEnabled'       => self::is_pay_for_order_flow_enabled(),
+				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 			]
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7372

#### Changes proposed in this Pull Request

- Only render dispute issuer evidence if `_wcpay_feature_dispute_issuer_evidence` option is on.

#### Testing instructions

- Make a local modification of `IssuerEvidenceList`'s return value [here](https://github.com/Automattic/woocommerce-payments/blob/f5aa7cdb994a36dcce2717ff52481a10f876a37c/client/payment-details/dispute-details/evidence-list.tsx#L115) to show something. For example:

```diff
- 	return <></>;
+ 	return <span>abc</span>;
```

* Purchase a product with `4000000000000259` to trigger a dispute.
* Enable feature flag by running `update_option( '_wcpay_feature_dispute_issuer_evidence', '1' );` in [WP Console](https://wordpress.org/plugins/wp-console/) or by modifying your database table `wp_options` directly.
* Go to the transaction details page.
* You should see your local change.
* Disable feature flag by running `update_option( '_wcpay_feature_dispute_issuer_evidence', '0' );` in [WP Console](https://wordpress.org/plugins/wp-console/) or by modifying your database table `wp_options` directly.
* Go to the transaction details page.
* You should *not* see your local change.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
