### PR TITLE
Sanitize the Tracks properties

### DIFF
--- a/changelog/fix-tracks-sanitization
+++ b/changelog/fix-tracks-sanitization
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Sanitize Tracks properties
+
+

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -278,8 +278,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		$identity = $this->tracks_get_identity( $user->ID );
 		$site_url = get_option( 'siteurl' );
 
-		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$properties['_lg']       = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
+		$properties['_lg']       = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ): '';
 		$properties['blog_url']  = $site_url;
 		$properties['blog_id']   = \Jetpack_Options::get_option( 'id' );
 		$properties['user_lang'] = $user->get( 'WPLANG' );
@@ -290,7 +289,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 
 		// Add client's user agent to the event properties.
 		if ( !empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$properties['_via_ua']  = $_SERVER['HTTP_USER_AGENT'];
+			$properties['_via_ua'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
 		}
 
 		$blog_details = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sanitize Tracks properties to prevent warnings. These values are passed on to Tracks where the values are properly sanitized, this change is done primarily to prevent warnings.
 
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a breakpoint to https://github.com/Automattic/woocommerce-payments/blob/6cc373feeadbee8dbe9d7fd190b77cc2cb20c2a7/includes/class-woopay-tracker.php#L307
* Go through WooPay checkout
* Make sure the `_lg` and `_via_ua` keys in the `$properties` array has the equivalent values from `$_SERVER`. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
