### PR TITLE
Fix subscription renewal when using the Order Items Threshold rule

### DIFF
--- a/changelog/fix-7806-subscriptions-renewal
+++ b/changelog/fix-7806-subscriptions-renewal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use order id from metadata to generate hashed data for customer.

--- a/changelog/fix-7806-subscriptions-renewal
+++ b/changelog/fix-7806-subscriptions-renewal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Use order id from metadata to generate hashed data for customer.
+Fix subscription renewal when using the order items threshold rule from fraud protection.

--- a/includes/core/server/request/class-create-intention.php
+++ b/includes/core/server/request/class-create-intention.php
@@ -155,7 +155,8 @@ class Create_Intention extends Request {
 	 */
 	public function set_fingerprint( string $fingerprint = '' ) {
 		$metadata = $this->get_param( 'metadata' );
-		$metadata = array_merge( $metadata, $this->get_fingerprint_metadata( $fingerprint ) );
+		$order_id = $metadata['order_id'] ?? null;
+		$metadata = array_merge( $metadata, $this->get_fingerprint_metadata( $fingerprint, $order_id ) );
 		$this->set_param( 'metadata', $metadata );
 	}
 

--- a/includes/core/server/request/trait-intention.php
+++ b/includes/core/server/request/trait-intention.php
@@ -17,11 +17,12 @@ trait Intention {
 	 * Returns a list of fingerprinting metadata to attach to order.
 	 *
 	 * @param string $fingerprint Fingerprint data.
+	 * @param int    $order_id    Order ID. Defaults to null.
 	 *
 	 * @return array List of fingerprinting metadata.
 	 */
-	private function get_fingerprint_metadata( $fingerprint = '' ): array {
-		$customer_fingerprint_metadata                                    = Buyer_Fingerprinting_Service::get_instance()->get_hashed_data_for_customer( $fingerprint );
+	private function get_fingerprint_metadata( $fingerprint = '', $order_id = null ): array {
+		$customer_fingerprint_metadata                                    = Buyer_Fingerprinting_Service::get_instance()->get_hashed_data_for_customer( $fingerprint, $order_id );
 		$customer_fingerprint_metadata['fraud_prevention_data_available'] = true;
 
 		return $customer_fingerprint_metadata;

--- a/includes/fraud-prevention/class-buyer-fingerprinting-service.php
+++ b/includes/fraud-prevention/class-buyer-fingerprinting-service.php
@@ -58,18 +58,25 @@ class Buyer_Fingerprinting_Service {
 	 * Returns fraud prevention data for an order.
 	 *
 	 * @param string $fingerprint User fingerprint.
+	 * @param int    $order_id    Order ID. Defaults to null.
 	 *
 	 * @return array An array of hashed data for an order.
 	 */
-	public function get_hashed_data_for_customer( $fingerprint ): array {
+	public function get_hashed_data_for_customer( $fingerprint, $order_id = null ): array {
 		global $wp;
-		$order_items_count = WC()->cart ? intval( WC()->cart->get_cart_contents_count() ) : null;
-		$order_id          = null;
-		if ( isset( $wp->query_vars['order-pay'] ) ) {
-			$order_id = absint( $wp->query_vars['order-pay'] );
-		} elseif ( isset( $_POST['wcpay_order_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$order_id = absint( $_POST['wcpay_order_id'] ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		if ( empty( $order_id ) ) {
+			if ( isset( $wp->query_vars['order-pay'] ) ) {
+				$order_id = absint( $wp->query_vars['order-pay'] );
+			} elseif ( isset( $_POST['wcpay_order_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$order_id = absint( $_POST['wcpay_order_id'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			} else {
+				$order_id = null;
+			}
 		}
+
+		$order_items_count = WC()->cart ? intval( WC()->cart->get_cart_contents_count() ) : null;
+
 		if ( ! $order_items_count && 0 < $order_id ) {
 			$order = wc_get_order( $order_id );
 			if ( $order ) {

--- a/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
+++ b/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
@@ -63,4 +63,30 @@ class Buyer_Fingerprinting_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->assertSame( $order_hashes, $expected_hashed_array );
 	}
+
+	public function test_it_hashes_order_info_with_order_id_parameter() {
+		$fingerprint = 'abc123';
+		$ip_country  = 'GB';
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function() use ( $ip_country ) {
+				return $ip_country;
+			}
+		);
+
+		$current_order    = WC_Helper_Order::create_order();
+		$current_order_id = $current_order->get_id();
+
+		$order_hashes          = $this->buyer_fingerprinting_service->get_hashed_data_for_customer( $fingerprint, $current_order_id );
+		$expected_hashed_array = [
+			'fraud_prevention_data_shopper_ip_hash' => hash( 'sha512', '127.0.0.1', false ),
+			'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
+			'fraud_prevention_data_ip_country'      => $ip_country,
+			'fraud_prevention_data_cart_contents'   => 4,
+		];
+
+		$this->assertSame( $order_hashes, $expected_hashed_array );
+	}
+
+
 }


### PR DESCRIPTION
Fixes #7806 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR fixes subscription renewal for **Order Items Threshold** rule by providing `order_id` parameter to customer data hash method in advanced fraud protection.

- Add `order_id` parameter to `get_hashed_data_for_customer`.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Before checking out this branch

1. Listen to Stripe webhooks
1. Purchase a subscription on your site.
2. Navigate to **Payments > Settings > Advanced fraud protection**.
3. Scroll down to Order Items Threshold, and then enable the filter with a min of 1 and max of 10 and save your settings.
4. Navigate to **WooCommerce > Subscriptions**.
5. Click on your recent subscription and choose Process renewal from the Subscription actions drop-down list, then click Update.
6. You should receive a note that the renewal failed.

##### Checkout to this branch
8. Build the client by running `npm run start`
4. Navigate to **WooCommerce > Subscriptions**.
5. Click on your recent subscription and choose Process renewal from the Subscription actions drop-down list, then click Update.
6. You should receive a note that the renewal succeeded.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
