### PR TITLE
Fix PO Notice not appearing when adding APMs

### DIFF
--- a/changelog/dev-fix-po-notice-not-appearing
+++ b/changelog/dev-fix-po-notice-not-appearing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Update to properly show tooltip on Payments > Settings page when account is in PO state.

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -111,10 +111,13 @@ const PaymentMethod = ( {
 	isPoEnabled,
 	isPoComplete,
 }: PaymentMethodProps ): React.ReactElement => {
+	// We want to show a tooltip if PO is enabled and not yet complete.
+	const isPoInProgress = isPoEnabled && ! isPoComplete;
+
 	// APMs are disabled if they are inactive or if Progressive Onboarding is enabled and not yet complete.
 	const disabled =
 		upeCapabilityStatuses.INACTIVE === status ||
-		( id !== 'card' && isPoEnabled && ! isPoComplete );
+		( id !== 'card' && isPoInProgress );
 	const {
 		accountFees,
 	}: { accountFees: Record< string, FeeStructure > } = useContext(
@@ -122,12 +125,13 @@ const PaymentMethod = ( {
 	);
 	const [ isManualCaptureEnabled ] = useManualCapture();
 
-	const needsAttention = [
+	const needsMoreInformation = [
 		upeCapabilityStatuses.INACTIVE,
 		upeCapabilityStatuses.PENDING_APPROVAL,
 		upeCapabilityStatuses.PENDING_VERIFICATION,
 	].includes( status );
 
+	const needsAttention = needsMoreInformation || isPoInProgress;
 	const shouldDisplayNotice = id === 'sofort';
 
 	const needsOverlay =

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -111,13 +111,15 @@ const PaymentMethod = ( {
 	isPoEnabled,
 	isPoComplete,
 }: PaymentMethodProps ): React.ReactElement => {
-	// We want to show a tooltip if PO is enabled and not yet complete.
-	const isPoInProgress = isPoEnabled && ! isPoComplete;
+	// We want to show a tooltip if PO is enabled and not yet complete. (We make an exception to not show this for card payments).
+	const isPoInProgress =
+		isPoEnabled &&
+		! isPoComplete &&
+		status !== upeCapabilityStatuses.ACTIVE;
 
 	// APMs are disabled if they are inactive or if Progressive Onboarding is enabled and not yet complete.
 	const disabled =
-		upeCapabilityStatuses.INACTIVE === status ||
-		( id !== 'card' && isPoInProgress );
+		upeCapabilityStatuses.INACTIVE === status || isPoInProgress;
 	const {
 		accountFees,
 	}: { accountFees: Record< string, FeeStructure > } = useContext(
@@ -194,9 +196,13 @@ const PaymentMethod = ( {
 								'woocommerce-payments'
 							) }
 							/* eslint-disable-next-line max-len */
-							href={ getDocumentationUrlForDisabledPaymentMethod(
-								paymentMethodId
-							) }
+							href={
+								isPoInProgress
+									? 'https://woocommerce.com/document/woopayments/startup-guide/gradual-signup/#additional-payment-methods'
+									: getDocumentationUrlForDisabledPaymentMethod(
+											paymentMethodId
+									  )
+							}
 						/>
 					),
 				},


### PR DESCRIPTION
Fixes #7548 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* A notice tooltip was not displaying correctly after PO.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<img width="1081" alt="Screenshot 2023-10-25 at 15 00 59" src="https://github.com/Automattic/woocommerce-payments/assets/11770181/5615b653-f97a-4246-a035-a1f58e6a92af">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Onboard a new PO account (without running `npm run listen` on the server).
* When you reach payments enabled status, go to `Payments > Settings` and verify that you can see the new warning icon and tooltip on all payment methods except card, and that clicking the `Learn more` link takes you to the Gradual Signup docs relating to adding payment methods (note: the actual content of the doc is slightly out of date and will be updated soon).
* Complete full account onboarding. (Without running the listener)
* Clear the cache. The account should now be in "pending_verification" state.
* Go to `Payments > Settings` - the warning icons and tooltips should still display, but the `Learn more` link should go to the APMs documentation (not gradual signup docs).
* Run the listener, make an update on the settings page (e.g. update the statement descriptor), save the change and clear the cache.
* The account should now be in `complete` state and you should now be able to add APMs as normal.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
