### PR TITLE
Use template type for StateFactory methods to assist IDEs better.

### DIFF
--- a/changelog/rpp-add-template-type-create_state
+++ b/changelog/rpp-add-template-type-create_state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Use template type for StateFactory methods to assist IDEs better.
+
+

--- a/src/Internal/Payment/State/AbstractPaymentState.php
+++ b/src/Internal/Payment/State/AbstractPaymentState.php
@@ -103,8 +103,11 @@ abstract class AbstractPaymentState {
 	 * This method should only be called whenever the process is ready to transition
 	 * to the next state, as each new state will be considered the payment's latest one.
 	 *
-	 * @param string $state_class The class of the state to crate.
-	 * @return AbstractPaymentState
+	 * @template T
+	 * @param class-string<T>|string $state_class The class of the state to crate.
+	 *
+	 * @return T
+	 *
 	 * @throws StateTransitionException In case the new state could not be created.
 	 * @throws ContainerException       When the dependency container cannot instantiate the state.
 	 */

--- a/src/Internal/Payment/State/AbstractPaymentState.php
+++ b/src/Internal/Payment/State/AbstractPaymentState.php
@@ -103,10 +103,10 @@ abstract class AbstractPaymentState {
 	 * This method should only be called whenever the process is ready to transition
 	 * to the next state, as each new state will be considered the payment's latest one.
 	 *
-	 * @template T
-	 * @param class-string<T>|string $state_class The class of the state to crate.
+	 * @template ConcreteState
+	 * @param class-string<ConcreteState> | string $state_class The class of the state to crate.
 	 *
-	 * @return T
+	 * @return AbstractPaymentState | ConcreteState
 	 *
 	 * @throws StateTransitionException In case the new state could not be created.
 	 * @throws ContainerException       When the dependency container cannot instantiate the state.

--- a/src/Internal/Payment/State/StateFactory.php
+++ b/src/Internal/Payment/State/StateFactory.php
@@ -38,11 +38,11 @@ class StateFactory {
 	/**
 	 * Creates a new state based on class name.
 	 *
-	 * @template T
-	 * @param class-string<T>|string $state_class Name of the state class.
-	 * @param PaymentContext         $context     Context for the new state.
+	 * @template ConcreteState
+	 * @param class-string<ConcreteState> | string $state_class Name of the state class.
+	 * @param PaymentContext                       $context     Context for the new state.
 	 *
-	 * @return T                          The generated payment state instance.
+	 * @return AbstractPaymentState | ConcreteState                        The generated payment state instance.
 	 * @throws ContainerException         When the dependency container cannot instantiate the state.
 	 * @throws StateTransitionException   When the class name is not a state.
 	 */

--- a/src/Internal/Payment/State/StateFactory.php
+++ b/src/Internal/Payment/State/StateFactory.php
@@ -38,9 +38,11 @@ class StateFactory {
 	/**
 	 * Creates a new state based on class name.
 	 *
-	 * @param string         $state_class Name of the state class.
-	 * @param PaymentContext $context     Context for the new state.
-	 * @return AbstractPaymentState       The generated payment state instance.
+	 * @template T
+	 * @param class-string<T>|string $state_class Name of the state class.
+	 * @param PaymentContext         $context     Context for the new state.
+	 *
+	 * @return T                          The generated payment state instance.
 	 * @throws ContainerException         When the dependency container cannot instantiate the state.
 	 * @throws StateTransitionException   When the class name is not a state.
 	 */


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

- Mostly assist IDEs to recognize class name for instances better. For example, in the following example, PhpStorm directs to both `ProcessedState::complete_processing` and `AbstractPaymentState::complete_processing` rather than only the one in the abstract.

### Before

![before](https://github.com/Automattic/woocommerce-payments/assets/10045087/64e90967-dd7d-44ba-9b3b-e4fe06af7c67) | 

### After 
  
![Markup on 2023-10-25 at 14:47:09](https://github.com/Automattic/woocommerce-payments/assets/10045087/5992aa12-e03d-4691-9ce1-17e5005bcf11)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
