### PR TITLE
Show Payments menu sub-items only for merchants that completed KYC

### DIFF
--- a/changelog/fix-7705-hide-payments-menu-subitems-if-details-not-submitted
+++ b/changelog/fix-7705-hide-payments-menu-subitems-if-details-not-submitted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide payments menu sub-items for merchants haven't completed KYC

--- a/changelog/fix-7705-hide-payments-menu-subitems-if-details-not-submitted
+++ b/changelog/fix-7705-hide-payments-menu-subitems-if-details-not-submitted
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide payments menu sub-items for merchants haven't completed KYC

--- a/changelog/fix-7705-show-payments-menu-subitems-only-if-details-submitted
+++ b/changelog/fix-7705-show-payments-menu-subitems-only-if-details-submitted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show Payments menu sub-items only for merchants that completed KYC 

--- a/client/components/test-mode-notice/index.js
+++ b/client/components/test-mode-notice/index.js
@@ -145,7 +145,10 @@ export const getTopicDetails = ( topic ) => {
  * @return {string} The correct notice message.
  */
 export const getNoticeMessage = ( topic ) => {
-	const urlComponent = getPaymentsSettingsUrlComponent();
+	const { detailsSubmitted } = wcpaySettings.accountStatus;
+	const urlComponent = detailsSubmitted
+		? getPaymentsSettingsUrlComponent()
+		: '';
 
 	if ( detailsTopics.includes( topic ) ) {
 		return (

--- a/client/components/test-mode-notice/test/__snapshots__/index.js.snap
+++ b/client/components/test-mode-notice/test/__snapshots__/index.js.snap
@@ -231,3 +231,24 @@ exports[`Test mode notification Component is rendered correctly 14`] = `<div />`
 exports[`Test mode notification Component is rendered correctly 15`] = `<div />`;
 
 exports[`Test mode notification Component is rendered correctly 16`] = `<div />`;
+
+exports[`Test mode notification Returns right notice message without URL component 1`] = `
+<div>
+  <div
+    class="wcpay-test-mode-notice components-notice is-warning"
+  >
+    <div
+      class="components-notice__content"
+    >
+      <span>
+        WooPayments is in test mode.
+         
+        
+      </span>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/client/components/test-mode-notice/test/index.js
+++ b/client/components/test-mode-notice/test/index.js
@@ -21,6 +21,13 @@ jest.mock( 'utils', () => ( {
 } ) );
 
 describe( 'Test mode notification', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			accountStatus: {
+				detailsSubmitted: true,
+			},
+		};
+	} );
 	// Set up easy to use lists containing test inputs.
 	const listTopics = [
 		topics.transactions,
@@ -92,6 +99,17 @@ describe( 'Test mode notification', () => {
 			expect( getNoticeMessage( topic ) ).toStrictEqual( expected );
 		}
 	);
+
+	test( 'Returns right notice message without URL component', () => {
+		global.wcpaySettings.accountStatus.detailsSubmitted = false;
+		const topic = topics.overview;
+		isInTestMode.mockReturnValue( true );
+		const { container: testModeNotice } = render(
+			<TestModeNotice topic={ topic } />
+		);
+
+		expect( testModeNotice ).toMatchSnapshot();
+	} );
 
 	test.each( topicsWithTestMode )(
 		'Component is rendered correctly',

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -344,13 +344,14 @@ class WC_Payments_Admin {
 		global $submenu;
 
 		try {
-			$should_render_full_menu = $this->account->is_stripe_account_valid();
+			// Render full payments menu with sub-items only if the merchant completed the KYC (details_submitted = true).
+			$should_render_full_menu = $this->account->is_account_fully_onboarded();
 		} catch ( Exception $e ) {
-			// There is an issue with connection but render full menu anyways to provide access to settings.
-			$should_render_full_menu = true;
+			// There is an issue with connection, don't render full menu, user will get redirected to the connect page.
+			$should_render_full_menu = false;
 		}
 
-		$top_level_link = $should_render_full_menu ? '/payments/overview' : '/payments/connect';
+		$top_level_link = $this->account->is_stripe_connected() ? '/payments/overview' : '/payments/connect';
 
 		$menu_icon = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgdmVyc2lvbj0iMS4xIgogICBpZD0ic3ZnNjciCiAgIHNvZGlwb2RpOmRvY25hbWU9IndjcGF5X21lbnVfaWNvbi5zdmciCiAgIHdpZHRoPSI4NTIiCiAgIGhlaWdodD0iNjg0IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWUsIDIwMjEtMDUtMjQpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnM3MSIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzY5IgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tYm90dG9tPSIwIgogICAgIGlua3NjYXBlOnpvb209IjI1NiIKICAgICBpbmtzY2FwZTpjeD0iLTg0Ljg1NzQyMiIKICAgICBpbmtzY2FwZTpjeT0iLTgzLjI5NDkyMiIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjEzMTIiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iMTA4MSIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMTE2IgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyMDIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMCIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmc2NyIgLz4KICA8cGF0aAogICAgIHRyYW5zZm9ybT0ic2NhbGUoLTEsIDEpIHRyYW5zbGF0ZSgtODUwLCAwKSIKICAgICBkPSJNIDc2OCw4NiBWIDU5OCBIIDg0IFYgODYgWiBtIDAsNTk4IGMgNDgsMCA4NCwtMzggODQsLTg2IFYgODYgQyA4NTIsMzggODE2LDAgNzY4LDAgSCA4NCBDIDM2LDAgMCwzOCAwLDg2IHYgNTEyIGMgMCw0OCAzNiw4NiA4NCw4NiB6IE0gMzg0LDEyOCB2IDQ0IGggLTg2IHYgODQgaCAxNzAgdiA0NCBIIDM0MCBjIC0yNCwwIC00MiwxOCAtNDIsNDIgdiAxMjggYyAwLDI0IDE4LDQyIDQyLDQyIGggNDQgdiA0NCBoIDg0IHYgLTQ0IGggODYgViA0MjggSCAzODQgdiAtNDQgaCAxMjggYyAyNCwwIDQyLC0xOCA0MiwtNDIgViAyMTQgYyAwLC0yNCAtMTgsLTQyIC00MiwtNDIgaCAtNDQgdiAtNDQgeiIKICAgICBmaWxsPSIjYTJhYWIyIgogICAgIGlkPSJwYXRoNjUiIC8+Cjwvc3ZnPgo=';
 
@@ -377,7 +378,7 @@ class WC_Payments_Admin {
 			return;
 		}
 
-		if ( ! $should_render_full_menu ) {
+		if ( ! $this->account->is_stripe_connected() ) {
 			if ( WC_Payments_Utils::should_use_progressive_onboarding_flow() ) {
 				wc_admin_register_page(
 					[

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -239,6 +239,21 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Checks if the account has completed onboarding/KYC.
+	 * Returns true if the onboarding/KYC is completed.
+	 *
+	 * @return bool True if the account is connected and details are submitted, false otherwise.
+	 */
+	public function is_account_fully_onboarded(): bool {
+		if ( ! $this->is_stripe_connected() ) {
+			return false;
+		}
+
+		$account = $this->get_cached_account_data();
+		return true === $account['details_submitted'];
+	}
+
+	/**
 	 * Gets the account status data for rendering on the settings page.
 	 *
 	 * @return array An array containing the status data, or [ 'error' => true ] on error or no connected account.

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -149,7 +149,8 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		update_option( '_wcpay_feature_upe', $is_upe_enabled ? '1' : '0' );
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu['wc-admin&path=/payments/overview'], 0, 2 );
@@ -163,7 +164,8 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
@@ -175,8 +177,9 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		global $menu;
 		$this->mock_current_user_is_admin();
 
-		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( false );
+		// Make sure we render the menu without submenu items.
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( false );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( false );
 		update_option( 'wcpay_activation_timestamp', time() - ( 3 * DAY_IN_SECONDS ) );
 		$this->payments_admin->add_payments_menu();
 
@@ -189,8 +192,9 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		global $menu;
 		$this->mock_current_user_is_admin();
 
-		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( false );
+		// Make sure we render the menu without submenu items.
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( false );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( false );
 		update_option( 'wcpay_menu_badge_hidden', 'no' );
 		update_option( 'wcpay_activation_timestamp', time() - ( DAY_IN_SECONDS * 2 ) );
 		$this->payments_admin->add_payments_menu();
@@ -493,7 +497,8 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
@@ -534,7 +539,8 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
@@ -577,7 +583,8 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
@@ -622,7 +629,8 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'is_account_fully_onboarded' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls     = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );


### PR DESCRIPTION
Fixes #7705 

#### Changes proposed in this Pull Request

#### Testing instructions

**Pre-requisites**
* Checkout the branch `fix/7705-hide-payments-menu-subitems-if-details-not-submitted` 
* Ensure Progressive onboarding feature flag is enabled

**PO, new UX**
* Delete/mark as deleted current account if you have one
* Navigate to Payments Connect page
* Start onboarding account as a builder (I want to set up test payments)
* Leave the KYC at address step, ensure you get redirected to `payments/overview` page
* Check that you don't see `View WooPayments settings` link in the test mode banner.
* Check that you are not able to see the Settings page and any other pages like Transactions, Deposits etc inside payments menu
* Complete the KYC by clicking Finish setup on the overview page
* Check that now payment menu contains sub-items and test mode banner contains `View WooPayments settings` link
* Wait a bit until builder account becomes complete
* Go live: Click `I want to setup real payments` in the overview page
* Now pick merchant flow and PO params (go live now, small payments amount)
* Complete Stripe KYC for PO account (without deposits)
* Check that account has payments enabled, payment menu contains sub-items and test mode banner contains `View WooPayments settings` link
* Click Finish setting up, and proceed on the Stripe side by setting deposits
* Verify your account is complete (both payments and deposits)

**Non-PO, old UX**
* Disable Progressive Onboarding flag
* Delete/mark as deleted current account if you have one
* Navigate to Payments Connect page
* Get redirected to the Stripe KYC, leave it on the address step, ensure you get redirected to `payments/overview` page
* Check that you don't see `View WooPayments settings` link in the test mode banner.
* Check that you are not able to see the Settings page and any other pages like Transactions, Deposits etc inside payments menu
* Complete the KYC by clicking Finish setup on the overview page
* Check that now payment menu contains sub-items and test mode banner contains `View WooPayments settings` link
* Wait a bit until builder account becomes complete

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-6.9.0#show-payments-menu-sub-items-only-for-merchants-that-completed-kyc_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
