### PR TITLE
Disputes: Use existing tracks events where possible

### DIFF
--- a/changelog/fix-7395
+++ b/changelog/fix-7395
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Updating tracks events
+
+

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -258,7 +258,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 												.DISPUTE_CHALLENGE_CLICKED,
 											{
 												dispute_status: dispute.status,
-												on_page: 'transactions_details',
+												on_page: 'transaction_details',
 											}
 										);
 									} }
@@ -280,7 +280,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 										disputeAcceptAction.acceptButtonTracksEvent,
 										{
 											dispute_status: dispute.status,
-											on_page: 'transactions_details',
+											on_page: 'transaction_details',
 										}
 									);
 									setModalOpen( true );
@@ -340,7 +340,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 														dispute_status:
 															dispute.status,
 														on_page:
-															'transactions_details',
+															'transaction_details',
 													}
 												);
 												setModalOpen( false );

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -255,9 +255,10 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 									onClick={ () => {
 										wcpayTracks.recordEvent(
 											wcpayTracks.events
-												.DISPUTE_CHALLENGE_CLICK,
+												.DISPUTE_CHALLENGE_CLICKED,
 											{
 												dispute_status: dispute.status,
+												on_page: 'transactions_details',
 											}
 										);
 									} }
@@ -279,6 +280,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 										disputeAcceptAction.acceptButtonTracksEvent,
 										{
 											dispute_status: dispute.status,
+											on_page: 'transactions_details',
 										}
 									);
 									setModalOpen( true );
@@ -337,6 +339,8 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 													{
 														dispute_status:
 															dispute.status,
+														on_page:
+															'transactions_details',
 													}
 												);
 												setModalOpen( false );

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -73,7 +73,7 @@ const DisputeUnderReviewFooter: React.FC< {
 										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
-										on_page: 'transactions_details',
+										on_page: 'transaction_details',
 									}
 								);
 							} }
@@ -145,7 +145,7 @@ const DisputeWonFooter: React.FC< {
 										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
-										on_page: 'transactions_details',
+										on_page: 'transaction_details',
 									}
 								);
 							} }
@@ -255,7 +255,7 @@ const DisputeLostFooter: React.FC< {
 											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 										{
 											dispute_status: dispute.status,
-											on_page: 'transactions_details',
+											on_page: 'transaction_details',
 										}
 									);
 								} }
@@ -328,7 +328,7 @@ const InquiryUnderReviewFooter: React.FC< {
 										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
-										on_page: 'transactions_details',
+										on_page: 'transaction_details',
 									}
 								);
 							} }
@@ -403,7 +403,7 @@ const InquiryClosedFooter: React.FC< {
 											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 										{
 											dispute_status: dispute.status,
-											on_page: 'transactions_details',
+											on_page: 'transaction_details',
 										}
 									);
 								} }

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -70,9 +70,10 @@ const DisputeUnderReviewFooter: React.FC< {
 							onClick={ () => {
 								wcpayTracks.recordEvent(
 									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
+										on_page: 'transactions_details',
 									}
 								);
 							} }
@@ -141,9 +142,10 @@ const DisputeWonFooter: React.FC< {
 							onClick={ () => {
 								wcpayTracks.recordEvent(
 									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
+										on_page: 'transactions_details',
 									}
 								);
 							} }
