### PR TITLE
chore: change PRB default height

### DIFF
--- a/changelog/chore-change-prb-default-height
+++ b/changelog/chore-change-prb-default-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+chore: change PRB default height for new installations

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -40,11 +40,11 @@ const buttonSizeOptions = [
 	{
 		label: makeButtonSizeText(
 			__(
-				'Default {{helpText}}(40 px){{/helpText}}',
+				'Small {{helpText}}(40 px){{/helpText}}',
 				'woocommerce-payments'
 			)
 		),
-		value: 'default',
+		value: 'small',
 	},
 	{
 		label: makeButtonSizeText(

--- a/client/settings/express-checkout-settings/payment-request-button-preview.js
+++ b/client/settings/express-checkout-settings/payment-request-button-preview.js
@@ -56,7 +56,7 @@ const BrowserHelpText = () => {
 };
 
 const buttonSizeToPxMap = {
-	default: 40,
+	small: 40,
 	medium: 48,
 	large: 56,
 };
@@ -120,7 +120,7 @@ const PaymentRequestButtonPreview = () => {
 								theme: theme,
 								height: `${
 									buttonSizeToPxMap[ size ] ||
-									buttonSizeToPxMap.default
+									buttonSizeToPxMap.medium
 								}px`,
 								size,
 							} }
@@ -142,7 +142,7 @@ const PaymentRequestButtonPreview = () => {
 											theme: theme,
 											height: `${
 												buttonSizeToPxMap[ size ] ||
-												buttonSizeToPxMap.default
+												buttonSizeToPxMap.medium
 											}px`,
 										},
 									},

--- a/client/settings/express-checkout-settings/test/index.js
+++ b/client/settings/express-checkout-settings/test/index.js
@@ -24,7 +24,7 @@ jest.mock( '../../../data', () => ( {
 	useWooPayCustomMessage: jest.fn().mockReturnValue( [ 'test', jest.fn() ] ),
 	useWooPayStoreLogo: jest.fn().mockReturnValue( [ 'test', jest.fn() ] ),
 	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'buy' ] ),
-	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'default' ] ),
+	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'small' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
 	useWooPayLocations: jest
 		.fn()

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -24,7 +24,7 @@ jest.mock( '../../../data', () => ( {
 	usePaymentRequestEnabledSettings: jest.fn(),
 	usePaymentRequestLocations: jest.fn(),
 	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'buy' ] ),
-	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'default' ] ),
+	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'small' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
 	useWooPayEnabledSettings: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
@@ -147,7 +147,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		// confirm default values
 		expect( screen.getByLabelText( 'Buy with' ) ).toBeChecked();
-		expect( screen.getByLabelText( 'Default (40 px)' ) ).toBeChecked();
+		expect( screen.getByLabelText( 'Small (40 px)' ) ).toBeChecked();
 		expect( screen.getByLabelText( /Dark/ ) ).toBeChecked();
 	} );
 
