### PR TITLE
Fix saved card payment error on blocks checkout

### DIFF
--- a/changelog/fix-7700-card-testing-prevention-prevents-saved-card-payments-on-blocks-checkout
+++ b/changelog/fix-7700-card-testing-prevention-prevents-saved-card-payments-on-blocks-checkout
@@ -1,5 +1,4 @@
 Significance: patch
 Type: fix
-Comment: Fix card testing prevention enabling breaking saved card payments on blocks checkout
 
-
+Fix saved card payments not working on block checkout while card testing prevention is active

--- a/changelog/fix-7700-card-testing-prevention-prevents-saved-card-payments-on-blocks-checkout
+++ b/changelog/fix-7700-card-testing-prevention-prevents-saved-card-payments-on-blocks-checkout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix card testing prevention enabling breaking saved card payments on blocks checkout
+
+

--- a/client/checkout/blocks/fields.js
+++ b/client/checkout/blocks/fields.js
@@ -23,7 +23,7 @@ const WCPayFields = ( {
 	stripe,
 	elements,
 	billing: { billingData },
-	eventRegistration: { onPaymentProcessing, onCheckoutSuccess },
+	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 	shouldSavePayment,
 } ) => {
@@ -49,7 +49,7 @@ const WCPayFields = ( {
 	// When it's time to process the payment, generate a Stripe payment method object.
 	useEffect(
 		() =>
-			onPaymentProcessing( () => {
+			onPaymentSetup( () => {
 				if ( PAYMENT_METHOD_NAME_CARD !== activePaymentMethod ) {
 					return;
 				}

--- a/client/checkout/blocks/generate-payment-method.js
+++ b/client/checkout/blocks/generate-payment-method.js
@@ -11,7 +11,7 @@ import { PAYMENT_METHOD_NAME_CARD } from '../constants.js';
  * @param {Object} billingData The billing data, which was collected from the checkout block.
  * @param {string} fingerprint User fingerprint.
  *
- * @return {Object} The `onPaymentProcessing` response object, including a type and meta data/error message.
+ * @return {Object} The `onPaymentSetup` response object, including a type and meta data/error message.
  */
 const generatePaymentMethod = async (
 	api,

--- a/client/checkout/blocks/saved-token-handler.js
+++ b/client/checkout/blocks/saved-token-handler.js
@@ -18,7 +18,7 @@ export const SavedTokenHandler = ( {
 	} );
 
 	useEffect( () => {
-		return onPaymentSetup( async () => {
+		return onPaymentSetup( () => {
 			const fraudPreventionToken = document
 				.querySelector( '#wcpay-fraud-prevention-token' )
 				?.getAttribute( 'value' );

--- a/client/checkout/blocks/saved-token-handler.js
+++ b/client/checkout/blocks/saved-token-handler.js
@@ -1,15 +1,40 @@
 /**
  * Internal dependencies
  */
+import { useEffect } from 'react';
 import { usePaymentCompleteHandler } from './hooks';
+import { select } from '@wordpress/data';
+
+const { getPaymentMethodData } = select( 'wc/store/payment' );
 
 export const SavedTokenHandler = ( {
 	api,
 	stripe,
 	elements,
-	eventRegistration: { onCheckoutSuccess },
+	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 } ) => {
+	useEffect( () => {
+		onPaymentSetup( async () => {
+			const paymentMethodData = getPaymentMethodData();
+
+			const fraudPreventionToken = document
+				.querySelector( '#wcpay-fraud-prevention-token' )
+				?.getAttribute( 'value' );
+
+			return {
+				type: 'success',
+				meta: {
+					paymentMethodData: {
+						...paymentMethodData,
+						'wcpay-fraud-prevention-token':
+							fraudPreventionToken ?? '',
+					},
+				},
+			};
+		} );
+	}, [ onPaymentSetup ] );
+
 	// Once the server has completed payment processing, confirm the intent of necessary.
 	usePaymentCompleteHandler(
 		api,

--- a/client/checkout/blocks/saved-token-handler.js
+++ b/client/checkout/blocks/saved-token-handler.js
@@ -3,9 +3,7 @@
  */
 import { useEffect } from 'react';
 import { usePaymentCompleteHandler } from './hooks';
-import { select } from '@wordpress/data';
-
-const { getPaymentMethodData } = select( 'wc/store/payment' );
+import { useSelect } from '@wordpress/data';
 
 export const SavedTokenHandler = ( {
 	api,
@@ -14,10 +12,13 @@ export const SavedTokenHandler = ( {
 	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 } ) => {
+	const paymentMethodData = useSelect( ( select ) => {
+		const store = select( 'wc/store/payment' );
+		return store.getPaymentMethodData();
+	} );
+
 	useEffect( () => {
 		onPaymentSetup( async () => {
-			const paymentMethodData = getPaymentMethodData();
-
 			const fraudPreventionToken = document
 				.querySelector( '#wcpay-fraud-prevention-token' )
 				?.getAttribute( 'value' );
@@ -33,7 +34,7 @@ export const SavedTokenHandler = ( {
 				},
 			};
 		} );
-	}, [ onPaymentSetup ] );
+	}, [ onPaymentSetup, paymentMethodData ] );
 
 	// Once the server has completed payment processing, confirm the intent of necessary.
 	usePaymentCompleteHandler(

--- a/client/checkout/blocks/saved-token-handler.js
+++ b/client/checkout/blocks/saved-token-handler.js
@@ -18,7 +18,7 @@ export const SavedTokenHandler = ( {
 	} );
 
 	useEffect( () => {
-		onPaymentSetup( async () => {
+		return onPaymentSetup( async () => {
 			const fraudPreventionToken = document
 				.querySelector( '#wcpay-fraud-prevention-token' )
 				?.getAttribute( 'value' );

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -41,7 +41,7 @@ const WCPayUPEFields = ( {
 	activePaymentMethod,
 	billing: { billingData },
 	shippingData,
-	eventRegistration: { onPaymentProcessing, onCheckoutSuccess },
+	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 	paymentIntentId,
 	paymentIntentSecret,
@@ -135,7 +135,7 @@ const WCPayUPEFields = ( {
 	// When it's time to process the payment, generate a Stripe payment method object.
 	useEffect(
 		() =>
-			onPaymentProcessing( () => {
+			onPaymentSetup( () => {
 				if ( PAYMENT_METHOD_NAME_CARD !== activePaymentMethod ) {
 					return;
 				}

--- a/client/checkout/blocks/upe-split-fields.js
+++ b/client/checkout/blocks/upe-split-fields.js
@@ -45,7 +45,7 @@ const WCPayUPEFields = ( {
 	testingInstructions,
 	billing: { billingData },
 	shippingData,
-	eventRegistration: { onPaymentProcessing, onCheckoutSuccess },
+	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 	paymentMethodId,
 	upeMethods,
@@ -133,7 +133,7 @@ const WCPayUPEFields = ( {
 	// When it's time to process the payment, generate a Stripe payment method object.
 	useEffect(
 		() =>
-			onPaymentProcessing( () => {
+			onPaymentSetup( () => {
 				if ( upeMethods[ paymentMethodId ] !== activePaymentMethod ) {
 					return;
 				}


### PR DESCRIPTION
Fixes #7700

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This issue fixes the saved payment method payments on blocks checkout while card testing prevention measures are active for the store, by adding a payment preparation step that injects the required keys to the payment meta data.

Also updates the calls to `onPaymentProcessing` event with `onPaymentSetup` event, because the prior one will get deprecated soon, and will be replaced with the new event. 

Context: p1699875691276639/1699871439.948359-slack-C02TS23QJ1X
https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/block-client-apis/checkout/checkout-flow-and-events.md#onpaymentprocessing

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Go to WooPayments dashboard on MC, open the settings for your blog ID 
2. Set `card_testing_prevention_enabled` meta value to 1 
3. Connect to your local store to sandbox
4. On WCPay dev tools, connect your store to sandbox, refresh the account cache
5. Add a beanie and go to blocks checkout
6. Try to pay with a saved card.
7. See that it's not accepted.
8. Checkout this branch. 
9. Repeat steps 5-7, and see that payment is going through.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.