### PR TITLE
Enable the new onboarding flow as default for all users

### DIFF
--- a/changelog/update-7738-enable-progressive-onboarding-as-default-flow
+++ b/changelog/update-7738-enable-progressive-onboarding-as-default-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Enable the new onboarding flow as default for all users

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -385,7 +385,7 @@ class WC_Payments_Admin {
 		}
 
 		if ( ! $this->account->is_stripe_connected() ) {
-			if ( WC_Payments_Utils::should_use_progressive_onboarding_flow() ) {
+			if ( WC_Payments_Utils::should_use_new_onboarding_flow() ) {
 				wc_admin_register_page(
 					[
 						'id'         => 'wc-payments-onboarding',

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -757,7 +757,7 @@ class WC_Payments_Account {
 			return false;
 		}
 
-		// Redirect directly to onboarding page if come from WC Admin task and are in treatment mode.
+		// Redirect directly to onboarding page if come from WC Admin task.
 		$http_referer = sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '' ) );
 		if ( 0 < strpos( $http_referer, 'task=payments' ) ) {
 			$this->redirect_to_onboarding_flow_page();
@@ -1885,7 +1885,7 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Redirects to the onboarding flow page if the Progressive Onboarding feature flag is enabled or in the experiment treatment mode.
+	 * Redirects to the onboarding flow page if the Progressive Onboarding is enabled (default experience).
 	 * Also checks if the server is connected and try to connect it otherwise.
 	 *
 	 * @return void

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -534,7 +534,7 @@ class WC_Payments_Account {
 		return [
 			'isEnabled'                   => $account['progressive_onboarding']['is_enabled'] ?? false,
 			'isComplete'                  => $account['progressive_onboarding']['is_complete'] ?? false,
-			'isNewFlowEnabled'            => WC_Payments_Utils::should_use_progressive_onboarding_flow(),
+			'isNewFlowEnabled'            => WC_Payments_Utils::should_use_new_onboarding_flow(),
 			'isEligibilityModalDismissed' => get_option( WC_Payments_Onboarding_Service::ONBOARDING_ELIGIBILITY_MODAL_OPTION, false ),
 		];
 	}
@@ -1885,13 +1885,13 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Redirects to the onboarding flow page if the Progressive Onboarding is enabled (default experience).
+	 * Redirects to the onboarding flow page.
 	 * Also checks if the server is connected and try to connect it otherwise.
 	 *
 	 * @return void
 	 */
 	private function redirect_to_onboarding_flow_page() {
-		if ( ! WC_Payments_Utils::should_use_progressive_onboarding_flow() ) {
+		if ( ! WC_Payments_Utils::should_use_new_onboarding_flow() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -21,7 +21,6 @@ class WC_Payments_Features {
 	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME = '_wcpay_feature_woopay_express_checkout';
 	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME = '_wcpay_feature_woopay_first_party_auth';
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
-	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
 	const PAY_FOR_ORDER_FLOW                = '_wcpay_feature_pay_for_order_flow';
 	const DEFERRED_UPE_SERVER_FLAG_NAME     = 'is_deferred_intent_creation_upe_enabled';
 	const DISPUTE_ISSUER_EVIDENCE           = '_wcpay_feature_dispute_issuer_evidence';
@@ -355,15 +354,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether Progressive Onboarding is enabled.
-	 *
-	 * @return bool
-	 */
-	public static function is_progressive_onboarding_enabled(): bool {
-		return '1' === get_option( self::PROGRESSIVE_ONBOARDING_FLAG_NAME, '0' );
-	}
-
-	/**
 	 * Checks whether the Fraud and Risk Tools feature flag is enabled.
 	 *
 	 * @return  bool
@@ -470,7 +460,6 @@ class WC_Payments_Features {
 				'clientSecretEncryption'         => self::is_client_secret_encryption_enabled(),
 				'woopayExpressCheckout'          => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled'        => self::is_auth_and_capture_enabled(),
-				'progressiveOnboarding'          => self::is_progressive_onboarding_enabled(),
 				'isPayForOrderFlowEnabled'       => self::is_pay_for_order_flow_enabled(),
 				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 				'isRefundControlsEnabled'        => self::is_streamline_refunds_enabled(),

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -728,12 +728,12 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Helper function to check whether to show default progressive onboarding experience or as an expection disable it (if specific constant is set) .
+	 * Helper function to check whether to show default new onboarding flow or as an exception disable it (if specific constant is set) .
 	 *
 	 * @return boolean
 	 */
-	public static function should_use_progressive_onboarding_flow(): bool {
-		if ( defined( 'WCPAY_DISABLE_PO' ) && WCPAY_DISABLE_PO ) {
+	public static function should_use_new_onboarding_flow(): bool {
+		if ( defined( 'WCPAY_DISABLE_NEW_ONBOARDING' ) && WCPAY_DISABLE_NEW_ONBOARDING ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -728,17 +728,16 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Helper function to check whether the user is either in the PO experiment, or has manually enabled PO via the dev tools.
-	 * TODO GH-7738 update the logic
+	 * Helper function to check whether to show default progressive onboarding experience or as an expection disable it (if specific constant is set) .
 	 *
 	 * @return boolean
 	 */
 	public static function should_use_progressive_onboarding_flow(): bool {
-		if ( self::is_in_progressive_onboarding_treatment_mode() || WC_Payments_Features::is_progressive_onboarding_enabled() ) {
-			return true;
+		if ( defined( 'WCPAY_DISABLE_PO' ) && WCPAY_DISABLE_PO ) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	/**
@@ -748,26 +747,6 @@ class WC_Payments_Utils {
 	 */
 	public static function force_disconnected_enabled(): bool {
 		return '1' === get_option( self::FORCE_DISCONNECTED_FLAG_NAME, '0' );
-	}
-
-	/**
-	 * Check to see if the current user is in progressive onboarding experiment treatment mode.
-	 * TODO GH-7738 cleanup experiment logic
-	 *
-	 * @return bool
-	 */
-	public static function is_in_progressive_onboarding_treatment_mode(): bool {
-		if ( ! isset( $_COOKIE['tk_ai'] ) ) {
-			return false;
-		}
-
-		$abtest = new \WCPay\Experimental_Abtest(
-			sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ),
-			'woocommerce',
-			'yes' === get_option( 'woocommerce_allow_tracking' )
-		);
-
-		return 'treatment' === $abtest->get_variation( 'woocommerce_payments_onboarding_progressive_express_2023_v3' );
 	}
 
 	/**

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -729,6 +729,7 @@ class WC_Payments_Utils {
 
 	/**
 	 * Helper function to check whether the user is either in the PO experiment, or has manually enabled PO via the dev tools.
+	 * TODO GH-7738 update the logic
 	 *
 	 * @return boolean
 	 */
@@ -751,6 +752,7 @@ class WC_Payments_Utils {
 
 	/**
 	 * Check to see if the current user is in progressive onboarding experiment treatment mode.
+	 * TODO GH-7738 cleanup experiment logic
 	 *
 	 * @return bool
 	 */

--- a/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js
@@ -11,12 +11,10 @@ import { merchantWCP, uiLoaded } from '../../../utils';
 describe( 'Admin merchant progressive onboarding', () => {
 	beforeAll( async () => {
 		await merchant.login();
-		await merchantWCP.enableProgressiveOnboarding();
 		await merchantWCP.enableActAsDisconnectedFromWCPay();
 	} );
 
 	afterAll( async () => {
-		await merchantWCP.disableProgressiveOnboarding();
 		await merchantWCP.disableActAsDisconnectedFromWCPay();
 		await merchant.logout();
 	} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -462,46 +462,6 @@ export const merchantWCP = {
 		} );
 	},
 
-	enableProgressiveOnboarding: async () => {
-		await page.goto( WCPAY_DEV_TOOLS, {
-			waitUntil: 'networkidle0',
-		} );
-
-		if (
-			! ( await page.$(
-				'#_wcpay_feature_progressive_onboarding:checked'
-			) )
-		) {
-			await expect( page ).toClick(
-				'label[for="_wcpay_feature_progressive_onboarding"]'
-			);
-		}
-
-		await expect( page ).toClick( 'input#submit' );
-		await page.waitForNavigation( {
-			waitUntil: 'networkidle0',
-		} );
-	},
-
-	disableProgressiveOnboarding: async () => {
-		await page.goto( WCPAY_DEV_TOOLS, {
-			waitUntil: 'networkidle0',
-		} );
-
-		if (
-			await page.$( '#_wcpay_feature_progressive_onboarding:checked' )
-		) {
-			await expect( page ).toClick(
-				'label[for="_wcpay_feature_progressive_onboarding"]'
-			);
-		}
-
-		await expect( page ).toClick( 'input#submit' );
-		await page.waitForNavigation( {
-			waitUntil: 'networkidle0',
-		} );
-	},
-
 	enableActAsDisconnectedFromWCPay: async () => {
 		await page.goto( WCPAY_DEV_TOOLS, {
 			waitUntil: 'networkidle0',

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -25,7 +25,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		'_wcpay_feature_customer_multi_currency'  => 'multiCurrency',
 		'_wcpay_feature_documents'                => 'documents',
 		'_wcpay_feature_auth_and_capture'         => 'isAuthAndCaptureEnabled',
-		'_wcpay_feature_progressive_onboarding'   => 'progressiveOnboarding',
 		'is_deferred_intent_creation_upe_enabled' => 'upeDeferred',
 	];
 
@@ -233,7 +232,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_woopay_express_checkout_enabled_returns_false_when_woopay_eligible_is_false() {
 		add_filter(
-			'pre_option_' . WC_Payments_Features::PROGRESSIVE_ONBOARDING_FLAG_NAME,
+			'pre_option_' . WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME,
 			function ( $pre_option, $option, $default ) {
 				return '1';
 			},
@@ -242,35 +241,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		);
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
 		$this->assertFalse( WC_Payments_Features::is_woopay_express_checkout_enabled() );
-	}
-
-	public function test_is_progressive_onboarding_enabled_returns_true() {
-		add_filter(
-			'pre_option_' . WC_Payments_Features::PROGRESSIVE_ONBOARDING_FLAG_NAME,
-			function ( $pre_option, $option, $default ) {
-				return '1';
-			},
-			10,
-			3
-		);
-		$this->assertTrue( WC_Payments_Features::is_progressive_onboarding_enabled() );
-	}
-
-	public function test_is_progressive_onboarding_enabled_returns_false_when_flag_is_false() {
-		add_filter(
-			'pre_option_' . WC_Payments_Features::PROGRESSIVE_ONBOARDING_FLAG_NAME,
-			function ( $pre_option, $option, $default ) {
-				return '0';
-			},
-			10,
-			3
-		);
-		$this->assertFalse( WC_Payments_Features::is_progressive_onboarding_enabled() );
-		$this->assertArrayNotHasKey( 'progressiveOnboarding', WC_Payments_Features::to_array() );
-	}
-
-	public function test_is_progressive_onboarding_enabled_returns_false_when_flag_is_not_set() {
-		$this->assertFalse( WC_Payments_Features::is_progressive_onboarding_enabled() );
 	}
 
 	public function test_deferred_upe_enabled_with_sepa() {


### PR DESCRIPTION
Fixes #7738

#### Changes proposed in this Pull Request

* Clean up from experiment/treatment code
* Make progressive onboarding default way
* As a last resort, support `WCPAY_DISABLE_NEW_ONBOARDING` constant to go with the old flow.

#### Testing instructions

* Check out the branch `update/7738-enable-progressive-onboarding-as-default-flow`
* Delete / mark as deleted current account if you have one
* Disable Progressive Onboarding feature flag (shouldn't be used now for decision)
* Onboard new account, you should see new UX flow and be able to onboard progressively if you select `Individual`, `My store is already live` and `Less than $250k`
* Set up deposits
* Verify that account is now complete
* Delete / mark as deleted current account
* In `woocommerce-payments.php` or `wp-config.php`, set `WCPAY_DISABLE_NEW_ONBOARDING ` constant to `true` with `define( 'WCPAY_DISABLE_NEW_ONBOARDING', true );`
* Onboard new account, you should be able to see old flow and onboard using that.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
