### PR TITLE
Use supported countries instead of business types for PO

### DIFF
--- a/changelog/update-6841-supported-countries-fallback
+++ b/changelog/update-6841-supported-countries-fallback
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Update PO onboarding country source to use available countries.
+
+

--- a/client/onboarding/steps/business-details.tsx
+++ b/client/onboarding/steps/business-details.tsx
@@ -14,14 +14,19 @@ import {
 	OnboardingSelectField,
 	OnboardingTextField,
 } from '../form';
-import { getBusinessTypes, getMccsFlatList } from 'onboarding/utils';
+import {
+	getAvailableCountries,
+	getBusinessTypes,
+	getMccsFlatList,
+} from 'onboarding/utils';
 import { BusinessType } from 'onboarding/types';
 
 const BusinessDetails: React.FC = () => {
 	const { data, setData } = useOnboardingContext();
-	const countries = getBusinessTypes();
+	const countries = getAvailableCountries();
+	const businessTypes = getBusinessTypes();
 
-	const selectedCountry = countries.find(
+	const selectedCountry = businessTypes.find(
 		( country ) => country.key === data.country
 	);
 	const selectedBusinessType = selectedCountry?.types.find(

--- a/client/onboarding/steps/test/business-details.tsx
+++ b/client/onboarding/steps/test/business-details.tsx
@@ -12,14 +12,39 @@ import { mocked } from 'ts-jest/utils';
 import BusinessDetails from '../business-details';
 import { OnboardingContextProvider } from '../../context';
 import strings from '../../strings';
-import { getBusinessTypes, getMccsFlatList } from 'onboarding/utils';
+import {
+	getAvailableCountries,
+	getBusinessTypes,
+	getMccsFlatList,
+} from 'onboarding/utils';
 
 jest.mock( 'onboarding/utils', () => ( {
+	getAvailableCountries: jest.fn(),
 	getBusinessTypes: jest.fn(),
 	getMccsFlatList: jest.fn(),
 } ) );
 
 const countries = [
+	{
+		key: 'ES',
+		name: 'Spain',
+		types: [],
+	},
+	{
+		key: 'US',
+		name: 'United States',
+		types: [],
+	},
+	{
+		key: 'FR',
+		name: 'France',
+		types: [],
+	},
+];
+
+mocked( getAvailableCountries ).mockReturnValue( countries );
+
+const businessTypes = [
 	{
 		key: 'US',
 		name: 'United States',
@@ -73,7 +98,7 @@ const countries = [
 	},
 ];
 
-mocked( getBusinessTypes ).mockReturnValue( countries );
+mocked( getBusinessTypes ).mockReturnValue( businessTypes );
 
 const mccsFlatList = [
 	{
@@ -167,6 +192,13 @@ describe( 'BusinessDetails', () => {
 		).not.toBeInTheDocument();
 		expect(
 			screen.queryByText( strings.placeholders[ 'company.structure' ] )
+		).not.toBeInTheDocument();
+
+		user.click( countryField );
+		user.click( screen.getByText( 'Spain' ) );
+
+		expect(
+			screen.queryByText( strings.placeholders.business_type )
 		).not.toBeInTheDocument();
 
 		user.click( countryField );

--- a/client/onboarding/utils.ts
+++ b/client/onboarding/utils.ts
@@ -19,6 +19,11 @@ export const fromDotNotation = (
 		return value != null ? set( result, key, value ) : result;
 	}, {} );
 
+export const getAvailableCountries = (): Country[] =>
+	Object.entries( wcpaySettings?.connect.availableCountries || [] )
+		.map( ( [ key, name ] ) => ( { key, name, types: [] } ) )
+		.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+
 export const getBusinessTypes = (): Country[] => {
 	const data = wcpaySettings?.onboardingFieldsData?.business_types;
 


### PR DESCRIPTION
Fixes #6841 

#### Changes proposed in this Pull Request
- Update PO business details step and utils to use countries from [`supported_countries`](https://github.com/Automattic/woocommerce-payments/blob/10d1cb52ed2162800d8a06c5a30632c1cba67538/includes/class-wc-payments-utils.php#L224) instead of [`get_business_types`](https://github.com/Automattic/woocommerce-payments/blob/10d1cb52ed2162800d8a06c5a30632c1cba67538/includes/class-wc-payments-onboarding-service.php#L105), to prevent missing a country while onboarding due to it not being added to the server.
- Ensure that's possible to onboard without providing a business type. The field will be hidden when you choose a country without type information.

Regarding this part of the issue:
>we can just not prompt the user for business information (and possibly alert ourselves to this so we can add the country!)

I've been thinking about it, and trying a couple of approaches, but I don't see a good way to properly warn us from the client.  A track event could be an option, but I don't think it's the way to do it. In the end, it will not alert us directly. It will be probably better to ensure we only have a single source of truth for supported countries in the server, rather than trying to cover these gaps with alerts or fallbacks, WDYT? 🤔 

#### Testing instructions
- If you have an account onboarded, be sure to enable `Force the WCPay plugin to act as disconnected from the WCPay Server` in WCPay Dev, and PO onboarding.
- Edit [`supported_countries`](https://github.com/Automattic/woocommerce-payments/blob/10d1cb52ed2162800d8a06c5a30632c1cba67538/includes/class-wc-payments-utils.php#L224) to add a new country, for example: `'AD' => __( 'Andorra', 'woocommerce-payments' ),`
- Proceed with the PO onboarding form until the business details step.
- Pick `United States` in the country field.
- The business type field should be visible.
- Pick the new country in the country field.
- The business type field shouldn't be visible.
- It should be possible to proceed with the onboarding.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
