### PR TITLE
Update plugin name to WooPayments

### DIFF
--- a/changelog/fix-update-plugin-name-to-woopayments
+++ b/changelog/fix-update-plugin-name-to-woopayments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update plugin name to WooPayments

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Payments
+ * Plugin Name: WooPayments
  * Plugin URI: https://woo.com/payments/
  * Description: Accept payments via credit card. Manage transactions within WordPress.
  * Author: Automattic


### PR DESCRIPTION
Fixes #6863 

#### Changes proposed in this Pull Request

Update plugin name according with new branding: WooPayments. It was reversed in https://github.com/Automattic/woocommerce-payments/pull/6808 after issues in iOS app. Now we are safe to do that, because more than 98% users updated to the needed version of the app.

#### Testing instructions

* Before checking out this branch plugin name in http://localhost:8082/wp-admin/plugins.php should be WooCommerce Payments.
* After checking out this branch, it should be WooPayments.

![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/c6818e36-1e72-4308-a983-02fdedf6f02a)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
