### PR TITLE
Capital loans page broken on WooCommerce 8.2

### DIFF
--- a/changelog/fix-7531-captial-loans
+++ b/changelog/fix-7531-captial-loans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Capital loans page broken on WooCommerce 8.2.0

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -23,7 +23,6 @@ import { useLoans } from 'wcpay/data';
 import { getAdminUrl } from 'wcpay/utils';
 
 import './style.scss';
-import { getQuery } from '@woocommerce/navigation';
 
 const columns = [
 	{

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -23,6 +23,7 @@ import { useLoans } from 'wcpay/data';
 import { getAdminUrl } from 'wcpay/utils';
 
 import './style.scss';
+import { getQuery } from '@woocommerce/navigation';
 
 const columns = [
 	{
@@ -218,6 +219,7 @@ const CapitalPage = (): JSX.Element => {
 				totalRows={ loans.length }
 				headers={ columns }
 				rows={ getRowsData( loans ) }
+				rowsPerPage={ loans.length }
 				summary={ getSummary( loans ) }
 				showMenu={ false }
 			/>

--- a/client/transactions/declarations.d.ts
+++ b/client/transactions/declarations.d.ts
@@ -89,7 +89,7 @@ declare module '@woocommerce/components' {
 		className?: string;
 		title?: string;
 		isLoading?: boolean;
-		rowsPerPage?: number;
+		rowsPerPage: number;
 		totalRows?: number;
 		headers?: TableCardColumn[];
 		rows?: TableCardBodyColumn[][];


### PR DESCRIPTION
Fixes #7531 

#### Changes proposed in this Pull Request

Due to a change in WooCommerce 8.2, `rowsPerPage` is now required on `<TableCard />` components.

This created a broken page for `Capital Loans`. 
![image](https://github.com/Automattic/woocommerce-payments/assets/57298/51ec6700-1b13-4cd3-ae11-72d010059ee5)

This fix adds the `rowsPerPage` parameter to allow the component and page to render as expected.

![image](https://github.com/Automattic/woocommerce-payments/assets/57298/b29ff8ac-0661-476a-9fff-426316ac1116)

Other instances of `<TableCard />` in WooPayments have `rowsPerPage` set and allow dynamic changing using filtering. As the loans page does not have any filtering, I have hardcoded the `rowsPerPage` to the number of loans. 

#### Testing instructions

1. With WooCommerce 8.2 installed and an account with an approved loan
2. Visit the Capital Loans page and confirm it shows as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
