### PR TITLE
Fixes to the account status logic

### DIFF
--- a/changelog/update-account-status-logic
+++ b/changelog/update-account-status-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Updates to the account status logic to reflect status more accurately in some cases.

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -246,7 +246,7 @@ exports[`StatusChip renders pending verification status 1`] = `
 </div>
 `;
 
-exports[`StatusChip renders pending verification status for po 1`] = `
+exports[`StatusChip renders pending verification status for progressive onboarding 1`] = `
 <div>
   <button
     class="wcpay-tooltip__content-wrapper"

--- a/client/components/account-status/test/index.js
+++ b/client/components/account-status/test/index.js
@@ -128,7 +128,7 @@ describe( 'StatusChip', () => {
 		expect( statusChip ).toMatchSnapshot();
 	} );
 
-	test( 'renders pending verification status for po', () => {
+	test( 'renders pending verification status for progressive onboarding', () => {
 		const { container: statusChip } = renderStatusChip(
 			'pending_verification',
 			true,

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -121,23 +121,23 @@ const DepositsStatus: React.FC< Props > = ( {
 } ) => {
 	const isPoInProgress = poEnabled && ! poComplete;
 
-	if ( accountStatus === 'pending_verification' || isPoInProgress ) {
+	if ( status === 'blocked' ) {
+		return (
+			<DepositsStatusSuspended
+				iconSize={ iconSize }
+				interval={ interval }
+			/>
+		);
+	} else if ( accountStatus === 'pending_verification' || isPoInProgress ) {
 		return (
 			<DepositsStatusPending
 				iconSize={ iconSize }
 				interval={ interval }
 			/>
 		);
-	} if ( status === 'disabled' ) {
+	} else if ( status === 'disabled' ) {
 		return (
 			<DepositsStatusDisabled
-				iconSize={ iconSize }
-				interval={ interval }
-			/>
-		);
-	} else if ( status === 'blocked' ) {
-		return (
-			<DepositsStatusSuspended
 				iconSize={ iconSize }
 				interval={ interval }
 			/>

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -20,7 +20,6 @@ type DepositsIntervals = 'daily' | 'weekly' | 'monthly' | 'manual';
 
 interface DepositsStatusProps {
 	iconSize: number;
-	isPoInProgress: boolean;
 	interval: DepositsIntervals;
 }
 
@@ -50,20 +49,12 @@ const DepositsStatusEnabled: React.FC< DepositsStatusProps > = ( props ) => {
 };
 
 const DepositsStatusDisabled: React.FC< DepositsStatusProps > = ( props ) => {
-	const { iconSize, isPoInProgress } = props;
-
-	const description = isPoInProgress
-		? __( 'Not connected', 'woocommerce-payments' )
-		: __( 'Disabled', 'woocommerce-payments' );
-
-	const className = isPoInProgress
-		? 'account-status__info__gray'
-		: 'account-status__info__red';
+	const { iconSize } = props;
 
 	return (
-		<span className={ className }>
+		<span className={ 'account-status__info__red' }>
 			<GridiconNotice size={ iconSize } />
-			{ description }
+			{ __( 'Disabled', 'woocommerce-payments' ) }
 		</span>
 	);
 };
@@ -130,19 +121,17 @@ const DepositsStatus: React.FC< Props > = ( {
 } ) => {
 	const isPoInProgress = poEnabled && ! poComplete;
 
-	if ( accountStatus === 'pending_verification' ) {
+	if ( accountStatus === 'pending_verification' || isPoInProgress ) {
 		return (
 			<DepositsStatusPending
 				iconSize={ iconSize }
-				isPoInProgress={ isPoInProgress }
 				interval={ interval }
 			/>
 		);
-	} else if ( status === 'disabled' ) {
+	} if ( status === 'disabled' ) {
 		return (
 			<DepositsStatusDisabled
 				iconSize={ iconSize }
-				isPoInProgress={ isPoInProgress }
 				interval={ interval }
 			/>
 		);
@@ -150,18 +139,13 @@ const DepositsStatus: React.FC< Props > = ( {
 		return (
 			<DepositsStatusSuspended
 				iconSize={ iconSize }
-				isPoInProgress={ isPoInProgress }
 				interval={ interval }
 			/>
 		);
 	}
 
 	return (
-		<DepositsStatusEnabled
-			iconSize={ iconSize }
-			isPoInProgress={ isPoInProgress }
-			interval={ interval }
-		/>
+		<DepositsStatusEnabled iconSize={ iconSize } interval={ interval } />
 	);
 };
 

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -18,6 +18,99 @@ import type { AccountStatus } from 'wcpay/types/account/account-status';
 type DepositsStatus = 'enabled' | 'disabled' | 'blocked';
 type DepositsIntervals = 'daily' | 'weekly' | 'monthly' | 'manual';
 
+interface DepositsStatusProps {
+	iconSize: number;
+	isPoInProgress: boolean;
+	interval: DepositsIntervals;
+}
+
+const getIntervalType = ( interval: DepositsIntervals ): string => {
+	switch ( interval ) {
+		case 'daily':
+		case 'weekly':
+		case 'monthly':
+			return __( 'Automatic', 'woocommerce-payments' );
+		case 'manual':
+			return __( 'Manual', 'woocommerce-payments' );
+		default:
+			return __( 'Unknown', 'woocommerce-payments' );
+	}
+};
+
+const DepositsStatusEnabled: React.FC< DepositsStatusProps > = ( props ) => {
+	const { iconSize, interval } = props;
+
+	const description = getIntervalType( interval );
+	return (
+		<span className={ 'account-status__info__green' }>
+			<GridiconCheckmarkCircle size={ iconSize } />
+			{ description }
+		</span>
+	);
+};
+
+const DepositsStatusDisabled: React.FC< DepositsStatusProps > = ( props ) => {
+	const { iconSize, isPoInProgress } = props;
+
+	const description = isPoInProgress
+		? __( 'Not connected', 'woocommerce-payments' )
+		: __( 'Disabled', 'woocommerce-payments' );
+
+	const className = isPoInProgress
+		? 'account-status__info__gray'
+		: 'account-status__info__red';
+
+	return (
+		<span className={ className }>
+			<GridiconNotice size={ iconSize } />
+			{ description }
+		</span>
+	);
+};
+
+const DepositsStatusSuspended: React.FC< DepositsStatusProps > = ( props ) => {
+	const { iconSize } = props;
+
+	const learnMoreHref =
+		'https://woo.com/document/woopayments/deposits/why-deposits-suspended/';
+
+	const description = createInterpolateElement(
+		/* translators: <a> - suspended accounts FAQ URL */
+		__(
+			'Temporarily suspended (<a>learn more</a>)',
+			'woocommerce-payments'
+		),
+		{
+			a: (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				<a
+					href={ learnMoreHref }
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		}
+	);
+
+	return (
+		<span className={ 'account-status__info__yellow' }>
+			<GridiconNotice size={ iconSize } />
+			{ description }
+		</span>
+	);
+};
+
+const DepositsStatusPending: React.FC< DepositsStatusProps > = ( props ) => {
+	const { iconSize } = props;
+
+	return (
+		<span className={ 'account-status__info__gray' }>
+			<GridiconNotice size={ iconSize } />
+			{ __( 'Pending verification', 'woocommerce-payments' ) }
+		</span>
+	);
+};
+
 interface Props {
 	status: DepositsStatus;
 	interval: DepositsIntervals;
@@ -35,65 +128,40 @@ const DepositsStatus: React.FC< Props > = ( {
 	poComplete,
 	iconSize,
 } ) => {
-	let className = 'account-status__info__green';
-	let description;
-	let icon = <GridiconCheckmarkCircle size={ iconSize } />;
-	const automaticIntervals: DepositsIntervals[] = [
-		'daily',
-		'weekly',
-		'monthly',
-	];
-	const showSuspendedNotice = 'blocked' === status;
+	const isPoInProgress = poEnabled && ! poComplete;
 
-	if ( 'pending_verification' === accountStatus ) {
-		description = __( 'Pending verification', 'woocommerce-payments' );
-		className = 'account-status__info__gray';
-		icon = <GridiconNotice size={ iconSize } />;
-	} else if ( 'disabled' === status ) {
-		description =
-			poEnabled && ! poComplete
-				? __( 'Not connected', 'woocommerce-payments' )
-				: __( 'Disabled', 'woocommerce-payments' );
-		className =
-			poEnabled && ! poComplete
-				? 'account-status__info__gray'
-				: 'account-status__info__red';
-		icon = <GridiconNotice size={ iconSize } />;
-	} else if ( showSuspendedNotice ) {
-		const learnMoreHref =
-			'https://woo.com/document/woopayments/deposits/why-deposits-suspended/';
-		description = createInterpolateElement(
-			/* translators: <a> - suspended accounts FAQ URL */
-			__(
-				'Temporarily suspended (<a>learn more</a>)',
-				'woocommerce-payments'
-			),
-			{
-				a: (
-					// eslint-disable-next-line jsx-a11y/anchor-has-content
-					<a
-						href={ learnMoreHref }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			}
+	if ( accountStatus === 'pending_verification' ) {
+		return (
+			<DepositsStatusPending
+				iconSize={ iconSize }
+				isPoInProgress={ isPoInProgress }
+				interval={ interval }
+			/>
 		);
-		className = 'account-status__info__yellow';
-		icon = <GridiconNotice size={ iconSize } />;
-	} else if ( automaticIntervals.includes( interval ) ) {
-		description = __( 'Automatic', 'woocommerce-payments' );
-	} else if ( 'manual' === interval ) {
-		description = __( 'Manual', 'woocommerce-payments' );
-	} else {
-		description = __( 'Unknown', 'woocommerce-payments' );
+	} else if ( status === 'disabled' ) {
+		return (
+			<DepositsStatusDisabled
+				iconSize={ iconSize }
+				isPoInProgress={ isPoInProgress }
+				interval={ interval }
+			/>
+		);
+	} else if ( status === 'blocked' ) {
+		return (
+			<DepositsStatusSuspended
+				iconSize={ iconSize }
+				isPoInProgress={ isPoInProgress }
+				interval={ interval }
+			/>
+		);
 	}
 
 	return (
-		<span className={ className }>
-			{ icon }
-			{ description }
-		</span>
+		<DepositsStatusEnabled
+			iconSize={ iconSize }
+			isPoInProgress={ isPoInProgress }
+			interval={ interval }
+		/>
 	);
 };
 

--- a/client/components/deposits-status/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-status/test/__snapshots__/index.js.snap
@@ -157,7 +157,7 @@ exports[`DepositsStatus renders monthly status 1`] = `
 exports[`DepositsStatus renders pending verification status 1`] = `
 <div>
   <span
-    class="account-status__info__gray"
+    class="account-status__info__yellow"
   >
     <svg
       class="gridicon gridicons-notice"
@@ -172,7 +172,15 @@ exports[`DepositsStatus renders pending verification status 1`] = `
         />
       </g>
     </svg>
-    Pending verification
+    Temporarily suspended (
+    <a
+      href="https://woo.com/document/woopayments/deposits/why-deposits-suspended/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      learn more
+    </a>
+    )
   </span>
 </div>
 `;

--- a/client/components/payments-status/index.tsx
+++ b/client/components/payments-status/index.tsx
@@ -60,11 +60,12 @@ interface Props {
 const PaymentsStatus: React.FC< Props > = ( props ) => {
 	const { paymentsEnabled, accountStatus } = props;
 
-	if ( 'pending_verification' === accountStatus ) {
-		return <PaymentsStatusPending iconSize={ props.iconSize } />;
+	if ( paymentsEnabled ) {
+		return <PaymentsStatusEnabled iconSize={ props.iconSize } />;
 	}
-	return paymentsEnabled ? (
-		<PaymentsStatusEnabled iconSize={ props.iconSize } />
+
+	return accountStatus === 'pending_verification' ? (
+		<PaymentsStatusPending iconSize={ props.iconSize } />
 	) : (
 		<PaymentsStatusDisabled iconSize={ props.iconSize } />
 	);


### PR DESCRIPTION
Fixes server/3899

Note: this should be tested in conjunction with the server PR.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* Improvement to the payments status logic, will return `Active` rather than pending if the account is pending verification but payments are enabled.
* Refactored the deposits logic to simplify slightly.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Following the instructions in the server/3899 PR, onboard a new PO US account with the tax capabilities, then go to **Payments > Overview** and ensure that the account status is `Pending`, the payments status is `Active`, and the deposits status is `Pending Verification`.
* Make a test transaction, clear the account cache and check the account status again, verifying that it did not change.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
