### PR TITLE
Do not show the WooPay button on the product page when WC Bookings require confirmation

### DIFF
--- a/changelog/do-not-show-woopay-button-when-bookings-require-confirmation
+++ b/changelog/do-not-show-woopay-button-when-bookings-require-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not show the WooPay button on the product page when WC Bookings require confirmation

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -634,6 +634,11 @@ class WC_Payments_WooPay_Button_Handler {
 			$is_supported = false;
 		}
 
+		// WC Bookings require confirmation products are not supported.
+		if ( is_a( $product, 'WC_Product_Booking' ) && $product->get_requires_confirmation() ) {
+			$is_supported = false;
+		}
+
 		return apply_filters( 'wcpay_woopay_button_is_product_supported', $is_supported, $product );
 	}
 

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -657,6 +657,11 @@ class WC_Payments_WooPay_Button_Handler {
 			class_exists( 'WC_Pre_Orders_Cart' ) &&
 			WC_Pre_Orders_Cart::cart_contains_pre_order() &&
 			class_exists( 'WC_Pre_Orders_Product' ) &&
+			/**
+			 * Psalm throws an error here even though we check the class existence.
+			 *
+			 * @psalm-suppress UndefinedClass
+			 */
 			WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() )
 		) {
 			$is_supported = false;

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -652,19 +652,19 @@ class WC_Payments_WooPay_Button_Handler {
 	private function has_allowed_items_in_cart() {
 		$is_supported = true;
 
+		/**
+		 * Psalm throws an error here even though we check the class existence.
+		 *
+		 * @psalm-suppress UndefinedClass
+		 */
 		// We don't support pre-order products to be paid upon release.
-		if (
-			class_exists( 'WC_Pre_Orders_Cart' ) &&
-			WC_Pre_Orders_Cart::cart_contains_pre_order() &&
-			class_exists( 'WC_Pre_Orders_Product' ) &&
-			/**
-			 * Psalm throws an error here even though we check the class existence.
-			 *
-			 * @psalm-suppress UndefinedClass
-			 */
-			WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() )
-		) {
-			$is_supported = false;
+		if ( class_exists( 'WC_Pre_Orders_Cart' ) && class_exists( 'WC_Pre_Orders_Product' ) ) {
+			if (
+				WC_Pre_Orders_Cart::cart_contains_pre_order() &&
+				WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() )
+			) {
+				$is_supported = false;
+			}
 		}
 
 		return apply_filters( 'wcpay_platform_checkout_button_are_cart_items_supported', $is_supported );


### PR DESCRIPTION
Fixes #7681 

#### Changes proposed in this Pull Request
Add a check to see if the WC Bookings product requires confirmation.

#### Screenshots
*Before*
<img width="670" alt="Screen Shot 2023-11-09 at 12 53 53 PM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/ac915959-a0da-4f61-a410-75151920a678">

*After*
<img width="672" alt="Screen Shot 2023-11-09 at 1 54 23 PM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/c8a2b99b-27eb-4bd3-99da-fa16a9db3561">


#### Testing instructions
1. Install and activate WC Bookings plugin
2. Check the "Requires confirmation?" box
3. Go to the Bookings product page
4. Should not see the WooPay button
5. Uncheck the "Requires confirmation?" box
6. Go to the Bookings product page
7. Should see the WooPay button
-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
