### PR TITLE
Buyer details reference: handle empty billing name.

### DIFF
--- a/changelog/fix-7740-customer-reference-rendering-no-name
+++ b/changelog/fix-7740-customer-reference-rendering-no-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When rendering customer reference on transaction details page, handle case with name being not provided in the order.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2097,7 +2097,7 @@ class WC_Payments_API_Client {
 			'number'              => $order->get_order_number(),
 			'url'                 => $order->get_edit_order_url(),
 			'customer_url'        => $this->get_customer_url( $order ),
-			'customer_name'       => $order->get_formatted_billing_full_name(),
+			'customer_name'       => trim( $order->get_formatted_billing_full_name() ),
 			'customer_email'      => $order->get_billing_email(),
 			'fraud_meta_box_type' => $order->get_meta( '_wcpay_fraud_meta_box_type' ),
 		];


### PR DESCRIPTION
Fixes #7740

#### Changes proposed in this Pull Request

As a followup of #7757, we handling the missing buer name case is `--` is getting displayed.

The problem we address is that how JS evaluates empty strings:

```
'' || null -> null
' ' || null -> ' ' 
```

And `' '` (space char) is due to how WooCommerce composes fill name.

#### Testing instructions

* CI checks shall pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
