### PR TITLE
Fix E2E tests to support deferred intent UPE

### DIFF
--- a/client/checkout/classic/upe-deferred-intent-creation/event-handlers.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/event-handlers.js
@@ -77,6 +77,13 @@ jQuery( function ( $ ) {
 	}
 
 	$( 'form#add_payment_method' ).on( 'submit', function () {
+		if (
+			$(
+				"#add_payment_method input:checked[name='payment_method']"
+			).val() !== 'woocommerce_payments'
+		) {
+			return;
+		}
 		// WC core calls block() when add_payment_method form is submitted, so we need to enable the ignore flag here to avoid
 		// the overlay blink when the form is blocked twice.
 		$.blockUI.defaults.ignoreIfBlocked = true;

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
@@ -49,15 +49,6 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 	it( 'should throw an error that the card expiration date is in the past', async () => {
 		const cardInvalidExpDate = config.get( 'cards.invalid-exp-date' );
 		await fillCardDetails( page, cardInvalidExpDate );
-		await page.waitForSelector(
-			'div#wcpay-errors > ul.woocommerce-error > li'
-		);
-		await expect( page ).toMatchElement(
-			'div#wcpay-errors > ul.woocommerce-error > li',
-			{
-				text: "Your card's expiration year is in the past.",
-			}
-		);
 		await expect( page ).toClick( '#place_order' );
 		await uiUnblocked();
 		await expect(

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
@@ -23,11 +23,6 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 		);
 	} );
 
-	afterEach( async () => {
-		// Clear card details for the next test
-		await clearCardDetails();
-	} );
-
 	afterAll( async () => {
 		// Clear the cart at the end so it's ready for another test
 		await shopperWCP.emptyCart();
@@ -44,6 +39,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error > li',
 			{ text: 'Error: Your card was declined.' }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card expiration date is in the past', async () => {
@@ -57,6 +53,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error',
 			{ text: "Your card's expiration year is in the past." }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card CVV number is invalid', async () => {
@@ -70,6 +67,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error',
 			{ text: "Your card's security code is incomplete." }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card was declined due to insufficient funds', async () => {
@@ -83,6 +81,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error > li',
 			{ text: 'Error: Your card has insufficient funds.' }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card was declined due to expired card', async () => {
@@ -96,6 +95,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error > li',
 			{ text: 'Error: Your card has expired.' }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card was declined due to incorrect CVC number', async () => {
@@ -109,6 +109,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error > li',
 			{ text: "Error: Your card's security code is incorrect." }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card was declined due to processing error', async () => {
@@ -123,6 +124,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 					'Error: An error occurred while processing your card. Try again in a little bit.',
 			}
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card was declined due to incorrect card number', async () => {
@@ -136,6 +138,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 			'div.woocommerce-NoticeGroup > ul.woocommerce-error',
 			{ text: 'Your card number is invalid.' }
 		);
+		await clearCardDetails();
 	} );
 
 	it( 'should throw an error that the card was declined due to invalid 3DS card', async () => {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -113,33 +113,28 @@ export async function clearCardDetails() {
 		const frameHandle = await page.waitForSelector(
 			'#payment .payment_method_woocommerce_payments .wcpay-upe-element iframe[name^="__privateStripeFrame"]'
 		);
+		const stripeFrame = await frameHandle.contentFrame();
+		const cardNumberInput = await stripeFrame.waitForSelector(
+			'[name="number"]',
+			{ timeout: 30000 }
+		);
+		await cardNumberInput.click( { clickCount: 3 } );
+		await page.keyboard.press( 'Backspace' );
 
-		try {
-			const stripeFrame = await frameHandle.contentFrame();
-			const cardNumberInput = await stripeFrame.waitForSelector(
-				'[name="number"]',
-				{ timeout: 30000 }
-			);
-			await cardNumberInput.click( { clickCount: 3 } );
-			await page.keyboard.press( 'Backspace' );
+		const cardDateInput = await stripeFrame.waitForSelector(
+			'[name="expiry"]',
+			{ timeout: 30000 }
+		);
+		await cardDateInput.click( { clickCount: 3 } );
+		await page.keyboard.press( 'Backspace' );
 
-			const cardDateInput = await stripeFrame.waitForSelector(
-				'[name="expiry"]',
-				{ timeout: 30000 }
-			);
-			await cardDateInput.click( { clickCount: 3 } );
-			await page.keyboard.press( 'Backspace' );
-
-			const cardCvcInput = await stripeFrame.waitForSelector(
-				'[name="cvc"]',
-				{ timeout: 30000 }
-			);
-			await cardCvcInput.click( { clickCount: 3 } );
-			await page.keyboard.press( 'Backspace' );
-			await page.waitFor( 1000 );
-		} catch ( e ) {
-			// do nothing because the card details clearing is an optional step which should not block the process
-		}
+		const cardCvcInput = await stripeFrame.waitForSelector(
+			'[name="cvc"]',
+			{ timeout: 30000 }
+		);
+		await cardCvcInput.click( { clickCount: 3 } );
+		await page.keyboard.press( 'Backspace' );
+		await page.waitFor( 1000 );
 	}
 }
 export async function fillCardDetailsPayForOrder( page, card ) {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -79,34 +79,70 @@ export async function fillCardDetails( page, card ) {
 
 // Clear WC Checkout Card Details
 export async function clearCardDetails() {
-	const frameHandle = await page.waitForSelector(
-		'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
-	);
-	const stripeFrame = await frameHandle.contentFrame();
+	if ( await page.$( '#payment #wcpay-card-element' ) ) {
+		console.log( 'am in' );
+		const frameHandle = await page.waitForSelector(
+			'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
+		);
+		const stripeFrame = await frameHandle.contentFrame();
 
-	const cardNumberInput = await stripeFrame.waitForSelector(
-		'[name="cardnumber"]'
-	);
-	await cardNumberInput.click();
-	await page.waitFor( 1000 );
-	await cardNumberInput.click( { clickCount: 3 } );
-	await page.keyboard.press( 'Backspace' );
+		const cardNumberInput = await stripeFrame.waitForSelector(
+			'[name="cardnumber"]'
+		);
+		await cardNumberInput.click();
+		await page.waitFor( 1000 );
+		await cardNumberInput.click( { clickCount: 3 } );
+		await page.keyboard.press( 'Backspace' );
 
-	const cardDateInput = await stripeFrame.waitForSelector(
-		'[name="exp-date"]'
-	);
-	await page.waitFor( 1000 );
-	await cardDateInput.click( { clickCount: 3 } );
-	await page.keyboard.press( 'Backspace' );
+		const cardDateInput = await stripeFrame.waitForSelector(
+			'[name="exp-date"]'
+		);
+		await page.waitFor( 1000 );
+		await cardDateInput.click( { clickCount: 3 } );
+		await page.keyboard.press( 'Backspace' );
 
-	const cardCvcInput = await stripeFrame.waitForSelector( '[name="cvc"]' );
-	await page.waitFor( 1000 );
-	await cardCvcInput.click( { clickCount: 3 } );
-	await page.keyboard.press( 'Backspace' );
+		const cardCvcInput = await stripeFrame.waitForSelector(
+			'[name="cvc"]'
+		);
+		await page.waitFor( 1000 );
+		await cardCvcInput.click( { clickCount: 3 } );
+		await page.keyboard.press( 'Backspace' );
 
-	await page.waitFor( 1000 );
+		await page.waitFor( 1000 );
+	} else {
+		// Handling Stripe UPE element
+		const frameHandle = await page.waitForSelector(
+			'#payment .payment_method_woocommerce_payments .wcpay-upe-element iframe[name^="__privateStripeFrame"]'
+		);
+
+		try {
+			const stripeFrame = await frameHandle.contentFrame();
+			const cardNumberInput = await stripeFrame.waitForSelector(
+				'[name="number"]',
+				{ timeout: 30000 }
+			);
+			await cardNumberInput.click( { clickCount: 3 } );
+			await page.keyboard.press( 'Backspace' );
+
+			const cardDateInput = await stripeFrame.waitForSelector(
+				'[name="expiry"]',
+				{ timeout: 30000 }
+			);
+			await cardDateInput.click( { clickCount: 3 } );
+			await page.keyboard.press( 'Backspace' );
+
+			const cardCvcInput = await stripeFrame.waitForSelector(
+				'[name="cvc"]',
+				{ timeout: 30000 }
+			);
+			await cardCvcInput.click( { clickCount: 3 } );
+			await page.keyboard.press( 'Backspace' );
+			await page.waitFor( 1000 );
+		} catch ( e ) {
+			// do nothing because the card details clearing is an optional step which should not block the process
+		}
+	}
 }
-
 export async function fillCardDetailsPayForOrder( page, card ) {
 	await page.waitForSelector( '.__PrivateStripeElement' );
 	const frameHandle = await page.waitForSelector(

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -80,7 +80,6 @@ export async function fillCardDetails( page, card ) {
 // Clear WC Checkout Card Details
 export async function clearCardDetails() {
 	if ( await page.$( '#payment #wcpay-card-element' ) ) {
-		console.log( 'am in' );
 		const frameHandle = await page.waitForSelector(
 			'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
 		);

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -110,18 +110,18 @@ export async function clearCardDetails() {
 export async function fillCardDetailsPayForOrder( page, card ) {
 	await page.waitForSelector( '.__PrivateStripeElement' );
 	const frameHandle = await page.waitForSelector(
-		'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
+		'#payment .payment_method_woocommerce_payments .wcpay-upe-element iframe'
 	);
 	const stripeFrame = await frameHandle.contentFrame();
 
 	const cardNumberInput = await stripeFrame.waitForSelector(
-		'[name="cardnumber"]',
+		'[name="number"]',
 		{ timeout: 30000 }
 	);
 	await cardNumberInput.type( card.number, { delay: 20 } );
 
 	const cardDateInput = await stripeFrame.waitForSelector(
-		'[name="exp-date"]'
+		'[name="expiry"]'
 	);
 
 	await cardDateInput.type( card.expires.month + card.expires.year, {
@@ -130,6 +130,12 @@ export async function fillCardDetailsPayForOrder( page, card ) {
 
 	const cardCvcInput = await stripeFrame.waitForSelector( '[name="cvc"]' );
 	await cardCvcInput.type( card.cvc, { delay: 20 } );
+	await page.waitFor( 1000 );
+
+	const zip = await stripeFrame.$( '[name="postalCode"]' );
+	if ( zip !== null ) {
+		await zip.type( '90210', { delay: 20 } );
+	}
 }
 
 // WooCommerce Blocks Checkout


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Post #7328, all stores, including the legacy card store, are treated as parties utilizing deferred intent creation UPE. Consequently, specific E2E tests covering legacy card use cases started failing. This PR fixes those tests.

While fixing tests, it became clear that we also need to clean up the tests' implementation by removing unnecessary feature flag toggling (since stores already use dUPE by default) and eliminate redundant `card/legacy UPE/split UPE` tests to leave only one group of tests ultimately. This is supposed to be done in a separate issue, and I think https://github.com/Automattic/woocommerce-payments/issues/6882 is a good candidate to cover it as well.

Some context on the changes: 
* By adding a check in `event-handlers.js`, we ensure that deferred UPE flow is not executed on the _Add payment method_ page if a gateway other than WooPayments is being used. This was done for other gateways in https://github.com/Automattic/woocommerce-payments/pull/3006, but skipped in deferred UPE initially because the error doesn't appear. However, the tests fail. I thought it was still important to stop the flow execution if another plugin is used, so I re-introduced this check and [the corresponding test](https://github.com/Automattic/woocommerce-payments/blob/edd225a66243123d74364db4c68c27dcc98728ed/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.js#L59) now passes.
* `tests/e2e/utils/payments.js` now handle Stripe UPE when filling the card details on _Pay for order page_ as well as cleaning up card details
* `await clearCardDetails()` invocation in `/wcpay/shopper/shopper-checkout-failures.spec.js` was moved to the end of every test, because the last 3DS-related test runs the 3DS authentication modal in the `iframe` which then clashes with the payment element `iframe`, making it not possible to clear the card data. Since clearing the card data is an optional step, we now skip it for the last 3DS flow
* [This assertion](https://github.com/Automattic/woocommerce-payments/blob/edd225a66243123d74364db4c68c27dcc98728ed/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js#L52-L60) was removed because we don't need to test the behavior of the Stripe Payment Element, we should focus on the functionality on our side.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In GitHub Actions, run [PR flow](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-pull-request.yml) on this branch twice sequentially and confirm all the tests are passing
* In GitHub Actions, run [E2E Tests - All](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml) flow on this branch and confirm that all the tests pass
* Ensure your local store uses deferred intent creation UPE, follow [these testing steps](https://github.com/Automattic/woocommerce-payments/pull/3006) and confirm they are successful. Right after, confirm that the payment method was successfully added by other gateway from that test.
* Perform a sanity check of the _add new payment method_ flow - add a new card using deferred intent creation UPE and confirm that it was added successfully and you can use it by making following purchases
-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.