### PR TITLE
Fix PSR container conflicts

### DIFF
--- a/changelog/fix-psr-container-conflicts
+++ b/changelog/fix-psr-container-conflicts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PSR container conflicts

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "automattic/jetpack-autoloader": "2.11.18",
         "automattic/jetpack-identity-crisis": "0.8.43",
         "automattic/jetpack-sync": "1.47.7",
-        "woocommerce/subscriptions-core": "6.3.0",
-        "psr/container": "^1.1"
+        "woocommerce/subscriptions-core": "6.3.0"
     },
     "require-dev": {
         "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f45536a544c784b5c85d2e507cb43d42",
+    "content-hash": "8129af4ef3d43b59f758a73688c5b91e",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -937,54 +937,6 @@
                 }
             ],
             "time": "2021-01-14T11:07:16+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
-            },
-            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "woocommerce/subscriptions-core",
@@ -3508,6 +3460,54 @@
                 }
             ],
             "time": "2022-02-18T12:54:07+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/log",

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -4,7 +4,8 @@
     "minimum-stability": "dev",
     "require-dev": {
         "league/container": "4.2",
-        "coenjacobs/mozart": "0.7.1"
+        "coenjacobs/mozart": "0.7.1",
+        "psr/container": "^1.1"
     },
     "license": "GPL-3.0-or-later",
     "scripts": {
@@ -20,9 +21,7 @@
             "dep_namespace": "WCPay\\Vendor\\",
             "dep_directory": "/packages/",
             "packages": [
-                "league/container"
-            ],
-            "excluded_packages":[
+                "league/container",
                 "psr/container"
             ],
             "classmap_directory": "/classmaps/",

--- a/lib/composer.lock
+++ b/lib/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f729373382094e28edcbed07d0c9f67",
+    "content-hash": "3aba07fadc9c18f4990a3cc73152afa8",
     "packages": [],
     "packages-dev": [
         {
@@ -243,26 +243,26 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.11.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "ff6248ea87a9f116e78edd6002e39e5128a0d4dd"
+                "reference": "b6a5854368533df0295c5761a0253656a2e52d9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/ff6248ea87a9f116e78edd6002e39e5128a0d4dd",
-                "reference": "ff6248ea87a9f116e78edd6002e39e5128a0d4dd",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/b6a5854368533df0295c5761a0253656a2e52d9e",
+                "reference": "b6a5854368533df0295c5761a0253656a2e52d9e",
                 "shasum": ""
             },
             "require": {
                 "ext-fileinfo": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "phpstan/phpstan": "^0.12.68",
-                "phpunit/phpunit": "^8.5.8 || ^9.3"
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
             },
             "type": "library",
             "autoload": {
@@ -283,7 +283,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.11.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.14.0"
             },
             "funding": [
                 {
@@ -295,32 +295,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-17T13:12:02+00:00"
+            "time": "2023-10-17T14:13:20+00:00"
         },
         {
             "name": "psr/container",
-            "version": "dev-master",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "90db7b9ac2a2c5b849fcb69dde58f3ae182c68f5"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/90db7b9ac2a2c5b849fcb69dde58f3ae182c68f5",
-                "reference": "90db7b9ac2a2c5b849fcb69dde58f3ae182c68f5",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
-            "default-branch": true,
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -347,9 +341,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2022-07-19T17:36:59+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "symfony/console",
@@ -357,12 +351,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273"
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/b504a3d266ad2bb632f196c0936ef2af5ff6e273",
-                "reference": "b504a3d266ad2bb632f196c0936ef2af5ff6e273",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4f71842f24c2023b91237c72a365306f3c58827",
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827",
                 "shasum": ""
             },
             "require": {
@@ -448,7 +442,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-19T20:11:33+00:00"
+            "time": "2023-08-07T06:12:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -582,7 +576,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "dev-main",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -645,7 +639,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/main"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -665,7 +659,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "dev-main",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -727,7 +721,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/main"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -747,7 +741,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "dev-main",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -812,7 +806,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/main"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -832,7 +826,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "dev-main",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -896,7 +890,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/main"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -916,7 +910,7 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "dev-main",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -976,7 +970,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/main"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -996,7 +990,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "dev-main",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -1060,7 +1054,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/main"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -1080,21 +1074,22 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "3.0.x-dev",
+            "version": "2.5.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "24ce74899f476f56d7e6c148c809afef0b7de19c"
+                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24ce74899f476f56d7e6c148c809afef0b7de19c",
-                "reference": "24ce74899f476f56d7e6c148c809afef0b7de19c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a2329596ddc8fd568900e3fc76cba42489ecc7f3",
+                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "psr/container": "^2.0"
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -1105,7 +1100,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1142,7 +1137,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/3.0"
+                "source": "https://github.com/symfony/service-contracts/tree/2.5"
             },
             "funding": [
                 {
@@ -1158,7 +1153,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-04-21T15:04:16+00:00"
         },
         {
             "name": "symfony/string",

--- a/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
+++ b/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
@@ -7,7 +7,7 @@ namespace WCPay\Vendor\League\Container\Argument;
 use WCPay\Vendor\League\Container\DefinitionContainerInterface;
 use WCPay\Vendor\League\Container\Exception\{ContainerException, NotFoundException};
 use WCPay\Vendor\League\Container\ReflectionContainer;
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 use ReflectionNamedType;
 

--- a/lib/packages/League/Container/Container.php
+++ b/lib/packages/League/Container/Container.php
@@ -10,7 +10,7 @@ use WCPay\Vendor\League\Container\Inflector\{InflectorAggregate, InflectorInterf
 use WCPay\Vendor\League\Container\ServiceProvider\{ServiceProviderAggregate,
     ServiceProviderAggregateInterface,
     ServiceProviderInterface};
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 
 class Container implements DefinitionContainerInterface
 {

--- a/lib/packages/League/Container/Definition/Definition.php
+++ b/lib/packages/League/Container/Definition/Definition.php
@@ -12,7 +12,7 @@ use WCPay\Vendor\League\Container\Argument\{
 };
 use WCPay\Vendor\League\Container\ContainerAwareTrait;
 use WCPay\Vendor\League\Container\Exception\ContainerException;
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 use ReflectionClass;
 
 class Definition implements ArgumentResolverInterface, DefinitionInterface

--- a/lib/packages/League/Container/DefinitionContainerInterface.php
+++ b/lib/packages/League/Container/DefinitionContainerInterface.php
@@ -7,7 +7,7 @@ namespace WCPay\Vendor\League\Container;
 use WCPay\Vendor\League\Container\Definition\DefinitionInterface;
 use WCPay\Vendor\League\Container\Inflector\InflectorInterface;
 use WCPay\Vendor\League\Container\ServiceProvider\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 
 interface DefinitionContainerInterface extends ContainerInterface
 {

--- a/lib/packages/League/Container/Exception/ContainerException.php
+++ b/lib/packages/League/Container/Exception/ContainerException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WCPay\Vendor\League\Container\Exception;
 
-use Psr\Container\ContainerExceptionInterface;
+use WCPay\Vendor\Psr\Container\ContainerExceptionInterface;
 use RuntimeException;
 
 class ContainerException extends RuntimeException implements ContainerExceptionInterface

--- a/lib/packages/League/Container/Exception/NotFoundException.php
+++ b/lib/packages/League/Container/Exception/NotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WCPay\Vendor\League\Container\Exception;
 
-use Psr\Container\NotFoundExceptionInterface;
+use WCPay\Vendor\Psr\Container\NotFoundExceptionInterface;
 use InvalidArgumentException;
 
 class NotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface

--- a/lib/packages/League/Container/ReflectionContainer.php
+++ b/lib/packages/League/Container/ReflectionContainer.php
@@ -7,7 +7,7 @@ namespace WCPay\Vendor\League\Container;
 use WCPay\Vendor\League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait};
 use WCPay\Vendor\League\Container\Exception\ContainerException;
 use WCPay\Vendor\League\Container\Exception\NotFoundException;
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionMethod;

--- a/lib/packages/Psr/Container/ContainerExceptionInterface.php
+++ b/lib/packages/Psr/Container/ContainerExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace WCPay\Vendor\Psr\Container;
+
+use Throwable;
+
+/**
+ * Base interface representing a generic exception in a container.
+ */
+interface ContainerExceptionInterface extends Throwable
+{
+}

--- a/lib/packages/Psr/Container/ContainerInterface.php
+++ b/lib/packages/Psr/Container/ContainerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WCPay\Vendor\Psr\Container;
+
+/**
+ * Describes the interface of a container that exposes methods to read its entries.
+ */
+interface ContainerInterface
+{
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get(string $id);
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has(string $id);
+}

--- a/lib/packages/Psr/Container/NotFoundExceptionInterface.php
+++ b/lib/packages/Psr/Container/NotFoundExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WCPay\Vendor\Psr\Container;
+
+/**
+ * No entry was found in the container.
+ */
+interface NotFoundExceptionInterface extends ContainerExceptionInterface
+{
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -7,7 +7,7 @@
 
 namespace WCPay;
 
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 use WCPay\Vendor\League\Container\Exception\ContainerException;
 use WCPay\Internal\DependencyManagement\ExtendedContainer;
 use WCPay\Internal\DependencyManagement\ServiceProvider\PaymentsServiceProvider;

--- a/src/Container.php
+++ b/src/Container.php
@@ -17,6 +17,25 @@ use WCPay\Internal\DependencyManagement\ServiceProvider\GenericServiceProvider;
 use WCPay\Internal\DependencyManagement\ServiceProvider\ProxiesServiceProvider;
 
 /**
+ * Hides errors during update from 6.6.0 or 6.6.1 to 6.6.2.
+ *
+ * This class would be loaded without the right dependencies (and autoloader)
+ * being loaded before it after the update is complete. When that happens,
+ * the ContainerInterface would still be in a different namespace, and would not exist here.
+ *
+ * Preventing the class from being loaded here does nothing but hide the error.
+ * All later requests will work properly.
+ */
+if (
+	! interface_exists( ContainerInterface::class )
+	&& isset( $_GET['action'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	&& 'upload-plugin' === $_GET['action'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	&& 'update.php' === $GLOBALS['pagenow']
+) {
+	wp_die( 'Updated successfully. Please reload the page.' );
+}
+
+/**
  * WCPay Dependency Injection Container.
  *
  * Wraps the ExtendedContainer implementation to only allow public access to

--- a/src/Container.php
+++ b/src/Container.php
@@ -33,7 +33,7 @@ if (
 	&& isset( $GLOBALS['pagenow'] )
 	&& 'update.php' === $GLOBALS['pagenow']
 ) {
-	wp_die( 'Updated successfully. Please reload the page.' );
+	wp_die();
 }
 
 /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -30,6 +30,7 @@ if (
 	! interface_exists( ContainerInterface::class )
 	&& isset( $_GET['action'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	&& 'upload-plugin' === $_GET['action'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	&& isset( $GLOBALS['pagenow'] )
 	&& 'update.php' === $GLOBALS['pagenow']
 ) {
 	wp_die( 'Updated successfully. Please reload the page.' );

--- a/src/Internal/DependencyManagement/DelegateContainer/LegacyContainer.php
+++ b/src/Internal/DependencyManagement/DelegateContainer/LegacyContainer.php
@@ -7,8 +7,8 @@
 
 namespace WCPay\Internal\DependencyManagement\DelegateContainer;
 
-use Psr\Container\ContainerInterface;
 use WC_Payments;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
 use WCPay\Vendor\League\Container\Exception\ContainerException;
 
 /**

--- a/src/Internal/DependencyManagement/DelegateContainer/WooContainer.php
+++ b/src/Internal/DependencyManagement/DelegateContainer/WooContainer.php
@@ -8,7 +8,6 @@
 namespace WCPay\Internal\DependencyManagement\DelegateContainer;
 
 use WCPay\Vendor\Psr\Container\ContainerInterface;
-use WCPay\Vendor\Psr\Container\NotFoundExceptionInterface;
 
 /**
  * WooCommerce container delegate.

--- a/src/Internal/DependencyManagement/DelegateContainer/WooContainer.php
+++ b/src/Internal/DependencyManagement/DelegateContainer/WooContainer.php
@@ -7,7 +7,8 @@
 
 namespace WCPay\Internal\DependencyManagement\DelegateContainer;
 
-use Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\ContainerInterface;
+use WCPay\Vendor\Psr\Container\NotFoundExceptionInterface;
 
 /**
  * WooCommerce container delegate.
@@ -21,6 +22,7 @@ class WooContainer implements ContainerInterface {
 	 *
 	 * @param string $id Identifier of the entry to look for.
 	 * @return mixed Entry.
+	 * @throws NotFoundExceptionInterface In case the class could not be found.
 	 */
 	public function get( $id ) {
 		return wc_get_container()->get( $id );

--- a/src/Internal/DependencyManagement/DelegateContainer/WooContainer.php
+++ b/src/Internal/DependencyManagement/DelegateContainer/WooContainer.php
@@ -22,7 +22,7 @@ class WooContainer implements ContainerInterface {
 	 *
 	 * @param string $id Identifier of the entry to look for.
 	 * @return mixed Entry.
-	 * @throws NotFoundExceptionInterface In case the class could not be found.
+	 * @psalm-suppress MissingThrowsDocblock.
 	 */
 	public function get( $id ) {
 		return wc_get_container()->get( $id );


### PR DESCRIPTION
Fixes #7488

#### Changes proposed in this Pull Request

Previously https://github.com/Automattic/woocommerce-payments/pull/7514, but it was reverted.

#### Testing instructions

Overall, if the container package is in our namespace, and a simple checkout flow works, we should be good.

Specific Testing Instructions for #7488 

1. On current stable release, install and activate [backwpup](https://wordpress.org/plugins/backwpup/) plugin. Observe Payment dashboard screens are not accessible.
2. Update with the release zip (see Slack) **manually**. There should be no error messages or warnings.
3. With this fix, check that Payment dashboards screens work, checkout and payment admin flows are functional