### PR TITLE
Remove estimated deposits from transaction list and details page

### DIFF
--- a/changelog/fix-7657_7658-estimated_deposits
+++ b/changelog/fix-7657_7658-estimated_deposits
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Smaller part of a larger change that has a clear changelog entry
+
+

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -70,7 +70,7 @@ const getDepositTimelineItem = (
 	body = []
 ) => {
 	let headline = '';
-	if ( event.deposit ) {
+	if ( event.deposit && ! event.deposit.id.includes( 'wcpay_estimated_' ) ) {
 		headline = sprintf(
 			isPositive
 				? // translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
@@ -89,7 +89,6 @@ const getDepositTimelineItem = (
 				moment( event.deposit.arrival_date * 1000 ).toISOString()
 			)
 		);
-
 		const depositUrl = getAdminUrl( {
 			page: 'wc-admin',
 			path: '/payments/deposits/details',
@@ -136,7 +135,7 @@ const getDepositTimelineItem = (
  */
 const getFinancingPaydownTimelineItem = ( event, formattedAmount, body ) => {
 	let headline = '';
-	if ( event.deposit ) {
+	if ( event.deposit && ! event.deposit.id.includes( 'wcpay_estimated_' ) ) {
 		headline = sprintf(
 			// translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
 			__(

--- a/client/transactions/list/deposit.tsx
+++ b/client/transactions/list/deposit.tsx
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
 import { Link } from '@woocommerce/components';
-import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { getAdminUrl } from 'wcpay/utils';
 

--- a/client/transactions/list/deposit.tsx
+++ b/client/transactions/list/deposit.tsx
@@ -16,7 +16,11 @@ interface DepositProps {
 }
 
 const Deposit = ( { depositId, dateAvailable }: DepositProps ): JSX.Element => {
-	if ( depositId && dateAvailable ) {
+	if (
+		depositId &&
+		dateAvailable &&
+		! depositId.includes( 'wcpay_estimated_' )
+	) {
 		const depositUrl = getAdminUrl( {
 			page: 'wc-admin',
 			path: '/payments/deposits/details',
@@ -29,15 +33,7 @@ const Deposit = ( { depositId, dateAvailable }: DepositProps ): JSX.Element => {
 			true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 		);
 
-		const estimated = depositId.includes( 'wcpay_estimated_' )
-			? __( 'Estimated', 'woocommerce-payments' )
-			: '';
-
-		return (
-			<Link href={ depositUrl }>
-				{ estimated } { formattedDateAvailable }
-			</Link>
-		);
+		return <Link href={ depositUrl }>{ formattedDateAvailable }</Link>;
 	}
 
 	return <></>;

--- a/client/transactions/list/test/__snapshots__/deposit.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/deposit.tsx.snap
@@ -6,8 +6,6 @@ exports[`Deposit renders with date and deposit available 1`] = `
     data-link-type="wc-admin"
     href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
   >
-    
-     
     Jan 7, 2020
   </a>
 </div>
@@ -17,17 +15,6 @@ exports[`Deposit renders with date available but no deposit 1`] = `<div />`;
 
 exports[`Deposit renders with deposit but no date available 1`] = `<div />`;
 
-exports[`Deposit renders with estimated date and deposit available 1`] = `
-<div>
-  <a
-    data-link-type="wc-admin"
-    href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=wcpay_estimated_mock"
-  >
-    Estimated
-     
-    Jan 7, 2020
-  </a>
-</div>
-`;
+exports[`Deposit renders with estimated date and deposit available 1`] = `<div />`;
 
 exports[`Deposit renders with no date or deposit available 1`] = `<div />`;

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -767,8 +767,6 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       data-link-type="wc-admin"
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
                     >
-                      
-                       
                       Jan 7, 2020
                     </a>
                   </td>
@@ -1700,8 +1698,6 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       data-link-type="wc-admin"
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
                     >
-                      
-                       
                       Jan 7, 2020
                     </a>
                   </td>
@@ -3336,8 +3332,6 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       data-link-type="wc-admin"
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
                     >
-                      
-                       
                       Jan 7, 2020
                     </a>
                   </td>
@@ -4314,8 +4308,6 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       data-link-type="wc-admin"
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
                     >
-                      
-                       
                       Jan 7, 2020
                     </a>
                   </td>
@@ -5289,8 +5281,6 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       data-link-type="wc-admin"
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
                     >
-                      
-                       
                       Jan 7, 2020
                     </a>
                   </td>


### PR DESCRIPTION
Fixes #7657 
Fixes #7658 

### Changes proposed in this Pull Request

As part of the efforts to simplify estimated deposits. Any estimates that come through from the server should not be shown.

This change removes references to estimated deposits from the transactions list and the transaction timeline.

### Screenshots

#### Transaction Details

**Before:**
![Screenshot 2023-11-09 at 4 15 23 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/c51a675c-10ae-406c-b563-e21f1716bf0f)
**After:**
![Screenshot 2023-11-10 at 1 29 31 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/e5f781ed-8fa0-4f6d-bbaf-fe5a4b61e9dc)

#### Transaction List

**Before:**
![Screenshot 2023-11-09 at 4 46 04 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/ab1695e0-3d11-4583-bdd8-a29d0bcdfeca)
**After:**
![Screenshot 2023-11-09 at 4 43 30 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/17d80ae1-6d78-4362-ad20-57546f924f53)

**Note:**
Deposit status is still shown in transaction list (when column is enabled.) This also shows up in the CSV export. This is resolved as part of #7630 ([specific line](https://github.com/Automattic/woocommerce-payments/commit/263db2ea2b6f91ab04c45a9d1a671f564079b35c#diff-f3ae55d63a28e488eedb193add7f91f1c19b25bbb8cfabd52d6a9f3ebf90d803L19))
![Screenshot 2023-11-09 at 4 59 27 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/44756513-390e-499d-a6c7-88149fe32a31)

#### Testing instructions

* Make a test purchase
* View transaction list and details pages
* When a loan is active there is a paydown transaction that also appears on the details page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
