### PR TITLE
RPP: Add order meta upon the AuthenticationRequired state

### DIFF
--- a/changelog/rpp-authentication-state-meta
+++ b/changelog/rpp-authentication-state-meta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Storing the metadata, that was forgotten in 7471
+
+

--- a/src/Internal/Payment/State/InitialState.php
+++ b/src/Internal/Payment/State/InitialState.php
@@ -106,6 +106,7 @@ class InitialState extends AbstractPaymentState {
 
 		// Intent requires authorization (3DS check).
 		if ( Intent_Status::REQUIRES_ACTION === $intent->get_status() ) {
+			$this->order_service->update_order_from_intent_that_requires_action( $context->get_order_id(), $intent, $context );
 			return $this->create_state( AuthenticationRequiredState::class );
 		}
 

--- a/src/Internal/Service/OrderService.php
+++ b/src/Internal/Service/OrderService.php
@@ -214,6 +214,34 @@ class OrderService {
 	}
 
 	/**
+	 * Updates the order with the necessary details whenever an intent requires action.
+	 *
+	 * @param int                                $order_id ID of the order.
+	 * @param WC_Payments_API_Abstract_Intention $intent   Remote object. To be abstracted soon.
+	 * @param PaymentContext                     $context  Context for the payment.
+	 * @throws Order_Not_Found_Exception
+	 */
+	public function update_order_from_intent_that_requires_action(
+		int $order_id,
+		WC_Payments_API_Abstract_Intention $intent,
+		PaymentContext $context
+	) {
+		$order = $this->get_order( $order_id );
+
+		$this->legacy_service->attach_intent_info_to_order(
+			$order,
+			$intent->get_id(),
+			$intent->get_status(),
+			$context->get_payment_method()->get_id(),
+			$context->get_customer_id(),
+			null,
+			$context->get_currency()
+		);
+
+		$this->legacy_service->update_order_status_from_intent( $order, $intent );
+	}
+
+	/**
 	 * Given the charge data, checks if there was an exchange and adds it to the given order as metadata
 	 *
 	 * @param int                    $order_id The order to update.

--- a/src/Internal/Service/OrderService.php
+++ b/src/Internal/Service/OrderService.php
@@ -234,7 +234,7 @@ class OrderService {
 			$intent->get_status(),
 			$context->get_payment_method()->get_id(),
 			$context->get_customer_id(),
-			null,
+			'',
 			$context->get_currency()
 		);
 


### PR DESCRIPTION
Fixes #7553

#### Changes proposed in this Pull Request

Introduce a new `update_order_from_intent_that_requires_action` method in the order service, and make sure it to call it before transitioning from `InitialState` to `AuthenticationRequiredState`.

#### Testing instructions

Check out with a 3DS card  (*** 3184), and make sure that checkout worked, incl. order notes.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
