### PR TITLE
fix: Stripe Link eligibility check

### DIFF
--- a/changelog/fix-stripe-link-eligibility
+++ b/changelog/fix-stripe-link-eligibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stripe Link eligibility at checkout

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1560,23 +1560,27 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function get_payment_methods_from_gateway_id( $gateway_id, $order_id = null ) {
 		$split_upe_gateway_prefix = self::GATEWAY_ID . '_';
 		// If $gateway_id begins with `woocommerce_payments_` payment method is a split UPE LPM.
-		// Otherwise $gateway_id must be `woocommerce_payments`.
+		// Otherwise, $gateway_id must be `woocommerce_payments`.
 		if ( substr( $gateway_id, 0, strlen( $split_upe_gateway_prefix ) ) === $split_upe_gateway_prefix ) {
-			$payment_methods = [ str_replace( $split_upe_gateway_prefix, '', $gateway_id ) ];
-		} elseif ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+			return [ str_replace( $split_upe_gateway_prefix, '', $gateway_id ) ];
+		}
+
+		$eligible_payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( $order_id, true );
+
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			// If split or deferred intent UPE is enabled and $gateway_id is `woocommerce_payments`, this must be the CC gateway.
 			// We only need to return single `card` payment method, adding `link` since deferred intent UPE gateway is compatible with Link.
 			$payment_methods = [ Payment_Method::CARD ];
-			if ( in_array( Payment_Method::LINK, $this->get_upe_enabled_payment_method_ids(), true ) ) {
+			if ( in_array( Payment_Method::LINK, $eligible_payment_methods, true ) ) {
 				$payment_methods[] = Payment_Method::LINK;
 			}
-		} else {
-			// $gateway_id must be `woocommerce_payments` and gateway is either legacy UPE or legacy card.
-			// Find the relevant gateway and return all available payment methods.
-			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( $order_id, true );
+
+			return $payment_methods;
 		}
 
-		return $payment_methods;
+		// $gateway_id must be `woocommerce_payments` and gateway is either legacy UPE or legacy card.
+		// Find the relevant gateway and return all available payment methods.
+		return $eligible_payment_methods;
 	}
 
 	/**

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -2364,6 +2364,11 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->will(
 				$this->returnValue( [ Payment_Method::CARD, Payment_Method::LINK ] )
 			);
+		$mock_upe_gateway->expects( $this->any() )
+			->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->will(
+				$this->returnValue( [ Payment_Method::CARD, Payment_Method::LINK ] )
+			);
 
 		$payment_methods = $mock_upe_gateway->get_payment_methods_from_gateway_id( UPE_Split_Payment_Gateway::GATEWAY_ID );
 


### PR DESCRIPTION
Reported p1697496446121059-slack-C7U3Y3VMY

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In a few, very edgy scenarios, `link` might be an item in the `upe_enabled_payment_method_ids` for the WooPayments gateway.
This can be a problem for non-US accounts, where Link is not available.
We're confirming with Stripe whether this error only appears in live mode (in test mode this doesn't seem to be an issue) p1697634872443619-slack-C9976E5MJ

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Without this fix:
	- Onboard with a non-US account
	- Try and force `link` in the `upe_enabled_payment_method_ids` option (you'll need to do this manually)
	- Add a product to the cart, go to checkout, place the order
	- You should see `link` in the list of payment methods sent to the `POST /v1/payment_intents` endpoint
![Screenshot 2023-10-18 at 4 10 45 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/218b1425-1929-460d-b66c-83303c6465e1)
- With this fix:
	- Onboard with a non-US account
	- Try and force `link` in the `upe_enabled_payment_method_ids` option (you'll need to do this manually)
	- Add a product to the cart, go to checkout, place the order
	- You should not see `link` in the list of payment methods sent to the `POST /v1/payment_intents` endpoint
![Screenshot 2023-10-18 at 4 11 45 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/58ae2581-6da1-43c5-a9c7-f1d103200d5d)
- Try the same for a US-based account (with Stripe Link enabled) - there should be no issue

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.