### PR TITLE
Add WC_Logger_Interface to Logger service to make it backward compatible

### DIFF
--- a/changelog/hotfix-use-logger-interface-instead-of-concrete-logger-class
+++ b/changelog/hotfix-use-logger-interface-instead-of-concrete-logger-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replaced the concrete logging class with a logger interface

--- a/src/Internal/Logger.php
+++ b/src/Internal/Logger.php
@@ -8,8 +8,8 @@
 namespace WCPay\Internal;
 
 use Exception;
-use WC_Logger;
 use WC_Log_Levels;
+use WC_Logger_Interface;
 use WC_Payment_Gateway_WCPay;
 use WCPay\Core\Mode;
 
@@ -21,9 +21,9 @@ class Logger {
 	const LOG_FILENAME = 'woocommerce-payments';
 
 	/**
-	 * The holding property for our WC_Logger instance.
+	 * The holding property for our WC_Logger_Interface instance.
 	 *
-	 * @var WC_Logger $logger
+	 * @var WC_Logger_Interface $logger
 	 */
 	private $wc_logger;
 
@@ -44,11 +44,11 @@ class Logger {
 	/**
 	 * Logger constructor.
 	 *
-	 * @param WC_Logger                $wc_logger    WC_Logger.
+	 * @param WC_Logger_Interface      $wc_logger    WC_Logger_Interface.
 	 * @param Mode                     $mode         Mode.
 	 * @param WC_Payment_Gateway_WCPay $gateway      WC_Payment_Gateway_WCPay.
 	 */
-	public function __construct( WC_Logger $wc_logger, Mode $mode, WC_Payment_Gateway_WCPay $gateway ) {
+	public function __construct( WC_Logger_Interface $wc_logger, Mode $mode, WC_Payment_Gateway_WCPay $gateway ) {
 		$this->wc_logger = $wc_logger;
 		$this->mode      = $mode;
 		$this->gateway   = $gateway;


### PR DESCRIPTION
Fixes #7612 

#### Changes proposed in this Pull Request

This PR adds a logger interface instead of a concrete logger class to prevent critical errors when logger is overwritten by other plugins.


#### Testing instructions

Make sure to check linked issue on how to reproduce an error. With this change, the error should not be thrown if you follow steps to reproduce on linked issue.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
