### PR TITLE
Add clear both to payment request button wrapper

### DIFF
--- a/changelog/fix-express-checkout-wrapper-float
+++ b/changelog/fix-express-checkout-wrapper-float
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear floats for payment request button wrapper.

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -1,6 +1,7 @@
 .wcpay-payment-request-wrapper {
 	margin-top: 1em;
 	width: 100%;
+	clear: both;
 
 	&:first-child {
 		margin-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This is a small styling update to the payment request buttons wrapper. It was found that on some themes that are using floats on the product page, the button wrapper would overlap the add to cart button. This change adds a `clear: both` to the wrapper now to break out of the float and avoids the overlap issue.

**Before**

![Screenshot 2023-10-25 at 9 50 28 AM](https://github.com/Automattic/woocommerce-payments/assets/68524302/4c46809d-6f1d-44cf-9f2e-3598deb5540f)

**After**

![Screenshot 2023-10-25 at 9 50 39 AM](https://github.com/Automattic/woocommerce-payments/assets/68524302/f0f85eff-b532-4366-8cf7-dfc7a7842b61)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

The easiest way to test that it fixes the specific issue is to visit the site and apply the same style and confirm it fixes the product page while not breaking anything on the cart or checkout page. It should also be checked in mobile view as well.

This change also could impact other themes so I checked the following list of themes to confirm no regressions:
- Storefront
- Botiga
- Astra
- Neve
- Minimalist E-Commerce
- Everglow

These should also be checked on product, cart, and checkout in desktop and mobile views. For an example of how it looked you can reference the screenshots in https://github.com/Automattic/woocommerce-payments/pull/6985 as they all were unchanged from my testing.

I was unable to find another theme that uses floats on the product page, so it would be great if we could also check against a theme that is using floats and confirm there are no regressions there either.

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.