### PR TITLE
Update to not hardcode country/address on builder flow account creation.

### DIFF
--- a/changelog/dev-7678-dev-mode-country-cant-be-changed
+++ b/changelog/dev-7678-dev-mode-country-cant-be-changed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update to the new onboarding builder flow to not prefill country/address to US.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1330,17 +1330,6 @@ class WC_Payments_Account {
 			$account_data = [
 				'setup_mode'    => 'test',
 				'business_type' => 'individual',
-				'individual'    => [
-					'first_name' => 'John',
-					'last_name'  => 'Woolliams',
-					'ssn_last_4' => '0000',
-					'phone'      => '+10000000000',
-					'dob'        => [
-						'day'   => '1',
-						'month' => '1',
-						'year'  => '1980',
-					],
-				],
 				'mcc'           => '5734',
 				'url'           => $url,
 				'business_name' => get_bloginfo( 'name' ),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1329,18 +1329,10 @@ class WC_Payments_Account {
 			}
 			$account_data = [
 				'setup_mode'    => 'test',
-				'country'       => 'US',
 				'business_type' => 'individual',
 				'individual'    => [
 					'first_name' => 'John',
 					'last_name'  => 'Woolliams',
-					'address'    => [
-						'country'     => 'US',
-						'state'       => 'California',
-						'city'        => 'South San Francisco',
-						'line1'       => '1040 Grand Ave',
-						'postal_code' => '94080',
-					],
 					'ssn_last_4' => '0000',
 					'phone'      => '+10000000000',
 					'dob'        => [


### PR DESCRIPTION
Fixes #7678

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* We no longer prefill country/address in the KYC builder flow. While this takes a bit longer, it means users can test region-specific payment settings.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove your previous account from the DB on your local server `localhost:8087 (or set `account_type` to something other than `wcpay` to make the system not recognize the account).
* Run `npm run listen`
* Initiate the new KYC flow, click the Builder flow option.
* You should be redirected to Stripe. You should be able to complete the test onboarding. Some details may be prefilled. Country should be selectable.
* Onboard a US account and verify the onboarding is successful.
* Repeat the process, this time onboarding a different country e.g. a European country.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
