### PR TITLE
Update Fraud & Risk docs link text in settings

### DIFF
--- a/changelog/update-6325-fraud-risk-link-text-in-settings
+++ b/changelog/update-6325-fraud-risk-link-text-in-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updates the anchor text for the fraud and risk tools documentation link on the Payments Settings page.

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -126,7 +126,7 @@ const FraudProtectionDescription = () => {
 			</p>
 			<ExternalLink href="https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/">
 				{ __(
-					'Learn more about risk filtering',
+					'Learn more about fraud protection',
 					'woocommerce-payments'
 				) }
 			</ExternalLink>


### PR DESCRIPTION
Fixes #6325 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR updates the anchor text for the fraud and risk tools documentation link on the WooPayments settings page from _Learn more about risk filtering_ to _Learn more about fraud protection_.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Tests should pass.
* Navigate to Payments > Settings and scroll down to the Fraud Protection section. 
* Observe the text to the left of the fraud protection card. The link's anchor text should read: "Learn more about fraud protection".
* Click the link and confirm that a new tab is opened and that the URL is: `https://woo.com/document/woopayments/fraud-and-disputes/fraud-protection/`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
