### PR TITLE
Transaction detail render customer with falling back to order details

### DIFF
--- a/changelog/fix-7740-transaction-detail-render-customer-name-fallback
+++ b/changelog/fix-7740-transaction-detail-render-customer-name-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When rendering customer reference in transaction details, fallback to order data.

--- a/client/components/customer-link/index.tsx
+++ b/client/components/customer-link/index.tsx
@@ -13,9 +13,11 @@ import { getAdminUrl } from 'wcpay/utils';
 import { ChargeBillingDetails } from 'wcpay/types/charges';
 
 const CustomerLink = ( props: {
-	customer: null | ChargeBillingDetails;
+	billing_details: null | ChargeBillingDetails;
+	order_details: null | OrderDetails;
 } ): JSX.Element => {
-	const customer = props.customer;
+	// Regular case: charge is performed with WooPayments and intent has billing details populated.
+	const customer = props.billing_details;
 	if ( customer && customer.name ) {
 		const searchTerm = customer.email
 			? `${ customer.name } (${ customer.email })`
@@ -27,6 +29,21 @@ const CustomerLink = ( props: {
 		} );
 
 		return <Link href={ url }>{ customer.name }</Link>;
+	}
+
+	// Special case: charge is performed with a mobile app, and intent billing details are not populated.
+	const order = props.order_details;
+	if ( order && order.customer_name ) {
+		const searchTerm = order.customer_email
+			? `${ order.customer_name } (${ order.customer_email })`
+			: order.customer_name;
+		const url = getAdminUrl( {
+			page: 'wc-admin',
+			path: '/payments/transactions',
+			search: [ searchTerm ],
+		} );
+
+		return <Link href={ url }>{ order.customer_name }</Link>;
 	}
 
 	return <>&ndash;</>;

--- a/client/components/customer-link/index.tsx
+++ b/client/components/customer-link/index.tsx
@@ -16,34 +16,23 @@ const CustomerLink = ( props: {
 	billing_details: null | ChargeBillingDetails;
 	order_details: null | OrderDetails;
 } ): JSX.Element => {
-	// Regular case: charge is performed with WooPayments and intent has billing details populated.
-	const customer = props.billing_details;
-	if ( customer && customer.name ) {
-		const searchTerm = customer.email
-			? `${ customer.name } (${ customer.email })`
-			: customer.name;
+	// Depending on the transaction chanel, charge billing details might be missing, and we have to rely on order for those.
+	const name =
+		props.billing_details?.name ||
+		props.order_details?.customer_name ||
+		null;
+	if ( name ) {
+		const email =
+			props.billing_details?.email ||
+			props.order_details?.customer_email ||
+			null;
 		const url = getAdminUrl( {
 			page: 'wc-admin',
 			path: '/payments/transactions',
-			search: [ searchTerm ],
+			search: [ email ? `${ name } (${ email })` : name ],
 		} );
 
-		return <Link href={ url }>{ customer.name }</Link>;
-	}
-
-	// Special case: charge is performed with a mobile app, and intent billing details are not populated.
-	const order = props.order_details;
-	if ( order && order.customer_name ) {
-		const searchTerm = order.customer_email
-			? `${ order.customer_name } (${ order.customer_email })`
-			: order.customer_name;
-		const url = getAdminUrl( {
-			page: 'wc-admin',
-			path: '/payments/transactions',
-			search: [ searchTerm ],
-		} );
-
-		return <Link href={ url }>{ order.customer_name }</Link>;
+		return <Link href={ url }>{ name }</Link>;
 	}
 
 	return <>&ndash;</>;

--- a/client/components/customer-link/test/__snapshots__/index.tsx.snap
+++ b/client/components/customer-link/test/__snapshots__/index.tsx.snap
@@ -12,7 +12,18 @@ exports[`CustomerLink renders a dash if customer name is undefined 2`] = `
 </div>
 `;
 
-exports[`CustomerLink renders a link to a customer with name and email 1`] = `
+exports[`CustomerLink renders a link to a customer from billing details 1`] = `
+<div>
+  <a
+    data-link-type="wc-admin"
+    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Some%20Name%20(some%40email.com)"
+  >
+    Some Name
+  </a>
+</div>
+`;
+
+exports[`CustomerLink renders a link to a customer from order details 1`] = `
 <div>
   <a
     data-link-type="wc-admin"

--- a/client/components/customer-link/test/index.tsx
+++ b/client/components/customer-link/test/index.tsx
@@ -11,24 +11,46 @@ import React from 'react';
 import CustomerLink from '../';
 import { ChargeBillingDetails } from 'wcpay/types/charges';
 
-function renderCustomer( customer: ChargeBillingDetails ) {
-	return render( <CustomerLink customer={ customer } /> );
+function renderCustomer( customer: ChargeBillingDetails, order: OrderDetails ) {
+	return render(
+		<CustomerLink billing_details={ customer } order_details={ order } />
+	);
 }
 
 describe( 'CustomerLink', () => {
-	test( 'renders a link to a customer with name and email', () => {
-		const { container: customerLink } = renderCustomer( {
-			name: 'Some Name',
-			email: 'some@email.com',
-		} as any );
+	test( 'renders a link to a customer from billing details', () => {
+		const { container: customerLink } = renderCustomer(
+			{
+				name: 'Some Name',
+				email: 'some@email.com',
+			} as any,
+			null as any
+		);
+		expect( customerLink ).toMatchSnapshot();
+	} );
+
+	test( 'renders a link to a customer from order details', () => {
+		const { container: customerLink } = renderCustomer(
+			null as any,
+			{
+				customer_name: 'Some Name',
+				customer_email: 'some@email.com',
+			} as any
+		);
 		expect( customerLink ).toMatchSnapshot();
 	} );
 
 	test( 'renders a dash if customer name is undefined', () => {
-		const { container: customerLink1 } = renderCustomer( null as any );
+		const { container: customerLink1 } = renderCustomer(
+			null as any,
+			null as any
+		);
 		expect( customerLink1 ).toMatchSnapshot();
 
-		const { container: customerLink2 } = renderCustomer( {} as any );
+		const { container: customerLink2 } = renderCustomer(
+			{} as any,
+			{} as any
+		);
 		expect( customerLink2 ).toMatchSnapshot();
 	} );
 } );

--- a/client/data/payment-intents/test/hooks.ts
+++ b/client/data/payment-intents/test/hooks.ts
@@ -57,6 +57,8 @@ export const chargeMock: Charge = {
 		number: Number( '67' ),
 		url: 'http://order.url',
 		customer_url: 'customer.url',
+		customer_name: '',
+		customer_email: '',
 		subscriptions: [],
 	},
 	outcome: {
@@ -89,6 +91,8 @@ export const paymentIntentMock: PaymentIntent = {
 		number: 123,
 		url: 'http://order.url',
 		customer_url: 'customer.url',
+		customer_name: '',
+		customer_email: '',
 		fraud_meta_box_type: 'review',
 	},
 };

--- a/client/payment-details/order-details/test/index.test.tsx
+++ b/client/payment-details/order-details/test/index.test.tsx
@@ -65,6 +65,8 @@ const chargeFromOrderMock = {
 		url: 'http://wcpay.test/wp-admin/post.php?post=776&action=edit',
 		customer_url:
 			'admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=55',
+		customer_name: '',
+		customer_email: '',
 		subscriptions: [],
 		fraud_meta_box_type: 'succeeded',
 	},

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -125,7 +125,12 @@ const composePaymentSummaryItems = ( {
 		},
 		{
 			title: __( 'Customer', 'woocommerce-payments' ),
-			content: <CustomerLink customer={ charge.billing_details } />,
+			content: (
+				<CustomerLink
+					billing_details={ charge.billing_details }
+					order_details={ charge.order }
+				/>
+			),
 		},
 		{
 			title: __( 'Order', 'woocommerce-payments' ),

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -102,6 +102,8 @@ const getMockTransactions: () => Transaction[] = () => [
 			url: 'https://example.com/order/123',
 			// eslint-disable-next-line camelcase
 			customer_url: 'https://example.com/customer/my-name',
+			customer_name: '',
+			customer_email: '',
 		},
 		channel: 'online',
 		source_identifier: '1234',
@@ -131,6 +133,8 @@ const getMockTransactions: () => Transaction[] = () => [
 			url: 'https://example.com/order/125',
 			// eslint-disable-next-line camelcase
 			customer_url: 'https://example.com/customer/my-name',
+			customer_name: '',
+			customer_email: '',
 		},
 		channel: 'online',
 		source_identifier: '1234',
@@ -160,6 +164,8 @@ const getMockTransactions: () => Transaction[] = () => [
 			url: 'https://example.com/order/335',
 			// eslint-disable-next-line camelcase
 			customer_url: 'https://example.com/customer/my-name',
+			customer_name: '',
+			customer_email: '',
 		},
 		channel: 'in_person',
 		source_identifier: '1234',

--- a/client/types/orders.d.ts
+++ b/client/types/orders.d.ts
@@ -15,6 +15,8 @@ interface OrderDetails {
 	number: number;
 	url: string;
 	customer_url: null | string;
+	customer_email: null | string;
+	customer_name: null | string;
 	subscriptions?: SubscriptionDetails[];
 	fraud_meta_box_type?: string;
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2097,6 +2097,8 @@ class WC_Payments_API_Client {
 			'number'              => $order->get_order_number(),
 			'url'                 => $order->get_edit_order_url(),
 			'customer_url'        => $this->get_customer_url( $order ),
+			'customer_name'       => $order->get_formatted_billing_full_name(),
+			'customer_email'      => $order->get_billing_email(),
 			'fraud_meta_box_type' => $order->get_meta( '_wcpay_fraud_meta_box_type' ),
 		];
 


### PR DESCRIPTION
Fixes #7740 

#### Changes proposed in this Pull Request

When rendering transaction details, use order details as fallback to charge billing details for rendering customer details.

#### Testing instructions

* in `client/payment-details/summary/index.tsx` find usage of `CustomerLink` and simulate missing billing details with `billing_details={ null }`
* rebuild the client and open any transaction details, ensure customer name is rendered without changes

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
