### PR TITLE
Add connect page non supported country banner 

### DIFF
--- a/changelog/add-7699-non-supported-country-banner
+++ b/changelog/add-7699-non-supported-country-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Display an error banner on the connect page when the WooCommerce country is not supported.

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -23,6 +23,7 @@ import scheduled from 'gridicons/dist/scheduled';
  */
 import wcpayTracks from 'tracks';
 import Page from 'components/page';
+import BannerNotice from 'components/banner-notice';
 import PaymentMethods from './payment-methods';
 import Incentive from './incentive';
 import InfoNotice from './info-notice-modal';
@@ -45,6 +46,8 @@ const ConnectAccountPage: React.FC = () => {
 		connectUrl,
 		connect: { availableCountries, country },
 	} = wcpaySettings;
+
+	const isCountrySupported = !! availableCountries[ country ];
 
 	useEffect( () => {
 		wcpayTracks.recordEvent( wcpayTracks.events.CONNECT_ACCOUNT_VIEW, {
@@ -125,7 +128,7 @@ const ConnectAccountPage: React.FC = () => {
 		}
 
 		// Inform the merchant if country specified in business address is not yet supported, but allow to proceed.
-		if ( ! availableCountries[ country ] ) {
+		if ( ! isCountrySupported ) {
 			return handleLocationCheck();
 		}
 
@@ -149,6 +152,11 @@ const ConnectAccountPage: React.FC = () => {
 				</Card>
 			) : (
 				<>
+					{ ! isCountrySupported && (
+						<BannerNotice status="error" isDismissible={ false }>
+							{ strings.nonSupportedCountry }
+						</BannerNotice>
+					) }
 					<Card>
 						<div className="connect-account-page__heading">
 							<img src={ LogoImg } alt="logo" />

--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -286,9 +286,13 @@ export default {
 		),
 	},
 	nonSupportedCountry: createInterpolateElement(
-		__(
-			'<b>WooPayments is not currently available in your location</b>. To be eligible for WooPayments, your business address must be in one of the following <a>supported countries</a>.',
-			'woocommerce-payments'
+		sprintf(
+			/* translators: %1$s: WooPayments */
+			__(
+				'<b>%1$s is not currently available in your location</b>. To be eligible for %1$s, your business address must be in one of the following <a>supported countries</a>.',
+				'woocommerce-payments'
+			),
+			'WooPayments'
 		),
 		{
 			b: <b />,

--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -285,4 +285,21 @@ export default {
 			'woocommerce-payments'
 		),
 	},
+	nonSupportedCountry: createInterpolateElement(
+		__(
+			'<b>WooPayments is not currently available in your location</b>. To be eligible for WooPayments, your business address must be in one of the following <a>supported countries</a>.',
+			'woocommerce-payments'
+		),
+		{
+			b: <b />,
+			a: (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				<a
+					href="https://woo.com/document/woopayments/compatibility/countries/"
+					target="_blank"
+					rel="noopener noreferrer"
+				/>
+			),
+		}
+	),
 };

--- a/client/connect-account-page/test/index.test.tsx
+++ b/client/connect-account-page/test/index.test.tsx
@@ -118,6 +118,26 @@ describe( 'ConnectAccountPage', () => {
 		).toBeInTheDocument();
 	} );
 
+	test( 'should display non supported country banner', () => {
+		global.wcpaySettings = {
+			connectUrl: '/wcpay-connect-url',
+			connect: {
+				country: 'CA',
+				availableCountries: {
+					GB: 'United Kingdom (UK)',
+					US: 'United States (US)',
+				},
+			},
+		};
+		render( <ConnectAccountPage /> );
+
+		expect(
+			screen.queryAllByText(
+				/woopayments is not currently available in your location/i
+			)[ 0 ]
+		).toBeInTheDocument();
+	} );
+
 	test( 'should prompt unsupported countries', () => {
 		global.wcpaySettings = {
 			connectUrl: '/wcpay-connect-url',


### PR DESCRIPTION
Fixes #7699

#### Changes proposed in this Pull Request
- Add a new error banner notice on the connect page when the WooCommerce country is not supported by WooPayments.
- Ensure the existing modal is displayed after clicking on `Finish setup`.

#### Testing instructions
- Ensure you don't have an onboarded account or force it to be disconnected from WCPay Dev.
- Go to **WooCommerce -> Settings** and select an unsupported country like `Antarctica`.
- Go to **Payments**.
- A new error banner should be visible with the message – **WooPayments is not currently available in your location**. To be eligible for WooPayments, your business address must be in one of the following [supported countries](https://woo.com/document/woopayments/compatibility/countries/).
- Click on `Finish setup`.
- The unsupported country modal should be displayed.

#### Screenshots
| Error notice | Modal |
|-|-|
|<img width="695" alt="Screenshot 2023-11-30 at 12 26 17" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/77c32807-5fde-4758-b19a-adfdfb621d3d">|<img width="513" alt="Screenshot 2023-11-30 at 12 26 30" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/0874d8e5-24af-4245-9b71-06e71c144127">|

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
