### PR TITLE
fire an event when disputed order notice is shown

### DIFF
--- a/client/order/index.js
+++ b/client/order/index.js
@@ -5,7 +5,6 @@ import { dateI18n } from '@wordpress/date';
 import ReactDOM from 'react-dom';
 import { dispatch } from '@wordpress/data';
 import moment from 'moment';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,15 +12,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { getConfig } from 'utils/order';
 import RefundConfirmationModal from './refund-confirm-modal';
 import CancelConfirmationModal from './cancel-confirm-modal';
-import InlineNotice from 'components/inline-notice';
+import BannerNotice from 'wcpay/components/banner-notice';
 import { formatExplicitCurrency } from 'utils/currency';
 import { reasons } from 'wcpay/disputes/strings';
 import { getDetailsURL } from 'wcpay/components/details-link';
-import {
-	isAwaitingResponse,
-	isInquiry,
-	isUnderReview,
-} from 'wcpay/disputes/utils';
+import { disputeAwaitingResponseStatuses } from 'wcpay/disputes/filters/config';
 import { useCharge } from 'wcpay/data';
 import wcpayTracks from 'tracks';
 import './style.scss';
@@ -142,222 +137,106 @@ jQuery( function ( $ ) {
 const DisputeNotice = ( { chargeId } ) => {
 	const { data: charge } = useCharge( chargeId );
 
-	if ( ! charge?.dispute ) {
+	if (
+		! charge?.dispute ||
+		! charge?.dispute?.evidence_details?.due_by ||
+		// Only show the notice if the dispute is awaiting a response.
+		! disputeAwaitingResponseStatuses.includes( charge?.dispute?.status )
+	) {
 		return null;
 	}
 
 	const { dispute } = charge;
-	const isPreDisputeInquiry = isInquiry( dispute );
 
-	let urgency = 'warning';
-	let actions;
+	const now = moment();
+	const dueBy = moment.unix( dispute.evidence_details?.due_by );
+	const countdownDays = Math.floor( dueBy.diff( now, 'days', true ) );
 
-	// Refunds are only allowed if the dispute is an inquiry or if it's won.
-	const isRefundable =
-		isPreDisputeInquiry || [ 'won' ].includes( dispute.status );
-	const shouldDisableRefund = ! isRefundable;
-	let disableRefund = false;
-
-	let refundDisabledNotice = '';
-	if ( shouldDisableRefund ) {
-		const refundButton = document.querySelector( 'button.refund-items' );
-		if ( refundButton ) {
-			disableRefund = true;
-
-			// Disable the refund button.
-			refundButton.disabled = true;
-
-			const disputeDetailsLink = getDetailsURL(
-				chargeId,
-				'transactions'
-			);
-
-			let tooltipText = '';
-
-			if ( isAwaitingResponse( dispute.status ) ) {
-				refundDisabledNotice = __(
-					'Refunds and order editing are disabled during disputes.',
-					'woocommerce-payments'
-				);
-				tooltipText = refundDisabledNotice;
-			} else if ( isUnderReview( dispute.status ) ) {
-				refundDisabledNotice = createInterpolateElement(
-					__(
-						// eslint-disable-next-line max-len
-						'This order has an active payment dispute. Refunds and order editing are disabled during this time. <a>View details</a>',
-						'woocommerce-payments'
-					),
-					{
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						a: <a href={ disputeDetailsLink } />,
-					}
-				);
-				tooltipText = __(
-					'Refunds and order editing are disabled during an active dispute.',
-					'woocommerce-payments'
-				);
-			} else if ( dispute.status === 'lost' ) {
-				refundDisabledNotice = createInterpolateElement(
-					__(
-						'Refunds and order editing have been disabled as a result of a lost dispute. <a>View details</a>',
-						'woocommerce-payments'
-					),
-					{
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						a: <a href={ disputeDetailsLink } />,
-					}
-				);
-				tooltipText = __(
-					'Refunds and order editing have been disabled as a result of a lost dispute.',
-					'woocommerce-payments'
-				);
-			}
-
-			// Change refund tooltip's text copy.
-			jQuery( refundButton )
-				.parent()
-				.find( '.woocommerce-help-tip' )
-				.attr( {
-					// jQuery.tipTip uses the title attribute to generate the tooltip.
-					title: tooltipText,
-					'aria-label': tooltipText,
-				} )
-				// Regenerate the tipTip tooltip.
-				.tipTip();
-		}
+	// If the dispute is due in the past, we don't want to show the notice.
+	if ( now.isAfter( dueBy ) ) {
+		return;
 	}
 
-	let showWarning = false;
-	let warningText = '';
-	let countdownDays = -1;
+	const amountFormatted = formatExplicitCurrency(
+		dispute.amount,
+		dispute.currency
+	);
 
-	if (
-		dispute.evidence_details?.due_by &&
-		// Only show the notice if the dispute is awaiting a response.
-		isAwaitingResponse( dispute.status )
-	) {
-		const now = moment();
-		const dueBy = moment.unix( dispute.evidence_details?.due_by );
-		countdownDays = Math.floor( dueBy.diff( now, 'days', true ) );
+	let urgency = 'warning';
+	let buttonLabel = __( 'Respond now', 'woocommerce-payments' );
+	let title = sprintf(
+		// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+		__(
+			'This order has a chargeback dispute of %1$s labeled as "%2$s". Please respond to this dispute before %3$s.',
+			'woocommerce-payments'
+		),
+		amountFormatted,
+		reasons[ dispute.reason ].display,
+		dateI18n( 'M j, Y', dueBy.local().toISOString() )
+	);
+	let suffix = '';
 
-		// If the dispute is due in the past, we don't want to show the notice.
-		if ( now.isBefore( dueBy ) ) {
-			showWarning = true;
+	// If the dispute is due within 7 days, use different wording.
+	if ( countdownDays <= 7 ) {
+		title = sprintf(
+			// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+			__(
+				'Please resolve the dispute on this order for %1$s labeled "%2$s" by %3$s.',
+				'woocommerce-payments'
+			),
+			amountFormatted,
+			reasons[ dispute.reason ].display,
+			dateI18n( 'M j, Y', dueBy.local().toISOString() )
+		);
+		suffix = sprintf(
+			// Translators: %s is the number of days left to respond to the dispute.
+			_n(
+				'(%s day left)',
+				'(%s days left)',
+				countdownDays,
+				'woocommerce-payments'
+			),
+			countdownDays
+		);
+	}
 
-			const titleStrings = {
-				// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-				dispute_default: __(
-					// eslint-disable-next-line max-len
-					'This order has been disputed in the amount of %1$s. The customer provided the following reason: %2$s. Please respond to this dispute before %3$s.',
-					'woocommerce-payments'
-				),
-				// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-				inquiry_default: __(
-					// eslint-disable-next-line max-len
-					'The card network involved in this order has opened an inquiry into the transaction with the following reason: %2$s. Please respond to this inquiry before %3$s, just like you would for a formal dispute.',
-					'woocommerce-payments'
-				),
-				// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-				dispute_urgent: __(
-					'Please resolve the dispute on this order for %1$s labeled "%2$s" by %3$s.',
-					'woocommerce-payments'
-				),
-				// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-				inquiry_urgent: __(
-					'Please resolve the inquiry on this order for %1$s labeled "%2$s" by %3$s.',
-					'woocommerce-payments'
-				),
-			};
-			const amountFormatted = formatExplicitCurrency(
-				dispute.amount,
-				dispute.currency
-			);
+	// If the dispute is due within 72 hours, we want to highlight it as urgent/red.
+	if ( countdownDays <= 3 ) {
+		urgency = 'error';
+	}
 
-			let buttonLabel = __( 'Respond now', 'woocommerce-payments' );
-			let suffix = '';
-
-			let titleText = isPreDisputeInquiry
-				? titleStrings.inquiry_default
-				: titleStrings.dispute_default;
-
-			// If the dispute is due within 7 days, use different wording.
-			if ( countdownDays < 7 ) {
-				titleText = isPreDisputeInquiry
-					? titleStrings.inquiry_urgent
-					: titleStrings.dispute_urgent;
-
-				suffix = sprintf(
-					// Translators: %s is the number of days left to respond to the dispute.
-					_n(
-						'(%s day left)',
-						'(%s days left)',
-						countdownDays,
-						'woocommerce-payments'
-					),
-					countdownDays
-				);
-			}
-
-			const title = sprintf(
-				titleText,
-				amountFormatted,
-				reasons[ dispute.reason ].display,
-				dateI18n( 'M j, Y', dueBy.local().toISOString() )
-			);
-
-			// If the dispute is due within 72 hours, we want to highlight it as urgent/red.
-			if ( countdownDays < 3 ) {
-				urgency = 'error';
-			}
-
-			if ( countdownDays < 1 ) {
-				buttonLabel = __( 'Respond today', 'woocommerce-payments' );
-				suffix = __( '(Last day today)', 'woocommerce-payments' );
-			}
-
-			actions = [
+	if ( countdownDays <= 1 ) {
+		urgency = 'error';
+		buttonLabel = __( 'Respond today', 'woocommerce-payments' );
+		suffix = __( '(Last day today)', 'woocommerce-payments' );
+	}
+	return (
+		<BannerNotice
+			status={ urgency }
+			isDismissible={ false }
+			actions={ [
 				{
 					label: buttonLabel,
 					variant: 'secondary',
 					onClick: () => {
 						wcpayTracks.recordEvent(
-							'wcpay_order_dispute_notice_action_click',
+							wcpayTracks.events
+								.ORDER_DISPUTE_NOTICE_BUTTON_CLICK,
 							{
-								due_by_days: countdownDays,
+								due_by_days: parseInt( countdownDays, 10 ),
 							}
 						);
 						window.location = getDetailsURL(
-							chargeId,
-							'transactions'
+							dispute.id,
+							'disputes'
 						);
 					},
 				},
-			];
-
-			warningText = `${ title } ${ suffix }`;
-		}
-	}
-
-	if ( ! showWarning && ! disableRefund ) {
-		return null;
-	}
-
-	wcpayTracks.recordEvent( 'wcpay_order_dispute_notice_view', {
-		urgency,
-		is_inquiry: isPreDisputeInquiry,
-		dispute_reason: dispute.reason,
-		due_by_days: countdownDays,
-	} );
-
-	return (
-		<InlineNotice
-			status={ urgency }
-			isDismissible={ false }
-			actions={ actions }
+			] }
 		>
-			{ showWarning && <strong>{ warningText }</strong> }
-
-			{ disableRefund && <div>{ refundDisabledNotice }</div> }
-		</InlineNotice>
+			<strong>
+				{ title } { suffix }
+			</strong>
+		</BannerNotice>
 	);
 };

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -76,8 +76,6 @@ const events = {
 	DISPUTE_INQUIRY_REFUND_MODAL_VIEW:
 		'wcpay_dispute_inquiry_refund_modal_view',
 	GOOGLEPAY_BUTTON_CLICK: 'gpay_button_click',
-	ORDER_DISPUTE_NOTICE_BUTTON_CLICK:
-		'wcpay_order_dispute_notice_action_click',
 	OVERVIEW_BALANCES_CURRENCY_CLICK:
 		'wcpay_overview_balances_currency_tab_click',
 	OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK:


### PR DESCRIPTION
Fixes #7437

In progress. The event is working but I'll need to refactor things to fire it in a mount effect, once only on render. The current component is doing a lot (including… some jQuery style DOM manipulation as a side effect!) so the refactor is worthwhile IMO. 

- fire a new event with relevant props
- refactor code to ensure props are available
- store isInquiry in a local variable to save multiple calls (not sure if this is necessary?)
- move `click` event name inline - keep name close to use for clarity
- remove parseInt for click event countdownDays – seems unnecessary

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
