### PR TITLE
Point Klarna documentation to correct url from 'Contact WooCommerce Support' badge

### DIFF
--- a/changelog/fix-correct-documentation-url-for-klarna
+++ b/changelog/fix-correct-documentation-url-for-klarna
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Adding missed functionality from another PR
+
+

--- a/client/components/payment-method-disabled-tooltip/index.tsx
+++ b/client/components/payment-method-disabled-tooltip/index.tsx
@@ -26,6 +26,7 @@ export const getDocumentationUrlForDisabledPaymentMethod = (
 	switch ( paymentMethodId ) {
 		case PAYMENT_METHOD_IDS.AFTERPAY_CLEARPAY:
 		case PAYMENT_METHOD_IDS.AFFIRM:
+		case PAYMENT_METHOD_IDS.KLARNA:
 			url = DocumentationUrlForDisabledPaymentMethod.BNPLS;
 			break;
 		default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Point Klarna documentation to the correct URL from 'Contact WooCommerce Support' badge.

#### Testing instructions

Tested in https://github.com/Automattic/woocommerce-payments/pull/6875

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
