### PR TITLE
Add additional security checks

### DIFF
--- a/changelog/fix-3579-add-additional-security-checks
+++ b/changelog/fix-3579-add-additional-security-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add additional security checks in the plugin

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -328,6 +328,9 @@ class WC_Payments_Admin {
 	 * Add payments menu items.
 	 */
 	public function add_payments_menu() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 		global $submenu;
 
 		try {
@@ -540,7 +543,9 @@ class WC_Payments_Admin {
 	 * Register the CSS and JS scripts
 	 */
 	public function register_payments_scripts() {
-		// TODO: Add check to see if user can manage_woocommerce and exit early if they cannot.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 
 		WC_Payments::register_script_with_dependencies( 'WCPAY_DASH_APP', 'dist/index' );
 
@@ -1025,6 +1030,9 @@ class WC_Payments_Admin {
 	 * if it is not and the user is attempting to view a WCPay admin page.
 	 */
 	public function maybe_redirect_to_onboarding() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 		if ( wp_doing_ajax() ) {
 			return;
 		}
@@ -1071,6 +1079,9 @@ class WC_Payments_Admin {
 	 * @see self::add_payments_menu()
 	 */
 	public function maybe_redirect_overview_to_connect() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 		if ( wp_doing_ajax() ) {
 			return;
 		}
@@ -1105,6 +1116,9 @@ class WC_Payments_Admin {
 	 * Redirect back to the connect page with an error message.
 	 */
 	public function maybe_redirect_onboarding_flow_to_connect(): void {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 		$url_params = wp_unslash( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $url_params['page'] ) && 'wc-admin' === $url_params['page']
 			&& isset( $url_params['path'] ) && '/payments/onboarding' === $url_params['path'] && ! $this->payments_api_client->is_server_connected() ) {

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -206,6 +206,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 	 * @dataProvider data_maybe_redirect_to_onboarding
 	 */
 	public function test_maybe_redirect_to_onboarding( $expected_times_redirect_called, $is_stripe_connected, $get_params ) {
+		$this->mock_current_user_is_admin();
 		$_GET = $get_params;
 
 		$this->mock_account
@@ -283,6 +284,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_maybe_redirect_overview_to_connect( $expected_times_redirect_called, $is_wc_registered_page, $get_params ) {
 		global $wp_actions;
+		$this->mock_current_user_is_admin();
 		// Avoid WP doing_it_wrong warnings.
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_actions['current_screen'] = true;
@@ -384,6 +386,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 	 * @dataProvider data_maybe_redirect_onboarding_flow_to_connect
 	 */
 	public function test_maybe_redirect_onboarding_flow_to_connect( $expected_times_redirect_called, $is_server_connected, $get_params ) {
+		$this->mock_current_user_is_admin();
 		$_GET = $get_params;
 
 		$this->mock_api_client


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments-server/issues/3579

#### Changes proposed in this Pull Request

* Add additional security checks spotted by internal audit

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Changes should make sense
* Tests should pass
* Bonus: smoke test 
  * you can see the payments menu and connect page
  * you can see onboarding page (for PO)
  * you can successfully onboard PO account

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
