### PR TITLE
Add country to PM amount limits

### DIFF
--- a/changelog/fix-7680-add-country-to-pm-amount-limits
+++ b/changelog/fix-7680-add-country-to-pm-amount-limits
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Per-country amount limits for payment methods

--- a/includes/payment-methods/class-affirm-payment-method.php
+++ b/includes/payment-methods/class-affirm-payment-method.php
@@ -33,13 +33,17 @@ class Affirm_Payment_Method extends UPE_Payment_Method {
 		$this->accept_only_domestic_payment = true;
 		$this->limits_per_currency          = [
 			'CAD' => [
-				'min' => 5000,
-				'max' => 3000000,
-			], // Represents CAD 50 - 30,000 CAD.
+				'CA' => [
+					'min' => 5000,
+					'max' => 3000000,
+				], // Represents CAD 50 - 30,000 CAD.
+			],
 			'USD' => [
-				'min' => 5000,
-				'max' => 3000000,
-			], // Represents USD 50 - 30,000 USD.
+				'US' => [
+					'min' => 5000,
+					'max' => 3000000,
+				], // Represents USD 50 - 30,000 USD.
+			],
 		];
 		$this->countries                    = [ 'US', 'CA' ];
 	}

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -62,7 +62,6 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 				], // Represents USD 1 - 4,000 USD.
 			],
 			'EUR' => [
-				// TODO: Stripe docs https://stripe.com/docs/payments/afterpay-clearpay doesn't have EUR as supported currency.
 				'default' => [
 					'min' => 100,
 					'max' => 100000,

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -32,29 +32,42 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 		$this->accept_only_domestic_payment = true;
 		$this->limits_per_currency          = [
 			'AUD' => [
-				'min' => 100,
-				'max' => 200000,
-			], // Represents AUD 1 - 2,000 AUD.
+				'AU' => [
+					'min' => 100,
+					'max' => 200000,
+				], // Represents AUD 1 - 2,000 AUD.
+			],
 			'CAD' => [
-				'min' => 100,
-				'max' => 200000,
-			], // Represents CAD 1 - 2,000 CAD.
+				'CA' => [
+					'min' => 100,
+					'max' => 200000,
+				], // Represents CAD 1 - 2,000 CAD.
+			],
 			'NZD' => [
-				'min' => 100,
-				'max' => 200000,
-			], // Represents NZD 1 - 2,000 NZD.
+				'NZ' => [
+					'min' => 100,
+					'max' => 200000,
+				], // Represents NZD 1 - 2,000 NZD.
+			],
 			'GBP' => [
-				'min' => 100,
-				'max' => 120000,
-			], // Represents GBP 1 - 1,200 GBP.
+				'UK' => [
+					'min' => 100,
+					'max' => 120000,
+				], // Represents GBP 1 - 1,200 GBP.
+			],
 			'USD' => [
-				'min' => 100,
-				'max' => 400000,
-			], // Represents USD 1 - 4,000 USD.
+				'US' => [
+					'min' => 100,
+					'max' => 400000,
+				], // Represents USD 1 - 4,000 USD.
+			],
 			'EUR' => [
-				'min' => 100,
-				'max' => 100000,
-			], // Represents EUR 1 - 1,000 EUR.
+				// TODO: Stripe docs https://stripe.com/docs/payments/afterpay-clearpay doesn't have EUR as supported currency.
+				'default' => [
+					'min' => 100,
+					'max' => 100000,
+				], // Represents EUR 1 - 1,000 EUR.
+			],
 		];
 	}
 

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -88,7 +88,7 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 			'NOK' => [
 				'NO' => [
 					'min' => 0,
-					'max' => 10000000,
+					'max' => 100000000,
 				],
 			],
 			'SEK' => [

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -34,29 +34,82 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 		$this->countries                    = [ 'US', 'GB', 'AT', 'DE', 'NL', 'BE', 'ES', 'IT', 'IE', 'DK', 'FI', 'NO', 'SE' ];
 		$this->limits_per_currency          = [
 			'USD' => [
-				'min' => 1000,
-				'max' => 500000,
-			], // Represents USD 10 - 5,000.
+				'US' => [
+					'min' => 0,
+					'max' => 1000000,
+				],
+			],
 			'GBP' => [
-				'min' => 1000,
-				'max' => 500000,
-			], // Represents GBP 10 - 5,000.
+				'UK' => [
+					'min' => 0,
+					'max' => 1150000,
+				],
+			],
 			'EUR' => [
-				'min' => 1000,
-				'max' => 500000,
-			], // Represents EUR 10 - 5,000.
+				'AT' => [
+					'min' => 1,
+					'max' => 1000000,
+				],
+				'BE' => [
+					'min' => 1,
+					'max' => 1000000,
+				],
+				'DE' => [
+					'min' => 1,
+					'max' => 1000000,
+				],
+				'NL' => [
+					'min' => 1,
+					'max' => 1000000,
+				],
+				'FI' => [
+					'min' => 0,
+					'max' => 1000000,
+				],
+				'ES' => [
+					'min' => 0,
+					'max' => 1000000,
+				],
+				'IE' => [
+					'min' => 0,
+					'max' => 400000,
+				],
+				'IT' => [
+					'min' => 0,
+					'max' => 1000000,
+				],
+				// TODO: set correct limits for next three.
+				'DK' => [
+					'min' => 100,
+					'max' => 10000000,
+				],
+				'NO' => [
+					'min' => 0,
+					'max' => 10000000,
+				],
+				'SE' => [
+					'min' => 0,
+					'max' => 15000000,
+				],
+			],
 			'DKK' => [
-				'min' => 1000,
-				'max' => 500000,
-			], // Represents DKK 10 - 5,000.
+				'DK' => [
+					'min' => 100,
+					'max' => 10000000,
+				],
+			],
 			'NOK' => [
-				'min' => 1000,
-				'max' => 500000,
-			], // Represents NOK 10 - 5,000.
+				'NO' => [
+					'min' => 0,
+					'max' => 10000000,
+				],
+			],
 			'SEK' => [
-				'min' => 1000,
-				'max' => 500000,
-			], // Represents SEK 10 - 5,000.
+				'SE' => [
+					'min' => 0,
+					'max' => 15000000,
+				],
+			],
 		];
 	}
 

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -60,7 +60,7 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 				],
 				'NL' => [
 					'min' => 1,
-					'max' => 1000000,
+					'max' => 1500000,
 				],
 				'FI' => [
 					'min' => 0,

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -82,7 +82,7 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 			'DKK' => [
 				'DK' => [
 					'min' => 100,
-					'max' => 10000000,
+					'max' => 100000000,
 				],
 			],
 			'NOK' => [

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -78,19 +78,6 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 					'min' => 0,
 					'max' => 1000000,
 				],
-				// TODO: set correct limits for next three.
-				'DK' => [
-					'min' => 100,
-					'max' => 10000000,
-				],
-				'NO' => [
-					'min' => 0,
-					'max' => 10000000,
-				],
-				'SE' => [
-					'min' => 0,
-					'max' => 15000000,
-				],
 			],
 			'DKK' => [
 				'DK' => [

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1012,7 +1012,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 				$skip_currency_check       = ! $force_currency_check && is_admin();
 				$processing_payment_method = $this->payment_methods[ $payment_method_id ];
-				if ( $processing_payment_method->is_enabled_at_checkout() && ( $skip_currency_check || $processing_payment_method->is_currency_valid( $this->get_account_domestic_currency(), $order_id ) ) ) {
+				if ( $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) && ( $skip_currency_check || $processing_payment_method->is_currency_valid( $this->get_account_domestic_currency(), $order_id ) ) ) {
 					$status = $active_payment_methods[ $payment_method_capability_key ]['status'] ?? null;
 					if ( 'active' === $status ) {
 						$enabled_payment_methods[] = $payment_method_id;

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -73,7 +73,7 @@ abstract class UPE_Payment_Method {
 	/**
 	 * Represent payment total limitations for the payment method (per-currency).
 	 *
-	 * @var array<string,array<string,int>>
+	 * @var array<string,array<string,array<string,int>>>
 	 */
 	protected $limits_per_currency = [];
 

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -134,9 +134,11 @@ abstract class UPE_Payment_Method {
 	 * Returns boolean dependent on whether payment method
 	 * can be used at checkout
 	 *
+	 * @param string $account_country Country of merchants account.
+	 *
 	 * @return bool
 	 */
-	public function is_enabled_at_checkout() {
+	public function is_enabled_at_checkout( string $account_country ) {
 		if ( $this->is_subscription_item_in_cart() || $this->is_changing_payment_method_for_subscription() ) {
 			return $this->is_reusable();
 		}
@@ -149,7 +151,11 @@ abstract class UPE_Payment_Method {
 			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) ) {
 				$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
 				if ( $amount > 0 ) {
-					$range            = $this->limits_per_currency[ $currency ];
+					$range = $this->limits_per_currency[ $currency ][ $account_country ] ?? null;
+					// If there is no range specified for the currency-country pair we don't support it and return false.
+					if ( null === $range ) {
+						return false;
+					}
 					$is_valid_minimum = null === $range['min'] || $amount >= $range['min'];
 					$is_valid_maximum = null === $range['max'] || $amount <= $range['max'];
 					return $is_valid_minimum && $is_valid_maximum;

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -151,7 +151,12 @@ abstract class UPE_Payment_Method {
 			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) ) {
 				$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
 				if ( $amount > 0 ) {
-					$range = $this->limits_per_currency[ $currency ][ $account_country ] ?? $this->limits_per_currency[ $currency ]['default'] ?? null;
+					$range = null;
+					if ( isset( $this->limits_per_currency[ $currency ][ $account_country ] ) ) {
+						$range = $this->limits_per_currency[ $currency ][ $account_country ];
+					} elseif ( isset( $this->limits_per_currency[ $currency ]['default'] ) ) {
+						$range = $this->limits_per_currency[ $currency ]['default'];
+					}
 					// If there is no range specified for the currency-country pair we don't support it and return false.
 					if ( null === $range ) {
 						return false;

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -151,7 +151,7 @@ abstract class UPE_Payment_Method {
 			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) ) {
 				$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
 				if ( $amount > 0 ) {
-					$range = $this->limits_per_currency[ $currency ][ $account_country ] ?? null;
+					$range = $this->limits_per_currency[ $currency ][ $account_country ] ?? $this->limits_per_currency[ $currency ]['default'] ?? null;
 					// If there is no range specified for the currency-country pair we don't support it and return false.
 					if ( null === $range ) {
 						return false;

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -154,7 +154,7 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 	 */
 	public function is_available() {
 		$processing_payment_method = $this->payment_methods[ $this->payment_method->get_id() ];
-		if ( ! $processing_payment_method->is_enabled_at_checkout() ) {
+		if ( ! $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) ) {
 			return false;
 		}
 		return parent::is_available();

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -1521,68 +1521,68 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'Credit card / debit card', $card_method->get_title() );
 		$this->assertEquals( 'Visa debit card', $card_method->get_title( $mock_visa_details ) );
 		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( $mock_mastercard_details ) );
-		$this->assertTrue( $card_method->is_enabled_at_checkout() );
+		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertTrue( $card_method->is_reusable() );
 		$this->assertEquals( $mock_token, $card_method->get_payment_token_for_user( $mock_user, $mock_payment_method_id ) );
 
 		$this->assertEquals( 'giropay', $giropay_method->get_id() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title( $mock_giropay_details ) );
-		$this->assertTrue( $giropay_method->is_enabled_at_checkout() );
+		$this->assertTrue( $giropay_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $giropay_method->is_reusable() );
 
 		$this->assertEquals( 'p24', $p24_method->get_id() );
 		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title() );
 		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title( $mock_p24_details ) );
-		$this->assertTrue( $p24_method->is_enabled_at_checkout() );
+		$this->assertTrue( $p24_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $p24_method->is_reusable() );
 
 		$this->assertEquals( 'sofort', $sofort_method->get_id() );
 		$this->assertEquals( 'Sofort', $sofort_method->get_title() );
 		$this->assertEquals( 'Sofort', $sofort_method->get_title( $mock_sofort_details ) );
-		$this->assertTrue( $sofort_method->is_enabled_at_checkout() );
+		$this->assertTrue( $sofort_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $sofort_method->is_reusable() );
 
 		$this->assertEquals( 'bancontact', $bancontact_method->get_id() );
 		$this->assertEquals( 'Bancontact', $bancontact_method->get_title() );
 		$this->assertEquals( 'Bancontact', $bancontact_method->get_title( $mock_bancontact_details ) );
-		$this->assertTrue( $bancontact_method->is_enabled_at_checkout() );
+		$this->assertTrue( $bancontact_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $bancontact_method->is_reusable() );
 
 		$this->assertEquals( 'eps', $eps_method->get_id() );
 		$this->assertEquals( 'EPS', $eps_method->get_title() );
 		$this->assertEquals( 'EPS', $eps_method->get_title( $mock_eps_details ) );
-		$this->assertTrue( $eps_method->is_enabled_at_checkout() );
+		$this->assertTrue( $eps_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $eps_method->is_reusable() );
 
 		$this->assertEquals( 'sepa_debit', $sepa_method->get_id() );
 		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title() );
 		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title( $mock_sepa_details ) );
-		$this->assertTrue( $sepa_method->is_enabled_at_checkout() );
+		$this->assertTrue( $sepa_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $sepa_method->is_reusable() );
 
 		$this->assertEquals( 'ideal', $ideal_method->get_id() );
 		$this->assertEquals( 'iDEAL', $ideal_method->get_title() );
 		$this->assertEquals( 'iDEAL', $ideal_method->get_title( $mock_ideal_details ) );
-		$this->assertTrue( $ideal_method->is_enabled_at_checkout() );
+		$this->assertTrue( $ideal_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $ideal_method->is_reusable() );
 
 		$this->assertEquals( 'au_becs_debit', $becs_method->get_id() );
 		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title() );
 		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title( $mock_becs_details ) );
-		$this->assertTrue( $becs_method->is_enabled_at_checkout() );
+		$this->assertTrue( $becs_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $becs_method->is_reusable() );
 
 		$this->assertSame( 'affirm', $affirm_method->get_id() );
 		$this->assertSame( 'Affirm', $affirm_method->get_title() );
 		$this->assertSame( 'Affirm', $affirm_method->get_title( $mock_affirm_details ) );
-		$this->assertTrue( $affirm_method->is_enabled_at_checkout() );
+		$this->assertTrue( $affirm_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $affirm_method->is_reusable() );
 
 		$this->assertSame( 'afterpay_clearpay', $afterpay_method->get_id() );
 		$this->assertSame( 'Afterpay', $afterpay_method->get_title() );
 		$this->assertSame( 'Afterpay', $afterpay_method->get_title( $mock_afterpay_details ) );
-		$this->assertTrue( $afterpay_method->is_enabled_at_checkout() );
+		$this->assertTrue( $afterpay_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $afterpay_method->is_reusable() );
 	}
 
@@ -1601,17 +1601,17 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$affirm_method     = $this->mock_payment_methods['affirm'];
 		$afterpay_method   = $this->mock_payment_methods['afterpay_clearpay'];
 
-		$this->assertTrue( $card_method->is_enabled_at_checkout() );
-		$this->assertFalse( $giropay_method->is_enabled_at_checkout() );
-		$this->assertFalse( $sofort_method->is_enabled_at_checkout() );
-		$this->assertFalse( $bancontact_method->is_enabled_at_checkout() );
-		$this->assertFalse( $eps_method->is_enabled_at_checkout() );
-		$this->assertFalse( $sepa_method->is_enabled_at_checkout() );
-		$this->assertFalse( $p24_method->is_enabled_at_checkout() );
-		$this->assertFalse( $ideal_method->is_enabled_at_checkout() );
-		$this->assertFalse( $becs_method->is_enabled_at_checkout() );
-		$this->assertFalse( $affirm_method->is_enabled_at_checkout() );
-		$this->assertFalse( $afterpay_method->is_enabled_at_checkout() );
+		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $giropay_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $sofort_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $bancontact_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $eps_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $sepa_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $p24_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $ideal_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $becs_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $affirm_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $afterpay_method->is_enabled_at_checkout( 'US' ) );
 	}
 
 	public function test_only_valid_payment_methods_returned_for_currency() {

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -1465,56 +1465,56 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'Credit card / debit card', $card_method->get_title() );
 		$this->assertEquals( 'Visa debit card', $card_method->get_title( $mock_visa_details ) );
 		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( $mock_mastercard_details ) );
-		$this->assertTrue( $card_method->is_enabled_at_checkout() );
+		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertTrue( $card_method->is_reusable() );
 		$this->assertEquals( $mock_token, $card_method->get_payment_token_for_user( $mock_user, $mock_payment_method_id ) );
 
 		$this->assertEquals( 'giropay', $giropay_method->get_id() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title( $mock_giropay_details ) );
-		$this->assertTrue( $giropay_method->is_enabled_at_checkout() );
+		$this->assertTrue( $giropay_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $giropay_method->is_reusable() );
 
 		$this->assertEquals( 'p24', $p24_method->get_id() );
 		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title() );
 		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title( $mock_p24_details ) );
