### PR TITLE
Update settings redirection to handle every case

### DIFF
--- a/changelog/fix-7730-better-hadling-settings-redirection
+++ b/changelog/fix-7730-better-hadling-settings-redirection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update settings redirect logic to handle all the new cases.
+
+

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -94,7 +94,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_wcpay_connect' ] ), 'maybe_redirect_to_wcpay_connect action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_capital_offer' ] ), 'maybe_redirect_to_capital_offer action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_server_link' ] ), 'maybe_redirect_to_server_link action does not exist.' );
-		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_settings_to_connect' ] ), 'maybe_redirect_settings_to_connect action does not exist.' );
+		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_settings_to_connect_or_overview' ] ), 'maybe_redirect_settings_to_connect_or_overview action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_onboarding_flow_to_overview' ] ), 'maybe_redirect_onboarding_flow_to_overview action does not exist.' );
 		$this->assertNotFalse( has_action( 'admin_init', [ $this->wcpay_account, 'maybe_activate_woopay' ] ), 'maybe_activate_woopay action does not exist.' );
 		$this->assertNotFalse( has_action( 'woocommerce_payments_account_refreshed', [ $this->wcpay_account, 'handle_instant_deposits_inbox_note' ] ), 'handle_instant_deposits_inbox_note action does not exist.' );
@@ -434,42 +434,45 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_maybe_redirect_settings_to_connect
+	 * @dataProvider data_maybe_redirect_settings_to_connect_or_overview
 	 */
-	public function test_maybe_redirect_settings_to_connect( $expected_redirect_to_count, $details_submitted, $get_params ) {
+	public function test_maybe_redirect_settings_to_connect_or_overview( $expected_redirect_to_count, $details_submitted, $get_params, $no_account = false, $path = null ) {
 		wp_set_current_user( 1 );
 		$_GET = $get_params;
 
-		$this->cache_account_details(
-			[
-				'account_id'        => 'acc_test',
-				'is_live'           => true,
-				'details_submitted' => $details_submitted,
-			]
-		);
-
+		if ( ! $no_account ) {
+			$this->cache_account_details(
+				[
+					'account_id'        => 'acc_test',
+					'is_live'           => true,
+					'details_submitted' => $details_submitted,
+				]
+			);
+		}
 		// Mock WC_Payments_Account without redirect_to to prevent headers already sent error.
 		$mock_wcpay_account = $this->getMockBuilder( WC_Payments_Account::class )
 			->setMethods( [ 'redirect_to' ] )
 			->setConstructorArgs( [ $this->mock_api_client, $this->mock_database_cache, $this->mock_action_scheduler_service, $this->mock_session_service ] )
 			->getMock();
 
-		$mock_wcpay_account->expects( $this->exactly( $expected_redirect_to_count ) )->method( 'redirect_to' );
+		$mock_wcpay_account->expects( $this->exactly( $expected_redirect_to_count ) )
+			->method( 'redirect_to' )
+			->with( "http://example.org/wp-admin/admin.php?page=wc-admin&path=/payments/$path" );
 
-		$mock_wcpay_account->maybe_redirect_settings_to_connect();
+		$mock_wcpay_account->maybe_redirect_settings_to_connect_or_overview();
 	}
 
 	/**
-	 * Data provider for test_maybe_redirect_settings_to_connect
+	 * Data provider for test_maybe_redirect_settings_to_connect_or_overview
 	 */
-	public function data_maybe_redirect_settings_to_connect() {
+	public function data_maybe_redirect_settings_to_connect_or_overview() {
 		return [
-			'no_get_params'           => [
+			'no_get_params'               => [
 				0,
 				false,
 				[],
 			],
-			'missing_param'           => [
+			'missing_param'               => [
 				0,
 				false,
 				[
@@ -477,7 +480,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 					'tab'  => 'checkout',
 				],
 			],
-			'incorrect_param'         => [
+			'incorrect_param'             => [
 				0,
 				false,
 				[
@@ -486,18 +489,31 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 					'section' => 'woocommerce_payments',
 				],
 			],
-			'account_fully_onboarded' => [
-				0,
-				true,
+			'no_account'                  => [
+				1,
+				false,
 				[
 					'page'    => 'wc-settings',
 					'tab'     => 'checkout',
 					'section' => 'woocommerce_payments',
 				],
+				true,
+				'connect',
 			],
-			'happy_path'              => [
+			'account_partially_onboarded' => [
 				1,
 				false,
+				[
+					'page'    => 'wc-settings',
+					'tab'     => 'checkout',
+					'section' => 'woocommerce_payments',
+				],
+				false,
+				'overview',
+			],
+			'account_fully_onboarded'     => [
+				0,
+				true,
 				[
 					'page'    => 'wc-settings',
 					'tab'     => 'checkout',


### PR DESCRIPTION
Fixes #7730

#### Changes proposed in this Pull Request
After a recent change where we decided to prevent non-fully onboarded accounts to the settings page, we ended up with this redirection being partially broken.

- Redirect settings to:
  - Connect page when there is no account.
  - Overview when the account is partially onboarded.
  - Skip redirection when the account is fully onboarded.

I'd like to know what you think about having both `is_account_partially_onboarded` and `is_account_fully_onboarded`, I find them a bit tricky because they're both based on `details_submitted` but can lead to thinking that they represent different things. Probably using the not operator (`!`) will be easier to read 🤔 

#### Testing instructions
- With an onboarded account.
- Go to **WooCommerce -> Settings -> Payments** and try the following cases by clicking on **Manage** button in WooPayments.
  - It should go to the settings page.
  - Edit [`is_account_partially_onboarded`](https://github.com/Automattic/woocommerce-payments/blob/cddb8ac6caa2a7abe3322ca57780c844e336fc93/includes/class-wc-payments-account.php#L232) and [`is_account_fully_onboarded`](https://github.com/Automattic/woocommerce-payments/blob/cddb8ac6caa2a7abe3322ca57780c844e336fc93/includes/class-wc-payments-account.php#L248) to return true and false respectively. It should redirect to the overview page.
  - Enable `Force the WCPay plugin to act as disconnected from the WCPay Server` in WCPay Dev. It should redirect to the connect page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
