### PR TITLE
Update links across the plugin to woo.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We currently support the following variables:
 
 ## Test account setup
 
-For setting up a test account follow [these instructions](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/dev-mode/).
+For setting up a test account follow [these instructions](https://woo.com/document/woopayments/testing-and-troubleshooting/dev-mode/).
 
 You will need a externally accessible URL to set up the plugin. You can use ngrok for this.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@ Full details of the Automattic Security Policy can be found on [automattic.com](
 
 ## Supported Versions
 
-Generally, only the latest version of the extension has continued support.  In some cases, we may opt to backport critical vulnerabilities fixes to previous versions. 
+Generally, only the latest version of the extension has continued support.  In some cases, we may opt to backport critical vulnerabilities fixes to previous versions.
 
 ## Reporting a Vulnerability
 
-[WooCommerce Payments](https://woocommerce.com/payments/) is an open-source plugin for WooCommerce. Our HackerOne program covers the plugin software.
+[WooPayments](https://woo.com/payments/) is an open-source plugin for WooCommerce. Our HackerOne program covers the plugin software.
 
 **For responsible disclosure of security issues and to be eligible for our bug bounty program, please submit your report via the [HackerOne](https://hackerone.com/automattic) portal.**
 

--- a/bin/wcpay-live-branches/wcpay-live-branches.user.js
+++ b/bin/wcpay-live-branches/wcpay-live-branches.user.js
@@ -388,7 +388,7 @@
 		 */
 		function appendHtml( el, contents ) {
 			const $el = $( el );
-			const wooColor = '#7F54B3'; // https://woocommerce.com/brand-and-logo-guidelines/
+			const wooColor = '#7F54B3'; // https://woo.com/brand-and-logo-guidelines/
 			const styles = $( '<style>' ).text( `
 				#wcpay-live-branches {
 					border: 3px dotted ${ wooColor };

--- a/changelog/dev-woo.com-update
+++ b/changelog/dev-woo.com-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update links across the plugin from woocommerce.com to woo.com (new site URL).

--- a/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
@@ -283,7 +283,7 @@ const AddPaymentMethodsTask = () => {
 						components: {
 							learnMoreLink: (
 								// eslint-disable-next-line max-len
-								<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/" />
+								<ExternalLink href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/" />
 							),
 						},
 					} ) }
@@ -303,7 +303,7 @@ const AddPaymentMethodsTask = () => {
 						</span>
 						<a
 							// eslint-disable-next-line max-len
-							href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled"
+							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled"
 							target="_blank"
 							rel="external noreferrer noopener"
 						>

--- a/client/checkout/blocks/fields.js
+++ b/client/checkout/blocks/fields.js
@@ -33,7 +33,7 @@ const WCPayFields = ( {
 		<p>
 			<strong>Test mode:</strong> use the test VISA card 4242424242424242
 			with any expiry date and CVC, or any test card numbers listed{ ' ' }
-			<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards">
+			<a href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards">
 				here
 			</a>
 			.

--- a/client/components/account-balances/strings.ts
+++ b/client/components/account-balances/strings.ts
@@ -26,7 +26,7 @@ export const fundLabelStrings = {
 
 export const documentationUrls = {
 	depositSchedule:
-		'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/',
+		'https://woo.com/document/woopayments/deposits/deposit-schedule/',
 	negativeBalance:
-		'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/',
+		'https://woo.com/document/woopayments/fees-and-debits/account-showing-negative-balance/',
 };

--- a/client/components/account-balances/test/index.test.tsx
+++ b/client/components/account-balances/test/index.test.tsx
@@ -339,7 +339,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/'
+			'https://woo.com/document/woopayments/deposits/deposit-schedule/'
 		);
 	} );
 
@@ -358,7 +358,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/'
+			'https://woo.com/document/woopayments/fees-and-debits/account-showing-negative-balance/'
 		);
 	} );
 
@@ -377,7 +377,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/'
+			'https://woo.com/document/woopayments/fees-and-debits/account-showing-negative-balance/'
 		);
 	} );
 
@@ -399,7 +399,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/'
+			'https://woo.com/document/woopayments/deposits/deposit-schedule/'
 		);
 	} );
 

--- a/client/components/deposits-overview/next-deposit.tsx
+++ b/client/components/deposits-overview/next-deposit.tsx
@@ -43,7 +43,7 @@ const DepositIncludesLoanPayoutNotice = () => (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
 						href={
-							'https://woocommerce.com/document/woopayments/stripe-capital/overview/'
+							'https://woo.com/document/woopayments/stripe-capital/overview/'
 						}
 						target="_blank"
 						rel="noreferrer"
@@ -73,7 +73,7 @@ const NewAccountWaitingPeriodNotice = () => (
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#new-accounts"
+						href="https://woo.com/document/woopayments/deposits/deposit-schedule/#new-accounts"
 					/>
 				),
 			},
@@ -104,7 +104,7 @@ const NegativeBalanceDepositsPausedNotice = () => (
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/"
+						href="https://woo.com/document/woopayments/fees-and-debits/account-showing-negative-balance/"
 					/>
 				),
 			},

--- a/client/components/deposits-overview/suspended-deposit-notice.tsx
+++ b/client/components/deposits-overview/suspended-deposit-notice.tsx
@@ -35,7 +35,7 @@ function SuspendedDepositNotice(): JSX.Element {
 					suspendLink: (
 						<Link
 							href={
-								'https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/'
+								'https://woo.com/document/woopayments/deposits/why-deposits-suspended/'
 							}
 						/>
 					),

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -176,7 +176,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
           <span
             class="wcpay-deposits-overview__heading__description__text"
           >
-            Your deposits are dispatched 
+            Your deposits are dispatched
             <strong>
               automatically every Monday
             </strong>
@@ -446,14 +446,14 @@ exports[`Suspended Deposit Notice Renders Component Renders 1`] = `
           data-wp-c16t="true"
           data-wp-component="FlexItem"
         >
-          Your deposits are 
+          Your deposits are
           <strong>
             temporarily suspended
           </strong>
-          . 
+          .
           <a
             data-link-type="wc-admin"
-            href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+            href="https://woo.com/document/woopayments/deposits/why-deposits-suspended/"
           >
             Learn more
           </a>

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -176,7 +176,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
           <span
             class="wcpay-deposits-overview__heading__description__text"
           >
-            Your deposits are dispatched
+            Your deposits are dispatched 
             <strong>
               automatically every Monday
             </strong>
@@ -446,11 +446,11 @@ exports[`Suspended Deposit Notice Renders Component Renders 1`] = `
           data-wp-c16t="true"
           data-wp-component="FlexItem"
         >
-          Your deposits are
+          Your deposits are 
           <strong>
             temporarily suspended
           </strong>
-          .
+          . 
           <a
             data-link-type="wc-admin"
             href="https://woo.com/document/woopayments/deposits/why-deposits-suspended/"

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -364,7 +364,7 @@ describe( 'Deposits Overview information', () => {
 			} )
 		).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/stripe-capital/overview/'
+			'https://woo.com/document/woopayments/stripe-capital/overview/'
 		);
 	} );
 
@@ -428,7 +428,7 @@ describe( 'Deposits Overview information', () => {
 		} );
 		expect( getByRole( 'link', { name: /Why\?/ } ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#new-accounts'
+			'https://woo.com/document/woopayments/deposits/deposit-schedule/#new-accounts'
 		);
 	} );
 } );

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -61,7 +61,7 @@ const DepositsStatus: React.FC< Props > = ( {
 		icon = <GridiconNotice size={ iconSize } />;
 	} else if ( showSuspendedNotice ) {
 		const learnMoreHref =
-			'https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/';
+			'https://woo.com/document/woopayments/deposits/why-deposits-suspended/';
 		description = createInterpolateElement(
 			/* translators: <a> - suspended accounts FAQ URL */
 			__(

--- a/client/components/deposits-status/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-status/test/__snapshots__/index.js.snap
@@ -20,7 +20,7 @@ exports[`DepositsStatus renders blocked status 1`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+      href="https://woo.com/document/woopayments/deposits/why-deposits-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -51,7 +51,7 @@ exports[`DepositsStatus renders blocked status 2`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+      href="https://woo.com/document/woopayments/deposits/why-deposits-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/components/payment-method-disabled-tooltip/index.tsx
+++ b/client/components/payment-method-disabled-tooltip/index.tsx
@@ -14,9 +14,9 @@ import PAYMENT_METHOD_IDS from 'wcpay/payment-methods/constants';
 
 export const DocumentationUrlForDisabledPaymentMethod = {
 	DEFAULT:
-		'https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
+		'https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
 	BNPLS:
-		'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
+		'https://woo.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
 };
 
 export const getDocumentationUrlForDisabledPaymentMethod = (

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -198,7 +198,7 @@ const PaymentMethod = ( {
 							/* eslint-disable-next-line max-len */
 							href={
 								isPoInProgress
-									? 'https://woocommerce.com/document/woopayments/startup-guide/gradual-signup/#additional-payment-methods'
+									? 'https://woo.com/document/woopayments/startup-guide/gradual-signup/#additional-payment-methods'
 									: getDocumentationUrlForDisabledPaymentMethod(
 											paymentMethodId
 									  )
@@ -315,7 +315,7 @@ const PaymentMethod = ( {
 						) }
 						<a
 							// eslint-disable-next-line max-len
-							href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation"
+							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation"
 							target="_blank"
 							rel="external noreferrer noopener"
 						>

--- a/client/components/tooltip/test/index.test.tsx
+++ b/client/components/tooltip/test/index.test.tsx
@@ -242,7 +242,7 @@ describe( 'ClickTooltip', () => {
 				content={
 					// Tooltip content includes a link element which should be navigable via keyboard
 					<span>
-						Tooltip content <a href="woocommerce.com">Link</a>
+						Tooltip content <a href="woo.com">Link</a>
 					</span>
 				}
 				onHide={ handleHideMock }

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -263,7 +263,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 									learnMore: (
 										<a
 											target="_blank"
-											href="https://woocommerce.com/document/woopay-customer-documentation/"
+											href="https://woo.com/document/woopay-customer-documentation/"
 											rel="noopener noreferrer"
 											onClick={ () => {
 												wcpayTracks.recordUserEvent(

--- a/client/connect-account-page/modal/index.js
+++ b/client/connect-account-page/modal/index.js
@@ -15,7 +15,7 @@ import './style.scss';
 const LearnMoreLink = ( props ) => (
 	<Link
 		{ ...props }
-		href="https://woocommerce.com/document/woopayments/compatibility/countries/"
+		href="https://woo.com/document/woopayments/compatibility/countries/"
 		target="_blank"
 		rel="noopener noreferrer"
 		type="external"

--- a/client/connect-account-page/modal/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/modal/test/__snapshots__/index.js.snap
@@ -51,7 +51,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
         <ul
           class="woocommerce-list"
           role="menu"
@@ -91,10 +91,10 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
             </div>
           </li>
         </ul>
-         
+
         <a
           data-link-type="external"
-          href="https://woocommerce.com/document/woopayments/compatibility/countries/"
+          href="https://woo.com/document/woopayments/compatibility/countries/"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -173,7 +173,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
         <ul
           class="woocommerce-list"
           role="menu"
@@ -213,10 +213,10 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
             </div>
           </li>
         </ul>
-         
+
         <a
           data-link-type="external"
-          href="https://woocommerce.com/document/woopayments/compatibility/countries/"
+          href="https://woo.com/document/woopayments/compatibility/countries/"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/client/connect-account-page/modal/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/modal/test/__snapshots__/index.js.snap
@@ -51,7 +51,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
         <ul
           class="woocommerce-list"
           role="menu"
@@ -91,7 +91,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
             </div>
           </li>
         </ul>
-
+         
         <a
           data-link-type="external"
           href="https://woo.com/document/woopayments/compatibility/countries/"
@@ -173,7 +173,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
         <ul
           class="woocommerce-list"
           role="menu"
@@ -213,7 +213,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
             </div>
           </li>
         </ul>
-
+         
         <a
           data-link-type="external"
           href="https://woo.com/document/woopayments/compatibility/countries/"

--- a/client/deposits/instant-deposits/modal.tsx
+++ b/client/deposits/instant-deposits/modal.tsx
@@ -29,7 +29,7 @@ const InstantDepositModal: React.FC< InstantDepositModalProps > = ( {
 	inProgress,
 } ) => {
 	const learnMoreHref =
-		'https://woocommerce.com/document/woopayments/deposits/instant-deposits/';
+		'https://woo.com/document/woopayments/deposits/instant-deposits/';
 	const feePercentage = `${ percentage }%`;
 	const description = createInterpolateElement(
 		/* translators: %s: amount representing the fee percentage, <a>: instant payout doc URL */

--- a/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
@@ -67,7 +67,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       </button>
     </div>
     <p>
-      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee.
+      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee. 
       <a
         href="https://woo.com/document/woopayments/deposits/instant-deposits/"
         rel="noopener noreferrer"
@@ -80,7 +80,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__balance"
       >
-        Balance available for instant deposit:
+        Balance available for instant deposit: 
         <span>
           $123.45
         </span>
@@ -88,7 +88,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__fee"
       >
-        1.5% service fee:
+        1.5% service fee: 
         <span>
           -
           $1.23
@@ -97,7 +97,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__net"
       >
-        Net deposit amount:
+        Net deposit amount: 
         <span>
           $122.22
         </span>

--- a/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
@@ -67,9 +67,9 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       </button>
     </div>
     <p>
-      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee. 
+      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee.
       <a
-        href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/"
+        href="https://woo.com/document/woopayments/deposits/instant-deposits/"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -80,7 +80,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__balance"
       >
-        Balance available for instant deposit: 
+        Balance available for instant deposit:
         <span>
           $123.45
         </span>
@@ -88,7 +88,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__fee"
       >
-        1.5% service fee: 
+        1.5% service fee:
         <span>
           -
           $1.23
@@ -97,7 +97,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__net"
       >
-        Net deposit amount: 
+        Net deposit amount:
         <span>
           $122.22
         </span>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
@@ -25,7 +25,7 @@ import SettingsSection from 'wcpay/settings/settings-section';
 
 const EnabledCurrenciesSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies';
+		'https://woo.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -12,9 +12,9 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
         Enabled currencies
       </h2>
       <p>
-        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. 
+        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules.
         <a
-          href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies"
+          href="https://woo.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies"
           rel="noreferrer"
           target="_blank"
         >
@@ -363,7 +363,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
       </div>
     </div>
     <p>
-      Are you sure you want to remove 
+      Are you sure you want to remove
       <strong>
         Euro (EUR €)
       </strong>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -12,7 +12,7 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
         Enabled currencies
       </h2>
       <p>
-        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules.
+        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. 
         <a
           href="https://woo.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies"
           rel="noreferrer"
@@ -363,7 +363,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
       </div>
     </div>
     <p>
-      Are you sure you want to remove
+      Are you sure you want to remove 
       <strong>
         Euro (EUR €)
       </strong>

--- a/client/multi-currency/multi-currency-settings/store-settings/index.js
+++ b/client/multi-currency/multi-currency-settings/store-settings/index.js
@@ -18,7 +18,7 @@ import PreviewModal from 'wcpay/multi-currency/preview-modal';
 
 const StoreSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings';
+		'https://woo.com/document/woopayments/currencies/multi-currency-setup/#store-settings';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
@@ -12,9 +12,9 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
         Store settings
       </h2>
       <p>
-        Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
+        Store settings allow your customers to choose which currency they would like to use when shopping at your store.
         <a
-          href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings"
+          href="https://woo.com/document/woopayments/currencies/multi-currency-setup/#store-settings"
           rel="noreferrer"
           target="_blank"
         >
@@ -66,7 +66,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              Customers will be notified via store alert banner. 
+              Customers will be notified via store alert banner.
               <button
                 class="components-button is-link"
                 type="button"
@@ -102,7 +102,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              A currency switcher is also available in your widgets. 
+              A currency switcher is also available in your widgets.
               <a
                 href="widgets.php"
               >

--- a/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
         Store settings
       </h2>
       <p>
-        Store settings allow your customers to choose which currency they would like to use when shopping at your store.
+        Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
         <a
           href="https://woo.com/document/woopayments/currencies/multi-currency-setup/#store-settings"
           rel="noreferrer"
@@ -66,7 +66,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              Customers will be notified via store alert banner.
+              Customers will be notified via store alert banner. 
               <button
                 class="components-button is-link"
                 type="button"
@@ -102,7 +102,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              A currency switcher is also available in your widgets.
+              A currency switcher is also available in your widgets. 
               <a
                 href="widgets.php"
               >

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -417,7 +417,7 @@ const SingleCurrencySettings = () => {
 													onClick={ () => {
 														open(
 															/* eslint-disable-next-line max-len */
-															'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding',
+															'https://woo.com/document/woopayments/currencies/multi-currency-setup/#price-rounding',
 															'_blank'
 														);
 													} }
@@ -482,7 +482,7 @@ const SingleCurrencySettings = () => {
 													onClick={ () => {
 														open(
 															/* eslint-disable-next-line max-len */
-															'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing',
+															'https://woo.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing',
 															'_blank'
 														);
 													} }

--- a/client/onboarding/strings.tsx
+++ b/client/onboarding/strings.tsx
@@ -52,7 +52,7 @@ export default {
 						// eslint-disable-next-line jsx-a11y/anchor-has-content
 						<a
 							href={
-								'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/dev-mode/'
+								'https://woo.com/document/woopayments/testing-and-troubleshooting/dev-mode/'
 							}
 							target="_blank"
 							rel="noreferrer"

--- a/client/order/cancel-confirm-modal/index.js
+++ b/client/order/cancel-confirm-modal/index.js
@@ -60,7 +60,7 @@ const CancelConfirmationModal = ( { originalOrderStatus } ) => {
 			howtoIssueRefunds: (
 				<a
 					target="_blank"
-					href="https://woocommerce.com/document/woopayments/managing-money/#refunds"
+					href="https://woo.com/document/woopayments/managing-money/#refunds"
 					rel="noopener noreferrer"
 				>
 					{ __( 'how to issue refunds', 'woocommerce-payments' ) }

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -41,7 +41,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 		'woocommerce-payments'
 	);
 	let learnMoreDocsUrl =
-		'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding';
+		'https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding';
 
 	if ( isInquiry( dispute ) ) {
 		/* translators: <a> link to dispute inquiry documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
@@ -51,7 +51,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 			'woocommerce-payments'
 		);
 		learnMoreDocsUrl =
-			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries';
+			'https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries';
 	}
 
 	return (

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -51,7 +51,7 @@ const DisputeUnderReviewFooter: React.FC< {
 								<a
 									target="_blank"
 									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+									href="https://woo.com/document/woopayments/fraud-and-disputes/"
 								/>
 							),
 						}
@@ -123,7 +123,7 @@ const DisputeWonFooter: React.FC< {
 								<a
 									target="_blank"
 									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+									href="https://woo.com/document/woopayments/fraud-and-disputes/"
 								/>
 							),
 						}
@@ -231,7 +231,7 @@ const DisputeLostFooter: React.FC< {
 								<a
 									target="_blank"
 									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+									href="https://woo.com/document/woopayments/fraud-and-disputes/"
 								/>
 							),
 						}
@@ -306,7 +306,7 @@ const InquiryUnderReviewFooter: React.FC< {
 								<a
 									target="_blank"
 									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries"
+									href="https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries"
 								/>
 							),
 						}
@@ -379,7 +379,7 @@ const InquiryClosedFooter: React.FC< {
 								<a
 									target="_blank"
 									rel="noopener noreferrer"
-									href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+									href="https://woo.com/document/woopayments/fraud-and-disputes/"
 								/>
 							),
 						}

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -107,7 +107,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 						),
 						{
 							a: (
-								<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#withdrawals" />
+								<ExternalLink href="https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/#withdrawals" />
 							),
 						}
 					) }
@@ -258,7 +258,7 @@ export const InquirySteps: React.FC< Props > = ( {
 										),
 										{
 											learnMoreLink: (
-												<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries" />
+												<ExternalLink href="https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries" />
 											),
 										}
 									) }

--- a/client/payment-details/dispute-details/dispute-summary-row.tsx
+++ b/client/payment-details/dispute-details/dispute-summary-row.tsx
@@ -65,7 +65,7 @@ const DisputeSummaryRow: React.FC< Props > = ( { dispute } ) => {
 									</Paragraphs>
 									<p>
 										<a
-											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/"
+											href="https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/"
 											target="_blank"
 											rel="noopener noreferrer"
 										>

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -515,7 +515,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 											a: (
 												// eslint-disable-next-line jsx-a11y/anchor-has-content, react/jsx-no-target-blank
 												<a
-													href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
+													href="https://woo.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
 													target="_blank"
 													rel="noreferer"
 												/>

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -39,14 +39,14 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -57,7 +57,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -254,16 +254,16 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
           <div
             class="payment-details-capture-notice__text"
           >
-            You must 
+            You must
             <a
-              href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
+              href="https://woo.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
               rel="noreferer"
               target="_blank"
             >
               capture
             </a>
              this charge within the next
-             
+
             <abbr
               title="Sep 15, 2023 / 12:33PM"
             >
@@ -340,14 +340,14 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -374,7 +374,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -571,16 +571,16 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
           <div
             class="payment-details-capture-notice__text"
           >
-            You must 
+            You must
             <a
-              href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
+              href="https://woo.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
               rel="noreferer"
               target="_blank"
             >
               capture
             </a>
              this charge within the next
-             
+
             <abbr
               title="Sep 15, 2023 / 12:33PM"
             >
@@ -648,14 +648,14 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -666,7 +666,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -908,14 +908,14 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -926,7 +926,7 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1168,14 +1168,14 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -1186,7 +1186,7 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1450,14 +1450,14 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -1468,7 +1468,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1738,16 +1738,16 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
               class="payment-details-summary__breakdown"
             >
               <p>
-                Refunded: 
+                Refunded:
                 $-20.00
               </p>
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $-0.70
               </p>
             </div>
@@ -1758,7 +1758,7 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1985,7 +1985,7 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
             <p
               class="payment-details-summary__amount"
             >
-              
+
               <span
                 class="payment-details-summary__amount-currency"
               >
@@ -1998,14 +1998,14 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $0.00
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $0.00
               </p>
             </div>
@@ -2016,7 +2016,7 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
             </div>
           </div>
         </div>
@@ -2234,16 +2234,16 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
               class="payment-details-summary__breakdown"
             >
               <p>
-                Refunded: 
+                Refunded:
                 $-12.00
               </p>
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $7.30
               </p>
             </div>
@@ -2254,7 +2254,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -2496,14 +2496,14 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -2514,7 +2514,7 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -2756,14 +2756,14 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             <div
               class="payment-details-summary__breakdown"
             >
-              
+
               <p>
-                Fees: 
+                Fees:
                 $-0.70
               </p>
-              
+
               <p>
-                Net: 
+                Net:
                 $19.30
               </p>
             </div>
@@ -2774,7 +2774,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
+              Payment ID:
               ch_38jdHA39KKA
             </div>
           </div>
@@ -2975,9 +2975,9 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             data-wp-c16t="true"
             data-wp-component="FlexItem"
           >
-            Good news! You won this dispute on -. The disputed amount and the dispute fee have been credited back to your account. 
+            Good news! You won this dispute on -. The disputed amount and the dispute fee have been credited back to your account.
             <a
-              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+              href="https://woo.com/document/woopayments/fraud-and-disputes/"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -39,14 +39,14 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -57,7 +57,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -254,7 +254,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
           <div
             class="payment-details-capture-notice__text"
           >
-            You must
+            You must 
             <a
               href="https://woo.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
               rel="noreferer"
@@ -263,7 +263,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
               capture
             </a>
              this charge within the next
-
+             
             <abbr
               title="Sep 15, 2023 / 12:33PM"
             >
@@ -340,14 +340,14 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -374,7 +374,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -571,7 +571,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
           <div
             class="payment-details-capture-notice__text"
           >
-            You must
+            You must 
             <a
               href="https://woo.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
               rel="noreferer"
@@ -580,7 +580,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
               capture
             </a>
              this charge within the next
-
+             
             <abbr
               title="Sep 15, 2023 / 12:33PM"
             >
@@ -648,14 +648,14 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -666,7 +666,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -908,14 +908,14 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -926,7 +926,7 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1168,14 +1168,14 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -1186,7 +1186,7 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1450,14 +1450,14 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -1468,7 +1468,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1738,16 +1738,16 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
               class="payment-details-summary__breakdown"
             >
               <p>
-                Refunded:
+                Refunded: 
                 $-20.00
               </p>
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $-0.70
               </p>
             </div>
@@ -1758,7 +1758,7 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -1985,7 +1985,7 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
             <p
               class="payment-details-summary__amount"
             >
-
+              
               <span
                 class="payment-details-summary__amount-currency"
               >
@@ -1998,14 +1998,14 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $0.00
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $0.00
               </p>
             </div>
@@ -2016,7 +2016,7 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
             </div>
           </div>
         </div>
@@ -2234,16 +2234,16 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
               class="payment-details-summary__breakdown"
             >
               <p>
-                Refunded:
+                Refunded: 
                 $-12.00
               </p>
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $7.30
               </p>
             </div>
@@ -2254,7 +2254,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -2496,14 +2496,14 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -2514,7 +2514,7 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -2756,14 +2756,14 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             <div
               class="payment-details-summary__breakdown"
             >
-
+              
               <p>
-                Fees:
+                Fees: 
                 $-0.70
               </p>
-
+              
               <p>
-                Net:
+                Net: 
                 $19.30
               </p>
             </div>
@@ -2774,7 +2774,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             <div
               class="payment-details-summary__id"
             >
-              Payment ID:
+              Payment ID: 
               ch_38jdHA39KKA
             </div>
           </div>
@@ -2975,7 +2975,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             data-wp-c16t="true"
             data-wp-component="FlexItem"
           >
-            Good news! You won this dispute on -. The disputed amount and the dispute fee have been credited back to your account.
+            Good news! You won this dispute on -. The disputed amount and the dispute fee have been credited back to your account. 
             <a
               href="https://woo.com/document/woopayments/fraud-and-disputes/"
               rel="noopener noreferrer"

--- a/client/payment-gateways/disable-confirmation-modal.js
+++ b/client/payment-gateways/disable-confirmation-modal.js
@@ -113,11 +113,11 @@ const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 						strong: <strong />,
 						wooCommercePaymentsLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a href="https://woocommerce.com/document/woopayments/" />
+							<a href="https://woo.com/document/woopayments/" />
 						),
 						contactSupportLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a href="https://woocommerce.com/my-account/create-a-ticket/?select=5278104" />
+							<a href="https://woo.com/my-account/create-a-ticket/?select=5278104" />
 						),
 					},
 				} ) }

--- a/client/payment-methods/capability-request/capability-request-map.ts
+++ b/client/payment-methods/capability-request/capability-request-map.ts
@@ -27,7 +27,7 @@ const CapabilityRequestList: Array< CapabilityRequestMap > = [
 				),
 				actions: 'link',
 				actionUrl:
-					'https://woocommerce.com/document/woopayments/payment-methods/#jcb',
+					'https://woo.com/document/woopayments/payment-methods/#jcb',
 				actionsLabel: __( 'Finish setup', 'woocommerce-payments' ),
 			},
 			pending: {

--- a/client/payment-methods/delete-modal.tsx
+++ b/client/payment-methods/delete-modal.tsx
@@ -94,7 +94,7 @@ const ConfirmPaymentMethodDeleteModal: React.FunctionComponent< {
 						) }
 						<a
 							// eslint-disable-next-line max-len
-							href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation"
+							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation"
 							target="_blank"
 							rel="external noreferrer noopener"
 						>

--- a/client/settings/advanced-settings/multi-currency-toggle.js
+++ b/client/settings/advanced-settings/multi-currency-toggle.js
@@ -40,7 +40,7 @@ const MultiCurrencyToggle = () => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/" />
+						<ExternalLink href="https://woo.com/document/woopayments/currencies/multi-currency-setup/" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
@@ -85,7 +85,7 @@ const MigrateAutomaticallyNotice: React.FC< Props > = ( {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/" />
+						<ExternalLink href="https://woo.com/document/woopayments/built-in-subscriptions/comparison/" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
@@ -134,7 +134,7 @@ const MigrateOptionNotice: React.FC< Props > = ( {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/" />
+						<ExternalLink href="https://woo.com/document/woopayments/built-in-subscriptions/comparison/" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/stripe-billing-toggle.tsx
+++ b/client/settings/advanced-settings/stripe-billing-toggle.tsx
@@ -56,7 +56,7 @@ const StripeBillingToggle: React.FC< Props > = ( { onChange } ) => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" />
+						<ExternalLink href="https://woo.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -54,7 +54,7 @@ const WCPaySubscriptionsToggle = () => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/built-in-subscriptions/" />
+						<ExternalLink href="https://woo.com/document/woopayments/built-in-subscriptions/" />
 					),
 				},
 			} ) }

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -176,7 +176,7 @@ const DepositsSchedule = () => {
 						'Learn more about deposit scheduling.',
 						'woocommerce-payments'
 					) }
-					href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/"
+					href="https://woo.com/document/woopayments/deposits/deposit-schedule/"
 					target="_blank"
 					rel="external noreferrer noopener"
 				>
@@ -203,7 +203,7 @@ const DepositsSchedule = () => {
 						'Learn more about deposit scheduling.',
 						'woocommerce-payments'
 					) }
-					href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/"
+					href="https://woo.com/document/woopayments/deposits/deposit-schedule/"
 					target="_blank"
 					rel="external noreferrer noopener"
 				>

--- a/client/settings/disable-upe-modal/index.js
+++ b/client/settings/disable-upe-modal/index.js
@@ -29,7 +29,7 @@ const NeedHelpBarSection = () => {
 				components: {
 					docsLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/">
+						<ExternalLink href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/">
 							{ sprintf(
 								/* translators: %s: WooPayments */
 								__( '%s docs', 'woocommerce-payments' ),
@@ -39,7 +39,7 @@ const NeedHelpBarSection = () => {
 					),
 					supportLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/contact-us/">
+						<ExternalLink href="https://woo.com/contact-us/">
 							{ __( 'contact support', 'woocommerce-payments' ) }
 						</ExternalLink>
 					),

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -96,7 +96,7 @@ const WooPaySettings = ( { section } ) => {
 												<a
 													target="_blank"
 													rel="noreferrer"
-													href="https://woocommerce.com/document/woopay-merchant-documentation/"
+													href="https://woo.com/document/woopay-merchant-documentation/"
 												/>
 											),
 											tosLink: (
@@ -117,7 +117,7 @@ const WooPaySettings = ( { section } ) => {
 												<a
 													target="_blank"
 													rel="noreferrer"
-													href="https://woocommerce.com/usage-tracking/"
+													href="https://woo.com/usage-tracking/"
 												/>
 											),
 										},
@@ -230,7 +230,7 @@ const WooPaySettings = ( { section } ) => {
 									/* eslint-enable prettier/prettier */
 									learnMoreLink: (
 										// eslint-disable-next-line max-len
-										<ExternalLink href="https://woocommerce.com/document/woopay-merchant-documentation/#checkout-appearance" />
+										<ExternalLink href="https://woo.com/document/woopay-merchant-documentation/#checkout-appearance" />
 									),
 								}
 							} ) }

--- a/client/settings/express-checkout/link-item.tsx
+++ b/client/settings/express-checkout/link-item.tsx
@@ -158,7 +158,7 @@ const LinkExpressCheckoutItem = (): React.ReactElement => {
 									target="_blank"
 									rel="noreferrer"
 									/* eslint-disable-next-line max-len */
-									href="https://woocommerce.com/document/woopayments/payment-methods/link-by-stripe/"
+									href="https://woo.com/document/woopayments/payment-methods/link-by-stripe/"
 									isSecondary
 								>
 									{ __(

--- a/client/settings/express-checkout/woopay-item.tsx
+++ b/client/settings/express-checkout/woopay-item.tsx
@@ -128,7 +128,7 @@ const WooPayExpressCheckoutItem = (): React.ReactElement => {
 																		target="_blank"
 																		rel="noreferrer"
 																		// eslint-disable-next-line max-len
-																		href="https://woocommerce.com/document/woopay-merchant-documentation/"
+																		href="https://woo.com/document/woopay-merchant-documentation/"
 																	/>
 																),
 																tosLink: (
@@ -149,7 +149,7 @@ const WooPayExpressCheckoutItem = (): React.ReactElement => {
 																	<a
 																		target="_blank"
 																		rel="noreferrer"
-																		href="https://woocommerce.com/usage-tracking/"
+																		href="https://woo.com/usage-tracking/"
 																	/>
 																),
 															},

--- a/client/settings/fraud-protection/advanced-settings/cards/cvc-verification.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/cvc-verification.tsx
@@ -47,7 +47,7 @@ const CVCVerificationRuleCard: React.FC = () => {
 										target="_blank"
 										type="external"
 										// eslint-disable-next-line max-len
-										href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+										href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
 									/>
 								),
 							},

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/cvc-verification.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/cvc-verification.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`CVC verification card renders correctly when CVC check is enabled 1`] =
                 data-wp-c16t="true"
                 data-wp-component="FlexItem"
               >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                 <a
                   data-link-type="external"
                   href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/cvc-verification.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/cvc-verification.test.tsx.snap
@@ -186,10 +186,10 @@ exports[`CVC verification card renders correctly when CVC check is enabled 1`] =
                 data-wp-c16t="true"
                 data-wp-component="FlexItem"
               >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                 <a
                   data-link-type="external"
-                  href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                  href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                   target="_blank"
                 >
                   Learn more

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -224,7 +224,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for 
+                      This filter screens for
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -232,7 +232,7 @@ Object {
                       >
                         IP addresses
                       </a>
-                       outside of your 
+                       outside of your
                       <a
                         href="admin.php?page=wc-settings&tab=general"
                       >
@@ -382,7 +382,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for customer's 
+                      This filter screens for customer's
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -976,10 +976,10 @@ Object {
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                           <a
                             data-link-type="external"
-                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                            href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                             target="_blank"
                           >
                             Learn more
@@ -1222,7 +1222,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for 
+                    This filter screens for
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -1230,7 +1230,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your 
+                     outside of your
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -1380,7 +1380,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's 
+                    This filter screens for customer's
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -1974,10 +1974,10 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                         <a
                           data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                          href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                           target="_blank"
                         >
                           Learn more
@@ -2105,7 +2105,7 @@ Object {
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more
     </div>
     <div>
       <div>
@@ -2285,7 +2285,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for 
+                      This filter screens for
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -2293,7 +2293,7 @@ Object {
                       >
                         IP addresses
                       </a>
-                       outside of your 
+                       outside of your
                       <a
                         href="admin.php?page=wc-settings&tab=general"
                       >
@@ -2443,7 +2443,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for customer's 
+                      This filter screens for customer's
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -2910,10 +2910,10 @@ Object {
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                           <a
                             data-link-type="external"
-                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                            href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                             target="_blank"
                           >
                             Learn more
@@ -3140,7 +3140,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for 
+                    This filter screens for
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -3148,7 +3148,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your 
+                     outside of your
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -3298,7 +3298,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's 
+                    This filter screens for customer's
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -3765,10 +3765,10 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                         <a
                           data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                          href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                           target="_blank"
                         >
                           Learn more
@@ -3897,7 +3897,7 @@ Object {
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more
     </div>
     <div>
       <div
@@ -4042,7 +4042,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for 
+                    This filter screens for
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -4050,7 +4050,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your 
+                     outside of your
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -4200,7 +4200,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's 
+                    This filter screens for customer's
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -4667,10 +4667,10 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                         <a
                           data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                          href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                           target="_blank"
                         >
                           Learn more
@@ -4860,7 +4860,7 @@ Object {
                 <p
                   class="fraud-protection-rule-card-description"
                 >
-                  This filter screens for 
+                  This filter screens for
                   <a
                     data-link-type="external"
                     href="https://simple.wikipedia.org/wiki/IP_address"
@@ -4868,7 +4868,7 @@ Object {
                   >
                     IP addresses
                   </a>
-                   outside of your 
+                   outside of your
                   <a
                     href="admin.php?page=wc-settings&tab=general"
                   >
@@ -5018,7 +5018,7 @@ Object {
                 <p
                   class="fraud-protection-rule-card-description"
                 >
-                  This filter screens for customer's 
+                  This filter screens for customer's
                   <a
                     data-link-type="external"
                     href="https://simple.wikipedia.org/wiki/IP_address"
@@ -5485,10 +5485,10 @@ Object {
                       data-wp-c16t="true"
                       data-wp-component="FlexItem"
                     >
-                      For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                      For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                       <a
                         data-link-type="external"
-                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                        href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                         target="_blank"
                       >
                         Learn more
@@ -5615,7 +5615,7 @@ Object {
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more
     </div>
     <div>
       <div>
@@ -5778,7 +5778,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for 
+                      This filter screens for
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -5786,7 +5786,7 @@ Object {
                       >
                         IP addresses
                       </a>
-                       outside of your 
+                       outside of your
                       <a
                         href="admin.php?page=wc-settings&tab=general"
                       >
@@ -5936,7 +5936,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for customer's 
+                      This filter screens for customer's
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -6484,10 +6484,10 @@ Object {
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                           <a
                             data-link-type="external"
-                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                            href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                             target="_blank"
                           >
                             Learn more
@@ -6696,7 +6696,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for 
+                    This filter screens for
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -6704,7 +6704,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your 
+                     outside of your
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -6854,7 +6854,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's 
+                    This filter screens for customer's
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -7402,10 +7402,10 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
                         <a
                           data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                          href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
                           target="_blank"
                         >
                           Learn more

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -224,7 +224,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for
+                      This filter screens for 
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -232,7 +232,7 @@ Object {
                       >
                         IP addresses
                       </a>
-                       outside of your
+                       outside of your 
                       <a
                         href="admin.php?page=wc-settings&tab=general"
                       >
@@ -382,7 +382,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for customer's
+                      This filter screens for customer's 
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -976,7 +976,7 @@ Object {
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                           <a
                             data-link-type="external"
                             href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -1222,7 +1222,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for
+                    This filter screens for 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -1230,7 +1230,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your
+                     outside of your 
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -1380,7 +1380,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's
+                    This filter screens for customer's 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -1974,7 +1974,7 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                         <a
                           data-link-type="external"
                           href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -2105,7 +2105,7 @@ Object {
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
     </div>
     <div>
       <div>
@@ -2285,7 +2285,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for
+                      This filter screens for 
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -2293,7 +2293,7 @@ Object {
                       >
                         IP addresses
                       </a>
-                       outside of your
+                       outside of your 
                       <a
                         href="admin.php?page=wc-settings&tab=general"
                       >
@@ -2443,7 +2443,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for customer's
+                      This filter screens for customer's 
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -2910,7 +2910,7 @@ Object {
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                           <a
                             data-link-type="external"
                             href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -3140,7 +3140,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for
+                    This filter screens for 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -3148,7 +3148,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your
+                     outside of your 
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -3298,7 +3298,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's
+                    This filter screens for customer's 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -3765,7 +3765,7 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                         <a
                           data-link-type="external"
                           href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -3897,7 +3897,7 @@ Object {
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
     </div>
     <div>
       <div
@@ -4042,7 +4042,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for
+                    This filter screens for 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -4050,7 +4050,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your
+                     outside of your 
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -4200,7 +4200,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's
+                    This filter screens for customer's 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -4667,7 +4667,7 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                         <a
                           data-link-type="external"
                           href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -4860,7 +4860,7 @@ Object {
                 <p
                   class="fraud-protection-rule-card-description"
                 >
-                  This filter screens for
+                  This filter screens for 
                   <a
                     data-link-type="external"
                     href="https://simple.wikipedia.org/wiki/IP_address"
@@ -4868,7 +4868,7 @@ Object {
                   >
                     IP addresses
                   </a>
-                   outside of your
+                   outside of your 
                   <a
                     href="admin.php?page=wc-settings&tab=general"
                   >
@@ -5018,7 +5018,7 @@ Object {
                 <p
                   class="fraud-protection-rule-card-description"
                 >
-                  This filter screens for customer's
+                  This filter screens for customer's 
                   <a
                     data-link-type="external"
                     href="https://simple.wikipedia.org/wiki/IP_address"
@@ -5485,7 +5485,7 @@ Object {
                       data-wp-c16t="true"
                       data-wp-component="FlexItem"
                     >
-                      For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                      For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                       <a
                         data-link-type="external"
                         href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -5615,7 +5615,7 @@ Object {
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
     </div>
     <div>
       <div>
@@ -5778,7 +5778,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for
+                      This filter screens for 
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -5786,7 +5786,7 @@ Object {
                       >
                         IP addresses
                       </a>
-                       outside of your
+                       outside of your 
                       <a
                         href="admin.php?page=wc-settings&tab=general"
                       >
@@ -5936,7 +5936,7 @@ Object {
                     <p
                       class="fraud-protection-rule-card-description"
                     >
-                      This filter screens for customer's
+                      This filter screens for customer's 
                       <a
                         data-link-type="external"
                         href="https://simple.wikipedia.org/wiki/IP_address"
@@ -6484,7 +6484,7 @@ Object {
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                           <a
                             data-link-type="external"
                             href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
@@ -6696,7 +6696,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for
+                    This filter screens for 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -6704,7 +6704,7 @@ Object {
                     >
                       IP addresses
                     </a>
-                     outside of your
+                     outside of your 
                     <a
                       href="admin.php?page=wc-settings&tab=general"
                     >
@@ -6854,7 +6854,7 @@ Object {
                   <p
                     class="fraud-protection-rule-card-description"
                   >
-                    This filter screens for customer's
+                    This filter screens for customer's 
                     <a
                       data-link-type="external"
                       href="https://simple.wikipedia.org/wiki/IP_address"
@@ -7402,7 +7402,7 @@ Object {
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.
+                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
                         <a
                           data-link-type="external"
                           href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -64,7 +64,7 @@ const GeneralSettings = () => {
 									target="_blank"
 									rel="noreferrer"
 									/* eslint-disable-next-line max-len */
-									href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards"
+									href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards"
 								/>
 							),
 							learnMoreLink: (
@@ -72,7 +72,7 @@ const GeneralSettings = () => {
 								<a
 									target="_blank"
 									rel="noreferrer"
-									href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/"
+									href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/"
 								/>
 							),
 						},

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -52,7 +52,7 @@ const ExpressCheckoutDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/woopayments/settings-guide/#express-checkouts">
+		<ExternalLink href="https://woo.com/document/woopayments/settings-guide/#express-checkouts">
 			{ __( 'Learn more', 'woocommerce-payments' ) }
 		</ExternalLink>
 	</>
@@ -83,7 +83,7 @@ const TransactionsDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/woopayments/">
+		<ExternalLink href="https://woo.com/document/woopayments/">
 			{ __( 'View our documentation', 'woocommerce-payments' ) }
 		</ExternalLink>
 	</>
@@ -104,7 +104,7 @@ const DepositsDescription = () => {
 					depositDelayDays
 				) }
 			</p>
-			<ExternalLink href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/">
+			<ExternalLink href="https://woo.com/document/woopayments/deposits/deposit-schedule/">
 				{ __(
 					'Learn more about pending schedules',
 					'woocommerce-payments'
@@ -124,7 +124,7 @@ const FraudProtectionDescription = () => {
 					'woocommerce-payments'
 				) }
 			</p>
-			<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/">
+			<ExternalLink href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/">
 				{ __(
 					'Learn more about risk filtering',
 					'woocommerce-payments'
@@ -144,7 +144,7 @@ const AdvancedDescription = () => {
 					'woocommerce-payments'
 				) }
 			</p>
-			<ExternalLink href="https://woocommerce.com/document/woopayments/settings-guide/#advanced-settings">
+			<ExternalLink href="https://woo.com/document/woopayments/settings-guide/#advanced-settings">
 				{ __( 'View our documentation', 'woocommerce-payments' ) }
 			</ExternalLink>
 		</>

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -45,7 +45,7 @@ const WooPayIncompatibilityNotice = () => (
 						<a
 							target="_blank"
 							rel="noreferrer"
-							href="https://woocommerce.com/document/woopay-merchant-documentation/#compatibility"
+							href="https://woo.com/document/woopay-merchant-documentation/#compatibility"
 						/>
 					),
 				},

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -18,9 +18,9 @@ import { PaymentMethod } from 'wcpay/types/payment-methods';
 import { createInterpolateElement } from '@wordpress/element';
 
 const countryFeeStripeDocsBaseLink =
-	'https://woocommerce.com/document/woopayments/fees-and-debits/fees/#';
+	'https://woo.com/document/woopayments/fees-and-debits/fees/#';
 const countryFeeStripeDocsBaseLinkNoCountry =
-	'https://woocommerce.com/document/woopayments/fees-and-debits/fees/';
+	'https://woo.com/document/woopayments/fees-and-debits/fees/';
 const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	AE: 'united-arab-emirates',
 	AU: 'australia',

--- a/client/utils/format-ssr.js
+++ b/client/utils/format-ssr.js
@@ -125,7 +125,7 @@ Taxonomies: Product Types: ${ printTerms( systemStatus.settings.taxonomies ) }
 Taxonomies: Product Visibility: ${ printTerms(
 		systemStatus.settings.product_visibility_terms
 	) }
-Connected to Woo.com: ${
+Connected to WooCommerce.com: ${
 		systemStatus.settings.woocommerce_com_connected === 'yes'
 			? CHECK_MARK
 			: DASH_MARK

--- a/client/utils/format-ssr.js
+++ b/client/utils/format-ssr.js
@@ -125,7 +125,7 @@ Taxonomies: Product Types: ${ printTerms( systemStatus.settings.taxonomies ) }
 Taxonomies: Product Visibility: ${ printTerms(
 		systemStatus.settings.product_visibility_terms
 	) }
-Connected to WooCommerce.com: ${
+Connected to woo.com: ${
 		systemStatus.settings.woocommerce_com_connected === 'yes'
 			? CHECK_MARK
 			: DASH_MARK

--- a/client/utils/format-ssr.js
+++ b/client/utils/format-ssr.js
@@ -125,7 +125,7 @@ Taxonomies: Product Types: ${ printTerms( systemStatus.settings.taxonomies ) }
 Taxonomies: Product Visibility: ${ printTerms(
 		systemStatus.settings.product_visibility_terms
 	) }
-Connected to woo.com: ${
+Connected to Woo.com: ${
 		systemStatus.settings.woocommerce_com_connected === 'yes'
 			? CHECK_MARK
 			: DASH_MARK

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -44,7 +44,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     >
       <span>
         <a
-          href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
+          href="https://woo.com/document/woopayments/fees-and-debits/fees/#united-states"
           rel="noreferrer"
           target="_blank"
         >
@@ -101,7 +101,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     >
       <span>
         <a
-          href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
+          href="https://woo.com/document/woopayments/fees-and-debits/fees/#united-states"
           rel="noreferrer"
           target="_blank"
         >
@@ -158,7 +158,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays custo
     >
       <span>
         <a
-          href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
+          href="https://woo.com/document/woopayments/fees-and-debits/fees/#united-states"
           rel="noreferrer"
           target="_blank"
         >

--- a/docs/version-support-policy.md
+++ b/docs/version-support-policy.md
@@ -1,6 +1,6 @@
 # Version Support Policy
 
-We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woo.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/).
+We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woocommerce.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/).
 
 However, in the practice, we're really enforcing only WordPress core with the `Requires at least` in [`readme.txt`](https://github.com/Automattic/woocommerce-payments/blob/develop/readme.txt) and [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php).
 

--- a/docs/version-support-policy.md
+++ b/docs/version-support-policy.md
@@ -1,6 +1,6 @@
 # Version Support Policy
 
-We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woocommerce.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/).
+We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woo.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/).
 
 However, in the practice, we're really enforcing only WordPress core with the `Requires at least` in [`readme.txt`](https://github.com/Automattic/woocommerce-payments/blob/develop/readme.txt) and [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php).
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -253,7 +253,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Customer bank statement', 'woocommerce-payments' ),
 				'description' => WC_Payments_Utils::esc_interpolated_html(
 					__( 'Edit the way your store name appears on your customers’ bank statements (read more about requirements <a>here</a>).', 'woocommerce-payments' ),
-					[ 'a' => '<a href="https://woocommerce.com/document/woopayments/customization-and-translation/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
+					[ 'a' => '<a href="https://woo.com/document/woopayments/customization-and-translation/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
 				),
 			],
 			'manual_capture'                     => [

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -411,7 +411,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$learn_more_text = WC_Payments_Utils::esc_interpolated_html(
 			__( '<a>Learn more</a>.', 'woocommerce-payments' ),
 			[
-				'a' => '<a href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay/#domain-registration" target="_blank">',
+				'a' => '<a href="https://woo.com/document/woopayments/payment-methods/apple-pay/#domain-registration" target="_blank">',
 			]
 		);
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -257,7 +257,7 @@ class WC_Payments_Checkout {
 						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
 						[
 							'strong' => '<strong>',
-							'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
+							'a'      => '<a href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
 						]
 					);
 					?>

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -273,7 +273,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 					$payment_method->get_testing_instructions(),
 					[
 						'strong' => '<strong>',
-						'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
+						'a'      => '<a href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
 					]
 				);
 				$settings[ $payment_method_id ]['forceNetworkSavedCards'] = $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
@@ -349,7 +349,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 							$testing_instructions,
 							[
 								'strong' => '<strong>',
-								'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
+								'a'      => '<a href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
 							]
 						);
 					}

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -213,7 +213,7 @@ class WC_Payments_Utils {
 
 	/**
 	 * List of countries enabled for Stripe platform account. See also this URL:
-	 * https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries
+	 * https://woo.com/document/woopayments/compatibility/countries/#supported-countries
 	 *
 	 * @return string[]
 	 */

--- a/includes/core/CONTRIBUTING.md
+++ b/includes/core/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are a few possible paths when it comes to services:
 
 1. __Create a facade for an existing service:__ Create a new service class within `core/service`, which simply facades the [existing service](service/customer-service.md). Doing so will allow us to modify the facade in the future, keeping existing methods with the same parameters as existing ones.
 This is what was done with the [customer service](service/customer-service.md), and is the recommended way if a certain feature requires access to an existing service quickly.
-2. __Move an existing service to the core directory:__ This should be done with consideration how the service could change in the future, and whether it is core to the gateway. If it more suitable to an extension (ex. [Multi-Currency](https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/)), or a consumer (ex. [WooPay](https://woocommerce.com/documentation/products/woopay/)), it likely needs to be somewhere else.
+2. __Move an existing service to the core directory:__ This should be done with consideration how the service could change in the future, and whether it is core to the gateway. If it more suitable to an extension (ex. [Multi-Currency](https://woo.com/document/woopayments/currencies/multi-currency-setup/)), or a consumer (ex. [WooPay](https://woo.com/documentation/products/woopay/)), it likely needs to be somewhere else.
 3. When __creating a new service__, similarly to moving existing ones here, please consider whether the service belongs to core. If it does, do it with care, as services should be reliable and resilient.
 
 🔗 Further information about services in core is available [within the services directory](services/README.md).

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -89,7 +89,7 @@ class Mode {
 		/**
 		 * Allows WooCommerce to enter dev mode.
 		 *
-		 * @see https://woocommerce.com/document/woopayments/testing-and-troubleshooting/dev-mode/
+		 * @see https://woo.com/document/woopayments/testing-and-troubleshooting/dev-mode/
 		 * @param bool $dev_mode The pre-determined dev mode.
 		 */
 		$this->dev_mode = (bool) apply_filters( 'wcpay_dev_mode', $dev_mode );
@@ -100,7 +100,7 @@ class Mode {
 		/**
 		 * Allows WooCommerce to enter test mode.
 		 *
-		 * @see https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#enabling-test-mode
+		 * @see https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#enabling-test-mode
 		 * @param bool $test_mode The pre-determined test mode.
 		 */
 		$this->test_mode = (bool) apply_filters( 'wcpay_test_mode', $test_mode );

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -137,7 +137,7 @@ class Order_Fraud_And_Risk_Meta_Box {
 				}
 
 				$callout     = __( 'Learn more', 'woocommerce-payments' );
-				$callout_url = 'https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/';
+				$callout_url = 'https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/';
 				$callout_url = add_query_arg( 'status_is', 'fraud-meta-box-not-wcpay-learn-more', $callout_url );
 				echo '<p>' . esc_html( $description ) . '</p><a href="' . esc_url( $callout_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
 				break;

--- a/includes/multi-currency/SettingsOnboardCta.php
+++ b/includes/multi-currency/SettingsOnboardCta.php
@@ -18,7 +18,7 @@ class SettingsOnboardCta extends \WC_Settings_Page {
 	 *
 	 * @var string
 	 */
-	const LEARN_MORE_URL = 'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/';
+	const LEARN_MORE_URL = 'https://woo.com/document/woopayments/currencies/multi-currency-setup/';
 
 	/**
 	 * MultiCurrency instance.

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -79,7 +79,7 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 					'WooPayments'
 				),
 				[
-					'a' => '<a href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/" target="wcpay_upe_learn_more">',
+					'a' => '<a href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/" target="wcpay_upe_learn_more">',
 				]
 			)
 		);

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -41,7 +41,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 					__( "Get immediate access to your funds when you need them – including nights, weekends, and holidays. With %s' <a>Instant Deposits feature</a>, you're able to transfer your earnings to a debit card within minutes.", 'woocommerce-payments' ),
 					'WooPayments'
 				),
-				[ 'a' => '<a href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/">' ]
+				[ 'a' => '<a href="https://woo.com/document/woopayments/deposits/instant-deposits/">' ]
 			)
 		);
 		$note->set_content_data( (object) [] );
@@ -51,7 +51,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Request an instant deposit', 'woocommerce-payments' ),
-			'https://woocommerce.com/document/woopayments/deposits/instant-deposits/#request-an-instant-deposit',
+			'https://woo.com/document/woopayments/deposits/instant-deposits/#request-an-instant-deposit',
 			'unactioned',
 			true
 		);

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -26,7 +26,7 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/ssl-and-https/#section-7';
+	const NOTE_DOCUMENTATION_URL = 'https://woo.com/document/ssl-and-https/#section-7';
 
 	/**
 	 * Checks if a note can and should be added.

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -24,7 +24,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/woocommerce-refunds/#how-do-i-inform-my-customers-about-the-refund-policy';
+	const NOTE_DOCUMENTATION_URL = 'https://woo.com/document/woocommerce-refunds/#how-do-i-inform-my-customers-about-the-refund-policy';
 
 	/**
 	 * Get the note.

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -27,7 +27,7 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 	/**
 	 * CTA button link
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/woopayments/payment-methods/link-by-stripe/';
+	const NOTE_DOCUMENTATION_URL = 'https://woo.com/document/woopayments/payment-methods/link-by-stripe/';
 
 	/**
 	 * The account service instance.

--- a/includes/subscriptions/assets/js/plugin-page.js
+++ b/includes/subscriptions/assets/js/plugin-page.js
@@ -75,7 +75,7 @@ jQuery( function ( $ ) {
 					wc_payments_plugin.get_woo_subscriptions_plugin_slug()
 			).attr( 'href' );
 		},
-		// Gets the Woo Subscriptions plugin slug. When the ite is connected to woo.com, the slug is different and includes a woocommerce-com- prefix.
+		// Gets the Woo Subscriptions plugin slug. When the site is connected to Woo.com, the slug is different and includes a woocommerce-com- prefix.
 		get_woo_subscriptions_plugin_slug() {
 			const element = document.querySelector(
 				'[data-slug="woocommerce-com-woocommerce-subscriptions"]'

--- a/includes/subscriptions/assets/js/plugin-page.js
+++ b/includes/subscriptions/assets/js/plugin-page.js
@@ -75,7 +75,7 @@ jQuery( function ( $ ) {
 					wc_payments_plugin.get_woo_subscriptions_plugin_slug()
 			).attr( 'href' );
 		},
-		// Gets the Woo Subscriptions plugin slug. When the ite is connected to WooCommerce.com, the slug is different and includes a woocommerce-com- prefix.
+		// Gets the Woo Subscriptions plugin slug. When the ite is connected to woo.com, the slug is different and includes a woocommerce-com- prefix.
 		get_woo_subscriptions_plugin_slug() {
 			const element = document.querySelector(
 				'[data-slug="woocommerce-com-woocommerce-subscriptions"]'

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -22,7 +22,7 @@
 							printf(
 								// Translators: %1-%4 placeholders are opening and closing a or strong HTML tags. %5$s: WooPayments, %6$s: Woo Subscriptions.
 								esc_html__( 'Your store has subscriptions using %5$s Stripe Billing functionality for payment processing. Due to the %1$soff-site billing engine%2$s these subscriptions use,%3$s they will continue to renew even after you deactivate %6$s%4$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" target="_blank">',
+								'<a href="https://woo.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" target="_blank">',
 								'</a>',
 								'<strong>',
 								'</strong>',
@@ -36,7 +36,7 @@
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
+								'<a href="https://woo.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
 								'</a>',
 								'Woo Subscriptions'
 							);

--- a/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
@@ -22,8 +22,8 @@
 							printf(
 							// translators: $1 $2 $3 placeholders are opening and closing HTML link tags, linking to documentation. $4 $5 placeholders are opening and closing strong HTML tags. $6 is WooPayments.
 								esc_html__( 'Your store has active subscriptions using the built-in %6$s functionality. Due to the %1$soff-site billing engine%3$s these subscriptions use, %4$sthey will continue to renew even after you deactivate %6$s%5$s. %2$sLearn more%3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" target="_blank">',
-								'<a href="https://woocommerce.com/document/woopayments/built-in-subscriptions/deactivate/#existing-subscriptions" target="_blank">',
+								'<a href="https://woo.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" target="_blank">',
+								'<a href="https://woo.com/document/woopayments/built-in-subscriptions/deactivate/#existing-subscriptions" target="_blank">',
 								'</a>',
 								'<strong>',
 								'</strong>',
@@ -36,7 +36,7 @@
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel all subscriptions%2$s prior to deactivating %3$s. ', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
+								'<a href="https://woo.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
 								'</a>',
 								'WooPayments'
 							);

--- a/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
@@ -22,8 +22,8 @@
 							printf(
 								// Translators: placeholders are opening and closing strong HTML tags. %6$s: WooPayments, %7$s: Woo Subscriptions.
 								esc_html__( 'Your store has subscriptions using %6$s Stripe Billing functionality for payment processing. Due to the %1$soff-site billing engine%3$s these subscriptions use,%4$s they will continue to renew even after you deactivate %6$s%5$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" target="_blank">',
-								'<a href="https://woocommerce.com/document/woopayments/built-in-subscriptions/deactivate/#existing-subscriptions" target="_blank">',
+								'<a href="https://woo.com/document/woopayments/built-in-subscriptions/comparison/#billing-engine" target="_blank">',
+								'<a href="https://woo.com/document/woopayments/built-in-subscriptions/deactivate/#existing-subscriptions" target="_blank">',
 								'</a>',
 								'<strong>',
 								'</strong>',
@@ -36,7 +36,7 @@
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
+								'<a href="https://woo.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
 								'</a>',
 								'WooPayments'
 							);

--- a/readme.txt
+++ b/readme.txt
@@ -22,17 +22,17 @@ See payments, track cash flow into your bank account, manage refunds, and stay o
 
 Features previously only available on your payment provider’s website are now part of your store’s **integrated payments dashboard**. This enables you to:
 
-- View the details of [payments, refunds, and other transactions](https://woocommerce.com/document/woopayments/managing-money/).
-- View and respond to [disputes and chargebacks](https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/).
-- [Track deposits](https://woocommerce.com/document/woopayments/deposits/) into your bank account or debit card.
+- View the details of [payments, refunds, and other transactions](https://woo.com/document/woopayments/managing-money/).
+- View and respond to [disputes and chargebacks](https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/).
+- [Track deposits](https://woo.com/document/woopayments/deposits/) into your bank account or debit card.
 
 **Pay as you go**
 
-WooPayments is **free to install**, with **no setup fees or monthly fees**. Pay-as-you-go fees start at 2.9% + $0.30 per transaction for U.S.-issued cards. [Read more about transaction fees](https://woocommerce.com/document/woopayments/fees-and-debits/fees/).
+WooPayments is **free to install**, with **no setup fees or monthly fees**. Pay-as-you-go fees start at 2.9% + $0.30 per transaction for U.S.-issued cards. [Read more about transaction fees](https://woo.com/document/woopayments/fees-and-debits/fees/).
 
 **Supported by the WooCommerce team**
 
-Our global support team is available to answer questions you may have about WooPayments installation, setup, or use. For assistance, [open a ticket on WooCommerce.com](https://woocommerce.com/my-account/create-a-ticket/?select=5278104).
+Our global support team is available to answer questions you may have about WooPayments installation, setup, or use. For assistance, [open a ticket on Woo.com](https://woo.com/my-account/create-a-ticket/?select=5278104).
 
 == Getting Started ==
 
@@ -44,7 +44,7 @@ Our global support team is available to answer questions you may have about WooP
 
 = Try it now =
 
-To try WooPayments (previously WooCommerce Payments) on your store, simply [install it](https://wordpress.org/plugins/woocommerce-payments/#installation) and follow the prompts. Please see our [Startup Guide](https://woocommerce.com/document/woopayments/startup-guide/) for a full walkthrough of the process.
+To try WooPayments (previously WooCommerce Payments) on your store, simply [install it](https://wordpress.org/plugins/woocommerce-payments/#installation) and follow the prompts. Please see our [Startup Guide](https://woo.com/document/woopayments/startup-guide/) for a full walkthrough of the process.
 
 WooPayments has experimental support for the Checkout block from [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/). Please check the [FAQ section](#faq) for more information.
 
@@ -56,9 +56,9 @@ Install and activate the WooCommerce and WooPayments plugins, if you haven't alr
 
 = What countries and currencies are supported? =
 
-If you are an individual or business based in [one of these countries](https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries), you can sign-up with WooPayments. After completing sign up, you can accept payments from customers anywhere in the world.
+If you are an individual or business based in [one of these countries](https://woo.com/document/woopayments/compatibility/countries/#supported-countries), you can sign-up with WooPayments. After completing sign up, you can accept payments from customers anywhere in the world.
 
-We are actively planning to expand into additional countries based on your interest. Let us know where you would like to [see WooPayments launch next](https://woocommerce.com/payments/#request-invite).
+We are actively planning to expand into additional countries based on your interest. Let us know where you would like to [see WooPayments launch next](https://woo.com/payments/#request-invite).
 
 = Why is a WordPress.com account and connection required? =
 
@@ -66,15 +66,15 @@ WooPayments uses the WordPress.com connection to authenticate each request, conn
 
 = How do I set up a store for a client? =
 
-If you are a developer or agency setting up a site for a client, please see [this page](https://woocommerce.com/document/woopayments/account-management/developer-or-agency-setup/) of our documentation for some tips on how to install WooPayments on client sites.
+If you are a developer or agency setting up a site for a client, please see [this page](https://woo.com/document/woopayments/account-management/developer-or-agency-setup/) of our documentation for some tips on how to install WooPayments on client sites.
 
 = How is WooPayments related to Stripe? =
 
-WooPayments is built in partnership with Stripe [Stripe](https://stripe.com/). When you sign up for WooPayments, your personal and business information is verified with Stripe and stored in an account connected to the WooPayments service. This account is then used in the background for managing your business account information and activity via WooPayments. [Learn more](https://woocommerce.com/document/woopayments/account-management/partnership-with-stripe/).
+WooPayments is built in partnership with Stripe [Stripe](https://stripe.com/). When you sign up for WooPayments, your personal and business information is verified with Stripe and stored in an account connected to the WooPayments service. This account is then used in the background for managing your business account information and activity via WooPayments. [Learn more](https://woo.com/document/woopayments/account-management/partnership-with-stripe/).
 
 = Are there Terms of Service and data usage policies? =
 
-You can read our Terms of Service and other policies [here](https://woocommerce.com/document/woopayments/our-policies/).
+You can read our Terms of Service and other policies [here](https://woo.com/document/woopayments/our-policies/).
 
 = How does the Checkout block work? =
 

--- a/templates/emails/customer-ipp-receipt.php
+++ b/templates/emails/customer-ipp-receipt.php
@@ -8,7 +8,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woo.com/document/template-structure/
+ * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails
  * @version 1.0.0
  */

--- a/templates/emails/customer-ipp-receipt.php
+++ b/templates/emails/customer-ipp-receipt.php
@@ -8,7 +8,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails
  * @version 1.0.0
  */

--- a/templates/emails/email-ipp-receipt-compliance-details.php
+++ b/templates/emails/email-ipp-receipt-compliance-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woo.com/document/template-structure/
+ * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails
  * @version 1.0.0
  */

--- a/templates/emails/email-ipp-receipt-compliance-details.php
+++ b/templates/emails/email-ipp-receipt-compliance-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails
  * @version 1.0.0
  */

--- a/templates/emails/email-ipp-receipt-store-details.php
+++ b/templates/emails/email-ipp-receipt-store-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woo.com/document/template-structure/
+ * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails
  * @version 1.0.0
  */

--- a/templates/emails/email-ipp-receipt-store-details.php
+++ b/templates/emails/email-ipp-receipt-store-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails
  * @version 1.0.0
  */

--- a/templates/emails/plain/customer-ipp-receipt.php
+++ b/templates/emails/plain/customer-ipp-receipt.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woo.com/document/template-structure/
+ * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails\Plain
  * @version 1.0.0
  */

--- a/templates/emails/plain/customer-ipp-receipt.php
+++ b/templates/emails/plain/customer-ipp-receipt.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails\Plain
  * @version 1.0.0
  */

--- a/templates/emails/plain/email-ipp-receipt-compliance-details.php
+++ b/templates/emails/plain/email-ipp-receipt-compliance-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woo.com/document/template-structure/
+ * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails\Plain
  * @version 1.0.0
  */

--- a/templates/emails/plain/email-ipp-receipt-compliance-details.php
+++ b/templates/emails/plain/email-ipp-receipt-compliance-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails\Plain
  * @version 1.0.0
  */

--- a/templates/emails/plain/email-ipp-receipt-store-details.php
+++ b/templates/emails/plain/email-ipp-receipt-store-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woo.com/document/template-structure/
+ * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails\Plain
  * @version 1.0.0
  */

--- a/templates/emails/plain/email-ipp-receipt-store-details.php
+++ b/templates/emails/plain/email-ipp-receipt-store-details.php
@@ -9,7 +9,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woo.com/document/template-structure/
  * @package WooCommerce\Payments\Templates\Emails\Plain
  * @version 1.0.0
  */

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -3,20 +3,20 @@
     "admin": {
       "username": "admin",
       "password": "password",
-      "email": "e2e-wcpay-admin@woocommerce.com"
+      "email": "e2e-wcpay-admin@woo.com"
     },
     "customer": {
       "username": "customer",
       "password": "password",
-      "email": "e2e-wcpay-customer@woocommerce.com"
+      "email": "e2e-wcpay-customer@woo.com"
     },
     "subscriptions-customer": {
       "username": "subscriptions-customer",
       "password": "password",
-      "email": "e2e-wcpay-customer@woocommerce.com"
+      "email": "e2e-wcpay-customer@woo.com"
     },
     "guest": {
-      "email": "e2e-wcpay-guest@woocommerce.com"
+      "email": "e2e-wcpay-guest@woo.com"
     }
   },
   "products": {
@@ -43,7 +43,7 @@
         "city": "San Francisco",
         "state": "CA",
         "postcode": "94110",
-        "email": "e2e-wcpay-subscriptions-customer@woocommerce.com"
+        "email": "e2e-wcpay-subscriptions-customer@woo.com"
       }
     },
     "customer": {
@@ -58,7 +58,7 @@
         "state": "CA",
         "postcode": "94110",
         "phone": "123456789",
-        "email": "e2e-wcpay-customer@woocommerce.com"
+        "email": "e2e-wcpay-customer@woo.com"
       },
       "shipping": {
         "firstname": "I am",
@@ -71,7 +71,7 @@
         "state": "CA",
         "postcode": "94110",
         "phone": "123456789",
-        "email": "e2e-wcpay-customer@woocommerce.com"
+        "email": "e2e-wcpay-customer@woo.com"
       }
     },
     "subscriptions-customer": {
@@ -86,7 +86,7 @@
         "state": "CA",
         "postcode": "94110",
         "phone": "123456789",
-        "email": "e2e-wcpay-subscriptions-customer@woocommerce.com"
+        "email": "e2e-wcpay-subscriptions-customer@woo.com"
       },
       "shipping": {
         "firstname": "I am",
@@ -99,7 +99,7 @@
         "state": "CA",
         "postcode": "94110",
         "phone": "123456789",
-        "email": "e2e-wcpay-subscriptions-customer@woocommerce.com"
+        "email": "e2e-wcpay-subscriptions-customer@woo.com"
       }
     }
   },

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -200,17 +200,17 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			'simulate legacy UPE Popular payment methods' => [
 				'payment_method_id'    => 'woocommerce_payments',
 				'payment_method_title' => 'Popular payment methods',
-				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
+				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments.</p><a href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
 			],
 			'simulate legacy UPE Bancontact'              => [
 				'payment_method_id'    => 'woocommerce_payments',
 				'payment_method_title' => 'Bancontact',
-				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
+				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><a href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
 			],
 			'simulate split UPE Bancontact'               => [
 				'payment_method_id'    => 'woocommerce_payments_bancontact',
 				'payment_method_title' => 'Bancontact',
-				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
+				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><a href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
 			],
 		];
 	}
@@ -240,7 +240,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Direct bank transfer.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>' );
+		$this->expectOutputString( '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Direct bank transfer.</p><a href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>' );
 	}
 
 	public function test_display_order_fraud_and_risk_meta_box_message_default() {

--- a/tests/unit/helpers/class-wc-helper-product.php
+++ b/tests/unit/helpers/class-wc-helper-product.php
@@ -69,7 +69,7 @@ class WC_Helper_Product {
 				'name'          => 'Dummy External Product',
 				'regular_price' => 10,
 				'sku'           => 'DUMMY EXTERNAL SKU',
-				'product_url'   => 'http://woocommerce.com',
+				'product_url'   => 'http://woo.com',
 				'button_text'   => 'Buy external product',
 			]
 		);

--- a/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
@@ -28,7 +28,7 @@ class WC_Payments_Notes_Additional_Payment_Methods_Test extends WCPAY_UnitTestCa
 		$note = WC_Payments_Notes_Additional_Payment_Methods::get_note();
 
 		$this->assertSame( 'Boost your sales by accepting new payment methods', $note->get_title() );
-		$this->assertSame( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooPayments. <a href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', $note->get_content() );
+		$this->assertSame( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooPayments. <a href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', $note->get_content() );
 		$this->assertSame( 'info', $note->get_type() );
 		$this->assertSame( 'wc-payments-notes-additional-payment-methods', $note->get_name() );
 		$this->assertSame( 'woocommerce-payments', $note->get_source() );

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -52,7 +52,7 @@ class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
 		list( $set_up_action ) = $note->get_actions();
 		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $set_up_action->name );
 		$this->assertSame( 'Set up now', $set_up_action->label );
-		$this->assertStringStartsWith( 'https://woocommerce.com/document/woopayments/payment-methods/link-by-stripe/', $set_up_action->query );
+		$this->assertStringStartsWith( 'https://woo.com/document/woopayments/payment-methods/link-by-stripe/', $set_up_action->query );
 	}
 
 	public function test_stripelink_setup_note_null_when_upe_disabled() {

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -2148,7 +2148,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'countries'              => [],
 					'upePaymentIntentData'   => null,
 					'upeSetupIntentData'     => null,
-					'testingInstructions'    => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">here</a>.',
+					'testingInstructions'    => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://woo.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">here</a>.',
 					'forceNetworkSavedCards' => false,
 				],
 				'link' => [

--- a/tests/unit/reports/test-class-wc-rest-payments-reports-authorizations-controller.php
+++ b/tests/unit/reports/test-class-wc-rest-payments-reports-authorizations-controller.php
@@ -78,7 +78,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 		$request = new WP_REST_Request( 'POST' );
 		$request->set_param( 'match', 'any' );
 		$request->set_param( 'order_id', 123 );
-		$request->set_param( 'customer_email', 'test@woocommerce.com' );
+		$request->set_param( 'customer_email', 'test@woo.com' );
 		$request->set_param( 'payment_method_type', 'visa' );
 
 		$mock_request = $this->mock_wcpay_request( List_Authorizations::class );
@@ -88,7 +88,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 				[
 					'match'             => 'any',
 					'order_id_is'       => 123,
-					'customer_email_is' => 'test@woocommerce.com',
+					'customer_email_is' => 'test@woo.com',
 					'source_is'         => 'visa',
 				],
 			);
@@ -195,7 +195,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 					'source'            => 'visa',
 					'source_identifier' => '4242',
 					'customer_name'     => 'Test One',
-					'customer_email'    => 'test1@woocommerce.com',
+					'customer_email'    => 'test1@woo.com',
 					'customer_country'  => 'US',
 					'fees'              => 312,
 					'currency'          => 'eur',
@@ -220,7 +220,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 					'source'            => 'visa',
 					'source_identifier' => '4242',
 					'customer_name'     => 'Test Two',
-					'customer_email'    => 'test2@woocommerce.com',
+					'customer_email'    => 'test2@woo.com',
 					'customer_country'  => 'US',
 					'fees'              => 98,
 					'currency'          => 'eur',
@@ -245,7 +245,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 					'source'            => 'mastercard',
 					'source_identifier' => '4242',
 					'customer_name'     => 'Test One',
-					'customer_email'    => 'test1@woocommerce.com',
+					'customer_email'    => 'test1@woo.com',
 					'customer_country'  => 'US',
 					'fees'              => 312,
 					'currency'          => 'eur',
@@ -276,7 +276,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 				'fees'             => 312,
 				'customer'         => [
 					'name'    => 'Test One',
-					'email'   => 'test1@woocommerce.com',
+					'email'   => 'test1@woo.com',
 					'country' => 'US',
 				],
 				'net_amount'       => 6988,
@@ -297,7 +297,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 				'fees'             => 98,
 				'customer'         => [
 					'name'    => 'Test Two',
-					'email'   => 'test2@woocommerce.com',
+					'email'   => 'test2@woo.com',
 					'country' => 'US',
 				],
 				'net_amount'       => 1702,
@@ -318,7 +318,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller_Test extends WCPAY_Unit
 				'fees'             => 312,
 				'customer'         => [
 					'name'    => 'Test One',
-					'email'   => 'test1@woocommerce.com',
+					'email'   => 'test1@woo.com',
 					'country' => 'US',
 				],
 				'net_amount'       => 6988,

--- a/tests/unit/reports/test-class-wc-rest-payments-reports-transactions-controller.php
+++ b/tests/unit/reports/test-class-wc-rest-payments-reports-transactions-controller.php
@@ -110,7 +110,7 @@ class WC_REST_Payments_Reports_Transactions_Controller_Test extends WCPAY_UnitTe
 	public function test_get_transactions_filter_all() {
 		$request = new WP_REST_Request( 'POST' );
 		$request->set_param( 'order_id', 345 );
-		$request->set_param( 'customer_email', 'test@woocommerce.com' );
+		$request->set_param( 'customer_email', 'test@woo.com' );
 		$request->set_param( 'payment_method_type', 'visa' );
 
 		$mock_request = $this->mock_wcpay_request( List_Transactions::class );
@@ -121,7 +121,7 @@ class WC_REST_Payments_Reports_Transactions_Controller_Test extends WCPAY_UnitTe
 				[
 					[
 						'order_id_is'       => 345,
-						'customer_email_is' => 'test@woocommerce.com',
+						'customer_email_is' => 'test@woo.com',
 						'source_is'         => 'visa',
 					],
 				]
@@ -199,7 +199,7 @@ class WC_REST_Payments_Reports_Transactions_Controller_Test extends WCPAY_UnitTe
 					'source'            => 'visa',
 					'source_identifier' => '3184',
 					'customer_name'     => 'Test Customer1',
-					'customer_email'    => 'test1@woocommerce.com',
+					'customer_email'    => 'test1@woo.com',
 					'customer_country'  => 'US',
 					'amount'            => 2583,
 					'net'               => 2426,
@@ -232,7 +232,7 @@ class WC_REST_Payments_Reports_Transactions_Controller_Test extends WCPAY_UnitTe
 					'source'            => 'giropay',
 					'source_identifier' => '3184',
 					'customer_name'     => 'Test Customer2',
-					'customer_email'    => 'test2@woocommerce.com',
+					'customer_email'    => 'test2@woo.com',
 					'customer_country'  => 'US',
 					'amount'            => 2583,
 					'net'               => 2452,
@@ -281,7 +281,7 @@ class WC_REST_Payments_Reports_Transactions_Controller_Test extends WCPAY_UnitTe
 				'fees'                 => 157,
 				'customer'             => [
 					'name'    => 'Test Customer1',
-					'email'   => 'test1@woocommerce.com',
+					'email'   => 'test1@woo.com',
 					'country' => 'US',
 				],
 				'net_amount'           => 2426,
@@ -307,7 +307,7 @@ class WC_REST_Payments_Reports_Transactions_Controller_Test extends WCPAY_UnitTe
 				'fees'                 => 131,
 				'customer'             => [
 					'name'    => 'Test Customer2',
-					'email'   => 'test2@woocommerce.com',
+					'email'   => 'test2@woo.com',
 					'country' => 'US',
 				],
 				'net_amount'           => 2452,

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Plugin Name: WooCommerce Payments
- * Plugin URI: https://woocommerce.com/payments/
+ * Plugin URI: https://woo.com/payments/
  * Description: Accept payments via credit card. Manage transactions within WordPress.
  * Author: Automattic
- * Author URI: https://woocommerce.com/
+ * Author URI: https://woo.com/
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
@@ -316,7 +316,7 @@ function wcpay_get_jetpack_idc_custom_content(): array {
 			__( 'We’ve detected that you have duplicate sites connected to %s. When Safe Mode is active, payments will not be interrupted. However, some features may not be available until you’ve resolved this issue below. Safe Mode is most frequently activated when you’re transferring your site from one domain to another, or creating a staging site for testing. A site adminstrator can resolve this issue. <safeModeLink>Learn more</safeModeLink>', 'woocommerce-payments' ),
 			'WooPayments'
 		),
-		'supportURL'                => 'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/safe-mode/',
+		'supportURL'                => 'https://woo.com/document/woopayments/testing-and-troubleshooting/safe-mode/',
 		'adminBarSafeModeLabel'     => sprintf(
 			/* translators: %s: WooPayments. */
 			__( '%s Safe Mode', 'woocommerce-payments' ),
@@ -327,7 +327,7 @@ function wcpay_get_jetpack_idc_custom_content(): array {
 			__( "<strong>Notice:</strong> It appears that your 'wp-config.php' file might be using dynamic site URL values. Dynamic site URLs could cause %s to enter Safe Mode. <dynamicSiteUrlSupportLink>Learn how to set a static site URL.</dynamicSiteUrlSupportLink>", 'woocommerce-payments' ),
 			'WooPayments'
 		),
-		'dynamicSiteUrlSupportLink' => 'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/safe-mode/#dynamic-site-urls',
+		'dynamicSiteUrlSupportLink' => 'https://woo.com/document/woopayments/testing-and-troubleshooting/safe-mode/#dynamic-site-urls',
 	];
 
 	$urls = Automattic\Jetpack\Identity_Crisis::get_mismatched_urls();


### PR DESCRIPTION
Fixes #7637 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

- Update hyperlinks across the plugin to refer to `woo.com` rather than `woocommerce.com`
- Update plugin URL to point to `woo.com` in the `woocommerce-payments.php` file.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spot check a few of the URLs in the diff to ensure they go to the correct woo.com documentation page.
* Check a few of the links in the plugin (for example, there are some hyperlinks on the `Payments > Settings` page like the Multi-Currency documentation link).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
