### PR TITLE
chore: WooPay button translation improvment

### DIFF
--- a/changelog/chore-woopay-button-translation-improvement
+++ b/changelog/chore-woopay-button-translation-improvement
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor improvement on the WooPay button translation capability
+
+

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import classNames from 'classnames';
 
@@ -17,8 +17,16 @@ import { getConfig } from 'wcpay/utils/checkout';
 import request from 'wcpay/checkout/utils/request';
 import { showErrorMessage } from 'wcpay/checkout/woopay/express-button/utils';
 import { buildAjaxURL } from 'wcpay/payment-request/utils';
+import interpolateComponents from '@automattic/interpolate-components';
 
 const BUTTON_WIDTH_THRESHOLD = 140;
+
+const ButtonTypeTextMap = {
+	default: __( 'WooPay', 'woocommerce-payments' ),
+	buy: __( 'Buy with WooPay', 'woocommerce-payments' ),
+	donate: __( 'Donate with WooPay', 'woocommerce-payments' ),
+	book: __( 'Book with WooPay', 'woocommerce-payments' ),
+};
 
 export const WoopayExpressCheckoutButton = ( {
 	listenForCartChanges = {},
@@ -43,14 +51,10 @@ export const WoopayExpressCheckoutButton = ( {
 		buttonWidthTypes.wide
 	);
 
-	const text =
-		buttonType !== 'default'
-			? sprintf(
-					__( `%s with`, 'woocommerce-payments' ),
-					buttonType.charAt( 0 ).toUpperCase() +
-						buttonType.slice( 1 ).toLowerCase()
-			  )
-			: '';
+	const buttonText =
+		ButtonTypeTextMap[ buttonType || 'default' ] ??
+		ButtonTypeTextMap.default;
+
 	const ThemedWooPayIcon = theme === 'dark' ? WoopayIcon : WoopayIconLight;
 
 	const {
@@ -374,7 +378,7 @@ export const WoopayExpressCheckoutButton = ( {
 		<button
 			ref={ buttonRef }
 			key={ `${ buttonType }-${ theme }-${ size }` }
-			aria-label={ buttonType !== 'default' ? text : __( 'WooPay' ) }
+			aria-label={ buttonText }
 			onClick={ ( e ) => initWoopayRef.current( e ) }
 			className={ classNames( 'woopay-express-button', {
 				'is-loading': isLoading,
@@ -390,8 +394,15 @@ export const WoopayExpressCheckoutButton = ( {
 				<span className="wc-block-components-spinner" />
 			) : (
 				<>
-					{ text }
-					<ThemedWooPayIcon />
+					{ interpolateComponents( {
+						mixedString: buttonText.replace(
+							ButtonTypeTextMap.default,
+							'{{wooPayLogo /}}'
+						),
+						components: {
+							wooPayLogo: <ThemedWooPayIcon />,
+						},
+					} ) }
 				</>
 			) }
 		</button>


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the "Buy with WooPay"/"Donate with WooPay"/"Book with WooPay" strings are not translatable, due to the trickery we're doing. We're trying to capitalize an enum string, and this doesn't play nicely with translation services.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
