### PR TITLE
Pass the pay-for-order params to the first-party auth flow

### DIFF
--- a/changelog/fix-pass-pay-for-order-params-to-first-party-auth-flow
+++ b/changelog/fix-pass-pay-for-order-params-to-first-party-auth-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass the pay-for-order params to the first-party auth flow

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -18,6 +18,7 @@ import request from 'wcpay/checkout/utils/request';
 import { showErrorMessage } from 'wcpay/checkout/woopay/express-button/utils';
 import { buildAjaxURL } from 'wcpay/payment-request/utils';
 import interpolateComponents from '@automattic/interpolate-components';
+import { appendRedirectionParams } from 'wcpay/checkout/woopay/utils';
 
 const BUTTON_WIDTH_THRESHOLD = 140;
 
@@ -331,7 +332,9 @@ export const WoopayExpressCheckoutButton = ( {
 			}
 
 			if ( isSessionDataSuccess ) {
-				window.location.href = event.data.value.redirect_url;
+				window.location.href = appendRedirectionParams(
+					event.data.value.redirect_url
+				);
 			} else if ( isSessionDataError ) {
 				onClickFallback( null );
 


### PR DESCRIPTION
Fixes #7762

#### Changes proposed in this Pull Request
This PR passes the pay-for-order params to the first-party auth flow so we can get the pay-for-order order on WooPay.


#### Testing instructions
1. Enable the Pay-for-order flow for WooPay
2. Create a pay-for-order order with WooCommerce Pre-Orders
3. Open the pay-for-order order
4. Add a product to your cart
5. Click the WooPay button
6. You should see the pay-for-order params `pay_for_order`, `order_id`, `key`, and the `billing_email` passing to WooPay

#### Screenshots
|Before|After|
|-|-|
|<img width="992" alt="Screen Shot 2023-11-21 at 2 12 45 PM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/6f02329a-0ced-44a2-b73d-24a17698e0b8">|<img width="1448" alt="Screen Shot 2023-11-21 at 3 02 50 PM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/0b591eb0-f8f8-4774-a030-d6dfc710ec59">|

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
