### PR TITLE
Use consistent colors on transaction page when disputed.

### DIFF
--- a/changelog/fix-7396-disputestatuschip
+++ b/changelog/fix-7396-disputestatuschip
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor UI change, background color on StatusChip for disputes
+
+

--- a/client/components/dispute-status-chip/index.tsx
+++ b/client/components/dispute-status-chip/index.tsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,10 +22,24 @@ import type {
 interface Props {
 	status: DisputeStatus | string;
 	dueBy?: CachedDispute[ 'due_by' ] | EvidenceDetails[ 'due_by' ];
+	includeTransactionType?: boolean;
 }
-const DisputeStatusChip: React.FC< Props > = ( { status, dueBy } ) => {
+const DisputeStatusChip: React.FC< Props > = ( {
+	status,
+	dueBy,
+	includeTransactionType,
+} ) => {
 	const mapping = displayStatus[ status ] || {};
-	const message = mapping.message || formatStringValue( status );
+	let message = mapping.message || formatStringValue( status );
+
+	// Statuses starting with warning_ are Inquiries and these are already prefaced with "Inquiry: "
+	if ( includeTransactionType && ! status.startsWith( 'warning' ) ) {
+		message = sprintf(
+			/** translators: %s is the status of the Dispute. */
+			__( 'Disputed: %s', 'woocommerce-payments' ),
+			message
+		);
+	}
 
 	const needsResponse = isAwaitingResponse( status );
 	const isUrgent =

--- a/client/components/dispute-status-chip/index.tsx
+++ b/client/components/dispute-status-chip/index.tsx
@@ -22,18 +22,18 @@ import type {
 interface Props {
 	status: DisputeStatus | string;
 	dueBy?: CachedDispute[ 'due_by' ] | EvidenceDetails[ 'due_by' ];
-	includeTransactionType?: boolean;
+	prefixDisputeType?: boolean;
 }
 const DisputeStatusChip: React.FC< Props > = ( {
 	status,
 	dueBy,
-	includeTransactionType,
+	prefixDisputeType,
 } ) => {
 	const mapping = displayStatus[ status ] || {};
 	let message = mapping.message || formatStringValue( status );
 
 	// Statuses starting with warning_ are Inquiries and these are already prefaced with "Inquiry: "
-	if ( includeTransactionType && ! status.startsWith( 'warning' ) ) {
+	if ( prefixDisputeType && ! status.startsWith( 'warning' ) ) {
 		message = sprintf(
 			/** translators: %s is the status of the Dispute. */
 			__( 'Disputed: %s', 'woocommerce-payments' ),

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -36,6 +36,7 @@ import OrderLink from 'components/order-link';
 import { formatCurrency, formatExplicitCurrency } from 'utils/currency';
 import CustomerLink from 'components/customer-link';
 import { ClickTooltip } from 'components/tooltip';
+import DisputeStatusChip from 'components/dispute-status-chip';
 import {
 	getDisputeFeeFormatted,
 	isAwaitingResponse,
@@ -233,12 +234,22 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 								<span className="payment-details-summary__amount-currency">
 									{ charge.currency || 'USD' }
 								</span>
-								<PaymentStatusChip
-									status={ getChargeStatus(
-										charge,
-										paymentIntent
-									) }
-								/>
+								{ charge.dispute ? (
+									<DisputeStatusChip
+										status={ charge.dispute.status }
+										dueBy={
+											charge.dispute.evidence_details
+												?.due_by
+										}
+									/>
+								) : (
+									<PaymentStatusChip
+										status={ getChargeStatus(
+											charge,
+											paymentIntent
+										) }
+									/>
+								) }
 							</Loadable>
 						</p>
 						<div className="payment-details-summary__breakdown">

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -242,7 +242,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 											charge.dispute.evidence_details
 												?.due_by
 										}
-										includeTransactionType={ true }
+										prefixDisputeType={ true }
 									/>
 								) : (
 									<PaymentStatusChip

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -241,6 +241,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 											charge.dispute.evidence_details
 												?.due_by
 										}
+										includeTransactionType={ true }
 									/>
 								) : (
 									<PaymentStatusChip


### PR DESCRIPTION
Fixes #7396 

#### Changes proposed in this Pull Request

This PR replaces the `<PaymentStatusChip />` with `<DisputeStatusChip />` when a transaction is disputed.

This allows for the urgency of the dispute to factor into the color of the chip which will match with the banner notice on the page.


**Before:**
![image](https://github.com/Automattic/woocommerce-payments/assets/57298/aa5b155f-b30f-4b6b-8faf-737529fb94db)

**After:**
![image](https://github.com/Automattic/woocommerce-payments/assets/57298/97bf777a-af29-427c-af46-db087a1ea5ee)

#### Testing instructions

* Create a disputed order
* In `client/disputes/utils.ts` update `isDueWithin` to always return `true`
* View the transaction details page of a disputed order.
* Confirm the StatusChip matches the BannerNotice color

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
