### PR TITLE
Add backup loading spinner style from WC blocks to WooPay button

### DIFF
--- a/changelog/fix-add-wc-blocks-loading-spinner-css
+++ b/changelog/fix-add-wc-blocks-loading-spinner-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WC blocks spinner to the WooPay checkout styles.

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -270,3 +270,50 @@
 		}
 	}
 }
+
+@keyframes spinner__animation {
+	0% {
+		animation-timing-function: cubic-bezier(
+			0.5856,
+			0.0703,
+			0.4143,
+			0.9297
+		);
+		transform: rotate( 0deg );
+	}
+	100% {
+		transform: rotate( 360deg );
+	}
+}
+
+/**
+ * Sourced from https://github.com/woocommerce/woocommerce-blocks/blob/4dfe904f761423c1ac494f0d6319c602965b5efe/assets/js/base/components/spinner/style.scss.
+ * Depending on the wc-blocks version, these styles are not loaded, so they need to be included here.
+ */
+.wc-block-components-spinner {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	color: inherit;
+	box-sizing: content-box;
+	text-align: center;
+	font-size: 1.25em;
+
+	&::after {
+		content: ' ';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin: -0.5em 0 0 -0.5em;
+		width: 1em;
+		height: 1em;
+		box-sizing: border-box;
+		transform-origin: 50% 50%;
+		transform: translateZ( 0 ) scale( 0.5 );
+		backface-visibility: hidden;
+		border-radius: 50%;
+		border: 0.2em solid currentColor;
+		border-left-color: transparent;
+		animation: spinner__animation 1s infinite linear;
+	}
+}


### PR DESCRIPTION
Context: p1696621678624469/1696340095.094999-slack-C01BZUL57SQ

#### Changes proposed in this Pull Request

Depending on the version of WooCommerce, the WC blocks loading spinner styles is not included. This PR adds a fallback CSS for the `wc-block-components-spinner` class.

#### Testing instructions

* Install WC [`8.2.0-rc2`](https://github.com/woocommerce/woocommerce/releases/tag/8.2.0-rc.2).
* Notice there's no spinner in the email input field or the WooPay button when it's clicked.
* Checkout this branch and run `npm run build`.
* Ensure the spinner is visible.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.