### PR TITLE
Disable WooPay first party auth when using adapted extensions

### DIFF
--- a/changelog/fix-disable-woopay-first-party
+++ b/changelog/fix-disable-woopay-first-party
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set WooPay first party feature flag to off when incompatible extensions are active.

--- a/includes/woopay/class-woopay-scheduler.php
+++ b/includes/woopay/class-woopay-scheduler.php
@@ -118,9 +118,9 @@ class WooPay_Scheduler {
 		$enabled_adapted_extensions = $this->get_extensions_in_list( $active_plugins, $adapted_extensions );
 
 		if ( count( $enabled_adapted_extensions ) > 0 ) {
-			update_option( \WC_Payments_Features::WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME, 0 );
+			update_option( '_wcpay_feature_woopay_first_party_auth', 0 );
 		} else {
-			update_option( \WC_Payments_Features::WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME, 1 );
+			update_option( '_wcpay_feature_woopay_first_party_auth', 1 );
 		}
 
 		update_option( self::ENABLED_ADAPTED_EXTENSIONS_OPTION_NAME, $enabled_adapted_extensions );

--- a/includes/woopay/class-woopay-scheduler.php
+++ b/includes/woopay/class-woopay-scheduler.php
@@ -117,6 +117,12 @@ class WooPay_Scheduler {
 	public function update_enabled_adapted_extensions( $active_plugins, $adapted_extensions ) {
 		$enabled_adapted_extensions = $this->get_extensions_in_list( $active_plugins, $adapted_extensions );
 
+		if ( count( $enabled_adapted_extensions ) > 0 ) {
+			update_option( \WC_Payments_Features::WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME, 0 );
+		} else {
+			update_option( \WC_Payments_Features::WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME, 1 );
+		}
+
 		update_option( self::ENABLED_ADAPTED_EXTENSIONS_OPTION_NAME, $enabled_adapted_extensions );
 	}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
It was discovered during compatibility testing that the new WooPay first party auth flow would break compatiblity with the WooPay adapted extensions. As a quick fix for this, we are going to disable the first party auth flow flag when we see that any of these extensions are enabled, and enable the flag when none of them are enabled.

This is accomplished in this PR by adding a check when we are updating the list of enabled adapted extensions and then setting the first party auth flag accordingly.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

For testing these changes specifically:
- Monitor the `wp_options` table for the option name `_wcpay_feature_woopay_first_party_auth`.
- Remove the option if it is present.
- Disable any adapted extensions (tested with [Gift Cards](https://woocommerce.com/products/gift-cards/) and [Points and Rewards](https://woocommerce.com/products/woocommerce-points-and-rewards/)).
- Confirm that the option is now set to 1.
- Enable either/all of the extensions listed.
- Confirm that the option is now set to 0.
- Go through a WooPay checkout and confirm you get the OTP modal.
- Disable all the adapted extensions.
- Confirm that the option is now set to 1.
- Go through a WooPay checkout and confirm you get the first party auth flow (taken directly to WooPay with no modal).

Testing the plugins still in compatiblity.
- Repeat the steps above until you get to having both plugins enabled and the option set to 0.
- Then follow these testing instructions for Gift Cards: https://github.com/Automattic/woopay/pull/1954
- Then follow these testing instructions for Points and Rewards: https://github.com/Automattic/woopay/pull/1950


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
