### PR TITLE
Fix the amount conversion rate for blocked transactions

### DIFF
--- a/changelog/fix-7583-mc-decimals
+++ b/changelog/fix-7583-mc-decimals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the amount conversion rate for blocked transactions on the transaction details page.

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -79,8 +79,8 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 			return new WP_Error( 'wcpay_missing_order', __( 'Order not found', 'woocommerce-payments' ), [ 'status' => 404 ] );
 		}
 
-		$amount          = (int) $order->get_total() * 100;
 		$currency        = $order->get_currency();
+		$amount          = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
 		$billing_details = WC_Payments_Utils::get_billing_details_from_order( $order );
 		$date_created    = $order->get_date_created();
 		$intent_id       = $order->get_meta( '_intent_id' );


### PR DESCRIPTION
Fixes #7583

#### Changes proposed in this Pull Request

This PR aims to fix the amount conversion rate for blocked transactions by using the `WC_Payments_Utils::prepare_amount` helper method. This method ensures that the correct conversion rate will be used.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch.
* Run `npm run start`
* Run `npm run listen` – or equivalent – to listen to Stripe webhooks
* Go to **Payments > Settings** and make sure Multi-Currency is enabled
* Go to the Fraud protection section, select "Advanced" and configure a rule to block your next order
  * You can set the "Maximum items per order" to be 2 on the "Order Items Threshold" rule – for example
* Go to the Multi-Currency tab and make sure any decimal currency is enabled (VND or JPY)
* On your shop, change the currency to the decimal currency you set up
* Proceed with the checkout – make sure it will be blocked by the rule engine
* Back on the dashboard, go to **WooCommerce > Orders** and open the one you just created
* Check the order note vs transaction details. They should have the same amount.

<table>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>

<tr>
<td>
<img width="358" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/5a228523-98a8-47eb-9df0-d3b196597cbf">
</td>
<td>
<img width="316" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/0263af6d-aaf7-4827-b39f-368ebf1435ab">
</td>
</tr>
</table>

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