@@ -250,9 +252,10 @@ const DisputeLostFooter: React.FC< {
 								onClick={ () => {
 									wcpayTracks.recordEvent(
 										wcpayTracks.events
-											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 										{
 											dispute_status: dispute.status,
+											on_page: 'transactions_details',
 										}
 									);
 								} }
@@ -322,9 +325,10 @@ const InquiryUnderReviewFooter: React.FC< {
 							onClick={ () => {
 								wcpayTracks.recordEvent(
 									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
+										on_page: 'transactions_details',
 									}
 								);
 							} }
@@ -396,9 +400,10 @@ const InquiryClosedFooter: React.FC< {
 								onClick={ () => {
 									wcpayTracks.recordEvent(
 										wcpayTracks.events
-											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK,
+											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 										{
 											dispute_status: dispute.status,
+											on_page: 'transactions_details',
 										}
 									);
 								} }

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -68,7 +68,7 @@ const events = {
 	DEPOSITS_ROW_CLICK: 'wcpay_deposits_row_click',
 	DEPOSITS_DOWNLOAD_CSV_CLICK: 'wcpay_deposits_download',
 	DISPUTES_ROW_ACTION_CLICK: 'wcpay_disputes_row_action_click',
-	DISPUTE_CHALLENGE_CLICK: 'wcpay_dispute_challenge_click',
+	DISPUTE_CHALLENGE_CLICK: 'wcpay_dispute_challenge_clicked',
 	DISPUTE_ACCEPT_CLICK: 'wcpay_dispute_accept_click',
 	DISPUTE_ACCEPT_MODAL_VIEW: 'wcpay_dispute_accept_modal_view',
 	DISPUTE_INQUIRY_REFUND_CLICK: 'wcpay_dispute_inquiry_refund_click',
@@ -84,7 +84,7 @@ const events = {
 		'wcpay_overview_deposits_change_schedule_click',
 	OVERVIEW_TASK_CLICK: 'wcpay_overview_task_click',
 	PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK:
-		'wcpay_payment_details_view_dispute_evidence_button_click',
+		'wcpay_view_submitted_evidence_clicked',
 	SETTINGS_DEPOSITS_MANAGE_IN_STRIPE_CLICK:
 		'wcpay_settings_deposits_manage_in_stripe_click',
 	MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED:

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -68,7 +68,7 @@ const events = {
 	DEPOSITS_ROW_CLICK: 'wcpay_deposits_row_click',
 	DEPOSITS_DOWNLOAD_CSV_CLICK: 'wcpay_deposits_download',
 	DISPUTES_ROW_ACTION_CLICK: 'wcpay_disputes_row_action_click',
-	DISPUTE_CHALLENGE_CLICK: 'wcpay_dispute_challenge_clicked',
+	DISPUTE_CHALLENGE_CLICKED: 'wcpay_dispute_challenge_clicked',
 	DISPUTE_ACCEPT_CLICK: 'wcpay_dispute_accept_click',
 	DISPUTE_ACCEPT_MODAL_VIEW: 'wcpay_dispute_accept_modal_view',
 	DISPUTE_INQUIRY_REFUND_CLICK: 'wcpay_dispute_inquiry_refund_click',
@@ -83,7 +83,7 @@ const events = {
 	OVERVIEW_DEPOSITS_CHANGE_SCHEDULE_CLICK:
 		'wcpay_overview_deposits_change_schedule_click',
 	OVERVIEW_TASK_CLICK: 'wcpay_overview_task_click',
-	PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICK:
+	PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED:
 		'wcpay_view_submitted_evidence_clicked',
 	SETTINGS_DEPOSITS_MANAGE_IN_STRIPE_CLICK:
 		'wcpay_settings_deposits_manage_in_stripe_click',


### PR DESCRIPTION
Partially fixes #7395 

#### Changes proposed in this Pull Request

This PR will use current tracking events rather than new tracking events for disputes. 

There were some new tracking events added as part of moving dispute details from a dedicated page to the transaction detail page. I found that there were some events that are currently in use that can be used instead.

While the buttons are on a different page, the user intent is the same so keeping the event name and any historical data makes sense here.

| Button | Transaction Details (current event) | Dispute Details (previous event) |
|--------|--------|--------|
| `Challenge dispute` | `dispute_challenge_click` | `dispute_challenge_clicked` |
| `View submitted evidence` | `payment_details_view_dispute_evidence_button_click` | `view_submitted_evidence_clicked` |

#### Testing instructions


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
