### PR TITLE
Gracefully handle absence of wc parameter when accessing configs

### DIFF
--- a/changelog/fix-prb-error
+++ b/changelog/fix-prb-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes an issue with payment request buttons that is currently not on production
+
+

--- a/client/utils/checkout.js
+++ b/client/utils/checkout.js
@@ -13,8 +13,10 @@ export const getConfig = ( name ) => {
 		config = wcpayConfig;
 	} else if ( typeof wcpay_upe_config !== 'undefined' ) {
 		config = wcpay_upe_config;
-	} else {
+	} else if ( typeof wc !== 'undefined' ) {
 		config = wc.wcSettings.getSetting( 'woocommerce_payments_data' );
+	} else {
+		return null;
 	}
 
 	return config[ name ] || null;


### PR DESCRIPTION
When WooPay is disabled, Apple Pay/Google Pay buttons on the Cart and Product pages don't open the payment model.
The following error is shown on the console.

```
ReferenceError: Can't find variable: wc
```

This issue happens after the new Tracks introduced in https://github.com/Automattic/woocommerce-payments/pull/7268


#### Changes proposed in this Pull Request


When Tracking Google Pay /Apple Pay button clicks, we [access configs values](https://github.com/Automattic/woocommerce-payments/blob/9a4f5768c0a9b0dc5b29046f22429e44013c0744/client/tracks/index.js#L44) using `getConfig`. The first value it's trying to access only exists on certain pages. If the value is not there it falls back to a secondary value. However, getConfig errors out when called from non checkout pages. This PR updates `getConfig` to return `null` instead of erroring out.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure WooPay is disabled from Payment -> Settings page.
2. Add a product to the cart
3. Click on Google Pay or Apple Pay button on the cart page or the product page
4. Payment model should open.
5. Check MC in ~5minutes for the presence of `wcpay_gpay_button_click` (or `wcpay_apple_pay_button_click`) event

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
