### PR TITLE
Fixed issue that would turn subscriptions into manual renewals when a payment method got deleted

### DIFF
--- a/changelog/fix-delete-subscription-payment-method
+++ b/changelog/fix-delete-subscription-payment-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Subscription turns into manual renewal after deleting payment method

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -48,7 +48,7 @@ class WC_Payments_Token_Service {
 		$this->payments_api_client = $payments_api_client;
 		$this->customer_service    = $customer_service;
 
-		add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
+		add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 9, 2 );
 		add_action( 'woocommerce_payment_token_set_default', [ $this, 'woocommerce_payment_token_set_default' ], 10, 2 );
 		add_filter( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );
 		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'get_account_saved_payment_methods_list_item_sepa' ], 10, 2 );


### PR DESCRIPTION
fixes #7457

#### Changes proposed in this Pull Request
This PR fixes a bug that would happen when a card that was being used by a subscription got deleted. This happened because the subscription payment method was updated while the old payment method still existed in cache and in Stripe.

Basically [this function](https://github.com/Automattic/woocommerce-subscriptions-core/blob/e8e078043a18e363c95b02030584741895567d58/includes/class-wcs-my-account-payment-methods.php#L101) executed before [this one](https://github.com/Automattic/woocommerce-payments/blob/a150749aeede5dd981510c1cb2edf47a69471040/includes/class-wc-payments-token-service.php#L220) then when we tried to load all payment methods [this line](https://github.com/Automattic/woocommerce-payments/blob/470ae8122dfd2db5bab8a7503f6b8a1d29ca9f3b/includes/class-wc-payments-token-service.php#L195) would re-add it back to the store

I've also created a PR in subscriptions-core https://github.com/Automattic/woocommerce-subscriptions-core/pull/527 to address the problem in the other side. But I think fixing it in WooPayments is better.

I thought about removing [this line ](https://github.com/Automattic/woocommerce-payments/blob/470ae8122dfd2db5bab8a7503f6b8a1d29ca9f3b/includes/class-wc-payments-token-service.php#L195)
 but then it would not be possible to automatically add payment methods available in stripe that are not yet available in the merchant site which seems to be a contract requirement according to #682 and #758


#### Testing instructions
- Place a subscription order using card `5555555555554444`
- Place another subscription using card `4242424242424242`
- Go to My Account > Payment Methods
- Delete the card `4242424242424242`
- Notice the message says the subscriptions got updated to use the other payment method
- Go to My Account > Subscriptions
- Make sure the subscriptions use `5555555555554444` now

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.