### PR TITLE
Add client's user agent to Tracks props

### DIFF
--- a/changelog/add-ua-field-to-tracks
+++ b/changelog/add-ua-field-to-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add client user-agent value to Tracks event props

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -288,6 +288,11 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		$properties['test_mode']     = WC_Payments::mode()->is_test() ? 1 : 0;
 		$properties['wcpay_version'] = WCPAY_VERSION_NUMBER;
 
+		// Add client's user agent to the event properties.
+		if ( !empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$properties['_via_ua']  = $_SERVER['HTTP_USER_AGENT'];
+		}
+
 		$blog_details = [
 			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
 		];


### PR DESCRIPTION
Fixes 2276-gh-automattic/woopay

#### Changes proposed in this Pull Request
Shopper events are recorded via server-side requests to Tracks backend. This PR adds the `_via_ua` property to record the client's user agent value.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See 2313-gh-automattic/woopay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
