### PR TITLE
Test/failed e2e winning dispute

### DIFF
--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -126,6 +126,8 @@ describe( 'Disputes > Submit winning dispute', () => {
 
 		// Confirm dispute status is Won.
 		await page.waitForSelector( 'li.woocommerce-timeline-item' );
+		await merchantWCP.openPaymentDetails( paymentDetailsLink );
+		await page.waitForSelector( 'li.woocommerce-timeline-item' );
 		await expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
 			text: 'Dispute won! The bank ruled in your favor.',
 		} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -120,11 +120,16 @@ describe( 'Disputes > Submit winning dispute', () => {
 			uiLoaded(),
 		] );
 
+		await new Promise( ( resolve ) => setTimeout( resolve, 10000 ) );
+
 		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
 		// Workaround - Open payment details page again and check dispute's status.
 		await merchantWCP.openPaymentDetails( paymentDetailsLink );
 
 		// Confirm dispute status is Won.
 		await page.waitForSelector( 'li.woocommerce-timeline-item' );
+		await expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
+			text: 'Dispute won! The bank ruled in your favor.',
+		} );
 	} );
 } );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -120,16 +120,11 @@ describe( 'Disputes > Submit winning dispute', () => {
 			uiLoaded(),
 		] );
 
-		await new Promise( ( resolve ) => setTimeout( resolve, 3000 ) );
-
 		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
 		// Workaround - Open payment details page again and check dispute's status.
 		await merchantWCP.openPaymentDetails( paymentDetailsLink );
 
 		// Confirm dispute status is Won.
 		await page.waitForSelector( 'li.woocommerce-timeline-item' );
-		await expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-			text: 'Dispute won! The bank ruled in your favor.',
-		} );
 	} );
 } );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -5,7 +5,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { merchantWCP, uiLoaded } from '../../../utils';
+import { merchantWCP, uiLoaded, takeScreenshot } from '../../../utils';
 import { fillCardDetails, setupProductCheckout } from '../../../utils/payments';
 
 const {
@@ -120,7 +120,8 @@ describe( 'Disputes > Submit winning dispute', () => {
 			uiLoaded(),
 		] );
 
-		await new Promise( ( resolve ) => setTimeout( resolve, 10000 ) );
+		await evalAndClick( '#toplevel_page_wcpaydev a' );
+		await takeScreenshot( 'merchant-disputes-submit-winning-wcpaydev' );
 
 		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
 		// Workaround - Open payment details page again and check dispute's status.

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -120,13 +120,13 @@ describe( 'Disputes > Submit winning dispute', () => {
 			uiLoaded(),
 		] );
 
+		await new Promise( ( resolve ) => setTimeout( resolve, 3000 ) );
+
 		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
 		// Workaround - Open payment details page again and check dispute's status.
 		await merchantWCP.openPaymentDetails( paymentDetailsLink );
 
 		// Confirm dispute status is Won.
-		await page.waitForSelector( 'li.woocommerce-timeline-item' );
-		await merchantWCP.openPaymentDetails( paymentDetailsLink );
 		await page.waitForSelector( 'li.woocommerce-timeline-item' );
 		await expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
 			text: 'Dispute won! The bank ruled in your favor.',


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
