### PR TITLE
Update dispute winning e2e test to look for other text that does not depend on webhook.

### DIFF
--- a/changelog/update-dispute-winning-e2e-test-no-webhook
+++ b/changelog/update-dispute-winning-e2e-test-no-webhook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update e2e tests so it does not fail when run on server repo.
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -125,9 +125,12 @@ describe( 'Disputes > Submit winning dispute', () => {
 		await merchantWCP.openPaymentDetails( paymentDetailsLink );
 
 		// Confirm dispute status is Won.
-		await page.waitForSelector( 'li.woocommerce-timeline-item' );
-		await expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-			text: 'Good news! You won this dispute',
-		} );
+		await page.waitForSelector( '.transaction-details-dispute-footer' );
+		await expect( page ).toMatchElement(
+			'.transaction-details-dispute-footer',
+			{
+				text: 'Good news! You won this dispute',
+			}
+		);
 	} );
 } );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -127,7 +127,7 @@ describe( 'Disputes > Submit winning dispute', () => {
 		// Confirm dispute status is Won.
 		await page.waitForSelector( 'li.woocommerce-timeline-item' );
 		await expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-			text: 'Dispute won! The bank ruled in your favor.',
+			text: 'Good news! You won this dispute',
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR fixes issue 4219 in server repo.

#### Problem summary

This [assert](https://github.com/Automattic/woocommerce-payments/blob/00df31ea882ffe287f9e6c2522cb13be2a40eeba/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js#L129-L131) has been failing when the `tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js` e2e test is run on server repo.

That is because it looks for a text from the timeline which only works if webhook handler is working on server.

<img width="1163" alt="285626403-542c019a-a67c-4161-bf37-f03caf42a20d" src="https://github.com/Automattic/woocommerce-payments/assets/73803630/414f4d85-53dd-4160-bf83-5240c470210e">

The server instance that is hit by the e2e tests on server repo does not handle webhook. There is an open work to fix that. Meanwhile, we can use other text on the payment details page to indicate that a dispute is won after submitting dispute evidence.

#### Changes proposed in this Pull Request

Look for the 'Good news! You won this dispute' text instead of 'Dispute won! The bank ruled in your favor.' from the timeline.

<img width="1179" alt="285667794-28ab81ef-ce1a-41ce-a2bc-82b5f365d9ed" src="https://github.com/Automattic/woocommerce-payments/assets/73803630/a2be0e4f-2c4f-49ab-a4e1-21f1afb548a0">

#### Testing instructions

* Make sure e2e test `merchant-disputes-submit-winning` (and other e2e tests in general) are passing.
* Make sure e2e test `merchant-disputes-submit-winning` (and other e2e tests in general) on server repo are passing. I created PR 4226 in server repo that points to this PR's branch as a test.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
