### PR TITLE
Update to handle redirect to new onboarding from WCAdmin Promo

### DIFF
--- a/changelog/4247-fix-incorrect-redirect
+++ b/changelog/4247-fix-incorrect-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixes a redirect to show the new onboarding when coming from WC Core.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1007,7 +1007,7 @@ class WC_Payments_Account {
 
 			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
 			$from_wc_pay_connect_page = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
-			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page ) ) {
+			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page || ! empty( $incentive ) ) ) {
 				// Redirect non-onboarded account to the onboarding flow, otherwise to payments overview page.
 				if ( ! $this->is_stripe_connected() ) {
 					$this->redirect_to_onboarding_flow_page();

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1005,9 +1005,10 @@ class WC_Payments_Account {
 
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
-			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
-			$from_wc_pay_connect_page = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
-			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page || ! empty( $incentive ) ) ) {
+			$from_wc_admin_task           = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
+			$from_wc_admin_incentive_page = ! empty( $incentive );
+			$from_wc_pay_connect_page     = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
+			if ( $from_wc_admin_task || $from_wc_pay_connect_page || $from_wc_admin_incentive_page ) {
 				// Redirect non-onboarded account to the onboarding flow, otherwise to payments overview page.
 				if ( ! $this->is_stripe_connected() ) {
 					$this->redirect_to_onboarding_flow_page();

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1006,7 +1006,7 @@ class WC_Payments_Account {
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
 			$from_wc_admin_task           = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
-			$from_wc_admin_incentive_page = ! empty( $incentive );
+			$from_wc_admin_incentive_page = false !== strpos( wp_get_referer(), 'path=%2Fwc-pay-welcome-page' );
 			$from_wc_pay_connect_page     = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
 			if ( $from_wc_admin_task || $from_wc_pay_connect_page || $from_wc_admin_incentive_page ) {
 				// Redirect non-onboarded account to the onboarding flow, otherwise to payments overview page.


### PR DESCRIPTION
Fixes server/4247

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Fix for a redirect that happens when a user comes from WooCommerce Admin and accepts the promo to install WooPayments. It should redirect to the new onboarding flow.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up new JN site (note: I found it easier NOT to use JN Live Branches for this PR, instead I installed a JN site with WooCommerce, then used `npm run build:release` to build a `.zip` of this plugin and installed it).
* Set the country on the WooCommerce Core Profiler to `ES`.
* Make sure to **not ** install WooPayments on the WooCommerce Core Profiler flow. (since we are using the JN test branch).
* Go to `Plugins` and disable WooPayments.
* When you are redirected to WC Home, you should see the `Payments (1)` in the menu. Click it, then click the prompt to install WooPayments.
* You should be redirected to the new onboarding flow and be able to onboard.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
