### PR TITLE
Enhance design of bnpl payment methods status in settings screen

### DIFF
--- a/changelog/update-6914-enhance-design-of-bnpl-payment-methods-status
+++ b/changelog/update-6914-enhance-design-of-bnpl-payment-methods-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Enhance design of bnpl payment methods status in settings screen

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import React, { useEffect, useState } from 'react';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import classNames from 'classnames';
+import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import { useManualCapture } from 'wcpay/data';
 import { HoverTooltip } from 'components/tooltip';
 import './style.scss';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
+import PAYMENT_METHOD_IDS from 'wcpay/payment-methods/constants';
 
 const LoadableCheckboxControl = ( {
 	label,
@@ -27,7 +29,69 @@ const LoadableCheckboxControl = ( {
 	setupTooltip = '',
 	delayMsOnCheck = 0,
 	delayMsOnUncheck = 0,
+	needsAttention = false,
+	paymentMethodId = '',
 } ) => {
+	const DocumentationUrlForDisabledPaymentMethod = {
+		DEFAULT:
+			'https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
+		BNPLS:
+			'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
+	};
+
+	const getDocumentationUrlForDisabledPaymentMethod = () => {
+		let url;
+		switch ( paymentMethodId ) {
+			case PAYMENT_METHOD_IDS.AFTERPAY_CLEARPAY:
+			case PAYMENT_METHOD_IDS.AFFIRM:
+				url = DocumentationUrlForDisabledPaymentMethod.BNPLS;
+				break;
+			default:
+				url = DocumentationUrlForDisabledPaymentMethod.DEFAULT;
+		}
+		return url;
+	};
+
+	const getTooltipContent = () => {
+		if ( isSetupRequired ) {
+			return setupTooltip;
+		}
+
+		if ( needsAttention ) {
+			return interpolateComponents( {
+				// translators: {{learnMoreLink}}: placeholders are opening and closing anchor tags.
+				mixedString: __(
+					'We need more information from you to enable this method. ' +
+						'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+					'woocommerce-payments'
+				),
+				components: {
+					learnMoreLink: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="noreferrer"
+							title={ __(
+								'Learn more about enabling payment methods',
+								'woocommerce-payments'
+							) }
+							/* eslint-disable-next-line max-len */
+							href={ getDocumentationUrlForDisabledPaymentMethod() }
+						/>
+					),
+				},
+			} );
+		}
+
+		return sprintf(
+			/* translators: %s: a payment method name. */
+			__(
+				'%s is not available to your customers when the "manual capture" setting is enabled.',
+				'woocommerce-payments'
+			),
+			label
+		);
+	};
 	const [ isLoading, setLoading ] = useState( false );
 	const [ checkedState, setCheckedState ] = useState( checked );
 	const [ isManualCaptureEnabled ] = useManualCapture();
@@ -87,25 +151,13 @@ const LoadableCheckboxControl = ( {
 				</div>
 			) }
 			{ ( isManualCaptureEnabled && ! isAllowingManualCapture ) ||
-			isSetupRequired ? (
+			isSetupRequired ||
+			needsAttention ? (
 				<div
 					className="loadable-checkbox__icon"
 					style={ { marginRight: '16px' } }
 				>
-					<HoverTooltip
-						content={
-							isSetupRequired
-								? setupTooltip
-								: sprintf(
-										/* translators: %s: a payment method name. */
-										__(
-											'%s is not available to your customers when the "manual capture" setting is enabled.',
-											'woocommerce-payments'
-										),
-										label
-								  )
-						}
-					>
+					<HoverTooltip content={ getTooltipContent() }>
 						<div>
 							<NoticeOutlineIcon
 								style={ {

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -94,7 +94,10 @@ const LoadableCheckboxControl = ( {
 					className="loadable-checkbox__icon"
 					style={ { marginRight: '16px' } }
 				>
-					<HoverTooltip content={ setupTooltip }>
+					<HoverTooltip
+						content={ setupTooltip }
+						className="wcpay-tooltip__tooltip--dark"
+					>
 						<div>
 							<NoticeOutlineIcon
 								style={ {

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -7,7 +7,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import React, { useEffect, useState } from 'react';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import classNames from 'classnames';
-import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ import { useManualCapture } from 'wcpay/data';
 import { HoverTooltip } from 'components/tooltip';
 import './style.scss';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
-import PAYMENT_METHOD_IDS from 'wcpay/payment-methods/constants';
 
 const LoadableCheckboxControl = ( {
 	label,
@@ -30,68 +28,7 @@ const LoadableCheckboxControl = ( {
 	delayMsOnCheck = 0,
 	delayMsOnUncheck = 0,
 	needsAttention = false,
-	paymentMethodId = '',
 } ) => {
-	const DocumentationUrlForDisabledPaymentMethod = {
-		DEFAULT:
-			'https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
-		BNPLS:
-			'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
-	};
-
-	const getDocumentationUrlForDisabledPaymentMethod = () => {
-		let url;
-		switch ( paymentMethodId ) {
-			case PAYMENT_METHOD_IDS.AFTERPAY_CLEARPAY:
-			case PAYMENT_METHOD_IDS.AFFIRM:
-				url = DocumentationUrlForDisabledPaymentMethod.BNPLS;
-				break;
-			default:
-				url = DocumentationUrlForDisabledPaymentMethod.DEFAULT;
-		}
-		return url;
-	};
-
-	const getTooltipContent = () => {
-		if ( isSetupRequired ) {
-			return setupTooltip;
-		}
-
-		if ( needsAttention ) {
-			return interpolateComponents( {
-				// translators: {{learnMoreLink}}: placeholders are opening and closing anchor tags.
-				mixedString: __(
-					'We need more information from you to enable this method. ' +
-						'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-					'woocommerce-payments'
-				),
-				components: {
-					learnMoreLink: (
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						<a
-							target="_blank"
-							rel="noreferrer"
-							title={ __(
-								'Learn more about enabling payment methods',
-								'woocommerce-payments'
-							) }
-							/* eslint-disable-next-line max-len */
-							href={ getDocumentationUrlForDisabledPaymentMethod() }
-						/>
-					),
-				},
-			} );
-		}
-
-		return sprintf(
-			/* translators: %s: a payment method name. */
-			__(
-				'%s is not available to your customers when the "manual capture" setting is enabled.',
-				'woocommerce-payments'
-			),
-			label
-		);
-	};
 	const [ isLoading, setLoading ] = useState( false );
 	const [ checkedState, setCheckedState ] = useState( checked );
 	const [ isManualCaptureEnabled ] = useManualCapture();
@@ -157,7 +94,7 @@ const LoadableCheckboxControl = ( {
 					className="loadable-checkbox__icon"
 					style={ { marginRight: '16px' } }
 				>
-					<HoverTooltip content={ getTooltipContent() }>
+					<HoverTooltip content={ setupTooltip }>
 						<div>
 							<NoticeOutlineIcon
 								style={ {

--- a/client/components/payment-methods-list/payment-method.scss
+++ b/client/components/payment-methods-list/payment-method.scss
@@ -183,25 +183,12 @@
 		}
 	}
 
-	.wcpay-pill {
+	.chip {
 		margin-left: $gap-smaller;
 		padding: 2px $gap-smaller;
 
 		@include breakpoint( '<660px' ) {
 			margin-left: 0;
-		}
-
-		&.payment-status-pending-approval,
-		&.payment-status-pending-verification {
-			border: 0 solid transparent;
-			background: #f0b849;
-			color: #1f1f1f;
-		}
-
-		&.payment-status-inactive {
-			border: 0 solid transparent;
-			background: $studio-yellow-5;
-			color: $studio-yellow-50;
 		}
 	}
 }

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -8,6 +8,7 @@ import React, { useContext } from 'react';
 /**
  * Internal dependencies
  */
+import interpolateComponents from '@automattic/interpolate-components';
 import { __, sprintf } from '@wordpress/i18n';
 import { HoverTooltip } from 'components/tooltip';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
@@ -18,12 +19,11 @@ import {
 	formatMethodFeesTooltip,
 } from 'wcpay/utils/account-fees';
 import WCPaySettingsContext from '../../settings/wcpay-settings-context';
+import Chip from '../chip';
 import LoadableCheckboxControl from '../loadable-checkbox';
+import { getDocumentationUrlForDisabledPaymentMethod } from '../payment-method-disabled-tooltip';
 import Pill from '../pill';
 import './payment-method.scss';
-import Chip from '../chip';
-import interpolateComponents from '@automattic/interpolate-components';
-import PAYMENT_METHOD_IDS from 'wcpay/payment-methods/constants';
 
 interface PaymentMethodProps {
 	id: string;
@@ -142,28 +142,6 @@ const PaymentMethod = ( {
 			return onCheckClick( id );
 		}
 		return onUncheckClick( id );
-	};
-
-	const DocumentationUrlForDisabledPaymentMethod = {
-		DEFAULT:
-			'https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
-		BNPLS:
-			'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
-	};
-
-	const getDocumentationUrlForDisabledPaymentMethod = (
-		paymentMethodId: string
-	) => {
-		let url;
-		switch ( paymentMethodId ) {
-			case PAYMENT_METHOD_IDS.AFTERPAY_CLEARPAY:
-			case PAYMENT_METHOD_IDS.AFFIRM:
-				url = DocumentationUrlForDisabledPaymentMethod.BNPLS;
-				break;
-			default:
-				url = DocumentationUrlForDisabledPaymentMethod.DEFAULT;
-		}
-		return url;
 	};
 
 	const getTooltipContent = ( paymentMethodId: string ) => {

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -66,52 +66,28 @@ const PaymentMethodLabel = ( {
 				</span>
 			) }
 			{ upeCapabilityStatuses.PENDING_APPROVAL === status && (
-				<HoverTooltip
-					content={ __(
-						'This payment method is pending approval. Once approved, you will be able to use it.',
-						'woocommerce-payments'
-					) }
-				>
-					<Chip
-						message={ __(
-							'Pending approval',
-							'woocommerce-payments'
-						) }
-						type="warning"
-					/>
-				</HoverTooltip>
+				<Chip
+					message={ __( 'Pending approval', 'woocommerce-payments' ) }
+					type="warning"
+				/>
 			) }
 			{ upeCapabilityStatuses.PENDING_VERIFICATION === status && (
-				<HoverTooltip
-					content={ sprintf(
-						__(
-							"%s won't be visible to your customers until you provide the required " +
-								'information. Follow the instructions sent by our partner Stripe to %s.',
-							'woocommerce-payments'
-						),
-						label,
-						wcpaySettings?.accountEmail ?? ''
+				<Chip
+					message={ __(
+						'Pending activation',
+						'woocommerce-payments'
 					) }
-				>
-					<Chip
-						message={ __(
-							'Pending activation',
-							'woocommerce-payments'
-						) }
-						type="warning"
-					/>
-				</HoverTooltip>
+					type="warning"
+				/>
 			) }
 			{ disabled && (
-				<PaymentMethodDisabledTooltip id={ id }>
-					<Chip
-						message={ __(
-							'More information needed',
-							'woocommerce-payments'
-						) }
-						type="warning"
-					/>
-				</PaymentMethodDisabledTooltip>
+				<Chip
+					message={ __(
+						'More information needed',
+						'woocommerce-payments'
+					) }
+					type="warning"
+				/>
 			) }
 		</>
 	);
@@ -146,9 +122,16 @@ const PaymentMethod = ( {
 	);
 	const [ isManualCaptureEnabled ] = useManualCapture();
 
+	const needsAttention = [
+		upeCapabilityStatuses.INACTIVE,
+		upeCapabilityStatuses.PENDING_APPROVAL,
+		upeCapabilityStatuses.PENDING_VERIFICATION,
+	].includes( status );
+
 	const needsOverlay =
 		( isManualCaptureEnabled && ! isAllowingManualCapture ) ||
-		isSetupRequired;
+		isSetupRequired ||
+		needsAttention;
 
 	const handleChange = ( newStatus: string ) => {
 		// If the payment method control is locked, reject any changes.
@@ -183,6 +166,8 @@ const PaymentMethod = ( {
 					isAllowingManualCapture={ isAllowingManualCapture }
 					isSetupRequired={ isSetupRequired }
 					setupTooltip={ setupTooltip }
+					needsAttention={ needsAttention }
+					paymentMethodId={ id }
 				/>
 			</div>
 			<div className="payment-method__text-container">

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -22,6 +22,7 @@ import LoadableCheckboxControl from '../loadable-checkbox';
 import Pill from '../pill';
 import PaymentMethodDisabledTooltip from '../payment-method-disabled-tooltip';
 import './payment-method.scss';
+import Chip from '../chip';
 
 interface PaymentMethodProps {
 	id: string;
@@ -71,9 +72,13 @@ const PaymentMethodLabel = ( {
 						'woocommerce-payments'
 					) }
 				>
-					<Pill className={ 'payment-status-pending-approval' }>
-						{ __( 'Pending approval', 'woocommerce-payments' ) }
-					</Pill>
+					<Chip
+						message={ __(
+							'Pending approval',
+							'woocommerce-payments'
+						) }
+						type="warning"
+					/>
 				</HoverTooltip>
 			) }
 			{ upeCapabilityStatuses.PENDING_VERIFICATION === status && (
@@ -88,19 +93,24 @@ const PaymentMethodLabel = ( {
 						wcpaySettings?.accountEmail ?? ''
 					) }
 				>
-					<Pill className={ 'payment-status-pending-verification' }>
-						{ __( 'Pending activation', 'woocommerce-payments' ) }
-					</Pill>
+					<Chip
+						message={ __(
+							'Pending activation',
+							'woocommerce-payments'
+						) }
+						type="warning"
+					/>
 				</HoverTooltip>
 			) }
 			{ disabled && (
 				<PaymentMethodDisabledTooltip id={ id }>
-					<Pill className={ 'payment-status-' + status }>
-						{ __(
+					<Chip
+						message={ __(
 							'More information needed',
 							'woocommerce-payments'
 						) }
-					</Pill>
+						type="warning"
+					/>
 				</PaymentMethodDisabledTooltip>
 			) }
 		</>

--- a/client/components/payment-methods-list/style.scss
+++ b/client/components/payment-methods-list/style.scss
@@ -5,3 +5,10 @@
 .woopayments-request-jcb {
 	margin: $grid-unit-30 $grid-unit-30 0 $grid-unit-30 !important;
 }
+
+.wcpay-tooltip__tooltip {
+	&.wcpay-tooltip__tooltip--dark a {
+		color: $white;
+		text-decoration: underline;
+	}
+}


### PR DESCRIPTION
Fixes #6914 

#### Changes proposed in this Pull Request
This pull requests Introduces design enhancements in the payment settings settings screen:

- Payment method status: use updated `Chip` component instead of current `Pill`.
- Icon: Use yellow warning icon and push back transparency of the payment method in the list to indicate inactivity.
- Tooltips:
   - Remove the payment status tooltips from the status component to the warning icon
   - Override color of anchor elements inside tooltips to use white instead of blue for improved legibility.

#### Screenshots
**Before**

<img width="701" alt="Screenshot 2023-10-06 at 12 53 28" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/95a2b1e0-5a17-46e7-a03e-55e12a89363e">


**After**

<img width="1062" alt="Screenshot 2023-10-06 at 12 52 07" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/b7eb9b1a-ce6e-43d8-be29-0527ae2d86dc">


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The React PaymentMethod component relies in props to render the elements in the UI. There are some options to modify those:

    - Manually editing the props in https://github.com/Automattic/woocommerce-payments/blob/281c2a00eac31e9a041f90721eaaddb9e0548790/client/payment-methods/index.js#L311
    - The React Developer tool allows to modify the props of a rendered component from the dev tools. Go to Components tab, select the component you want to modify and now you can modify the props at will.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
