### PR TITLE
Polish logic of redirect when click Set Up WooPayments from WC Home

### DIFF
--- a/changelog/tweak-7625-set-up-woopayments-link-from-core-polish-current-logic
+++ b/changelog/tweak-7625-set-up-woopayments-link-from-core-polish-current-logic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Addition to 7625 - polish logic of redirect when click Set Up WooPayments from WC Home
+
+

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -223,21 +223,6 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Checks if the account has been completed.
-	 * Returns false if the account is not connected.
-	 *
-	 * @return bool True if the account is connected and complete, false otherwise or on error.
-	 */
-	public function is_account_complete(): bool {
-		if ( ! $this->is_stripe_connected() ) {
-			return false;
-		}
-
-		$account = $this->get_cached_account_data();
-		return 'complete' === $account['status'];
-	}
-
-	/**
 	 * Checks if the account has not completed onboarding due to users abandoning the process half way.
 	 * Returns true if the onboarding is started but did not finish.
 	 *
@@ -949,11 +934,12 @@ class WC_Payments_Account {
 			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
 			$from_wc_pay_connect_page = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
 			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page ) ) {
-				// Redirect complete accounts to payments overview page, otherwise to the onboarding flow.
-				if ( $this->is_account_complete() ) {
-					$this->redirect_to( static::get_overview_page_url() );
-				} else {
+				// Redirect partially onboarded accounts (details_submitted = false) to the onboarding flow, otherwise to payments overview page.
+				if ( $this->is_stripe_connected() && $this->is_account_partially_onboarded() ) {
 					$this->redirect_to_onboarding_flow_page();
+				} else {
+					// Accounts with details_submitted = true (complete, rejected, restricted_soon etc) will be redirected to the overview page.
+					$this->redirect_to( static::get_overview_page_url() );
 				}
 			}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -934,11 +934,11 @@ class WC_Payments_Account {
 			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
 			$from_wc_pay_connect_page = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
 			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page ) ) {
-				// Redirect non-onboarded and partially onboarded accounts (details_submitted = false) to the onboarding flow, otherwise to payments overview page.
-				if ( ! $this->is_stripe_connected() || $this->is_account_partially_onboarded() ) {
+				// Redirect non-onboarded account to the onboarding flow, otherwise to payments overview page.
+				if ( ! $this->is_stripe_connected() ) {
 					$this->redirect_to_onboarding_flow_page();
 				} else {
-					// Accounts with stripe connected and details_submitted = true (complete, rejected, restricted_soon etc) will be redirected to the overview page.
+					// Accounts with Stripe account connected will be redirected to the overview page.
 					$this->redirect_to( static::get_overview_page_url() );
 				}
 			}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -934,11 +934,11 @@ class WC_Payments_Account {
 			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
 			$from_wc_pay_connect_page = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
 			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page ) ) {
-				// Redirect partially onboarded accounts (details_submitted = false) to the onboarding flow, otherwise to payments overview page.
-				if ( $this->is_stripe_connected() && $this->is_account_partially_onboarded() ) {
+				// Redirect non-onboarded and partially onboarded accounts (details_submitted = false) to the onboarding flow, otherwise to payments overview page.
+				if ( ! $this->is_stripe_connected() || $this->is_account_partially_onboarded() ) {
 					$this->redirect_to_onboarding_flow_page();
 				} else {
-					// Accounts with details_submitted = true (complete, rejected, restricted_soon etc) will be redirected to the overview page.
+					// Accounts with stripe connected and details_submitted = true (complete, rejected, restricted_soon etc) will be redirected to the overview page.
 					$this->redirect_to( static::get_overview_page_url() );
 				}
 			}


### PR DESCRIPTION
Related #7625

**Follow up of** https://github.com/Automattic/woocommerce-payments/pull/7652 with intent to improve the solution for more account statuses by making decision based on `details_submitted` value, see p1699436266692369/1699365759.939169-slack-C03KTTK2YMA

#### Description

Merchants currently observe an issue with Set up WooPayments task: when account completed the KYC / are rejected / pending - have Stripe account connected, the link redirect them to `payments/onboarding` which results in Not allowed page error
![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/99ed7ebd-0600-46f9-a2bb-49eed25c1023)

#### Changes proposed in this Pull Request

I decided that the best experience for merchants will be to get redirected to `payments/overview` page if the account connected to Stripe in any status. If we try to redirect the merchant to `payments/onboarding` page when they have Stripe account connected, they'll face Not allowed page. That's why we should redirect even partially onboarded users (details_submitted = false) to the overview page. They'll be able to proceed from there by hitting Finish Setup button
![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/7823295b-44db-4725-8cd0-29e6902d7294)

**Important**
Tests are not added since there is no tests for `maybe_handle_onboarding` function. Creating tests for it is out of scope for this PR. It'll be done in https://github.com/Automattic/woocommerce-payments/issues/7654

#### Testing instructions

**Pre-requisites**
* Checkout the branch `tweak/7625-set-up-woopayments-link-from-core-polish-current-logic` 
* Ensure Progressive onboarding feature flag is enabled

**Stripe account not connected**
* Navigate to Payments Connect page
* Onboard an account as a builder, it'll end up in `Complete` status
* Get back to WC Home and click Set up WooPayments
* Ensure you get redirected to `payments/overview` page

**Stripe account connected (pending)**
* Delete/mark as deleted current account 
* Navigate to Payments Connect page
* Complete PO as a merchant, it should and up in the `Pending` status
* Get back to WC Home and click Set up WooPayments
* Ensure you get redirected to `payments/overview` page

**Stripe KYC left early / partially onboarded accounts**
* Delete/mark as deleted current account 
* Navigate to Payments Connect page
* Start onboarding as a builder, leave the KYC immediately on the Stripe step (Return to Dev Shared Account WCPay)
* You should see Finish setting up WooPayments on the overview page
* Get back to WC Home and click Set up WooPayments
* Ensure you get redirected to `payments/overview` page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-6.8.0#fix-not-allowed-page-when-clicking-set-up-woopayments-from-core-and-account-is-already-onboarded_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.