### PR TITLE
Show/hide WooPay checkout page tooltip on click

### DIFF
--- a/changelog/fix-woopay-learn-more-tooltip
+++ b/changelog/fix-woopay-learn-more-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+show/hide WooPay checkout page tooltip on click

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -40,6 +40,9 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		() => setIsInfoFlyoutVisible( false ),
 		[]
 	);
+	const toggleTooltip = () => {
+		setIsInfoFlyoutVisible( ! isInfoFlyoutVisible );
+	};
 	const isRegisteredUser = useWooPayUser();
 	const { isWCPayChosen, isNewPaymentTokenChosen } = useSelectedPaymentMethod(
 		isBlocksCheckout
@@ -117,11 +120,11 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	};
 
 	useEffect( () => {
-		// Record Tracks event when user hovers over the info icon for the first time.
+		// Record Tracks event when user clicks on the info icon for the first time.
 		if ( isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
 			setHasShownInfoFlyout( true );
 			wcpayTracks.recordUserEvent(
-				wcpayTracks.events.WOOPAY_SAVE_MY_INFO_TOOLTIP_HOVER
+				wcpayTracks.events.WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK
 			);
 		} else if ( ! isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
 			setHasShownInfoFlyout( false );
@@ -242,22 +245,17 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 						className="woopay-logo"
 						alt="WooPay"
 					/>
-					<Icon
-						icon={ info }
-						size={ 20 }
-						className={ `info-icon ${
-							isInfoFlyoutVisible ? 'focused' : ''
+					<button
+						className={ `info-button ${
+							isInfoFlyoutVisible ? 'flyout-visible' : ''
 						}` }
-						onMouseOver={ setInfoFlyoutVisible }
-						onMouseOut={ setInfoFlyoutNotVisible }
-					/>
-					<div
-						className="save-details-flyout"
-						onMouseOver={ setInfoFlyoutVisible }
-						onFocus={ setInfoFlyoutVisible }
-						onMouseOut={ setInfoFlyoutNotVisible }
-						onBlur={ setInfoFlyoutNotVisible }
+						type="button"
+						onClick={ toggleTooltip }
+						onBlur={ toggleTooltip }
 					>
+						<Icon icon={ info } size={ 20 } className="info-icon" />
+					</button>
+					<div className="save-details-flyout">
 						<div>
 							<LockIconG size={ 16 } />
 						</div>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -32,14 +32,6 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const [ isInfoFlyoutVisible, setIsInfoFlyoutVisible ] = useState( false );
 	const [ hasShownInfoFlyout, setHasShownInfoFlyout ] = useState( false );
 
-	const setInfoFlyoutVisible = useCallback(
-		() => setIsInfoFlyoutVisible( true ),
-		[]
-	);
-	const setInfoFlyoutNotVisible = useCallback(
-		() => setIsInfoFlyoutVisible( false ),
-		[]
-	);
 	const toggleTooltip = () => {
 		setIsInfoFlyoutVisible( ! isInfoFlyoutVisible );
 	};

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -56,18 +56,27 @@
 			margin-top: 0.375rem;
 		}
 
+		.info-button {
+			border: none;
+			background: transparent;
+
+			&:focus + .save-details-flyout {
+				display: none;
+			}
+		}
+
+		.info-button.flyout-visible:focus + .save-details-flyout {
+			display: flex;
+		}
+
 		.info-icon {
 			fill: $gray-600;
 			margin-top: 0.1875rem;
 			object-fit: none;
 
 			&:hover,
-			&.focused {
+			&:focus {
 				fill: #3d9cd2;
-			}
-
-			&:hover + .save-details-flyout {
-				display: flex;
 			}
 		}
 

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -59,6 +59,11 @@
 		.info-button {
 			border: none;
 			background: transparent;
+			padding: 0;
+
+			&:focus {
+				outline: none;
+			}
 
 			&:focus + .save-details-flyout {
 				display: none;

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -119,7 +119,7 @@ const events = {
 	WOOPAY_SAVE_MY_INFO_TOS_CLICK: 'checkout_save_my_info_tos_click',
 	WOOPAY_SAVE_MY_INFO_PRIVACY_CLICK:
 		'checkout_save_my_info_privacy_policy_click',
-	WOOPAY_SAVE_MY_INFO_TOOLTIP_HOVER: 'checkout_save_my_info_tooltip_hover',
+	WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK: 'checkout_save_my_info_tooltip_click',
 	WOOPAY_SAVE_MY_INFO_TOOLTIP_LEARN_MORE_CLICK:
 		'checkout_save_my_info_tooltip_learn_more_click',
 	// Onboarding flow.


### PR DESCRIPTION
Fixes #6484 

#### Changes proposed in this Pull Request
<!--
Title: A descriptive, yet concise, title.
-->
The tooltip on the checkout page in the WooPay "save my info" box would show the tooltip on hover. However, when hovering and then moving to the tip box, it would not stay visible long enough to click on the link in the tip. It would have been possible to have it hover longer, but it was suggested to make it accessible by clicking on the tooltip.

@elizaan36 @pierorocca for demo purposes.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Go to the checkout page with WooPay enabled.
2. Scroll to the WooPay save info section.
3. Hover over the tooltip icon, the icon should turn blue, but the tip should not appear.
4. Click on the icon, the tip should appear.
5. The link in the tip should be clickable.
6. Click on the icon again, the tip should disappear.
7. Click the icon to make the tip appear again then click outside the tip box but not on the icon, the tip should disappear.
8. In mobile view the tip icon should work the same.
9. Make sure the tip box doesn't appear when the icon hasn't been clicked.
10. Make sure the tip box does not appear and disappear almost immediately.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

https://github.com/Automattic/woocommerce-payments/assets/7651258/6f0a5296-a877-4622-b5e8-5b8ea6b69ce8

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