-		$this->assertTrue( $p24_method->is_enabled_at_checkout() );
+		$this->assertTrue( $p24_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $p24_method->is_reusable() );
 
 		$this->assertEquals( 'sofort', $sofort_method->get_id() );
 		$this->assertEquals( 'Sofort', $sofort_method->get_title() );
 		$this->assertEquals( 'Sofort', $sofort_method->get_title( $mock_sofort_details ) );
-		$this->assertTrue( $sofort_method->is_enabled_at_checkout() );
+		$this->assertTrue( $sofort_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $sofort_method->is_reusable() );
 
 		$this->assertEquals( 'bancontact', $bancontact_method->get_id() );
 		$this->assertEquals( 'Bancontact', $bancontact_method->get_title() );
 		$this->assertEquals( 'Bancontact', $bancontact_method->get_title( $mock_bancontact_details ) );
-		$this->assertTrue( $bancontact_method->is_enabled_at_checkout() );
+		$this->assertTrue( $bancontact_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $bancontact_method->is_reusable() );
 
 		$this->assertEquals( 'eps', $eps_method->get_id() );
 		$this->assertEquals( 'EPS', $eps_method->get_title() );
 		$this->assertEquals( 'EPS', $eps_method->get_title( $mock_eps_details ) );
-		$this->assertTrue( $eps_method->is_enabled_at_checkout() );
+		$this->assertTrue( $eps_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $eps_method->is_reusable() );
 
 		$this->assertEquals( 'sepa_debit', $sepa_method->get_id() );
 		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title() );
 		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title( $mock_sepa_details ) );