@@ -191,7 +191,7 @@ describe( 'PaymentRequestSettings', () => {
 			setButtonTypeMock,
 		] );
 		usePaymentRequestButtonSize.mockReturnValue( [
-			'default',
+			'small',
 			setButtonSizeMock,
 		] );
 		usePaymentRequestButtonTheme.mockReturnValue( [

--- a/client/settings/express-checkout-settings/test/woopay-settings.test.js
+++ b/client/settings/express-checkout-settings/test/woopay-settings.test.js
@@ -94,7 +94,7 @@ describe( 'WooPaySettings', () => {
 		);
 
 		usePaymentRequestButtonSize.mockReturnValue(
-			getMockPaymentRequestButtonSize( [ 'default' ], jest.fn() )
+			getMockPaymentRequestButtonSize( [ 'small' ], jest.fn() )
 		);
 
 		usePaymentRequestButtonTheme.mockReturnValue(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -374,7 +374,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Size of the button displayed for Express Checkouts', 'woocommerce-payments' ),
 				'type'        => 'select',
 				'description' => __( 'Select the size of the button.', 'woocommerce-payments' ),
-				'default'     => 'default',
+				'default'     => 'medium',
 				'desc_tip'    => true,
 				'options'     => [
 					'default' => __( 'Default', 'woocommerce-payments' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -377,9 +377,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'medium',
 				'desc_tip'    => true,
 				'options'     => [
-					'default' => __( 'Default', 'woocommerce-payments' ),
-					'medium'  => __( 'Medium', 'woocommerce-payments' ),
-					'large'   => __( 'Large', 'woocommerce-payments' ),
+					'small'  => __( 'Small', 'woocommerce-payments' ),
+					'medium' => __( 'Medium', 'woocommerce-payments' ),
+					'large'  => __( 'Large', 'woocommerce-payments' ),
 				],
 			],
 			'platform_checkout_button_locations' => [

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -197,7 +197,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return '56';
 		}
 
-		// for the "default" and "catch-all" scenarios.
+		// for the "default"/"small" and "catch-all" scenarios.
 		return '40';
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -605,6 +605,7 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-track-upe-status.php';
 		require_once __DIR__ . '/migrations/class-delete-active-woopay-webhook.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Allowed_Payment_Request_Button_Sizes_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Track_Upe_Status', 'maybe_track' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_WooPay_Webhook', 'maybe_delete' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -601,6 +601,7 @@ class WC_Payments {
 		add_action( 'woocommerce_admin_field_payment_gateways', [ __CLASS__, 'hide_gateways_on_settings_page' ], 5 );
 
 		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-types-update.php';
+		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-sizes-update.php';
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-track-upe-status.php';
 		require_once __DIR__ . '/migrations/class-delete-active-woopay-webhook.php';

--- a/includes/migrations/class-allowed-payment-request-button-sizes-update.php
+++ b/includes/migrations/class-allowed-payment-request-button-sizes-update.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Class Allowed_Payment_Request_Button_Sizes_Update
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Migrations;
+
+use WC_Payment_Gateway_WCPay;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Allowed_Payment_Request_Button_Sizes_Update
+ *
+ * In version 6.9.0, the "default" size got renamed to "small" - ensure that the settings are up-to-date for existing merchants.
+ *
+ * @since 6.9.0
+ */
+class Allowed_Payment_Request_Button_Sizes_Update {
+
+	/**
+	 * Version in which this migration was introduced.
+	 *
+	 * @var string
+	 */
+	const VERSION_SINCE = '6.9.0';
+
+	/**
+	 * WCPay gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $gateway;
+
+	/**
+	 * Allowed_Payment_Request_Button_Sizes_Update constructor.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway.
+	 */
+	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Only execute the migration if not applied yet.
+	 */
+	public function maybe_migrate() {
+		$previous_version = get_option( 'woocommerce_woocommerce_payments_version' );
+		if ( version_compare( self::VERSION_SINCE, $previous_version, '>' ) ) {
+			$this->migrate();
+		}
+	}
+
+	/**
+	 * Does the actual migration as described in the class docblock.
+	 */
+	private function migrate() {
+		$button_size = $this->gateway->get_option( 'payment_request_button_size' );
+		if ( 'default' === $button_size ) {
+			$this->gateway->update_option(
+				'payment_request_button_size',
+				'small'
+			);
+		}
+
+	}
+}

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -624,14 +624,14 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_settings_saves_payment_request_button_size() {
-		$this->assertEquals( 'default', $this->gateway->get_option( 'payment_request_button_size' ) );
+		$this->assertEquals( 'medium', $this->gateway->get_option( 'payment_request_button_size' ) );
 
 		$request = new WP_REST_Request();
-		$request->set_param( 'payment_request_button_size', 'medium' );
+		$request->set_param( 'payment_request_button_size', 'default' );
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( 'medium', $this->gateway->get_option( 'payment_request_button_size' ) );
+		$this->assertEquals( 'default', $this->gateway->get_option( 'payment_request_button_size' ) );
 	}
 
 	public function test_update_settings_saves_payment_request_button_type() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1333,7 +1333,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->wcpay_gateway->get_option( 'payment_request_button_locations' )
 		);
 		$this->assertEquals(
-			'default',
+			'medium',
 			$this->wcpay_gateway->get_option( 'payment_request_button_size' )
 		);
 

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -252,7 +252,7 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 			[
 				'type'         => 'buy',
 				'theme'        => 'dark',
-				'height'       => '40',
+				'height'       => '48',
 				'locale'       => 'en',
 				'branded_type' => 'long',
 			],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

From p1699707588541559-slack-C043JN7AJHY

Changing the "default" value for new installations to "medium". No change in the labels is necessary.

Before:
![Screenshot 2023-11-14 at 8 47 28 AM](https://github.com/Automattic/woocommerce-payments/assets/273592/e76f96ac-58ac-4a5f-96c5-083adfbd10de)


After:
![Screenshot 2023-11-14 at 8 47 56 AM](https://github.com/Automattic/woocommerce-payments/assets/273592/600b3c0a-9ed4-400f-9315-8d0c38c56609)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to your WooPayments settings
- Go to the PRB settings for WooPay (or GooglePay/Apple Pay)
- Ensure you have a value different than "medium" pre-selected
- Go to the Dev Tools
- Delete all the WooPayments options via the "Delete saved WCPay Gateway settings" link
- Go back to the PRB settings page
- "medium" should be the newly selected value

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.