### PR TITLE
Allow requests with IDs to be extended

### DIFF
--- a/changelog/fix-7508-request-extension
+++ b/changelog/fix-7508-request-extension
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Allow requests with item IDs to be extended without exceptions.

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -460,7 +460,7 @@ abstract class Request {
 				'wcpay_core_extend_class_incorrectly'
 			);
 		}
-		$obj = new $current_class( $base_request->api_client, $base_request->http_interface );
+		$obj = new $current_class( $base_request->api_client, $base_request->http_interface, $base_request->id );
 		$obj->set_params( array_merge( static::DEFAULT_PARAMS, $base_request->params ) );
 
 		// Carry over the base class and protected mode into the child request.

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -460,7 +460,7 @@ abstract class Request {
 				'wcpay_core_extend_class_incorrectly'
 			);
 		}
-		$obj = new $current_class( $base_request->api_client, $base_request->http_interface, $base_request->id );
+		$obj = new $current_class( $base_request->api_client, $base_request->http_interface, $base_request->id ?? null );
 		$obj->set_params( array_merge( static::DEFAULT_PARAMS, $base_request->params ) );
 
 		// Carry over the base class and protected mode into the child request.

--- a/tests/unit/core/server/request/test-class-core-request.php
+++ b/tests/unit/core/server/request/test-class-core-request.php
@@ -8,6 +8,7 @@
 use WCPay\Core\Server\Request;
 use WCPay\Core\Server\Request\Paginated;
 use WCPay\Core\Server\Request\List_Transactions;
+use WCPay\Core\Server\Request\Update_Intention;
 
 // phpcs:disable
 class My_Request extends Request {
@@ -53,6 +54,10 @@ class Another_ThirdParty_Request extends WooPay_Request {
 	public function set_param_4( int $value ) {
 		$this->set_param( 'param_4', $value );
 	}
+}
+
+class Request_With_Id extends Update_Intention {
+
 }
 // phpcs:enable
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
@@ -133,5 +138,22 @@ class WCPay_Core_Request_Test extends WCPAY_UnitTestCase {
 			],
 			$result
 		);
+	}
+
+	public function test_extension_works_with_ids() {
+		$intent_id = 'pi_XYZ';
+		$hook      = 'some_request_class_with_id';
+		$base      = Update_Intention::create( $intent_id );
+
+		add_filter(
+			$hook,
+			function( $base ) {
+				return Request_With_Id::extend( $base );
+			}
+		);
+
+		$filtered = $base->apply_filters( $hook );
+		$this->assertInstanceOf( Request_With_Id::class, $filtered );
+		$this->assertStringContainsString( $intent_id, $filtered->get_api() );
 	}
 }


### PR DESCRIPTION
Fixes #7508

#### Changes proposed in this Pull Request

Allow requests with IDs to be extended without triggering an exception. Without this PR, this is how requests get created during extension:

https://github.com/Automattic/woocommerce-payments/blob/287990726914e93078e5af4207498136206d59a4/includes/core/server/class-request.php#L463-L464

As you can notice, the third constructor parameter (ID) was being skipped. This causes requests that require IDs to immediately throw an exception, because if a `set_id()` method exists within the class, the parameter is automatically verified.

This PR simply adds the `$id` parameter.

#### Testing instructions

The description in https://github.com/Automattic/woocommerce-payments/issues/7508 is pretty good, and recommended.

The easiest way to understand the issue would be to to undo the fix from `class-request.php` and run the test: You will immediately see the problematic exception.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply)