### PR TITLE
Improve E2E checkout tests

### DIFF
--- a/changelog/deferred-intent
+++ b/changelog/deferred-intent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Improve E2E checkout tests

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -147,6 +147,23 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch(
 				`${ card.expires.month }/${ card.expires.year }`
 			);
+			await waitTwentySecondsSinceLastCardAdded();
+		} );
+
+		it( 'should be able to set payment method as default', async () => {
+			await shopperWCP.goToPaymentMethods();
+			await shopperWCP.addNewPaymentMethod( 'basic', card );
+			// Take note of the time when we added this card
+			timeAdded = Date.now();
+
+			// Verify that the card was added
+			await expect( page ).not.toMatch(
+				'You cannot add a new payment method so soon after the previous one. Please wait for 20 seconds.'
+			);
+			await expect( page ).toMatch( 'Payment method successfully added' );
+			await expect( page ).toMatch(
+				`${ card.expires.month }/${ card.expires.year }`
+			);
 			await shopperWCP.setDefaultPaymentMethod( card.label );
 			// Verify that the card was set as default
 			await expect( page ).toMatch(
@@ -160,6 +177,10 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 		} );
 
 		afterAll( async () => {
+			await waitTwentySecondsSinceLastCardAdded();
+		} );
+
+		async function waitTwentySecondsSinceLastCardAdded() {
 			// Make sure that at least 20s had already elapsed since the last card was added.
 			// Otherwise, you will get the error message,
 			// "You cannot add a new payment method so soon after the previous one."
@@ -171,6 +192,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 					: 0;
 
 			await new Promise( ( r ) => setTimeout( r, remainingWaitTime ) );
-		} );
+		}
 	} );
 } );

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -125,15 +125,12 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).not.toMatchElement(
 				'input#wc-woocommerce_payments-new-payment-method'
 			);
+			await shopper.login();
 		} );
 	} );
 
 	describe( 'My Account', () => {
 		let timeAdded;
-
-		beforeAll( async () => {
-			await shopper.login();
-		} );
 
 		it( 'should add the card as a new payment method', async () => {
 			await shopperWCP.goToPaymentMethods();

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -22,7 +22,6 @@ const UPE_METHOD_CHECKBOXES = [
 	'#inspector-checkbox-control-3', // eps
 	'#inspector-checkbox-control-4', // giropay
 	'#inspector-checkbox-control-5', // ideal
-	'#inspector-checkbox-control-6', // sofort
 ];
 const card = config.get( 'cards.basic' );
 const card2 = config.get( 'cards.basic2' );
@@ -57,6 +56,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				waitUntil: 'networkidle0',
 			} );
 			await expect( page ).toMatch( 'Order received' );
+			console.log( 'DONE should successfully place order with Giropay' );
 		} );
 
 		it( 'should successfully place order with the default card', async () => {
@@ -66,6 +66,9 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await fillCardDetails( page, card );
 			await shopper.placeOrder();
 			await expect( page ).toMatch( 'Order received' );
+			console.log(
+				'DONE should successfully place order with the default card'
+			);
 		} );
 
 		it( 'should process a payment with authentication for the 3DS card', async () => {
@@ -79,6 +82,9 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				waitUntil: 'networkidle0',
 			} );
 			await expect( page ).toMatch( 'Order received' );
+			console.log(
+				'DONE should process a payment with authentication for the 3DS card'
+			);
 		} );
 
 		it( 'should successfully save the card', async () => {
@@ -96,6 +102,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch(
 				`${ card.expires.month }/${ card.expires.year }`
 			);
+			console.log( 'DONE should successfully save the card' );
 		} );
 
 		it( 'should process a payment with the saved card', async () => {
@@ -109,12 +116,14 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			);
 			await shopper.placeOrder();
 			await expect( page ).toMatch( 'Order received' );
+			console.log( 'DONE should process a payment with the saved card' );
 		} );
 
 		it( 'should delete the card', async () => {
 			await shopperWCP.goToPaymentMethods();
 			await shopperWCP.deleteSavedPaymentMethod( card.label );
 			await expect( page ).toMatch( 'Payment method deleted' );
+			console.log( 'DONE should delete the card' );
 		} );
 
 		it( 'should not allow guest user to save the card', async () => {
@@ -127,6 +136,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				'input#wc-woocommerce_payments-new-payment-method'
 			);
 			await shopper.login();
+			console.log( 'DONE should not allow guest user to save the card' );
 		} );
 	} );
 
