### PR TITLE
Update JCB request capability docs link and capitalize it on the transaction details page

### DIFF
--- a/changelog/fix-finish-setup-link
+++ b/changelog/fix-finish-setup-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Capitalize the JCB label on transactions details page.

--- a/client/payment-details/payment-method/card/index.js
+++ b/client/payment-details/payment-method/card/index.js
@@ -52,7 +52,9 @@ const formatPaymentMethodDetails = ( charge ) => {
 		? sprintf(
 				// Translators: %1$s card brand, %2$s card funding (prepaid, credit, etc.).
 				__( '%1$s %2$s card', 'woocommerce-payments' ),
-				network.charAt( 0 ).toUpperCase() + network.slice( 1 ), // Brand
+				network === 'jcb'
+					? network.toUpperCase()
+					: network.charAt( 0 ).toUpperCase() + network.slice( 1 ), // Brand
 				fundingTypes[ funding ]
 		  )
 		: undefined;

--- a/client/payment-methods/capability-request/capability-request-map.ts
+++ b/client/payment-methods/capability-request/capability-request-map.ts
@@ -27,7 +27,7 @@ const CapabilityRequestList: Array< CapabilityRequestMap > = [
 				),
 				actions: 'link',
 				actionUrl:
-					'https://woocommerce.com/document/woopayments/payment-methods/',
+					'https://woocommerce.com/document/woopayments/payment-methods/#jcb',
 				actionsLabel: __( 'Finish setup', 'woocommerce-payments' ),
 			},
 			pending: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes the following issues:
- Updates the JCB capability request docs link button URL.
- Fixes the issue where JCB is not capitalized on the transaction details page.

Before: 
<img width="403" alt="Screenshot 2023-10-06 at 12 36 03" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/a70bb3b0-a86c-4bab-8e3a-89c3d2e0caf6">

After:
<img width="389" alt="Screenshot 2023-10-06 at 12 34 30" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/2764ab0e-512b-44eb-a64c-f50f12701f5c">

#### Testing instructions
- Connect a Japanese account and create a test order with a JCB [test card](https://stripe.com/docs/testing#asia-pacific) or use my existing test account `acct_1Ny71xQuMKrISNuR`.
- Navigate to `Payments` -> `Transactions`.
- Select the transaction paid with the JCB test card and navigate to the details page.
- Scroll down the `Payment method` section.
- Verify the `Type` value has JCB capitalized.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
