### PR TITLE
Update subscriptions-core to 6.5.0

### DIFF
--- a/changelog/6.5.0-1
+++ b/changelog/6.5.0-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure proper backfilling of subscription metadata (i.e. dates and cache) to the postmeta table when HPOS is enabled and compatibility mode (data syncing) is turned on.

--- a/changelog/6.5.0-2
+++ b/changelog/6.5.0-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fetch and update the `_cancelled_email_sent` meta in a HPOS compatibile way.

--- a/changelog/6.5.0-3
+++ b/changelog/6.5.0-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Introduce a new wcs_get_subscription_grouping_key() function to generate a unique key for a subscription based on its billing schedule. This function uses the existing recurring cart key concept.

--- a/changelog/6.5.0-4
+++ b/changelog/6.5.0-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecate the WC_Subscriptions_Synchroniser::add_to_recurring_cart_key(). Use WC_Subscriptions_Synchroniser::add_to_recurring_product_grouping_key() instead.

--- a/changelog/subscriptions-core-6.5.0
+++ b/changelog/subscriptions-core-6.5.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update subscriptions-core to 6.5.0

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "automattic/jetpack-autoloader": "2.11.18",
         "automattic/jetpack-identity-crisis": "0.8.43",
         "automattic/jetpack-sync": "1.47.7",
-        "woocommerce/subscriptions-core": "6.4.0"
+        "woocommerce/subscriptions-core": "6.5.0"
     },
     "require-dev": {
         "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95d672ebb995c8245e0659d2e4d7db3d",
+    "content-hash": "45a4186c72ccc12c21580071f7821cc3",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -940,16 +940,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "6.4.0",
+            "version": "6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "a94c9aab6d47f32461974ed09a4d3cad590f25b0"
+                "reference": "19ca9b7cf2b48cba4abd6ecf811475382b9d6673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/a94c9aab6d47f32461974ed09a4d3cad590f25b0",
-                "reference": "a94c9aab6d47f32461974ed09a4d3cad590f25b0",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/19ca9b7cf2b48cba4abd6ecf811475382b9d6673",
+                "reference": "19ca9b7cf2b48cba4abd6ecf811475382b9d6673",
                 "shasum": ""
             },
             "require": {
@@ -960,7 +960,7 @@
                 "dave-liddament/sarb": "^1.1",
                 "phpunit/phpunit": "9.5.14",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
-                "yoast/phpunit-polyfills": "1.0.3"
+                "yoast/phpunit-polyfills": "1.1.0"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -990,10 +990,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/6.4.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/6.5.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2023-10-18T03:32:50+00:00"
+            "time": "2023-11-09T04:27:49+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR bumps the version of `subscriptions-core` from 6.4.0 to 6.5.0.
GitHub release: https://github.com/Automattic/woocommerce-subscriptions-core/releases/tag/6.5.0

Full changelog:
```
* Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
* Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.
* Fix - When processing an early renewal order, make sure the suspension count is reset back to 0 on payment complete.
* Fix - Ensure proper backfilling of subscription metadata (i.e. dates and cache) to the postmeta table when HPOS is enabled and compatibility mode (data syncing) is turned on.
* Fix - Fetch and update the `_cancelled_email_sent` meta in a HPOS compatibile way.
* Dev - Introduce a new wcs_get_subscription_grouping_key() function to generate a unique key for a subscription based on its billing schedule. This function uses the existing recurring cart key concept.
* Dev - Deprecate the WC_Subscriptions_Synchroniser::add_to_recurring_cart_key(). Use WC_Subscriptions_Synchroniser::add_to_recurring_product_grouping_key() instead.
```

Half of the changes we made to this subscriptions core version do not impact WooPayments merchants and so I've only added the changelog entries that are relevant.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch and run `composer install`
2. Inside `vendor/woocommerce/subscriptions-core` check changelog.txt file and confirm the version has been updated to 6.5.0

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 