@@ -149,6 +159,9 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				`${ card.expires.month }/${ card.expires.year }`
 			);
 			await waitTwentySecondsSinceLastCardAdded();
+			console.log(
+				'DONE should add the card as a new payment method and set it as default payment method'
+			);
 		} );
 
 		it( 'should be able to set payment method as default', async () => {
@@ -170,11 +183,18 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch(
 				'This payment method was successfully set as your default.'
 			);
+			console.log(
+				'DONE should be able to set payment method as default'
+			);
 		} );
 
 		it( 'should be able to delete the card', async () => {
 			await shopperWCP.deleteSavedPaymentMethod( card.label );
 			await expect( page ).toMatch( 'Payment method deleted.' );
+
+			await shopperWCP.deleteSavedPaymentMethod( card2.label );
+			await expect( page ).toMatch( 'Payment method deleted.' );
+			console.log( 'DONE should be able to delete the card' );
 		} );
 
 		afterAll( async () => {

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -52,7 +52,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				waitUntil: 'networkidle0',
 			} );
 			await expect( page ).toMatch( 'Order received' );
-			console.log( 'DONE should successfully place order with Giropay' );
 		} );
 
 		it( 'should successfully place order with the default card', async () => {
@@ -62,9 +61,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await fillCardDetails( page, card );
 			await shopper.placeOrder();
 			await expect( page ).toMatch( 'Order received' );
-			console.log(
-				'DONE should successfully place order with the default card'
-			);
 		} );
 
 		it( 'should process a payment with authentication for the 3DS card', async () => {
@@ -79,9 +75,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				waitUntil: 'networkidle0',
 			} );
 			await expect( page ).toMatch( 'Order received' );
-			console.log(
-				'DONE should process a payment with authentication for the 3DS card'
-			);
 		} );
 
 		it( 'should successfully save the card', async () => {
@@ -99,7 +92,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch(
 				`${ card.expires.month }/${ card.expires.year }`
 			);
-			console.log( 'DONE should successfully save the card' );
 		} );
 
 		it( 'should process a payment with the saved card', async () => {
@@ -113,14 +105,12 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			);
 			await shopper.placeOrder();
 			await expect( page ).toMatch( 'Order received' );
-			console.log( 'DONE should process a payment with the saved card' );
 		} );
 
 		it( 'should delete the card', async () => {
 			await shopperWCP.goToPaymentMethods();
 			await shopperWCP.deleteSavedPaymentMethod( card.label );
 			await expect( page ).toMatch( 'Payment method deleted' );
-			console.log( 'DONE should delete the card' );
 		} );
 
 		it( 'should not allow guest user to save the card', async () => {
@@ -133,7 +123,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				'input#wc-woocommerce_payments-new-payment-method'
 			);
 			await shopper.login();
-			console.log( 'DONE should not allow guest user to save the card' );
 		} );
 	} );
 
@@ -156,9 +145,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 				`${ card.expires.month }/${ card.expires.year }`
 			);
 			await waitTwentySecondsSinceLastCardAdded();
