### PR TITLE
Pass the pay-for-order params to get the pre-fetch session data.

### DIFF
--- a/changelog/fix-pay-for-order-and-first-party-auth-compatibility
+++ b/changelog/fix-pay-for-order-and-first-party-auth-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass the pay-for-order params to get the pre-fetch session data

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -89,6 +89,12 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					return 'woopay.url';
 				case 'woopaySessionNonce':
 					return 'sessionnonce';
+				case 'billing_email':
+					return 'test@test.com';
+				case 'key':
+					return 'testkey';
+				case 'order_id':
+					return 1;
 				default:
 					return 'foo';
 			}
@@ -116,6 +122,12 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					return 'woopay.url';
 				case 'woopaySessionNonce':
 					return 'sessionnonce';
+				case 'billing_email':
+					return 'test@test.com';
+				case 'key':
+					return 'testkey';
+				case 'order_id':
+					return 1;
 				default:
 					return 'foo';
 			}

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -311,6 +311,9 @@ export const WoopayExpressCheckoutButton = ( {
 						),
 						{
 							_ajax_nonce: getConfig( 'woopaySessionNonce' ),
+							order_id: getConfig( 'order_id' ),
+							key: getConfig( 'key' ),
+							billing_email: getConfig( 'billing_email' ),
 						}
 					)
 						.then( ( response ) => {


### PR DESCRIPTION
Fixes #7796 

#### Changes proposed in this Pull Request
This PR passes the pay-for-order params to get the pre-fetch session data.

#### Testing instructions
1. Enable the Pay-for-order flow for WooPay
2. Create a pay-for-order order with WooCommerce Pre-Orders
3. Open the pay-for-order order and click on the WooPay button
4. We should be redirected to the WooPay checkout page and using the first-party auth flow

Note: You should see the checkout error.

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
