### PR TITLE
Show survey for merchants that disable WooPay

### DIFF
--- a/changelog/add-show-survey-users-disable-woopay
+++ b/changelog/add-show-survey-users-disable-woopay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show survey for merchants that disable WooPay.

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -101,7 +101,9 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 
 			// Prevent show modal again.
 			setInitialIsPaymentRequestEnabled( true );
-            // Set last disable date to prevent feedback window opening up on successive "Save button" clicks. This value is overwritten on page refresh.
+            // Set last disable date to prevent feedback window opening up
+			// on successive "Save button" clicks. This value is overwritten
+			// on page refresh.
 			wcpaySettings.woopayLastDisableDate = new Date();
 		}
 	};

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -32,7 +32,7 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 	const [
 		isWooPayDisableFeedbackOpen,
 		setIsWooPayDisableFeedbackOpen,
-	] = useState( true );
+	] = useState( false );
 
 	if (
 		initialIsPaymentRequestEnabled === null &&

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -101,7 +101,7 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 
 			// Prevent show modal again.
 			setInitialIsPaymentRequestEnabled( true );
-            // Set last disable date to prevent feedback window opening up
+			// Set last disable date to prevent feedback window opening up
 			// on successive "Save button" clicks. This value is overwritten
 			// on page refresh.
 			wcpaySettings.woopayLastDisableDate = new Date();

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -32,7 +32,7 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 	const [
 		isWooPayDisableFeedbackOpen,
 		setIsWooPayDisableFeedbackOpen,
-	] = useState( false );
+	] = useState( true );
 
 	if (
 		initialIsPaymentRequestEnabled === null &&

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -101,6 +101,7 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 
 			// Prevent show modal again.
 			setInitialIsPaymentRequestEnabled( true );
+            // Set last disable date to prevent feedback window opening up on successive "Save button" clicks. This value is overwritten on page refresh.
 			wcpaySettings.woopayLastDisableDate = new Date();
 		}
 	};

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -13,6 +13,7 @@ import { useSettings } from '../../data';
 import wcpayTracks from '../../tracks';
 import SettingsSection from '../settings-section';
 import './style.scss';
+import WooPayDisableFeedback from '../woopay-disable-feedback';
 
 const SaveSettingsSection = ( { disabled = false } ) => {
 	const { saveSettings, isSaving, isLoading, settings } = useSettings();
@@ -23,6 +24,15 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 		initialIsPaymentRequestEnabled,
 		setInitialIsPaymentRequestEnabled,
 	] = useState( null );
+	// Keep the inital value of is_woopay_enabled
+	// in state for showing the feedback modal on change.
+	const [ initialIsWooPayEnabled, setInitialIsWooPayEnabled ] = useState(
+		null
+	);
+	const [
+		isWooPayDisableFeedbackOpen,
+		setIsWooPayDisableFeedbackOpen,
+	] = useState( false );
 
 	if (
 		initialIsPaymentRequestEnabled === null &&
@@ -34,15 +44,26 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 		);
 	}
 
+	if (
+		initialIsWooPayEnabled === null &&
+		settings &&
+		typeof settings.is_woopay_enabled !== 'undefined'
+	) {
+		setInitialIsWooPayEnabled( settings.is_woopay_enabled );
+	}
+
 	const saveOnClick = async () => {
 		const isSuccess = await saveSettings();
+
+		if ( ! isSuccess ) {
+			return;
+		}
 
 		// Track the event when the value changed and the
 		// settings were successfully saved.
 		if (
-			isSuccess &&
 			initialIsPaymentRequestEnabled !==
-				settings.is_payment_request_enabled
+			settings.is_payment_request_enabled
 		) {
 			wcpayTracks.recordEvent(
 				wcpayTracks.events.PAYMENT_REQUEST_SETTINGS_CHANGE,
@@ -56,6 +77,31 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 				settings.is_payment_request_enabled
 			);
 		}
+
+		// Show the feedback modal when WooPay is disabled.
+		if ( initialIsWooPayEnabled && ! settings.is_woopay_enabled ) {
+			const { woopayLastDisableDate } = wcpaySettings;
+
+			// Do not show feedback modal if WooPay
+			// was disabled in the last 7 days.
+			if ( woopayLastDisableDate ) {
+				const date1 = new Date( woopayLastDisableDate );
+				const date2 = new Date();
+				const diffTime = Math.abs( date2 - date1 );
+				const diffDays = Math.ceil(
+					diffTime / ( 1000 * 60 * 60 * 24 )
+				);
+
+				if ( diffDays < 7 ) {
+					return;
+				}
+			}
+
+			setIsWooPayDisableFeedbackOpen( true );
+
+			// Prevent show modal again.
+			setInitialIsPaymentRequestEnabled( true );
+		}
 	};
 
 	return (
@@ -68,6 +114,13 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 			>
 				{ __( 'Save changes', 'woocommerce-payments' ) }
 			</Button>
+			{ isWooPayDisableFeedbackOpen ? (
+				<WooPayDisableFeedback
+					onRequestClose={ () =>
+						setIsWooPayDisableFeedbackOpen( false )
+					}
+				/>
+			) : null }
 		</SettingsSection>
 	);
 };

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -101,6 +101,7 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 
 			// Prevent show modal again.
 			setInitialIsPaymentRequestEnabled( true );
+			wcpaySettings.woopayLastDisableDate = new Date();
 		}
 	};
 

--- a/client/settings/woopay-disable-feedback/index.js
+++ b/client/settings/woopay-disable-feedback/index.js
@@ -10,14 +10,22 @@ import { Modal } from '@wordpress/components';
  */
 import './style.scss';
 import Loadable from 'wcpay/components/loadable';
+import WooPayIcon from 'assets/images/woopay.svg?asset';
 
 const WooPayDisableFeedback = ( { onRequestClose } ) => {
 	const [ isLoading, setIsLoading ] = useState( true );
 
 	return (
 		<Modal
-			title={ __( 'WooPay Feedback', 'woocommerce-payments' ) }
+			title={
+				<img
+					src={ WooPayIcon }
+					alt={ __( 'WooPay Logo', 'woocommerce-payments' ) }
+					className="woopay-disable-feedback-logo"
+				/>
+			}
 			isDismissible={ true }
+			shouldCloseOnClickOutside={ false } // Should be false because of the iframe.
 			shouldCloseOnEsc={ true }
 			onRequestClose={ onRequestClose }
 			className="woopay-disable-feedback"

--- a/client/settings/woopay-disable-feedback/index.js
+++ b/client/settings/woopay-disable-feedback/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import { Modal } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Loadable from 'wcpay/components/loadable';
+
+const WooPayDisableFeedback = ( { onRequestClose } ) => {
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	return (
+		<Modal
+			title={ __( 'WooPay Feedback', 'woocommerce-payments' ) }
+			isDismissible={ true }
+			shouldCloseOnEsc={ true }
+			onRequestClose={ onRequestClose }
+			className="woopay-disable-feedback"
+		>
+			<Loadable isLoading={ isLoading }>
+				<iframe
+					title={ __(
+						'WooPay Disable Feedback',
+						'woocommerce-payments'
+					) }
+					src="https://woocommerce.survey.fm/woopay-disabled-merchants-feedback-triggered"
+					className="woopay-disable-feedback-iframe"
+					onLoad={ () => {
+						setIsLoading( false );
+					} }
+				/>
+			</Loadable>
+		</Modal>
+	);
+};
+
+export default WooPayDisableFeedback;

--- a/client/settings/woopay-disable-feedback/style.scss
+++ b/client/settings/woopay-disable-feedback/style.scss
@@ -1,0 +1,11 @@
+.woopay-disable-feedback {
+	&-iframe {
+		width: 100%;
+		height: 100%;
+
+		@media ( min-width: 600px ) {
+			width: 500px;
+			height: 500px;
+		}
+	}
+}

--- a/client/settings/woopay-disable-feedback/style.scss
+++ b/client/settings/woopay-disable-feedback/style.scss
@@ -1,11 +1,23 @@
 .woopay-disable-feedback {
+	@media ( min-width: 960px ) {
+		max-height: calc( 100% - 120px );
+	}
+
+	.components-modal__content {
+		padding: 0;
+	}
+
 	&-iframe {
 		width: 100%;
 		height: 100%;
 
 		@media ( min-width: 600px ) {
-			width: 500px;
-			height: 500px;
+			width: 600px;
+			height: 650px;
 		}
+	}
+
+	&-logo {
+		height: 40px;
 	}
 }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -854,6 +854,7 @@ class WC_Payments_Admin {
 			'storeCurrency'                 => get_option( 'woocommerce_currency' ),
 			'isBnplAffirmAfterpayEnabled'   => WC_Payments_Features::is_bnpl_affirm_afterpay_enabled(),
 			'isWooPayStoreCountryAvailable' => WooPay_Utilities::is_store_country_available(),
+			'woopayLastDisableDate'         => $this->wcpay_gateway->get_option( 'platform_checkout_last_disable_date' ),
 			'isStripeBillingEnabled'        => WC_Payments_Features::is_stripe_billing_enabled(),
 			'isStripeBillingEligible'       => WC_Payments_Features::is_stripe_billing_eligible(),
 			'capabilityRequestNotices'      => get_option( 'wcpay_capability_request_dismissed_notices ', [] ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2034,6 +2034,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->update_option( 'platform_checkout', $is_woopay_enabled ? 'yes' : 'no' );
 
 			if ( ! $is_woopay_enabled ) {
+				$this->update_option( 'platform_checkout_last_disable_date', gmdate( 'Y-m-d' ) );
+			}
+
+			if ( ! $is_woopay_enabled ) {
 				WooPay_Order_Status_Sync::remove_webhook();
 			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
When a merchant disables WooPay, show a feedback survey modal.

<img width="1111" alt="Screenshot 2023-10-06 at 15 39 33" src="https://github.com/Automattic/woocommerce-payments/assets/1693223/f46079a9-6069-455d-90c1-3f3ababe4585">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With WooPay enabled, access WCPay settings.
* On Express Checkout options, disable WooPay checkbox.
* Click `Save changes` button.
* The modal with WooPay survey should be shown.
* Dismiss the modal.
* Without reloading the page, enable WooPay checkbox.
* Click `Save changes` button.
* Disable WooPay checkbox.
* Click `Save changes` button.
* The modal should not be shown.
* Reload the page.
* Enable WooPay checkbox.
* Click `Save changes` button.
* Reload the page.
* Click `Save changes` button.
* Disable WooPay checkbox.
* Click `Save changes` button.
* The modal should not be shown.
* Enable WooPay checkbox.
* Click `Save changes` button.
* On phpMyAdmin, run this query:

```
SELECT *  FROM `wp_options` WHERE `option_name` LIKE 'woocommerce_woocommerce_payments_settings'
```

* On the `option_value`, look for the `platform_checkout_last_disable_date` setting and change it to a date older than 7 days.
* Reload the WCPay settings page.
* Disable WooPay checkbox.
* Click `Save changes` button.
* The modal should not be shown.
* Click the `Customize` button on WooPay section on Express checkouts options.
* Redo the steps on this page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
