### PR TITLE
Decode HTML entities in international IP filter country list

### DIFF
--- a/changelog/fix-7838-fraud-filters-html-encode-bug
+++ b/changelog/fix-7838-fraud-filters-html-encode-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix country names with accents not showing correctly on international country fraud filter

--- a/client/settings/fraud-protection/advanced-settings/allow-countries-notice.tsx
+++ b/client/settings/fraud-protection/advanced-settings/allow-countries-notice.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import FraudPreventionSettingsContext from './context';
 import FraudProtectionRuleCardNotice from './rule-card-notice';
 import { getSettingCountries, getSupportedCountriesType } from './utils';
+import { decodeEntities } from '@wordpress/html-entities';
 
 const getNoticeText = ( filterType: string, blocking: boolean ) => {
 	if ( 'all_except' === filterType ) {
@@ -61,13 +62,15 @@ const AllowedCountriesNotice: React.FC< AllowedCountriesNoticeProps > = ( {
 		<FraudProtectionRuleCardNotice type={ 'info' }>
 			{ getNoticeText( supportedCountriesType, isBlocking ) }
 			<strong>
-				{ settingCountries
-					.map(
-						( countryCode ) =>
-							wcSettings.countries[ countryCode ] ?? false
-					)
-					.filter( ( element ) => element )
-					.join( ', ' ) }
+				{ decodeEntities(
+					settingCountries
+						.map(
+							( countryCode ) =>
+								wcSettings.countries[ countryCode ] ?? false
+						)
+						.filter( ( element ) => element )
+						.join( ', ' )
+				) }
 			</strong>
 		</FraudProtectionRuleCardNotice>
 	);

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/allow-countries-notice.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/allow-countries-notice.test.tsx.snap
@@ -711,3 +711,181 @@ Object {
   "unmount": [Function],
 }
 `;
+
+exports[`Allowed countries rule card notice tests renders html entities correctly 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    >
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    >
+              Orders from outside of the following countries will be blocked by the filter:  São Tomé and Príncipe   
+    </div>
+    <div>
+      <div
+        class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
+      >
+        <div
+          class="components-notice__content"
+        >
+          <div
+            class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
+          >
+            <div
+              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexItem"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                size="24"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                />
+              </svg>
+            </div>
+            <div
+              class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexItem"
+            >
+              Orders from outside of the following countries will be blocked by the filter: 
+              <strong>
+                São Tomé and Príncipe
+              </strong>
+            </div>
+          </div>
+          <div
+            class="components-notice__actions"
+          />
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
+    >
+      <div
+        class="components-notice__content"
+      >
+        <div
+          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
+        >
+          <div
+            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="FlexItem"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              height="24"
+              size="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+              />
+            </svg>
+          </div>
+          <div
+            class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="FlexItem"
+          >
+            Orders from outside of the following countries will be blocked by the filter: 
+            <strong>
+              São Tomé and Príncipe
+            </strong>
+          </div>
+        </div>
+        <div
+          class="components-notice__actions"
+        />
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
@@ -132,4 +132,24 @@ describe( 'Allowed countries rule card notice tests', () => {
 			/Orders from the following countries will be blocked by the filter: Canada, United States/i
 		);
 	} );
+	test( 'renders html entities correctly', () => {
+		global.wcSettings.admin.preloadSettings.general.woocommerce_allowed_countries =
+			'specific';
+		global.wcSettings.admin.preloadSettings.general.woocommerce_specific_allowed_countries = [
+			'ST',
+		];
+		global.wcSettings.countries.ST =
+			'S&atilde;o Tom&eacute; and Pr&iacute;ncipe';
+		mockContext.protectionSettingsUI.test_key.block = true;
+
+		const container = render(
+			<FraudPreventionSettingsContext.Provider value={ mockContext }>
+				<AllowedCountriesNotice setting={ 'test_key' } />
+			</FraudPreventionSettingsContext.Provider>
+		);
+		expect( container ).toMatchSnapshot();
+		expect( container.baseElement ).toHaveTextContent(
+			/São Tomé and Príncipe/i
+		);
+	} );
 } );


### PR DESCRIPTION
Fixes #7838

#### Changes proposed in this Pull Request

This fixes the country name display issue mentioned in the linked issue that shows HTML encoded country names directly, where it should display the decoded string. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Checkout this branch
- On your local client, rebuild the assets with `npm run build:client`
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=general 
- Set "Selling locations" dropdown to "Sell to specific countries"
- Select "Åland Islands", "Curaçao", and "São Tomé and Príncipe" in the "Sell to specific countries" textarea.
- Save the settings.
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ffraud-protection and scroll down to "International IP Address" filter.
- You should see the country names rendered correctly.

<img width="716" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3295/829e702b-68d5-4ede-b9d5-75b2c8ecf213">


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