-		$this->assertTrue( $sepa_method->is_enabled_at_checkout() );
+		$this->assertTrue( $sepa_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $sepa_method->is_reusable() );
 
 		$this->assertEquals( 'ideal', $ideal_method->get_id() );
 		$this->assertEquals( 'iDEAL', $ideal_method->get_title() );
 		$this->assertEquals( 'iDEAL', $ideal_method->get_title( $mock_ideal_details ) );
-		$this->assertTrue( $ideal_method->is_enabled_at_checkout() );
+		$this->assertTrue( $ideal_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $ideal_method->is_reusable() );
 
 		$this->assertEquals( 'au_becs_debit', $becs_method->get_id() );
 		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title() );
 		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title( $mock_becs_details ) );
-		$this->assertTrue( $becs_method->is_enabled_at_checkout() );
+		$this->assertTrue( $becs_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $becs_method->is_reusable() );
 	}
 
@@ -1533,15 +1533,15 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$ideal_method      = $this->mock_payment_methods['ideal'];
 		$becs_method       = $this->mock_payment_methods['au_becs_debit'];
 
-		$this->assertTrue( $card_method->is_enabled_at_checkout() );
-		$this->assertFalse( $giropay_method->is_enabled_at_checkout() );
-		$this->assertFalse( $sofort_method->is_enabled_at_checkout() );
-		$this->assertFalse( $bancontact_method->is_enabled_at_checkout() );
-		$this->assertFalse( $eps_method->is_enabled_at_checkout() );
-		$this->assertFalse( $sepa_method->is_enabled_at_checkout() );
-		$this->assertFalse( $p24_method->is_enabled_at_checkout() );
-		$this->assertFalse( $ideal_method->is_enabled_at_checkout() );
-		$this->assertFalse( $becs_method->is_enabled_at_checkout() );
+		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $giropay_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $sofort_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $bancontact_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $eps_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $sepa_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $p24_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $ideal_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $becs_method->is_enabled_at_checkout( 'US' ) );
 	}
 
 	public function test_only_valid_payment_methods_returned_for_currency() {


### PR DESCRIPTION
Fixes #7680 

#### Changes proposed in this Pull Request

Adds more granularity in amount limits for Klarna payment method settings currency limits per-merchant-country

#### Testing instructions

- For Klarna, Affirm, Afterpay
- For each supported country 
- For each supported currency
Check the availability in the checkout


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
