### PR TITLE
Bump tested up to WP 6.4

### DIFF
--- a/changelog/dev-update-tested-up-to-for-6-8-0
+++ b/changelog/dev-update-tested-up-to-for-6-8-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump tested up to version for WP to 6.4

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 7.3
 Stable tag: 6.7.1
 License: GPLv2 or later


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Since WP 6.4 has been released, this PR bumps the tested up to for it. No bumping for WC 8.3.0 since it hasn't been released yet.

#### Testing instructions

* Code changes make sense

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
