### PR TITLE
Prevent access to settings for partially onboarded accounts

### DIFF
--- a/changelog/fix-5815-settings-access-partially-onboarded
+++ b/changelog/fix-5815-settings-access-partially-onboarded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent settings access to partially onboarded accounts

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -94,6 +94,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_wcpay_connect' ] ), 'maybe_redirect_to_wcpay_connect action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_capital_offer' ] ), 'maybe_redirect_to_capital_offer action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_server_link' ] ), 'maybe_redirect_to_server_link action does not exist.' );
+		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_settings_to_connect' ] ), 'maybe_redirect_settings_to_connect action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_activate_woopay' ] ), 'maybe_activate_woopay action does not exist.' );
 		$this->assertNotFalse( has_action( 'woocommerce_payments_account_refreshed', [ $this->wcpay_account, 'handle_instant_deposits_inbox_note' ] ), 'handle_instant_deposits_inbox_note action does not exist.' );
 		$this->assertNotFalse( has_action( 'woocommerce_payments_account_refreshed', [ $this->wcpay_account, 'handle_loan_approved_inbox_note' ] ), 'handle_loan_approved_inbox_note action does not exist.' );
@@ -359,6 +360,81 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		$this->assertFalse( $this->wcpay_account->maybe_redirect_to_wcpay_connect() );
 	}
+
+	/**
+	 * @dataProvider data_maybe_redirect_settings_to_connect
+	 */
+	public function test_maybe_redirect_settings_to_connect( $expected_redirect_to_count, $details_submitted, $get_params ) {
+		wp_set_current_user( 1 );
+		$_GET = $get_params;
+
+		$this->cache_account_details(
+			[
+				'account_id'        => 'acc_test',
+				'is_live'           => true,
+				'details_submitted' => $details_submitted,
+			]
+		);
+
+		// Mock WC_Payments_Account without redirect_to to prevent headers already sent error.
+		$mock_wcpay_account = $this->getMockBuilder( WC_Payments_Account::class )
+			->setMethods( [ 'redirect_to' ] )
+			->setConstructorArgs( [ $this->mock_api_client, $this->mock_database_cache, $this->mock_action_scheduler_service, $this->mock_session_service ] )
+			->getMock();
+
+		$mock_wcpay_account->expects( $this->exactly( $expected_redirect_to_count ) )->method( 'redirect_to' );
+
+		$mock_wcpay_account->maybe_redirect_settings_to_connect();
+	}
+
+	/**
+	 * Data provider for test_maybe_redirect_settings_to_connect
+	 */
+	public function data_maybe_redirect_settings_to_connect() {
+		return [
+			'no_get_params'           => [
+				0,
+				false,
+				[],
+			],
+			'missing_param'           => [
+				0,
+				false,
+				[
+					'page' => 'wc-settings',
+					'tab'  => 'checkout',
+				],
+			],
+			'incorrect_param'         => [
+				0,
+				false,
+				[
+					'page'    => 'wc-admin',
+					'tab'     => 'checkout',
+					'section' => 'woocommerce_payments',
+				],
+			],
+			'account_fully_onboarded' => [
+				0,
+				true,
+				[
+					'page'    => 'wc-settings',
+					'tab'     => 'checkout',
+					'section' => 'woocommerce_payments',
+				],
+			],
+			'happy_path'              => [
+				1,
+				false,
+				[
+					'page'    => 'wc-settings',
+					'tab'     => 'checkout',
+					'section' => 'woocommerce_payments',
+				],
+			],
+		];
+	}
+
 
 	public function test_try_is_stripe_connected_returns_true_when_connected() {
 		$this->mock_empty_cache();


### PR DESCRIPTION
Fixes #5815
Follow up from #5414

#### Changes proposed in this Pull Request
Prevent access to settings for partially onboarded accounts, by redirecting them to the connect page on direct access.

More details in https://github.com/Automattic/woocommerce-payments-server/issues/3129

#### Testing instructions
- Disconnect your existing account if you have one.
- Initiate the onboarding process and leave it as soon as you land on the Stripe KYC process, clicking on "Return to [your site name]".
- Got to **WooCommerce → Settings → Payments** and click on **Manage** for WooPayments.
- Should redirect to connect page preventing access to WooPayments settings.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : [link](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-6.7.0#prevent-access-to-settings-for-partially-onboarded-accounts)
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
