### PR TITLE
Remove WC beta tests from matrix config & add a todo comment

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,6 +28,7 @@ env:
   FORCE_E2E_DEPS_SETUP: true
 
 jobs:
+  # [TODO] Enable WC beta tests after fixing failures caused by blocks checkout being default on newer versions
   generate-matrix:
     name: "Generate the matrix for subscriptions-tests dynamically"
     runs-on: ubuntu-latest
@@ -37,7 +38,7 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          WC_VERSIONS=$( echo "[\"7.7.0\", \"latest\", \"beta\"]" )
+          WC_VERSIONS=$( echo "[\"7.7.0\", \"latest\"]" )
           echo "matrix={\"woocommerce\":$WC_VERSIONS,\"test_groups\":[\"wcpay\", \"subscriptions\"],\"test_branches\":[\"merchant\", \"shopper\"]}" >> $GITHUB_OUTPUT
 
   # Run WCPay & subscriptions tests against specific WC versions

--- a/changelog/skip-wc-beta-tests
+++ b/changelog/skip-wc-beta-tests
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Skip E2E tests against WC beta
+Comment: Skip E2E tests against WC beta

--- a/changelog/skip-wc-beta-tests
+++ b/changelog/skip-wc-beta-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skip E2E tests against WC beta


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Temporarily removes tests against WC beta since it's failing constantly after the latest beta release. This is due to WC Blocks being the default checkout option. 

#### Testing instructions

* Trigger a new [E2E Tests - All](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml) test against this branch and confirm that beta tests are not running or listed on the test sidebar. (Ref run - https://github.com/Automattic/woocommerce-payments/actions/runs/6720840048)

Ignore the failing WCPay - Merchant tests since they're being investigated.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
