### PR TITLE
Handle rejected capability status

### DIFF
--- a/changelog/fix-7449-handle-rejected-pm-capability-status
+++ b/changelog/fix-7449-handle-rejected-pm-capability-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add rejected payment method capability status

--- a/client/additional-methods-setup/constants.js
+++ b/client/additional-methods-setup/constants.js
@@ -19,4 +19,5 @@ export const upeCapabilityStatuses = {
 	ACTIVE: 'active',
 	INACTIVE: 'inactive',
 	UNREQUESTED: 'unrequested',
+	REJECTED: 'rejected',
 };

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -71,6 +71,12 @@ const PaymentMethodLabel = ( {
 					type="warning"
 				/>
 			) }
+			{ upeCapabilityStatuses.REJECTED === status && (
+				<Chip
+					message={ __( 'Rejected', 'woocommerce-payments' ) }
+					type="alert"
+				/>
+			) }
 			{ upeCapabilityStatuses.PENDING_VERIFICATION === status && (
 				<Chip
 					message={ __(
@@ -133,7 +139,10 @@ const PaymentMethod = ( {
 		upeCapabilityStatuses.PENDING_VERIFICATION,
 	].includes( status );
 
-	const needsAttention = needsMoreInformation || isPoInProgress;
+	const needsAttention =
+		needsMoreInformation ||
+		isPoInProgress ||
+		upeCapabilityStatuses.REJECTED === status;
 	const shouldDisplayNotice = id === 'sofort';
 
 	const needsOverlay =
@@ -171,6 +180,33 @@ const PaymentMethod = ( {
 				label,
 				wcpaySettings?.accountEmail ?? ''
 			);
+		}
+
+		if ( upeCapabilityStatuses.REJECTED === status ) {
+			return interpolateComponents( {
+				// translators: {{contactSupportLink}}: placeholders are opening and closing anchor tags.
+				mixedString: __(
+					'Please contact support for more details. ' +
+						'{{contactSupportLink}}Learn more.{{/contactSupportLink}}',
+					'woocommerce-payments'
+				),
+				components: {
+					contactSupportLink: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="noreferrer"
+							title={ __(
+								'Contact Support',
+								'woocommerce-payments'
+							) }
+							href={
+								'https://woocommerce.com/document/woopayments/TODO/correct-link'
+							}
+						/>
+					),
+				},
+			} );
 		}
 
 		if ( isSetupRequired ) {

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -186,8 +186,7 @@ const PaymentMethod = ( {
 			return interpolateComponents( {
 				// translators: {{contactSupportLink}}: placeholders are opening and closing anchor tags.
 				mixedString: __(
-					'Please contact support for more details. ' +
-						'{{contactSupportLink}}Learn more.{{/contactSupportLink}}',
+					'Please {{contactSupportLink}}contact support{{/contactSupportLink}} for more details.',
 					'woocommerce-payments'
 				),
 				components: {
@@ -201,7 +200,7 @@ const PaymentMethod = ( {
 								'woocommerce-payments'
 							) }
 							href={
-								'https://woocommerce.com/document/woopayments/TODO/correct-link'
+								'https://woo.com/my-account/contact-support/'
 							}
 						/>
 					),


### PR DESCRIPTION
Fixes #7449 

#### Changes proposed in this Pull Request

Handles a new `rejected` capability status in the settings screen by displaying correct badge and tooltip text.

Note: The text in tooltip is not final. 

#### Testing instructions

- Use 4091-gh-Automattic/woocommerce-payments-server
- Open `payment` -> `settings` 
- observe that Klarna has the badge and tooltip 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
