### PR TITLE
Silence QIT semgrep false positives

### DIFF
--- a/changelog/dev-silence-qit-false-positives
+++ b/changelog/dev-silence-qit-false-positives
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just silencing QIT false positives.
+
+

--- a/includes/admin/class-wc-rest-user-exists-controller.php
+++ b/includes/admin/class-wc-rest-user-exists-controller.php
@@ -40,6 +40,10 @@ class WC_REST_User_Exists_Controller extends WP_REST_Controller {
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
+			// Silence the nosemgrep audit rule because this controller (and its routes) is not being used.
+			// This file is only left to avoid plugin upgrade errors.
+			// See this issue for a permanent fix: https://github.com/Automattic/woocommerce-payments/issues/6304
+			// nosemgrep: audit.php.wp.security.rest-route.permission-callback.return-true -- reason: this controller is not being used.
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'user_exists' ],

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -149,6 +149,8 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 						$session_email = is_array( $customer ) && isset( $customer['email'] ) ? $customer['email'] : '';
 					}
 
+					// Silence the filter_input warning because we are sanitizing the input with sanitize_email().
+					// nosemgrep: audit.php.lang.misc.filter-input-no-filter
 					$user_email = sanitize_email( wp_unslash( filter_input( INPUT_POST, 'email' ) ) ) ?? $session_email;
 
 					$js_config['order_id']      = $order->get_id();

--- a/includes/multi-currency/CurrencySwitcherBlock.php
+++ b/includes/multi-currency/CurrencySwitcherBlock.php
@@ -149,6 +149,9 @@ class CurrencySwitcherBlock {
 		}
 
 		$widget_content .= '</select></div></form>';
+
+		// Silence XSS warning because we are manually constructing the content and escaping everything above.
+		// nosemgrep: audit.php.wp.security.xss.block-attr -- reason: we are manually constructing the content and escaping everything above.
 		return $widget_content;
 	}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

There are 3 false positive QIT warnings and errors (in the 6.8.0 state of the code) that I believe we should silence since they hamper the usefulness of the QIT release step and alarm folks unnecessarily. I checked and double-checked each situation and I believe we are safe to silence them.

#### Testing instructions

* The code changes make sense

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
