### PR TITLE
Fix WooPay button location Tracks

### DIFF
--- a/changelog/fix-woopay-btn-location-updates
+++ b/changelog/fix-woopay-btn-location-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix a bug in WooPay button update Tracks

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -118,7 +118,7 @@ class WC_Payments_WooPay_Button_Handler {
 
 			$this->gateway->update_option( 'platform_checkout_button_locations', array_keys( $all_locations ) );
 
-			WC_Payments::woopay_tracker()->woopay_locations_updated( $all_locations, $all_locations );
+			WC_Payments::woopay_tracker()->woopay_locations_updated( $all_locations, array_keys( $all_locations ) );
 		}
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );


### PR DESCRIPTION
When a WCPay site is onboarded, on the latest version of WCPay, we enable the WooPay express button by default on all available pages. This is tracked by calling the `woopay_locations_updated` function, which expects a second parameter containing an array of enabled pages. However, we currently pass an associative array, which makes `woopay_locations_updated` not record the enabled pages as expected. This PR fixes it.

#### Changes proposed in this Pull Request
Pass the correct parameters when recording WooPay button updates on new merchants.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To simulate a new merchant site and access [this branch](https://github.com/Automattic/woocommerce-payments/blob/cce35cc1add4547ee28d96c922db64754987546a/includes/class-wc-payments-woopay-button-handler.php#L115), remove the `platform_checkout_button_locations` key from `woocommerce_woocommerce_payments_settings` option in your `wp_options` table.
* In your admin area, go to Payments -> Settings
* Click 'Customize' button in WooPay
* This should repopulate the `platform_checkout_button_locations` key with default options and record a new Tracks entry.
* In ~5 minutes, go to Tracks Live view in MC and search for `wcadmin_woopay_express_button_locations_updated` event
* Find the event from your local environment and make sure it has the `cart_enabled`, `checkout_enabled` and `product_enabled` props set to 1

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
