### PR TITLE
Update Fraud & Risk tools radio button to match colors with the current theme

### DIFF
--- a/changelog/fix-7539-radio-bg-color
+++ b/changelog/fix-7539-radio-bg-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update Fraud & Risk tools radio input background color to match the current theme.

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -103,7 +103,10 @@
 				width: 12px;
 				height: 12px;
 				margin: 3px;
-				background-color: #3582c4;
+				background-color: var(
+					--wp-components-color-accent,
+					var( --wp-admin-theme-color, #3858e9 )
+				);
 				line-height: 1.14285714;
 			}
 		}


### PR DESCRIPTION
Fixes #7539

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR aims to update the background color of the radio buttons in the Fraud & Risk tools section to match the user's current theme.

<table>
<tr>
<td>
<b>Before</b>
</td>
</tr>

<tr>
<td>
<img width="1048" alt="Screenshot 2023-11-09 at 17 30 26" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/37a6b90d-4e44-4908-b4d0-0ee087fef82d">

</td>
</tr>

<tr>
<td>
<b>After</b>
</td>
</tr>

<tr>
<td>
<img width="1048" alt="Screenshot 2023-11-09 at 17 30 14" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/20208979-0875-40ba-b064-1c521fb1a238">

</td>
</tr>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Before checking out to this branch
* Go to **Users > Profile**, change the "Admin Color Scheme" to "Sunrise" (This one is easy to identify the issue), and save the changes
* Go to **Payments > Settings** and scroll down to the "Fraud protection" section
* You should notice that the primary colors aren't matching
<img width="691" alt="Screenshot 2023-11-09 at 17 37 31" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/d076c785-e370-47d0-8a64-c6ea6d6a5bc4">

#### Checkout to this branch
* The tests should pass
* Run `npm run start`
* Refresh the page
* The primary colors should match
<img width="691" alt="Screenshot 2023-11-09 at 17 38 16" src="https://github.com/Automattic/woocommerce-payments/assets/16882226/5ec8fc1f-04cb-4bbe-884c-49fe9d2077cb">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
