### PR TITLE
Remove 'dispute' from possible value of ParentSegment in `details-link`.

### DIFF
--- a/changelog/remove-7363-parentsegment-dispute
+++ b/changelog/remove-7363-parentsegment-dispute
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Removing possible value of an argument type that is no longer used.
+
+

--- a/client/components/details-link/index.tsx
+++ b/client/components/details-link/index.tsx
@@ -15,7 +15,7 @@ import { getAdminUrl } from 'wcpay/utils';
 /**
  * The parent segment is the first part of the URL after the /payments/ path.
  */
-type ParentSegment = 'deposits' | 'transactions' | 'disputes';
+type ParentSegment = 'deposits' | 'transactions';
 
 export const getDetailsURL = (
 	/**

--- a/client/components/details-link/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/details-link/test/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details link renders dispute details with ID 1`] = `
 <div>
   <a
     data-link-type="wc-admin"
-    href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=dp_mock"
+    href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
   >
     <svg
       class="gridicon gridicons-info-outline needs-offset"

--- a/client/components/details-link/test/index.test.tsx
+++ b/client/components/details-link/test/index.test.tsx
@@ -21,14 +21,14 @@ describe( 'Details link', () => {
 
 	test( 'renders dispute details with ID', () => {
 		const { container: link } = render(
-			<DetailsLink id="dp_mock" parentSegment="disputes" />
+			<DetailsLink id="po_mock" parentSegment="deposits" />
 		);
 		expect( link ).toMatchSnapshot();
 	} );
 
 	test( 'empty render with no ID', () => {
 		const { container: link } = render(
-			<DetailsLink parentSegment="disputes" />
+			<DetailsLink parentSegment="deposits" />
 		);
 		expect( link ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
Partially fixes https://github.com/Automattic/woocommerce-payments/issues/7363

#### Changes proposed in this Pull Request

Remove 'dispute' from possible value of ParentSegment in `details-link`.

#### Testing instructions

* Make sure all tests pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
