### PR TITLE
Get WooPay 1st party auth flow to work on page load

### DIFF
--- a/changelog/update-2210-1st-party-auth-on-page-load
+++ b/changelog/update-2210-1st-party-auth-on-page-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Get WooPay 1st party auth flow to work on page load.

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -351,8 +351,12 @@ export const WoopayExpressCheckoutButton = ( {
 	}, [ context, onClickFallback, isPreview, isProductPage, newIframe ] );
 
 	useEffect( () => {
-		initWoopayRef.current = defaultOnClick;
-	}, [ defaultOnClick ] );
+		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
+			initWoopayRef.current = defaultOnClick;
+		} else {
+			initWoopayRef.current = onClickFallback;
+		}
+	}, [ defaultOnClick, onClickFallback ] );
 
 	useEffect( () => {
 		const handlePageShow = ( event ) => {

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -35,6 +35,7 @@ export const WoopayExpressCheckoutButton = ( {
 	const sessionDataPromiseRef = useRef( null );
 	const initWoopayRef = useRef( null );
 	const buttonRef = useRef( null );
+	const initialOnClickEventRef = useRef( null );
 	const isLoadingRef = useRef( false );
 	const { type: buttonType, height, size, theme, context } = buttonSettings;
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -83,7 +84,17 @@ export const WoopayExpressCheckoutButton = ( {
 		}
 	}, [ isPreview, context ] );
 
-	const defaultOnClick = useCallback(
+	const defaultOnClick = useCallback( ( event ) => {
+		// This will only be called if user clicks the button too quickly.
+		// It saves the event for later use.
+		initialOnClickEventRef.current = event;
+		// Set isLoadingRef to true to prevent multiple clicks.
+		isLoadingRef.current = true;
+		setIsLoading( true );
+	}, [] );
+
+	const onClickFallback = useCallback(
+		// OTP flow
 		( e ) => {
 			e.preventDefault();
 
@@ -116,23 +127,18 @@ export const WoopayExpressCheckoutButton = ( {
 					return;
 				}
 
-				addToCartRef
-					.current( productData )
-					.then( ( res ) => {
-						if ( res.error ) {
-							if ( res.submit ) {
-								// Some extensions needs to submit the form
-								// to show error messages.
-								document.querySelector( 'form.cart' ).submit();
-							}
-							return;
+				addToCartRef.current( productData ).then( ( res ) => {
+					if ( res.error ) {
+						if ( res.submit ) {
+							// Some extensions needs to submit the form
+							// to show error messages.
+							document.querySelector( 'form.cart' ).submit();
 						}
+						return;
+					}
 
-						expressCheckoutIframe( api, context, emailSelector );
-					} )
-					.catch( () => {
-						// handle error.
-					} );
+					expressCheckoutIframe( api, context, emailSelector );
+				} );
 			} else {
 				expressCheckoutIframe( api, context, emailSelector );
 			}
@@ -174,12 +180,19 @@ export const WoopayExpressCheckoutButton = ( {
 		iframe.style.position = 'absolute';
 		iframe.style.top = '0';
 
+		iframe.addEventListener( 'error', () => {
+			initWoopayRef.current = onClickFallback;
+		} );
+
 		iframe.addEventListener( 'load', () => {
 			// Change button's onClick handle to use express checkout flow.
 			initWoopayRef.current = ( e ) => {
 				e.preventDefault();
 
-				if ( isPreview || isLoadingRef.current ) {
+				if (
+					isPreview ||
+					( isLoadingRef.current && ! initialOnClickEventRef.current )
+				) {
 					return;
 				}
 
@@ -201,14 +214,16 @@ export const WoopayExpressCheckoutButton = ( {
 						return;
 					}
 
-					if ( listenForCartChanges.stop ) {
+					if ( typeof listenForCartChanges.stop === 'function' ) {
 						// Temporarily stop listening for cart changes to prevent
 						// rendering a new button + iFrame when the cart is updated.
 						listenForCartChanges.stop();
 					}
 
 					addToCartRef.current( productData ).then( () => {
-						if ( listenForCartChanges.start ) {
+						if (
+							typeof listenForCartChanges.start === 'function'
+						) {
 							// Start listening for cart changes, again.
 							listenForCartChanges.start();
 						}
@@ -252,7 +267,7 @@ export const WoopayExpressCheckoutButton = ( {
 								getConfig( 'woopayHost' )
 							);
 						} )
-						.catch( () => {
+						?.catch( () => {
 							const errorMessage = __(
 								'Something went wrong. Please try again.',
 								'woocommerce-payments'
@@ -263,10 +278,21 @@ export const WoopayExpressCheckoutButton = ( {
 						} );
 				}
 			};
+
+			// Trigger first party auth flow if button was clicked before iframe was loaded.
+			if ( initialOnClickEventRef.current ) {
+				initWoopayRef.current( initialOnClickEventRef.current );
+			}
 		} );
 
 		return iframe;
-	}, [ isProductPage, context, isPreview, listenForCartChanges ] );
+	}, [
+		isProductPage,
+		context,
+		isPreview,
+		listenForCartChanges,
+		onClickFallback,
+	] );
 
 	useEffect( () => {
 		if ( isPreview || ! getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
@@ -310,7 +336,7 @@ export const WoopayExpressCheckoutButton = ( {
 				showErrorMessage( context, errorMessage );
 
 				// Set button's default onClick handle to use modal checkout flow.
-				initWoopayRef.current = defaultOnClick;
+				initWoopayRef.current = onClickFallback;
 				isLoadingRef.current = false;
 				setIsLoading( false );
 			}
@@ -322,10 +348,9 @@ export const WoopayExpressCheckoutButton = ( {
 			window.removeEventListener( 'message', onMessage );
 		};
 		// Note: Any changes to this dependency array may cause a duplicate iframe to be appended.
-	}, [ context, defaultOnClick, isPreview, isProductPage, newIframe ] );
+	}, [ context, onClickFallback, isPreview, isProductPage, newIframe ] );
 
 	useEffect( () => {
-		// Set button's default onClick handle to use modal checkout flow.
 		initWoopayRef.current = defaultOnClick;
 	}, [ defaultOnClick ] );
 

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -96,7 +96,7 @@ export const WoopayExpressCheckoutButton = ( {
 	const onClickFallback = useCallback(
 		// OTP flow
 		( e ) => {
-			e.preventDefault();
+			e?.preventDefault();
 
 			if ( isPreview ) {
 				return; // eslint-disable-line no-useless-return
@@ -329,11 +329,7 @@ export const WoopayExpressCheckoutButton = ( {
 			if ( isSessionDataSuccess ) {
 				window.location.href = event.data.value.redirect_url;
 			} else if ( isSessionDataError ) {
-				const errorMessage = __(
-					'WooPay is unavailable at this time. Please try again.',
-					'woocommerce-payments'
-				);
-				showErrorMessage( context, errorMessage );
+				onClickFallback( null );
 
 				// Set button's default onClick handle to use modal checkout flow.
 				initWoopayRef.current = onClickFallback;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2210

#### Changes proposed in this Pull Request

At the moment, when the product page, cart or checkout page loads and a user clicks right away at the WooPay button, it triggers the OTP modal flow instead of the first party auth flow. That's happening because the first party auth flow depends on the iframe being loaded and that can take from some milliseconds to a couple of seconds.

This PR addresses that behavior and makes the first party auth the default flow from the moment the page loads. The only moment the OTP flow should be triggered is when the first party auth fails at any point before redirecting to WooPay checkout.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Make sure to build assets for WCPay on this branch. 
- Give each test a few runs to make sure everything is working as expected.

**Test 1st party authentication works on page load**

1. Have WCPay and WooPay running. 
2. Go to the following pages:
2.1. Product page
2.2. Cart page
2.3. Checkout page
3. Be ready for when the page loads and the WooPay button becomes clickable, to click on it.
4. You should be taken to the WooPay checkout.

**Test 1st party authentication works a few seconds after the page loads**

1. Have WCPay and WooPay running. 
2. Go to the following pages:
2.1. Product page
2.2. Cart page
2.3. Checkout page
3. When the page loads, wait a few seconds and click on WooPay button.
4. You should be taken to the WooPay checkout.

**Test 1st party authentication failure**

1. Have WCPay and WooPay running. 
2. Go to the following pages:
2.1. Product page
2.2. Cart page
2.3. Checkout page
3. Have WooPay server/containers down.
4. Click on WooPay button.
5. You should see an error alert saying "WooPay is unavailable at this time. Please try again.".
6. Have WooPay server/containers up again.
7. Click on WooPay button.
8. You should see the OTP modal and be able to get to the WooPay checkout from it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.