### PR TITLE
misc: align deferred intent UPE checkout script with previous UPE versions

### DIFF
--- a/changelog/misc-checkout-scipt-alignment
+++ b/changelog/misc-checkout-scipt-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Align deferred intent creation UPE checkout script with UPE inn terms of fonts appearance

--- a/client/checkout/classic/upe-deferred-intent-creation/event-handlers.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/event-handlers.js
@@ -28,9 +28,16 @@ import { isPreviewing } from 'wcpay/checkout/preview';
 
 jQuery( function ( $ ) {
 	enqueueFraudScripts( getUPEConfig( 'fraudServices' ) );
+	const publishableKey = getUPEConfig( 'publishableKey' );
+
+	if ( ! publishableKey ) {
+		// If no configuration is present, probably this is not the checkout page.
+		return;
+	}
+
 	const api = new WCPayAPI(
 		{
-			publishableKey: getUPEConfig( 'publishableKey' ),
+			publishableKey: publishableKey,
 			accountId: getUPEConfig( 'accountId' ),
 			forceNetworkSavedCards: getUPEConfig( 'forceNetworkSavedCards' ),
 			locale: getUPEConfig( 'locale' ),

--- a/client/checkout/classic/upe-deferred-intent-creation/payment-processing.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/payment-processing.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getUPEConfig } from 'wcpay/utils/checkout';
-import { getAppearance } from '../../upe-styles';
+import { getAppearance, getFontRulesFromPage } from '../../upe-styles';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 import {
 	appendFingerprintInputToForm,
@@ -160,6 +160,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		paymentMethodCreation: 'manual',
 		paymentMethodTypes: paymentMethodTypes,
 		appearance: initializeAppearance( api ),
+		fonts: getFontRulesFromPage(),
 	};
 
 	const elements = api


### PR DESCRIPTION
> Not urgent, miscellaneous changes to align with the split UPE & legacy UPE.

#### Changes proposed in this Pull Request
The deferred intent creation UPE checkout script doesn't apply font rules from page to the Stripe Payment Element, while it does so in previous [legacy UPE](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/upe.js#L254) and [split UPE](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/upe-split.js#L220) checkouts. This PR aligns with this setting. 

On top of it, we now stop loading the script if there's no `publishableKey` just as a measure to prevent the script from loading on the wrong page. I couldn't find a way to test it because if we're on non-checkout page, the script is simply not enqueued. This is also just a tiny alignment of dUPE to follow [split UPE](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/upe-split.js#L74-L77)/[legacy UPE](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/upe.js#L52-L55)/[non-UPE](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/index.js#L25-L28) approach.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test fonts, start by checking out `develop`, building the code.
1. Activate `Deli` theme
2. Navigate to shortcode checkout and confirm the font _within_ the Stripe Payment Element is not in line with the page fonts

At this point, checkout `misc/checkout-scipt-alignment` and
* Refresh the page and confirm, that fonts are aligned now

|  Legacy UPE (as an example)           | Deferred intent UPE before this PR | Deferred intent UPE after this PR |
--------------- | --------------- | --------------- | 
| ![image](https://github.com/Automattic/woocommerce-payments/assets/22319444/18870f52-6efd-42c6-a2c6-a6b0b670de3e) | ![image](https://github.com/Automattic/woocommerce-payments/assets/22319444/98d59d70-804a-432a-a6b7-04479f2425a6)| ![image](https://github.com/Automattic/woocommerce-payments/assets/22319444/6dd0ed8f-71e4-4413-bab4-cdd673247913)


Although, like I mentioned earlier, I have no use-case to test the script loading prevention after the `publishableKey` check, this change is the alignment with split UPE, legacy UPE & legacy card. The only thing as part of testing, perform a test purchase on the shortcode page and e.g., add payment method page and confirm that everything works as expected. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
