### PR TITLE
Fix - HPOS compatibility on Edit Order Screen

### DIFF
--- a/changelog/7466-fix-hpos-compat-order-edit
+++ b/changelog/7466-fix-hpos-compat-order-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order status inconsistency in HPOS mode on Order Edit screen.

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -56,9 +56,10 @@ jQuery( function ( $ ) {
 	);
 
 	$( 'select#order_status' ).on( 'change', function () {
-		
 		//get the original status of the order from post or order data.
-		let originalStatus = $( 'input#original_post_status' ).val() || $( 'input#original_order_status' ).val(); 
+		let originalStatus =
+			$( 'input#original_post_status' ).val() ||
+			$( 'input#original_order_status' ).val();
 		//TODO: Remove this after https://github.com/woocommerce/woocommerce/issues/40871 is fixed.
 		if ( originalStatus && ! originalStatus.startsWith( 'wc-' ) ) {
 			originalStatus = 'wc-' + originalStatus;

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -56,7 +56,14 @@ jQuery( function ( $ ) {
 	);
 
 	$( 'select#order_status' ).on( 'change', function () {
-		const originalStatus = $( 'input#original_post_status' ).val();
+		
+		//get the original status of the order from post or order data.
+		let originalStatus = $( 'input#original_post_status' ).val() || $( 'input#original_order_status' ).val(); 
+		//TODO: Remove this after https://github.com/woocommerce/woocommerce/issues/40871 is fixed.
+		if ( originalStatus && ! originalStatus.startsWith( 'wc-' ) ) {
+			originalStatus = 'wc-' + originalStatus;
+		}
+
 		const canRefund = getConfig( 'canRefund' );
 		const refundAmount = getConfig( 'refundAmount' );
 		if (

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js
@@ -46,8 +46,7 @@ describe( 'Order > Status Change', () => {
 			await merchant.logout();
 		} );
 
-		// TODO: unskip when https://github.com/Automattic/woocommerce-payments/issues/7466 is closed
-		it.skip( 'Show Cancel Confirmation modal, do not change status if Do Nothing selected', async () => {
+		it( 'Show Cancel Confirmation modal, do not change status if Do Nothing selected', async () => {
 			// Select cancel from the order status dropdown.
 			await expect( page ).toSelect(
 				orderStatusDropdownSelector,
@@ -148,8 +147,7 @@ describe( 'Order > Status Change', () => {
 			await merchant.logout();
 		} );
 
-		// TODO: unskip when https://github.com/Automattic/woocommerce-payments/issues/7466 is closed
-		it.skip( 'Show Refund Confirmation modal, do not change status if Cancel clicked', async () => {
+		it( 'Show Refund Confirmation modal, do not change status if Cancel clicked', async () => {
 			// Select refunded from the order status dropdown.
 			await expect( page ).toSelect(
 				orderStatusDropdownSelector,


### PR DESCRIPTION
Fixes #7466

#### Changes proposed in this Pull Request

When HPOS is enabled, the order status should be fetched from `#original_order_status` and not `#original_post_status`. 
- Modified the code to work with both HPOS and POSTS.
- Added a workaround for core issue https://github.com/woocommerce/woocommerce/issues/40871
Ref: p1697706516222469-slack-C0E1AV8T0

#### Testing instructions

- Enable HPOS
- On Order Edit screen, change the Order Status in the dropdown to Cancelled or Refunded
- In the modal, click on "Do Nothing" ( on the Cancel Modal) or "Cancelled" (on the Refund Modal)
- Verify that the original status is set back correctly in the dropdown. 

(Without the fix in this branch, the dropdown is not set correctly when user cancels the action)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.