### PR TITLE
Update steps to resolve wording in dispute details on transaction details page

### DIFF
--- a/changelog/update-7380-steps-to-resolve-wording
+++ b/changelog/update-7380-steps-to-resolve-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Wording change of dispute details section on transaction details page that has not been public to users.
+
+

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -80,7 +80,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 					{ customer?.email
 						? createInterpolateElement(
 								__(
-									'<a>Email the customer</a> to address their concerns.',
+									'<a>Email the customer</a> to identify the issue and work towards a resolution where possible.',
 									'woocommerce-payments'
 								),
 								{
@@ -95,14 +95,14 @@ export const DisputeSteps: React.FC< Props > = ( {
 								}
 						  )
 						: __(
-								'Email the customer to address their concerns.',
+								'Email the customer to identify the issue and work towards a resolution where possible.',
 								'woocommerce-payments'
 						  ) }
 				</li>
 				<li>
 					{ createInterpolateElement(
 						__(
-							'Provide <a>guidance on dispute withdrawal</a> if the customer agrees.',
+							'Assist the customer <a>in withdrawing their dispute</a> if they agree to do so.',
 							'woocommerce-payments'
 						),
 						{

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -415,7 +415,7 @@ describe( 'PaymentDetailsSummary', () => {
 			name: /Email the customer/i,
 		} );
 		screen.getByRole( 'link', {
-			name: /guidance on dispute withdrawal/i,
+			name: /in withdrawing their dispute/i,
 		} );
 
 		// Actions


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7380

#### Changes proposed in this Pull Request

Change wording for steps to resolve in dispute details section on transaction details page to:
```
1. Email the customer to identify the issue and work towards a resolution where possible.
2. Assist the customer in withdrawing their dispute if they agree to do so.
```

Step 3 remains unchanged.

#### Testing instructions

* Purchase a product with `4000000000000259` to trigger a dispute.
* Open the transaction details page.
* Make sure the 1st and 2nd steps to resolve are per the new design.

![Image](https://github.com/Automattic/woocommerce-payments/assets/3147296/5bccccd1-151b-4a05-bb7c-8c34cec6070b)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
