### PR TITLE
Replace AJAX setup intent roundtrip with create/confirm on the back-end

### DIFF
--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -267,37 +267,17 @@ jQuery( function ( $ ) {
 	 * @param {Object} paymentMethod Payment method object.
 	 */
 	const handleAddCard = ( $form, paymentMethod ) => {
-		api.setupIntent( paymentMethod.id )
-			.then( function ( confirmedSetupIntent ) {
-				// Populate form with the setup intent and re-submit.
-				$form.append(
-					$( '<input type="hidden" />' )
-						.attr( 'id', 'wcpay-setup-intent' )
-						.attr( 'name', 'wcpay-setup-intent' )
-						.val( confirmedSetupIntent.id )
-				);
-
-				// WC core calls block() when add_payment_form is submitted, so we need to enable the ignore flag here to avoid
+		$form.append(
+			`<input type="hidden" id="wcpay-payment-method" name="wcpay-payment-method" value="${ paymentMethod.id }" />`
+		);
+						// WC core calls block() when add_payment_form is submitted, so we need to enable the ignore flag here to avoid
 				// the overlay blink when the form is blocked twice. We can restore its default value once the form is submitted.
 				const defaultIgnoreIfBlocked =
 					$.blockUI.defaults.ignoreIfBlocked;
 				$.blockUI.defaults.ignoreIfBlocked = true;
-
-				// Re-submit the form.
-				$form.removeClass( 'processing' ).submit();
-
-				// Restore default value for ignoreIfBlocked.
-				$.blockUI.defaults.ignoreIfBlocked = defaultIgnoreIfBlocked;
-			} )
-			.catch( function ( error ) {
-				paymentMethodGenerated = null;
-				$form.removeClass( 'processing' ).unblock();
-				if ( error.responseJSON && ! error.responseJSON.success ) {
-					showError( error.responseJSON.data.error.message );
-				} else if ( error.message ) {
-					showError( error.message );
-				}
-			} );
+		$form.removeClass( 'processing' ).submit();
+		// Restore default value for ignoreIfBlocked.
+		$.blockUI.defaults.ignoreIfBlocked = defaultIgnoreIfBlocked;
 	};
 
 	/**

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -9,7 +9,7 @@ import { getConfig } from 'utils/checkout';
 import { handleWooPayEmailInput } from '../woopay/email-input-iframe';
 import WCPayAPI from './../api';
 import enqueueFraudScripts from 'fraud-scripts';
-import { isWCPayChosen } from '../utils/upe';
+import { appendPaymentMethodIdToForm, isWCPayChosen } from '../utils/upe';
 import { isPreviewing } from '../preview';
 import {
 	getFingerprint,
@@ -267,17 +267,8 @@ jQuery( function ( $ ) {
 	 * @param {Object} paymentMethod Payment method object.
 	 */
 	const handleAddCard = ( $form, paymentMethod ) => {
-		$form.append(
-			`<input type="hidden" id="wcpay-payment-method" name="wcpay-payment-method" value="${ paymentMethod.id }" />`
-		);
-						// WC core calls block() when add_payment_form is submitted, so we need to enable the ignore flag here to avoid
-				// the overlay blink when the form is blocked twice. We can restore its default value once the form is submitted.
-				const defaultIgnoreIfBlocked =
-					$.blockUI.defaults.ignoreIfBlocked;
-				$.blockUI.defaults.ignoreIfBlocked = true;
+		appendPaymentMethodIdToForm( $form, paymentMethod.id );
 		$form.removeClass( 'processing' ).submit();
-		// Restore default value for ignoreIfBlocked.
-		$.blockUI.defaults.ignoreIfBlocked = defaultIgnoreIfBlocked;
 	};
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3043,49 +3043,57 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function add_payment_method() {
 		try {
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			if ( ! isset( $_POST['wcpay-setup-intent'] ) ) {
-				throw new Add_Payment_Method_Exception(
-					sprintf(
-						/* translators: %s: WooPayments */
-						__( 'A %s payment method was not provided', 'woocommerce-payments' ),
-						'WooPayments'
-					),
-					'payment_method_intent_not_provided'
-				);
-			}
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			$setup_intent_id = ! empty( $_POST['wcpay-setup-intent'] ) ? wc_clean( $_POST['wcpay-setup-intent'] ) : false;
-
 			$customer_id = $this->customer_service->get_customer_id_by_user_id( get_current_user_id() );
+			$payment_information             = Payment_Information::from_payment_request( $_POST, null, null, null, null, $this->get_payment_method_to_use_for_intent() ); // phpcs:ignore WordPress.Security.NonceVerification
 
-			if ( ! $setup_intent_id || null === $customer_id ) {
+			if ( null === $customer_id ) {
 				throw new Add_Payment_Method_Exception(
 					__( "We're not able to add this payment method. Please try again later", 'woocommerce-payments' ),
 					'invalid_setup_intent_id'
 				);
 			}
 
-			$setup_intent_request = Get_Setup_Intention::create( $setup_intent_id );
-			/** @var WC_Payments_API_Setup_Intention $setup_intent */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-			$setup_intent = $setup_intent_request->send();
+			// For $0 orders, we need to save the payment method using a setup intent.
+			$setup_intent = $this->create_and_confirm_setup_intent();
+			$next_action   = $setup_intent->get_next_action();
+			$client_secret = $setup_intent->get_client_secret();
 
-			if ( Intent_Status::SUCCEEDED !== $setup_intent->get_status() ) {
-				throw new Add_Payment_Method_Exception(
-					__( 'Failed to add the provided payment method. Please try again later', 'woocommerce-payments' ),
-					'invalid_response_status'
-				);
+			// 3DS handling - copied over from process_payment.
+			if ( Intent_Status::REQUIRES_ACTION === $setup_intent->get_status() ) {
+				if ( isset( $next_action['type'] ) && 'redirect_to_url' === $next_action['type'] && ! empty( $next_action['redirect_to_url']['url'] ) ) {
+					$response = [
+						'result'   => 'success',
+						'redirect' => $next_action['redirect_to_url']['url'],
+					];
+				} else {
+					$response = [
+						'result'         => 'success',
+						// Include a new nonce for update_order_status to ensure the update order
+						// status call works when a guest user creates an account during checkout.
+						'redirect'       => sprintf(
+							'#wcpay-confirm-%s:%s:%s:%s',
+							'si',
+							3057,
+							WC_Payments_Utils::encrypt_client_secret( $this->account->get_stripe_account_id(), $client_secret ),
+							wp_create_nonce( 'wcpay_update_order_status_nonce' )
+						),
+						// Include the payment method ID so the Blocks integration can save cards.
+						'payment_method' => $payment_information->get_payment_method(),
+					];
+				}
+			}
+
+			if ( Intent_Status::SUCCEEDED === $setup_intent->get_status() ) {
+				$response = [
+					'result'   => 'success',
+					'redirect' => apply_filters( 'wcpay_get_add_payment_method_redirect_url', wc_get_endpoint_url( 'payment-methods' ) ),
+				];
 			}
 
 			$payment_method = $setup_intent->get_payment_method_id();
 			$this->token_service->add_payment_method_to_user( $payment_method, wp_get_current_user() );
 
-			return [
-				'result'   => 'success',
-				'redirect' => apply_filters( 'wcpay_get_add_payment_method_redirect_url', wc_get_endpoint_url( 'payment-methods' ) ),
-			];
+			return $response;
 		} catch ( Exception $e ) {
 			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error', [ 'icon' => 'error' ] );
 			Logger::log( 'Error when adding payment method: ' . $e->getMessage() );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
