### PR TITLE
Update yoast/phpunit-polyfills to 1.1.0 to prevent version mismatch with WP 6.4

### DIFF
--- a/changelog/fix-compatibility-workflow
+++ b/changelog/fix-compatibility-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix a PHPUnit polyfills incompatibility with latest WP (6.4) in the compatibility workflow
+
+

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "php-stubs/wordpress-stubs": "5.8.2",
         "php-stubs/woocommerce-stubs": "6.8.0",
         "rregeer/phpunit-coverage-check": "0.3.1",
-        "yoast/phpunit-polyfills": "1.0.3",
+        "yoast/phpunit-polyfills": "1.1.0",
         "cweagans/composer-patches": "1.7.1",
         "automattic/jetpack-changelogger": "3.3.2",
         "spatie/phpunit-watcher": "1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f93d75411ac254bc7e8b67beb00ff064",
+    "content-hash": "95d672ebb995c8245e0659d2e4d7db3d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -6462,16 +6462,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -6479,13 +6479,12 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -6519,7 +6518,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         },
         {
             "name": "yosymfony/resource-watcher",
@@ -6594,5 +6593,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
WordPress 6.4 was just released, and WP `latest` now points to 6.4.

The [compatibility](https://github.com/Automattic/woocommerce-payments/actions/workflows/compatibility.yml), [PHP lint and tests](https://github.com/Automattic/woocommerce-payments/actions/workflows/php-lint-test.yml), and [code coverage](https://github.com/Automattic/woocommerce-payments/actions/workflows/coverage.yml) workflows started to fail with the following error message (e.g., [this run](https://github.com/Automattic/woocommerce-payments/actions/runs/6790976207/job/18461563090)):
```
Error: Version mismatch detected for the PHPUnit Polyfills. Please ensure that PHPUnit Polyfills 1.1.0 or higher is loaded. Found version: 1.0.3
```

#### Changes proposed in this Pull Request

- Update `yoast/phpunit-polyfills` in composer.json to the suggested minimum compatible version, i.e. `1.1.0`

#### Testing instructions

* All CI pipelines pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