-			console.log(
-				'DONE should add the card as a new payment method and set it as default payment method'
-			);
 		} );
 
 		it( 'should be able to set payment method as default', async () => {
@@ -180,9 +166,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch(
 				'This payment method was successfully set as your default.'
 			);
-			console.log(
-				'DONE should be able to set payment method as default'
-			);
 		} );
 
 		it( 'should be able to delete cards', async () => {
@@ -191,7 +174,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 
 			await shopperWCP.deleteSavedPaymentMethod( card2.label );
 			await expect( page ).toMatch( 'Payment method deleted.' );
-			console.log( 'DONE should be able to delete the card' );
 		} );
 
 		afterAll( async () => {

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -18,11 +18,11 @@ import { uiUnblocked } from '@woocommerce/e2e-utils/build/page-utils';
 const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
 
 const UPE_METHOD_CHECKBOXES = [
-	'#inspector-checkbox-control-5', // bancontact
-	'#inspector-checkbox-control-6', // eps
-	'#inspector-checkbox-control-7', // giropay
-	'#inspector-checkbox-control-8', // ideal
-	'#inspector-checkbox-control-9', // sofort
+	'#inspector-checkbox-control-2', // bancontact
+	'#inspector-checkbox-control-3', // eps
+	'#inspector-checkbox-control-4', // giropay
+	'#inspector-checkbox-control-5', // ideal
+	'#inspector-checkbox-control-6', // sofort
 ];
 const card = config.get( 'cards.basic' );
 const card2 = config.get( 'cards.basic2' );

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -34,11 +34,9 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 		await merchantWCP.enablePaymentMethod( UPE_METHOD_CHECKBOXES );
 		await merchant.logout();
 		await shopper.login();
-		await shopperWCP.changeAccountCurrencyTo( 'EUR' );
 	} );
 
 	afterAll( async () => {
-		await shopperWCP.changeAccountCurrencyTo( 'USD' );
 		await shopperWCP.logout();
 		await merchant.login();
 		await merchantWCP.disablePaymentMethod( UPE_METHOD_CHECKBOXES );
@@ -47,6 +45,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 
 	describe( 'Enabled UPE with deferred intent creation', () => {
 		it( 'should successfully place order with Giropay', async () => {
+			await shopperWCP.goToShopWithCurrency( 'EUR' );
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -154,19 +154,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			);
 		} );
 
-		it( 'should be able set card as default', async () => {
-			await shopperWCP.addNewPaymentMethod( 'basic', card );
-			await shopperWCP.setDefaultPaymentMethod();
-
-			// Take note of the time when we added this card
-			timeAdded = Date.now();
-
-			// Verify that the card was set as default
-			await expect( page ).toMatch(
-				'This payment method was successfully set as your default.'
-			);
-		} );
-
 		it( 'should be able to delete the card', async () => {
 			await shopperWCP.deleteSavedPaymentMethod( card.label );
 			await expect( page ).toMatch( 'Payment method deleted.' );

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -18,7 +18,7 @@ import { uiUnblocked } from '@woocommerce/e2e-utils/build/page-utils';
 const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
 
 const UPE_METHOD_CHECKBOXES = [
-	'#inspector-checkbox-control-4', // giropay
+	'#inspector-checkbox-control-7', // giropay
 ];
 const card = config.get( 'cards.basic' );
 const card2 = config.get( 'cards.basic2' );

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -34,9 +34,11 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 		await merchantWCP.enablePaymentMethod( UPE_METHOD_CHECKBOXES );
 		await merchant.logout();
 		await shopper.login();
+		await shopperWCP.changeAccountCurrencyTo( 'EUR' );
 	} );
 
 	afterAll( async () => {
+		await shopperWCP.changeAccountCurrencyTo( 'USD' );
 		await shopperWCP.logout();
 		await merchant.login();
 		await merchantWCP.disablePaymentMethod( UPE_METHOD_CHECKBOXES );
@@ -45,7 +47,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 
 	describe( 'Enabled UPE with deferred intent creation', () => {
 		it( 'should successfully place order with Giropay', async () => {
-			await shopperWCP.goToShopWithCurrency( 'EUR' );
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -18,10 +18,7 @@ import { uiUnblocked } from '@woocommerce/e2e-utils/build/page-utils';
 const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
 
 const UPE_METHOD_CHECKBOXES = [
-	'#inspector-checkbox-control-2', // bancontact
-	'#inspector-checkbox-control-3', // eps
 	'#inspector-checkbox-control-4', // giropay
-	'#inspector-checkbox-control-5', // ideal
 ];
 const card = config.get( 'cards.basic' );
 const card2 = config.get( 'cards.basic2' );
@@ -33,11 +30,9 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 		await merchantWCP.enablePaymentMethod( UPE_METHOD_CHECKBOXES );
 		await merchant.logout();
 		await shopper.login();
-		await shopperWCP.changeAccountCurrencyTo( 'EUR' );
 	} );
 
 	afterAll( async () => {
-		await shopperWCP.changeAccountCurrencyTo( 'USD' );
 		await shopperWCP.logout();
 		await merchant.login();
 		await merchantWCP.disablePaymentMethod( UPE_METHOD_CHECKBOXES );
@@ -46,6 +41,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 
 	describe( 'Enabled UPE with deferred intent creation', () => {
 		it( 'should successfully place order with Giropay', async () => {
+			await shopperWCP.goToShopWithCurrency( 'EUR' );
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);
@@ -72,6 +68,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 		} );
 
 		it( 'should process a payment with authentication for the 3DS card', async () => {
+			await shopperWCP.goToShopWithCurrency( 'EUR' );
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);
@@ -188,7 +185,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			);
 		} );
 
-		it( 'should be able to delete the card', async () => {
+		it( 'should be able to delete cards', async () => {
 			await shopperWCP.deleteSavedPaymentMethod( card.label );
 			await expect( page ).toMatch( 'Payment method deleted.' );
 

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -64,7 +64,6 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 		} );
 
 		it( 'should process a payment with authentication for the 3DS card', async () => {
-			await shopperWCP.goToShopWithCurrency( 'EUR' );
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);
@@ -129,7 +128,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 	describe( 'My Account', () => {
 		let timeAdded;
 
-		it( 'should add the card as a new payment method and set it as default payment method', async () => {
+		it( 'should add the card as a new payment method', async () => {
 			await shopperWCP.goToPaymentMethods();
 			await shopperWCP.addNewPaymentMethod( 'basic', card );
 

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -132,7 +132,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 	describe( 'My Account', () => {
 		let timeAdded;
 
-		it( 'should add the card as a new payment method', async () => {
+		it( 'should add the card as a new payment method and set it as default payment method', async () => {
 			await shopperWCP.goToPaymentMethods();
 			await shopperWCP.addNewPaymentMethod( 'basic', card );
 
@@ -146,6 +146,11 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch( 'Payment method successfully added' );
 			await expect( page ).toMatch(
 				`${ card.expires.month }/${ card.expires.year }`
+			);
+			await shopperWCP.setDefaultPaymentMethod( card.label );
+			// Verify that the card was set as default
+			await expect( page ).toMatch(
+				'This payment method was successfully set as your default.'
 			);
 		} );
 

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -115,10 +115,26 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await shopperWCP.deleteSavedPaymentMethod( card.label );
 			await expect( page ).toMatch( 'Payment method deleted' );
 		} );
+
+		it( 'should not allow guest user to save the card', async () => {
+			await shopperWCP.logout();
+			await setupProductCheckout(
+				config.get( 'addresses.customer.billing' )
+			);
+
+			await expect( page ).not.toMatchElement(
+				'input#wc-woocommerce_payments-new-payment-method'
+			);
+		} );
 	} );
 
 	describe( 'My Account', () => {
 		let timeAdded;
+
+		beforeAll( async () => {
+			await shopper.login();
+		} );
+
 		it( 'should add the card as a new payment method', async () => {
 			await shopperWCP.goToPaymentMethods();
 			await shopperWCP.addNewPaymentMethod( 'basic', card );
@@ -133,6 +149,19 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			await expect( page ).toMatch( 'Payment method successfully added' );
 			await expect( page ).toMatch(
 				`${ card.expires.month }/${ card.expires.year }`
+			);
+		} );
+
+		it( 'should be able set card as default', async () => {
+			await shopperWCP.addNewPaymentMethod( 'basic', card );
+			await shopperWCP.setDefaultPaymentMethod();
+
+			// Take note of the time when we added this card
+			timeAdded = Date.now();
+
+			// Verify that the card was set as default
+			await expect( page ).toMatch(
+				'This payment method was successfully set as your default.'
 			);
 		} );
 

--- a/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-deferred-intent-creation-upe-enabled.spec.js
@@ -25,6 +25,7 @@ const UPE_METHOD_CHECKBOXES = [
 	'#inspector-checkbox-control-9', // sofort
 ];
 const card = config.get( 'cards.basic' );
+const card2 = config.get( 'cards.basic2' );
 const MIN_WAIT_TIME_BETWEEN_PAYMENT_METHODS = 20000;
 
 describe( 'Enabled UPE with deferred intent creation', () => {
@@ -152,7 +153,7 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 
 		it( 'should be able to set payment method as default', async () => {
 			await shopperWCP.goToPaymentMethods();
-			await shopperWCP.addNewPaymentMethod( 'basic', card );
+			await shopperWCP.addNewPaymentMethod( 'basic2', card2 );
 			// Take note of the time when we added this card
 			timeAdded = Date.now();
 
@@ -162,9 +163,9 @@ describe( 'Enabled UPE with deferred intent creation', () => {
 			);
 			await expect( page ).toMatch( 'Payment method successfully added' );
 			await expect( page ).toMatch(
-				`${ card.expires.month }/${ card.expires.year }`
+				`${ card2.expires.month }/${ card2.expires.year }`
 			);
-			await shopperWCP.setDefaultPaymentMethod( card.label );
+			await shopperWCP.setDefaultPaymentMethod( card2.label );
 			// Verify that the card was set as default
 			await expect( page ).toMatch(
 				'This payment method was successfully set as your default.'

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -153,6 +153,7 @@ export const shopperWCP = {
 		} );
 
 		await page.select( '#wcpay_selected_currency', currencyToSet );
+		await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
 		await expect( page ).toClick( 'button', {
 			text: 'Save changes',
 		} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -129,8 +129,11 @@ export const shopperWCP = {
 		await expect( page ).toClick( 'label', { text: label } );
 	},
 
-	setDefaultPaymentMethod: async () => {
-		await expect( page ).toClick( '.button.default' );
+	setDefaultPaymentMethod: async ( label ) => {
+		const [ paymentMethodRow ] = await page.$x(
+			`//tr[contains(., '${ label }')]`
+		);
+		await expect( paymentMethodRow ).toClick( '.button.default' );
 		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 	},
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -129,6 +129,11 @@ export const shopperWCP = {
 		await expect( page ).toClick( 'label', { text: label } );
 	},
 
+	setDefaultPaymentMethod: async () => {
+		await expect( page ).toClick( '.button.default' );
+		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+	},
+
 	toggleCreateAccount: async () => {
 		await expect( page ).toClick( '#createaccount' );
 	},

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -153,7 +153,6 @@ export const shopperWCP = {
 		} );
 
 		await page.select( '#wcpay_selected_currency', currencyToSet );
-		await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
 		await expect( page ).toClick( 'button', {
 			text: 'Save changes',
 		} );


### PR DESCRIPTION
Fixes #6882 

#### Changes proposed in this Pull Request

This is adding more test coverage for the deferred intent UPE. The split UPE tests were ported over to test with the deferred intent flag enabled instead. The e2e coverage is already in pretty good shape and covers the main checkout flows. I've added a couple more covering the following scenarios: 

- Guest cannot save card
- Default payment method can be set on Payment Methods page

The default payment method test has added some flakiness that I haven't been able to pin down even though the test looks fine in the browser. 

https://github.com/Automattic/woocommerce-payments/issues/5022#issuecomment-1663973487 is a great reference for potential tests in the future.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.