### PR TITLE
Add a Track event to the Pay For Order page

### DIFF
--- a/changelog/add-pay-for-order-tracks
+++ b/changelog/add-pay-for-order-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add pay-for-order Tracks events

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -454,12 +454,12 @@ class WC_Payments_WooPay_Button_Handler {
 			return 'cart';
 		}
 
-		if ( $this->is_checkout() ) {
-			return 'checkout';
-		}
-
 		if ( $this->is_pay_for_order_page() ) {
 			return 'pay_for_order';
+		}
+
+		if ( $this->is_checkout() ) {
+			return 'checkout';
 		}
 
 		return '';

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -70,6 +70,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_payments_save_user_in_woopay', [ $this, 'must_save_payment_method_to_platform' ] );
+		add_action( 'before_woocommerce_pay_form', [ $this, 'pay_for_order_page_view' ] );
 	}
 
 	/**
@@ -420,6 +421,15 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			[
 				'theme_type' => 'short_code',
 			]
+		);
+	}
+
+	/**
+	 * Record a Tracks event that the pay-for-order page has loaded.
+	 */
+	public function pay_for_order_page_view() {
+		$this->maybe_record_wcpay_shopper_event(
+			'pay_for_order_page_view'
 		);
 	}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

- Add `wcpay_pay_for_order_page_view` event
- Fix an issue where `source` property in following events to be `checkout` instead of `pay_for_order`
    - wcpay_woopay_button_load
    - wcpay_woopay_button_click



<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make a product purchase (Using WooPay or std. checkout flow, it doesn't matter)
* As an admin, go to edit order page and change order status to "Pending payment"
* Copy "Customer payment page" link
* As a customer, visit the above link
* Click on the WooPay express button
* In ~5 minutes, visit MC Tracks Live view page.
* Check for the presence of `wcpay_pay_for_order_page_view`, `wcpay_woopay_button_load` and `wcpay_woopay_button_click` events.
* Make sure `wcpay_woopay_button_load` and `wcpay_woopay_button_click` has the `source` property with a value `pay_for_order`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
