### PR TITLE
Display Klarna & Afterpay on the checkout for UK based stores

### DIFF
--- a/changelog/fix-klarna-afterpay-availability-in-uk
+++ b/changelog/fix-klarna-afterpay-availability-in-uk
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Display Klarna & Afterpay on the checkout for UK based stores

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -50,7 +50,7 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 				], // Represents NZD 1 - 2,000 NZD.
 			],
 			'GBP' => [
-				'UK' => [
+				'GB' => [
 					'min' => 100,
 					'max' => 120000,
 				], // Represents GBP 1 - 1,200 GBP.

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -40,7 +40,7 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 				],
 			],
 			'GBP' => [
-				'UK' => [
+				'GB' => [
 					'min' => 0,
 					'max' => 1150000,
 				],


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7849

#### Changes proposed in this Pull Request
This PR updates the currency shortcut to be valid for the UK so that it's displayed on the checkout page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout `trunk`
* Set up a UK based store, make sure that Klarna capability is enabled
* Enable Afterpay & Klarna in _Payments -> Settings_
* Add a product, navigate to the checkout page
* Confirm neither Afterpay nor Klarna are displayed
* Checkout `fix/klarna-afterpay-availability-in-uk`
* Refresh the checkout page and confirm both payment methods are available

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
