### PR TITLE
chore: cleanup unused hook dependency

### DIFF
--- a/changelog/chore-cleanup-unused-hook-dependency
+++ b/changelog/chore-cleanup-unused-hook-dependency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: chore: cleanup unused hook dependency
+
+

--- a/client/additional-methods-setup/upe-preview-methods-selector/setup-complete-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/setup-complete-task.js
@@ -5,7 +5,6 @@ import React from 'react';
 import { useEffect, useContext } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -75,7 +74,6 @@ const SetupComplete = () => {
 	const {
 		featureFlags: { multiCurrency },
 	} = useContext( WCPaySettingsContext );
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 
 	useEffect( () => {
 		if ( ! isActive ) {
@@ -83,7 +81,7 @@ const SetupComplete = () => {
 		}
 
 		window.wcpaySettings.additionalMethodsSetup.isUpeEnabled = true;
-	}, [ isActive, updateOptions ] );
+	}, [ isActive ] );
 
 	return (
 		<WizardTaskItem


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7603

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Looks like there's a hook with some unused dependencies.
Was introduced here: https://github.com/Automattic/woocommerce-payments/commit/ac8066be6b6d5ec620c2d8eeb208105f29787254
Was edited here, without cleaning up the dependencies: https://github.com/Automattic/woocommerce-payments/commit/bde51655cffdf249a991fba510ad243a072ffc3e

Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Static analysis.
But you can also manually verify:
- Set up a new store (so that there are no payment methods enabled)
- Go to the task to enable additional payment methods
- Complete the task
- The payment methods should still be enabled

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
