### PR TITLE
Always show Express payment buttons for Pay for Order page

### DIFF
--- a/changelog/fix-express-pay-pay-for-order-page
+++ b/changelog/fix-express-pay-pay-for-order-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show Google Pay/Apple Pay buttons in the Pay for Order page

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -499,11 +499,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return false;
 		}
 
-		// Order total doesn't matter for Pay for Order page. Thus, this page should always display payment buttons.
-		if ( $this->is_pay_for_order_page() ) {
-			return true;
-		}
-
 		// Page not supported.
 		if ( ! $this->is_product() && ! $this->is_cart() && ! $this->is_checkout() ) {
 			return false;
@@ -534,6 +529,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 		if ( ( $this->is_checkout() || $this->is_cart() ) && ! $this->has_allowed_items_in_cart() ) {
 			Logger::log( 'Items in the cart have unsupported product type ( Payment Request button disabled )' );
 			return false;
+		}
+
+		// Order total doesn't matter for Pay for Order page. Thus, this page should always display payment buttons.
+		if ( $this->is_pay_for_order_page() ) {
+			return true;
 		}
 
 		// Cart total is 0 or is on product page and product price is 0.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -381,8 +381,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 		];
 
 		wp_localize_script( 'WCPAY_PAYMENT_REQUEST', 'wcpayPaymentRequestPayForOrderParams', $data );
-
-		$this->display_payment_request_button_html();
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -499,6 +499,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return false;
 		}
 
+		// Order total doesn't matter for Pay for Order page. Thus, this page should always display payment buttons.
+		if ( $this->is_pay_for_order_page() ) {
+			return true;
+		}
+
 		// Page not supported.
 		if ( ! $this->is_product() && ! $this->is_cart() && ! $this->is_checkout() ) {
 			return false;


### PR DESCRIPTION
Fixes #6650

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

A while ago, a regression was introduced making Express pay buttons not showing in the Pay for Order page. This fixes the issue.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need these requirements to test this PR:
- Apple Pay/Google Pay setup
- An SSL-accessible website for your local env (like Jurassic tunnel)

Testing instructions:
* Take a Needs Payments order (you can create a new order and select cash)
* Go to WooCommerce > Orders > Your order. Copy the link in "Customer Payment page"

<img width="678" alt="Screenshot 2023-10-23 at 12 13 48" src="https://github.com/Automattic/woocommerce-payments/assets/12542046/3703555b-98b9-44ba-96f7-60caa6ee2118">

* Open the link in either Safari/Chrome. There should not be a button for Google Pay/Apple Pay
* Get this PR and refresh the page
* The button for Google Pay/Apple Pay should be showing now next to WooPay (and after the order summary)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
