### PR TITLE
Revert "Exclude estimated deposits from useDeposits data hook by default"

### DIFF
--- a/changelog/7604-no-estimated-deposits-on-deposits-detail-page
+++ b/changelog/7604-no-estimated-deposits-on-deposits-detail-page
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Exclude estimated deposits from the deposits list screen

--- a/changelog/revert-7605-7604-no-estimated-deposits-on-deposits-detail-page
+++ b/changelog/revert-7605-7604-no-estimated-deposits-on-deposits-detail-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Reverting a change no longer for inclusion in 6.8. No user-facing changes.
+
+

--- a/client/data/deposits/hooks.ts
+++ b/client/data/deposits/hooks.ts
@@ -124,14 +124,8 @@ export const useDeposits = ( {
 	date_between: dateBetween,
 	status_is: statusIs,
 	status_is_not: statusIsNot,
-}: Query ): CachedDeposits => {
-	// Temporarily default to excluding estimated deposits.
-	// Client components can (temporarily) opt-in by passing `status_is=estimated`.
-	// When we remove estimated deposits from server / APIs we can remove this default.
-	if ( ! statusIsNot && statusIs !== 'estimated' ) {
-		statusIsNot = 'estimated';
-	}
-	return useSelect(
+}: Query ): CachedDeposits =>
+	useSelect(
 		( select ) => {
 			const {
 				getDeposits,
@@ -182,7 +176,6 @@ export const useDeposits = ( {
 			statusIsNot,
 		]
 	);
-};
 
 export const useDepositsSummary = ( {
 	match,
@@ -192,14 +185,8 @@ export const useDepositsSummary = ( {
 	date_between: dateBetween,
 	status_is: statusIs,
 	status_is_not: statusIsNot,
-}: Query ): DepositsSummaryCache => {
-	// Temporarily default to excluding estimated deposits.
-	// Client components can (temporarily) opt-in by passing `status_is=estimated`.
-	// When we remove estimated deposits from server / APIs we can remove this default.
-	if ( ! statusIsNot && statusIs !== 'estimated' ) {
-		statusIsNot = 'estimated';
-	}
-	return useSelect(
+}: Query ): DepositsSummaryCache =>
+	useSelect(
 		( select ) => {
 			const { getDepositsSummary, isResolving } = select( STORE_NAME );
 
@@ -228,7 +215,6 @@ export const useDepositsSummary = ( {
 			statusIsNot,
 		]
 	);
-};
 
 export const useInstantDeposit = (
 	transactionIds: string[]


### PR DESCRIPTION
See issue #7667.

We are now planning to release all user-facing changes to estimated deposits in WooPayments 6.9.

This PR reverts #7605 which can then be re-opened for a 6.9 release.

### Testing instructions

* Ensure your store has an estimated deposit by purchasing a product and setting the deposit schedule to daily, weekly or monthly.
* Visit the **Payments → Deposits** screen.
* Ensure `Estimated` deposits appear in the list.
* Ensure the summary at the bottom of the table is correct.

![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/c760b8d0-a119-4837-a7de-91b5a8725d19)


### Post-merge


- [x] Re-open issue #7604 
- [x] Re-open PR #7605
	- Re-opened here: #7688