### PR TITLE
WC Beta E2E tests - Add workaround to revert to classic checkout

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,7 +28,6 @@ env:
   FORCE_E2E_DEPS_SETUP: true
 
 jobs:
-  # [TODO] Enable WC beta tests after fixing failures caused by blocks checkout being default on newer versions
   generate-matrix:
     name: "Generate the matrix for subscriptions-tests dynamically"
     runs-on: ubuntu-latest
@@ -38,7 +37,7 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          WC_VERSIONS=$( echo "[\"7.7.0\", \"latest\"]" )
+          WC_VERSIONS=$( echo "[\"7.7.0\", \"latest\", \"beta\"]" )
           echo "matrix={\"woocommerce\":$WC_VERSIONS,\"test_groups\":[\"wcpay\", \"subscriptions\"],\"test_branches\":[\"merchant\", \"shopper\"]}" >> $GITHUB_OUTPUT
 
   # Run WCPay & subscriptions tests against specific WC versions

--- a/changelog/update-e2e-wc-8.3-workaround
+++ b/changelog/update-e2e-wc-8.3-workaround
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Comment: E2E - Enable WC beta tests & add workaround to revert to classic checkout for WC 8.3.0 & above

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -221,9 +221,12 @@ if [[ "$IS_WORKAROUND_REQUIRED" = "1" ]]; then
 	CART_PAGE_ID=$(cli_debug wp option get woocommerce_cart_page_id)
 	CHECKOUT_PAGE_ID=$(cli_debug wp option get woocommerce_checkout_page_id)
 
+	CART_SHORTCODE="<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->"
+	CHECKOUT_SHORTCODE="<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->"
+
 	# Update cart & checkout pages to use shortcode.
-	cli wp post update "$CART_PAGE_ID" --post_content="<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->"
-	cli wp post update "$CHECKOUT_PAGE_ID" --post_content="<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->"
+	cli wp post update "$CART_PAGE_ID" --post_content="$CART_SHORTCODE"
+	cli wp post update "$CHECKOUT_PAGE_ID" --post_content="$CHECKOUT_SHORTCODE"
 fi
 # End - Workaround for > WC 8.3 compatibility by updating cart & checkout pages to use shortcode.
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -212,14 +212,14 @@ cli wp wc --user=admin tool run install_pages
 
 # Start - Workaround for > WC 8.3 compatibility by updating cart & checkout pages to use shortcode.
 # To be removed when WooPayments L-2 support is >= WC 8.3
-INSTALLED_WC_VERSION=$(wp plugin get woocommerce --field=version)
-IS_WORKAROUND_REQUIRED=$(wp eval "echo version_compare(\"$INSTALLED_WC_VERSION\", \"8.3\", \">=\");")
+INSTALLED_WC_VERSION=$(cli_debug wp plugin get woocommerce --field=version)
+IS_WORKAROUND_REQUIRED=$(cli_debug wp eval "echo version_compare(\"$INSTALLED_WC_VERSION\", \"8.3\", \">=\");")
 
 if [[ "$IS_WORKAROUND_REQUIRED" = "1" ]]; then
 	echo "Updating cart & checkout pages for WC > 8.3 compatibility..."
 	# Get cart & checkout page IDs.
-	CART_PAGE_ID=$(wp option get woocommerce_cart_page_id)
-	CHECKOUT_PAGE_ID=$(wp option get woocommerce_checkout_page_id)
+	CART_PAGE_ID=$(cli_debug wp option get woocommerce_cart_page_id)
+	CHECKOUT_PAGE_ID=$(cli_debug wp option get woocommerce_checkout_page_id)
 
 	# Update cart & checkout pages to use shortcode.
 	cli wp post update "$CART_PAGE_ID" --post_content="<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->"


### PR DESCRIPTION
Fixes #7599

#### Changes proposed in this Pull Request

This PR adds a workaround for E2E test failures when using WC 8.3.0 or above since these versions uses blocks for checkout & cart pages. Though WC 8.3.0 or above uses block layout, it is possible to switch to classic layout by using the `[woocommerce_cart]` & `[woocommerce_checkout]` shortcodes.

This PR updates the setup script to check whether the installed version is >= WC 8.3.0 & if yes, modifies the cart & checkout page to use shortcodes via WP-CLI. 

However, this is a temporary workaround since we have blocks tests for basic payment flows. A permanent solution would be to update the tests to use block checkout flows.

#### Testing instructions

* Against this branch trigger a new [E2E Tests - All ](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml) and confirm that beta tests are enabled again and are passing as expected. (Ref run - https://github.com/Automattic/woocommerce-payments/actions/runs/6823945830)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
