### PR TITLE
Revert "feat: add UPE appearance filter (#7578)"

### DIFF
--- a/changelog/feat-add-upe-appearance-filter
+++ b/changelog/feat-add-upe-appearance-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add UPE appearance filter.

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -553,7 +553,8 @@ export default class WCPayAPI {
 			_ajax_nonce: getConfig( 'saveUPEAppearanceNonce' ),
 		} )
 			.then( ( response ) => {
-				return response.data;
+				// There is not any action to take or harm caused by a failed update, so just returning success status.
+				return response.success;
 			} )
 			.catch( ( error ) => {
 				if ( error.message ) {

--- a/client/checkout/blocks/upe-deferred-intent-creation/payment-elements.js
+++ b/client/checkout/blocks/upe-deferred-intent-creation/payment-elements.js
@@ -24,11 +24,8 @@ const PaymentElements = ( { api, ...props } ) => {
 	useEffect( () => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance( true );
-			upeAppearance = await api.saveUPEAppearance(
-				upeAppearance,
-				'true'
-			);
+			const upeAppearance = getAppearance( true );
+			await api.saveUPEAppearance( upeAppearance, 'true' );
 			setAppearance( upeAppearance );
 		}
 

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -295,11 +295,8 @@ const ConsumableWCPayFields = ( { api, ...props } ) => {
 	useEffect( () => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance( true );
-			upeAppearance = await api.saveUPEAppearance(
-				upeAppearance,
-				'true'
-			);
+			const upeAppearance = getAppearance( true );
+			await api.saveUPEAppearance( upeAppearance, 'true' );
 
 			// Update appearance state
 			setAppearance( upeAppearance );

--- a/client/checkout/blocks/upe-split-fields.js
+++ b/client/checkout/blocks/upe-split-fields.js
@@ -301,11 +301,8 @@ const ConsumableWCPayFields = ( { api, ...props } ) => {
 	useEffect( () => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance( true );
-			upeAppearance = await api.saveUPEAppearance(
-				upeAppearance,
-				'true'
-			);
+			const upeAppearance = getAppearance( true );
+			await api.saveUPEAppearance( upeAppearance, 'true' );
 
 			// Update appearance state
 			setAppearance( upeAppearance );

--- a/client/checkout/classic/upe-deferred-intent-creation/payment-processing.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/payment-processing.js
@@ -41,13 +41,13 @@ for ( const paymentMethodType in getUPEConfig( 'paymentMethodsConfig' ) ) {
  * @param {Object} api The API object used to save the UPE configuration.
  * @return {Object} The appearance object for the UPE.
  */
-async function initializeAppearance( api ) {
-	const appearance = getUPEConfig( 'upeAppearance' );
-	if ( appearance ) {
-		return appearance;
+function initializeAppearance( api ) {
+	let appearance = getUPEConfig( 'upeAppearance' );
+	if ( ! appearance ) {
+		appearance = getAppearance();
+		api.saveUPEAppearance( appearance );
 	}
-
-	return await api.saveUPEAppearance( getAppearance() );
+	return appearance;
 }
 
 /**

--- a/client/checkout/classic/upe-deferred-intent-creation/test/payment-processing.test.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/test/payment-processing.test.js
@@ -266,13 +266,6 @@ describe( 'Stripe Payment Element mounting', () => {
 		} );
 
 		getUPEConfig.mockImplementation( ( argument ) => {
-			if (
-				argument === 'wcBlocksUPEAppearance' ||
-				argument === 'upeAppearance'
-			) {
-				return {};
-			}
-
 			if ( argument === 'currency' ) {
 				return 'eur';
 			}

--- a/client/checkout/classic/upe-split.js
+++ b/client/checkout/classic/upe-split.js
@@ -210,7 +210,8 @@ jQuery( function ( $ ) {
 		let appearance = getUPEConfig( 'upeAppearance' );
 
 		if ( ! appearance ) {
-			appearance = await api.saveUPEAppearance( getAppearance() );
+			appearance = getAppearance();
+			api.saveUPEAppearance( appearance );
 		}
 
 		const elements = api.getStripe().elements( {

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -244,7 +244,8 @@ jQuery( function ( $ ) {
 		let appearance = getConfig( 'upeAppearance' );
 
 		if ( ! appearance ) {
-			appearance = await api.saveUPEAppearance( getAppearance() );
+			appearance = getAppearance();
+			api.saveUPEAppearance( appearance );
 		}
 
 		elements = api.getStripe().elements( {

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1104,14 +1104,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			$is_blocks_checkout = isset( $_POST['is_blocks_checkout'] ) ? rest_sanitize_boolean( wc_clean( wp_unslash( $_POST['is_blocks_checkout'] ) ) ) : false;
 			$appearance         = isset( $_POST['appearance'] ) ? json_decode( wc_clean( wp_unslash( $_POST['appearance'] ) ) ) : null;
 
-			/**
-			 * This filter is only called on "save" of the appearance, to avoid calling it on every page load.
-			 * If you apply changes through this filter, you'll need to clear the transient data to see them at checkout.
-			 *
-			 * @since 6.8.0
-			 */
-			$appearance = apply_filters( 'wcpay_upe_appearance', $appearance, $is_blocks_checkout );
-
 			$appearance_transient = $is_blocks_checkout ? self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT : self::UPE_APPEARANCE_TRANSIENT;
 
 			if ( null !== $appearance ) {
@@ -1120,7 +1112,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			wp_send_json_success( $appearance, 200 );
 		} catch ( Exception $e ) {
-			// Send back error, so it can be displayed to the customer.
+			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(
 				[
 					'error' => [


### PR DESCRIPTION
This reverts commit 9907d387252af82f2a3600f84959c7569ab7881a / PR https://github.com/Automattic/woocommerce-payments/pull/7578.

@csmcneill  noticed that the filter isn't applied correctly when using code snippets, and in order to avoid any post-release issues, I'm reverting the changes to ensure a smooth release.

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
