### PR TITLE
Update Subscriptions Core to 6.3.0

### DIFF
--- a/changelog/subscriptions-core-6.3.0
+++ b/changelog/subscriptions-core-6.3.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update subscriptions-core to 6.3.0.

--- a/changelog/subscriptions-core-6.3.0-1
+++ b/changelog/subscriptions-core-6.3.0-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.

--- a/changelog/subscriptions-core-6.3.0-2
+++ b/changelog/subscriptions-core-6.3.0-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.

--- a/changelog/subscriptions-core-6.3.0-3
+++ b/changelog/subscriptions-core-6.3.0-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure renewal orders paid via the Block Checkout are correctly linked to their subscription.

--- a/changelog/subscriptions-core-6.3.0-4
+++ b/changelog/subscriptions-core-6.3.0-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Resolved an issue that caused paying for failed/pending parent orders that include Product Add-ons to not calculate the correct total.

--- a/changelog/subscriptions-core-6.3.0-5
+++ b/changelog/subscriptions-core-6.3.0-5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure the order needs processing transient is deleted when a subscription order (eg renewal) is created. Fixes issues with renewal orders going straight to a completed status.

--- a/changelog/subscriptions-core-6.3.0-6
+++ b/changelog/subscriptions-core-6.3.0-6
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Store the correct subscription start date in postmeta and ordermeta when HPOS and data syncing is being used.

--- a/changelog/subscriptions-core-6.3.0-7
+++ b/changelog/subscriptions-core-6.3.0-7
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+When HPOS is enabled, deleting a customer will now delete their subscriptions.

--- a/changelog/subscriptions-core-6.3.0-8
+++ b/changelog/subscriptions-core-6.3.0-8
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Missing styles on the Edit Subscription page when HPOS is enabled.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "automattic/jetpack-autoloader": "2.11.18",
         "automattic/jetpack-identity-crisis": "0.8.43",
         "automattic/jetpack-sync": "1.47.7",
-        "woocommerce/subscriptions-core": "6.2.0",
+        "woocommerce/subscriptions-core": "6.3.0",
         "psr/container": "^1.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86b5f217949dc6931b79653be4a6dca8",
+    "content-hash": "f45536a544c784b5c85d2e507cb43d42",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -988,16 +988,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "6.2.0",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "47cfe92d60239d1b8b12a5f640a3772b0e4e1272"
+                "reference": "8ba0249f97df46caafd625950853f8f5e5a29984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/47cfe92d60239d1b8b12a5f640a3772b0e4e1272",
-                "reference": "47cfe92d60239d1b8b12a5f640a3772b0e4e1272",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/8ba0249f97df46caafd625950853f8f5e5a29984",
+                "reference": "8ba0249f97df46caafd625950853f8f5e5a29984",
                 "shasum": ""
             },
             "require": {
@@ -1038,10 +1038,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/6.2.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/6.3.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2023-08-10T23:43:48+00:00"
+            "time": "2023-10-06T04:31:08+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Today we tagged Subscriptions Core v6.3.0 with the following changes

```
* Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
* Fix - Resolved an issue that caused subscriptions with an unpaid early renewal order to be incorrectly considered as needing payment.
* Fix - When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.
* Fix - Ensure renewal orders paid via the Block Checkout are correctly linked to their subscription.
* Fix - Resolved an issue that caused paying for failed/pending parent orders that include Product Add-ons to not calculate the correct total.
* Fix - Ensure the order needs processing transient is deleted when a subscription order (eg renewal) is created. Fixes issues with renewal orders going straight to a completed status.
* Fix - Store the correct subscription start date in postmeta and ordermeta when HPOS and data syncing is being used.
* Fix - When HPOS is enabled, deleting a customer will now delete their subscriptions.
* Fix - Missing styles on the Edit Subscription page when HPOS is enabled.
```

This PR bumps WooPayments to use the latest version and adds all the relevant changelog entries for those stores using the WCPay Subscriptions feature.