### PR TITLE
Restructure the pay-for-order check for express buttons

### DIFF
--- a/changelog/update-restructure-pay-for-order-check
+++ b/changelog/update-restructure-pay-for-order-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Restructure the pay-for-order check

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -57,11 +57,11 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_after_add_to_cart_form', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 21 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
+			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}
 
-		if ( WC_Payments_Features::is_pay_for_order_flow_enabled() && class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '11.1.0', '>=' ) ) {
+		if ( $this->is_pay_for_order_flow_supported() ) {
 			add_action( 'wp_enqueue_scripts', [ $this, 'add_pay_for_order_params_to_js_config' ], 5 );
-			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}
 	}
 
@@ -94,7 +94,9 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			?>
 			<div class='wcpay-payment-request-wrapper' >
 			<?php
-				$this->platform_checkout_button_handler->display_woopay_button_html();
+				if ( ! $this->payment_request_button_handler->is_pay_for_order_page() || $this->is_pay_for_order_flow_supported() ) {
+					$this->platform_checkout_button_handler->display_woopay_button_html();
+				}
 				$this->payment_request_button_handler->display_payment_request_button_html();
 			?>
 			</div >
@@ -104,7 +106,16 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	}
 
 	/**
-	 * Check if WooPay is enabled
+	 * Check if the pay-for-order flow is supported.
+	 *
+	 * @return bool
+	 */
+	private function is_pay_for_order_flow_supported() {
+		return ( WC_Payments_Features::is_pay_for_order_flow_enabled() && class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '11.1.0', '>=' ) );
+	}
+
+	/**
+	 * Check if WooPay is enabled.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Restructure the pay-for-order check for express buttons.

This is a follow-up to make express buttons work with older versions of WC Blocks.  This should be reviewed after https://github.com/Automattic/woocommerce-payments/pull/7535 is merged.


#### Testing instructions
1. Install and activate the latest WC Blocks `>= 11.1.0`
2. Go to WCPay Dev -> Enable the Pay-for-order flow for WooPay
3. Create a pay-for-order order
4. Go to the pay-for-order page, you should see the WooPay and express checkout buttons
5. Check other product pages, you should see the WooPay and express checkout buttons
7. Disable the WC Blocks plugin
8. Go to the pay-for-order page, you should not see the WooPay express button, but you should see other express checkout buttons
9. Check other product pages, you should see the WooPay and express checkout buttons

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
