### PR TITLE
RPP: Default to automatic capture

### DIFF
--- a/changelog/rpp-7416-use_automatic_capture_as_default
+++ b/changelog/rpp-7416-use_automatic_capture_as_default
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Use automatic capture as default flag in new payment process flow
+Use automatic capture as default flag in new payment process.

--- a/changelog/rpp-7416-use_automatic_capture_as_default
+++ b/changelog/rpp-7416-use_automatic_capture_as_default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Use automatic capture as default flag in new payment process flow

--- a/src/Internal/Payment/PaymentContext.php
+++ b/src/Internal/Payment/PaymentContext.php
@@ -93,21 +93,21 @@ class PaymentContext {
 	}
 
 	/**
-	 * Controls whether manual capture is enabled.
+	 * Controls whether automatic capture is enabled.
 	 *
-	 * @param bool $manual_capture Whether to enable it or not.
+	 * @param bool $automatic_capture Whether to enable it or not.
 	 */
-	public function toggle_manual_capture( bool $manual_capture ) {
-		$this->set( 'manual_capture', $manual_capture );
+	public function toggle_automatic_capture( bool $automatic_capture ) {
+		$this->set( 'automatic_capture', $automatic_capture );
 	}
 
 	/**
-	 * Indicates whether the payment should be captured manually.
+	 * Indicates whether the payment should be captured automatically.
 	 *
 	 * @return bool
 	 */
-	public function should_capture_manually(): bool {
-		return $this->get( 'manual_capture' ) ?? false;
+	public function should_capture_automatically(): bool {
+		return $this->get( 'automatic_capture' ) ?? false;
 	}
 
 	/**

--- a/src/Internal/Service/PaymentProcessingService.php
+++ b/src/Internal/Service/PaymentProcessingService.php
@@ -67,16 +67,16 @@ class PaymentProcessingService {
 	 * Process payment.
 	 *
 	 * @param int  $order_id Order ID provided by WooCommerce core.
-	 * @param bool $manual_capture Whether to only create an authorization instead of a charge (optional).
+	 * @param bool $automatic_capture Whether to only create an authorization instead of a charge (optional).
 	 *
 	 * @throws StateTransitionException  In case a state cannot be initialized.
 	 * @throws PaymentRequestException   When the request is malformed. This should be converted to a failure state.
 	 * @throws Order_Not_Found_Exception When order is not found.
 	 * @throws ContainerException        When the dependency container cannot instantiate the state.
 	 */
-	public function process_payment( int $order_id, bool $manual_capture = false ) {
+	public function process_payment( int $order_id, bool $automatic_capture = false ) {
 		// Start with a basis context.
-		$context = $this->create_payment_context( $order_id, $manual_capture );
+		$context = $this->create_payment_context( $order_id, $automatic_capture );
 
 		$request       = new PaymentRequest( $this->legacy_proxy );
 		$initial_state = $this->state_factory->create_state( InitialState::class, $context );
@@ -127,13 +127,13 @@ class PaymentProcessingService {
 	 * Instantiates a new empty payment context.
 	 *
 	 * @param int  $order_id ID of the order that the context belongs to.
-	 * @param bool $manual_capture Whether manual capture is enabled.
+	 * @param bool $automatic_capture Whether automatic capture is enabled.
 	 *
 	 * @return PaymentContext
 	 */
-	protected function create_payment_context( int $order_id, bool $manual_capture = false ): PaymentContext {
+	protected function create_payment_context( int $order_id, bool $automatic_capture = false ): PaymentContext {
 		$context = new PaymentContext( $order_id );
-		$context->toggle_manual_capture( $manual_capture );
+		$context->toggle_automatic_capture( $automatic_capture );
 
 		return $context;
 	}

--- a/src/Internal/Service/PaymentProcessingService.php
+++ b/src/Internal/Service/PaymentProcessingService.php
@@ -49,8 +49,8 @@ class PaymentProcessingService {
 	/**
 	 * Service constructor.
 	 *
-	 * @param StateFactory                $state_factory Factory for payment states.
-	 * @param LegacyProxy                 $legacy_proxy Legacy proxy.
+	 * @param StateFactory                $state_factory          Factory for payment states.
+	 * @param LegacyProxy                 $legacy_proxy           Legacy proxy.
 	 * @param PaymentContextLoggerService $context_logger_service Context Logging Service.
 	 */
 	public function __construct(
@@ -66,7 +66,7 @@ class PaymentProcessingService {
 	/**
 	 * Process payment.
 	 *
-	 * @param int  $order_id Order ID provided by WooCommerce core.
+	 * @param int  $order_id          Order ID provided by WooCommerce core.
 	 * @param bool $automatic_capture Whether to only create an authorization instead of a charge (optional).
 	 *
 	 * @throws StateTransitionException  In case a state cannot be initialized.
@@ -89,7 +89,7 @@ class PaymentProcessingService {
 	/**
 	 * Get redirect URL when authentication is required (3DS).
 	 *
-	 * @param WC_Payments_API_Abstract_Intention $intent Intent object.
+	 * @param WC_Payments_API_Abstract_Intention $intent   Intent object.
 	 * @param int                                $order_id Order id.
 	 *
 	 * @return string
@@ -126,7 +126,7 @@ class PaymentProcessingService {
 	/**
 	 * Instantiates a new empty payment context.
 	 *
-	 * @param int  $order_id ID of the order that the context belongs to.
+	 * @param int  $order_id          ID of the order that the context belongs to.
 	 * @param bool $automatic_capture Whether automatic capture is enabled.
 	 *
 	 * @return PaymentContext

--- a/src/Internal/Service/PaymentRequestService.php
+++ b/src/Internal/Service/PaymentRequestService.php
@@ -33,7 +33,8 @@ class PaymentRequestService {
 		$request->set_currency_code( $context->get_currency() );
 		$request->set_payment_method( $context->get_payment_method()->get_id() );
 		$request->set_customer( $context->get_customer_id() );
-		$request->set_capture_method( $context->should_capture_manually() );
+		// We are using the automatic capture, but intent signature accepts manual capture, so we have to change bool here.
+		$request->set_capture_method( ! $context->should_capture_automatically() );
 		$request->set_metadata( $context->get_metadata() );
 		$request->set_level3( $context->get_level3_data() );
 		$request->set_payment_methods( [ 'card' ] ); // Initial payment process only supports cards.

--- a/tests/unit/src/Internal/Payment/PaymentContextTest.php
+++ b/tests/unit/src/Internal/Payment/PaymentContextTest.php
@@ -63,18 +63,18 @@ class PaymentContextTest extends WCPAY_UnitTestCase {
 		$this->assertSame( $currency, $this->sut->get_currency() );
 	}
 
-	public function test_manual_capture_disabled() {
-		$toggle_manual_capture = false;
+	public function test_automatic_capture_disabled() {
+		$toggle_automatic_capture = false;
 
-		$this->sut->toggle_manual_capture( $toggle_manual_capture );
-		$this->assertSame( $toggle_manual_capture, $this->sut->should_capture_manually() );
+		$this->sut->toggle_automatic_capture( $toggle_automatic_capture );
+		$this->assertSame( $toggle_automatic_capture, $this->sut->should_capture_automatically() );
 	}
 
-	public function test_manual_capture_enabled() {
-		$toggle_manual_capture = true;
+	public function test_automatic_capture_enabled() {
+		$toggle_automatic_capture = true;
 
-		$this->sut->toggle_manual_capture( $toggle_manual_capture );
-		$this->assertSame( $toggle_manual_capture, $this->sut->should_capture_manually() );
+		$this->sut->toggle_automatic_capture( $toggle_automatic_capture );
+		$this->assertSame( $toggle_automatic_capture, $this->sut->should_capture_automatically() );
 	}
 
 	public function test_metadata() {

--- a/tests/unit/src/Internal/Service/PaymentRequestServiceTest.php
+++ b/tests/unit/src/Internal/Service/PaymentRequestServiceTest.php
@@ -48,15 +48,15 @@ class PaymentRequestServiceTest extends WCPAY_UnitTestCase {
 	 */
 	public function test_create_intent( $fingerprint ) {
 		$context_data = [
-			'get_amount'              => 123,
-			'get_currency'            => 'usd',
-			'get_payment_method'      => new NewPaymentMethod( 'pm_XYZ' ),
-			'get_customer_id'         => 'cus_XYZ',
-			'should_capture_manually' => false,
-			'get_metadata'            => [ 'metadata' ],
-			'get_level3_data'         => [ 'level3data' ],
-			'get_cvc_confirmation'    => 'confirmation',
-			'get_fingerprint'         => $fingerprint,
+			'get_amount'                   => 123,
+			'get_currency'                 => 'usd',
+			'get_payment_method'           => new NewPaymentMethod( 'pm_XYZ' ),
+			'get_customer_id'              => 'cus_XYZ',
+			'should_capture_automatically' => false,
+			'get_metadata'                 => [ 'metadata' ],
+			'get_level3_data'              => [ 'level3data' ],
+			'get_cvc_confirmation'         => 'confirmation',
+			'get_fingerprint'              => $fingerprint,
 		];
 
 		$request_data = [
@@ -64,7 +64,7 @@ class PaymentRequestServiceTest extends WCPAY_UnitTestCase {
 			'set_currency_code'    => 'usd',
 			'set_payment_method'   => 'pm_XYZ',
 			'set_customer'         => 'cus_XYZ',
-			'set_capture_method'   => false, // No manual capture.
+			'set_capture_method'   => true, // By default, the automatic capture is set to false.
 			'set_metadata'         => [ 'metadata' ],
 			'set_level3'           => [ 'level3data' ],
 			'set_payment_methods'  => [ 'card' ],


### PR DESCRIPTION
Fixes #7416 

#### Changes proposed in this Pull Request

This PR implements a shift in the payment processing workflow, transitioning from manual to automatic capture in RPP. The default value would be set to `false` which means that instead of taking funds directly, the authorization will be created that can be captured later.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add product to basket and pay for it
* Make sure that new order is not captured, and that the uncaptured authorization is created.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
