### PR TITLE
Code quality: remove redundant pluralised string in account balances

### DIFF
--- a/changelog/fix-code-quality-account-balances-remove-duplicate-string
+++ b/changelog/fix-code-quality-account-balances-remove-duplicate-string
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Not user-facing: code quality fix only.
+
+

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -219,6 +219,7 @@ const AccountBalances: React.FC = () => {
 											  } )
 											: interpolateComponents( {
 													mixedString: sprintf(
+														// Translators: %d is the number of days, e.g. 1, 2, 3, etc.
 														__(
 															'The amount of funds still in the %d day pending period. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
 															'woocommerce-payments'

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { Flex, TabPanel } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**
@@ -219,10 +219,8 @@ const AccountBalances: React.FC = () => {
 											  } )
 											: interpolateComponents( {
 													mixedString: sprintf(
-														_n(
+														__(
 															'The amount of funds still in the %d day pending period. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-															'The amount of funds still in the %d day pending period. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-															tab.delayDays,
 															'woocommerce-payments'
 														),
 														tab.delayDays


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes an unnecessary usage of `__n()` in order to improve the code quality.
`__n()` is used to pluralise a string depending on a provided integer: e.g. `1 day` or `2 days`.

In this case, either output string was identical, so we can remove this unnecessary to simplify the code and increase readability:

`1  : The amount of funds still in the 1 day pending period.`
`2+ : The amount of funds still in the 2 day pending period.`

I've also added a missing translator's comment to help with translation.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Payments → Overview
* Ensure that the `Pending funds` tooltip is accurate and the link works.
	`The amount of funds still in the %d day pending period. Learn more.`

![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/5d2afd5a-688e-4064-97cc-d95bcd030a27)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
