### PR TITLE
Fix display style of additional thank-you order-received text in Woo 8.1 and 8.2

### DIFF
--- a/changelog/fix-thank-you-message-with-correct-style
+++ b/changelog/fix-thank-you-message-with-correct-style
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Correct the style for duplicate relevant notice in the thank-you page.
+Correct the display style for duplicate relevant notices in the thank-you page.

--- a/changelog/fix-thank-you-message-with-correct-style
+++ b/changelog/fix-thank-you-message-with-correct-style
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Correct the style for duplicate relevant notice in the thank-you page.

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -82,13 +82,9 @@ class WC_Payments_Order_Success_Page {
 	 */
 	public function add_notice_previous_paid_order( $text ) {
 		if ( isset( $_GET[ Duplicate_Payment_Prevention_Service::FLAG_PREVIOUS_ORDER_PAID ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			echo "
-				<script type='text/javascript'>
-					document.querySelector('.woocommerce-notice').classList.add('woocommerce-info');
-				</script>
-			";
-
-			$text .= ' ' . __( 'We detected and prevented an attempt to pay for a duplicate order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' );
+			$text .= $this->format_addtional_thankyou_order_received_text(
+				__( 'We detected and prevented an attempt to pay for a duplicate order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' )
+			);
 		}
 
 		return $text;
@@ -103,17 +99,46 @@ class WC_Payments_Order_Success_Page {
 	 */
 	public function add_notice_previous_successful_intent( $text ) {
 		if ( isset( $_GET[ Duplicate_Payment_Prevention_Service::FLAG_PREVIOUS_SUCCESSFUL_INTENT ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			echo "
-				<script type='text/javascript'>
-					document.querySelector('.woocommerce-notice').classList.add('woocommerce-info');
-				</script>
-			";
-
-			$text .= ' ' .  __( 'We prevented multiple payments for the same order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' );
-
+			$text .= $this->format_addtional_thankyou_order_received_text(
+				__( 'We prevented multiple payments for the same order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' )
+			);
 		}
 
 		return $text;
+	}
+
+
+	/**
+	 * Formats the additional text to be displayed on the thank you page, with the side effect
+	 * as a workaround for an issue in Woo core 8.1.x and 8.2.x.
+	 *
+	 * @param string $additonal_text
+	 *
+	 * @return string Formatted text.
+	 */
+	private function format_addtional_thankyou_order_received_text( string $additonal_text ): string {
+		/**
+		 * This condition is a workaround for Woo core 8.1.x and 8.2.x as it formatted the filtered text,
+		 * while it should format the original text only.
+		 *
+		 * Safely to remove this conditional when WooPayments requires Woo core 8.3.x or higher.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/pull/39758 Introducs the issue since 8.1.0.
+		 * @see https://github.com/woocommerce/woocommerce/pull/40353 Fix the issue since 8.3.0.
+		 */
+		if( version_compare( WC_VERSION, '8.0', '>' )
+			&& version_compare( WC_VERSION, '8.3', '<' )
+		) {
+			echo "
+				<script type='text/javascript'>
+					document.querySelector('.woocommerce-thankyou-order-received')?.classList?.add('woocommerce-info');
+				</script>
+			";
+
+			return $additonal_text;
+		}
+
+		return sprintf( ' <div class="woocommerce-info">%s</div>', $additonal_text );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -135,10 +135,10 @@ class WC_Payments_Order_Success_Page {
 				</script>
 			";
 
-			return $additional_text;
+			return ' ' . $additional_text;
 		}
 
-		return sprintf( ' <div class="woocommerce-info">%s</div>', $additional_text );
+		return sprintf( '<div class="woocommerce-info">%s</div>', $additional_text );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -112,18 +112,18 @@ class WC_Payments_Order_Success_Page {
 	 * Formats the additional text to be displayed on the thank you page, with the side effect
 	 * as a workaround for an issue in Woo core 8.1.x and 8.2.x.
 	 *
-	 * @param string $additonal_text
+	 * @param string $additional_text
 	 *
 	 * @return string Formatted text.
 	 */
-	private function format_addtional_thankyou_order_received_text( string $additonal_text ): string {
+	private function format_addtional_thankyou_order_received_text( string $additional_text ): string {
 		/**
 		 * This condition is a workaround for Woo core 8.1.x and 8.2.x as it formatted the filtered text,
 		 * while it should format the original text only.
 		 *
-		 * Safely to remove this conditional when WooPayments requires Woo core 8.3.x or higher.
+		 * It's safe to remove this conditional when WooPayments requires Woo core 8.3.x or higher.
 		 *
-		 * @see https://github.com/woocommerce/woocommerce/pull/39758 Introducs the issue since 8.1.0.
+		 * @see https://github.com/woocommerce/woocommerce/pull/39758 Introduce the issue since 8.1.0.
 		 * @see https://github.com/woocommerce/woocommerce/pull/40353 Fix the issue since 8.3.0.
 		 */
 		if( version_compare( WC_VERSION, '8.0', '>' )
@@ -135,10 +135,10 @@ class WC_Payments_Order_Success_Page {
 				</script>
 			";
 
-			return $additonal_text;
+			return $additional_text;
 		}
 
-		return sprintf( ' <div class="woocommerce-info">%s</div>', $additonal_text );
+		return sprintf( ' <div class="woocommerce-info">%s</div>', $additional_text );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -82,10 +82,13 @@ class WC_Payments_Order_Success_Page {
 	 */
 	public function add_notice_previous_paid_order( $text ) {
 		if ( isset( $_GET[ Duplicate_Payment_Prevention_Service::FLAG_PREVIOUS_ORDER_PAID ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			$text .= sprintf(
-				'<div class="woocommerce-info">%s</div>',
-				esc_attr__( 'We detected and prevented an attempt to pay for a duplicate order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' )
-			);
+			echo "
+				<script type='text/javascript'>
+					document.querySelector('.woocommerce-notice').classList.add('woocommerce-info');
+				</script>
+			";
+
+			$text .= ' ' . __( 'We detected and prevented an attempt to pay for a duplicate order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' );
 		}
 
 		return $text;
@@ -100,10 +103,14 @@ class WC_Payments_Order_Success_Page {
 	 */
 	public function add_notice_previous_successful_intent( $text ) {
 		if ( isset( $_GET[ Duplicate_Payment_Prevention_Service::FLAG_PREVIOUS_SUCCESSFUL_INTENT ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			$text .= sprintf(
-				'<div class="woocommerce-info">%s</div>',
-				esc_attr__( 'We prevented multiple payments for the same order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' )
-			);
+			echo "
+				<script type='text/javascript'>
+					document.querySelector('.woocommerce-notice').classList.add('woocommerce-info');
+				</script>
+			";
+
+			$text .= ' ' .  __( 'We prevented multiple payments for the same order. If this was a mistake and you wish to try again, please create a new order.', 'woocommerce-payments' );
+
 		}
 
 		return $text;


### PR DESCRIPTION
Fixes the following issue when testing #7450

#### Issue 

In Woo core 8.1.x and 8.2.x, the additional messages for `DuplicatePaymentPreventionService` and `Duplicate_Payment_Prevention_Service` with the div tag is escaped. They look like this: 

![Markup on 2023-10-27 at 14:20:06](https://github.com/Automattic/woocommerce-payments/assets/10045087/88c60d2b-a781-4009-8ec6-b0c9065011b3)

The expected style would be something like screenshots in #5247 and #5346.

#### Cause 

https://github.com/woocommerce/woocommerce/pull/39758 - this issue is introduced in 8.1
https://github.com/woocommerce/woocommerce/pull/40353 - will be fixed in 8.3. 

#### Changes proposed in this Pull Request

- Add a specific handling for Woo 8.1 and 8.2 by adding a small JavaScript code to add style class `woocommerce-info` for the message. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with 8.1 and 8.2. The message looks good, though a bit different from the original one. 
* Test with dev version 8.3. The message style looks good and similar to two PRs: #5247 and #5346.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
