### PR TITLE
Fix incorrect amounts caused by zero-decimal currencies on JS CSV export

### DIFF
--- a/changelog/fix-7834-zero-decimals-csv-export
+++ b/changelog/fix-7834-zero-decimals-csv-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect amounts caused by zero-decimal currencies on Transactions, Deposits and Deposits CSV export

--- a/client/deposits/list/index.tsx
+++ b/client/deposits/list/index.tsx
@@ -25,7 +25,7 @@ import { useDispatch } from '@wordpress/data';
  */
 import { useDeposits, useDepositsSummary } from 'wcpay/data';
 import { displayType, displayStatus } from '../strings';
-import { formatExplicitCurrency } from 'utils/currency';
+import { formatExplicitCurrency, formatExportAmount } from 'utils/currency';
 import DetailsLink, { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 import Page from '../../components/page';
@@ -143,7 +143,7 @@ export const DepositsList = (): JSX.Element => {
 				display: clickable( displayType[ deposit.type ] ),
 			},
 			amount: {
-				value: deposit.amount / 100,
+				value: formatExportAmount( deposit.amount, deposit.currency ),
 				display: clickable(
 					formatExplicitCurrency( deposit.amount, deposit.currency )
 				),

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -33,7 +33,7 @@ import Page from 'components/page';
 import { TestModeNotice } from 'components/test-mode-notice';
 import { reasons } from './strings';
 import { formatStringValue } from 'utils';
-import { formatExplicitCurrency } from 'utils/currency';
+import { formatExplicitCurrency, formatExportAmount } from 'utils/currency';
 import DisputesFilters from './filters';
 import DownloadButton from 'components/download-button';
 import disputeStatusMapping from 'components/dispute-status-chip/mappings';
@@ -232,7 +232,7 @@ export const DisputesList = (): JSX.Element => {
 			};
 		} = {
 			amount: {
-				value: dispute.amount / 100,
+				value: formatExportAmount( dispute.amount, dispute.currency ),
 				display: clickable(
 					formatExplicitCurrency( dispute.amount, dispute.currency )
 				),

--- a/client/payment-details/readers/index.js
+++ b/client/payment-details/readers/index.js
@@ -19,7 +19,7 @@ import { useCardReaderStats } from 'wcpay/data';
 import { TestModeNotice } from 'components/test-mode-notice';
 import Page from 'components/page';
 import DownloadButton from 'components/download-button';
-import { formatExplicitCurrency } from 'utils/currency';
+import { formatExplicitCurrency, formatExportAmount } from 'utils/currency';
 
 const PaymentCardReaderChargeDetails = ( props ) => {
 	const { readers, chargeError, isLoading } = useCardReaderStats(
@@ -100,7 +100,12 @@ const RenderPaymentCardReaderChargeDetails = ( props ) => {
 							display: reader.count,
 						},
 						{
-							value: reader.fee ? reader.fee.amount / 100 : 0,
+							value: reader.fee
+								? formatExportAmount(
+										reader.fee.amount,
+										reader.fee.currency
+								  )
+								: 0,
 							display: reader.fee
 								? formatExplicitCurrency(
 										reader.fee.amount,

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -40,7 +40,11 @@ import { getDetailsURL } from 'components/details-link';
 import { displayType } from 'transactions/strings';
 import { displayStatus as displayDepositStatus } from 'deposits/strings';
 import { formatStringValue } from 'utils';
-import { formatCurrency, formatExplicitCurrency } from 'utils/currency';
+import {
+	formatCurrency,
+	formatExplicitCurrency,
+	formatExportAmount,
+} from 'utils/currency';
 import { getChargeChannel } from 'utils/charge';
 import Deposit from './deposit';
 import ConvertedAmount from './converted-amount';
@@ -343,7 +347,7 @@ export const TransactionsList = (
 			const fromAmount = txn.customer_amount ? txn.customer_amount : 0;
 
 			return {
-				value: amount / 100,
+				value: formatExportAmount( amount, currency ),
 				display: clickable(
 					<ConvertedAmount
 						amount={ amount }
@@ -357,8 +361,10 @@ export const TransactionsList = (
 		const formatFees = () => {
 			const isCardReader =
 				txn.metadata && txn.metadata.charge_type === 'card_reader_fee';
-			const feeAmount =
-				( isCardReader ? txn.amount : txn.fees * -1 ) / 100;
+			const feeAmount = formatExportAmount(
+				isCardReader ? txn.amount : txn.fees * -1,
+				currency
+			);
 			return {
 				value: feeAmount,
 				display: clickable(
@@ -461,7 +467,7 @@ export const TransactionsList = (
 			// fees should display as negative. The format $-9.99 is determined by WC-Admin
 			fees: formatFees(),
 			net: {
-				value: txn.net / 100,
+				value: formatExportAmount( txn.net, currency ),
 				display: clickable(
 					formatExplicitCurrency( txn.net, currency )
 				),

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -82,6 +82,24 @@ export const isZeroDecimalCurrency = ( currencyCode ) => {
 };
 
 /**
+ * Formats the amount for CSV export, considering zero-decimal currencies
+ *
+ * @param {number} amount       Amount
+ * @param {string} currencyCode Currency code
+ *
+ * @return {number} Export amount
+ */
+export const formatExportAmount = ( amount, currencyCode ) => {
+	const isZeroDecimal = isZeroDecimalCurrency( currencyCode );
+
+	if ( ! isZeroDecimal ) {
+		amount /= 100;
+	}
+
+	return amount;
+};
+
+/**
  * Formats amount according to the given currency.
  *
  * @param {number} amount       Amount

--- a/client/utils/currency/test/index.js
+++ b/client/utils/currency/test/index.js
@@ -109,4 +109,11 @@ describe( 'Currency utilities', () => {
 
 		expect( utils.formatCurrency( 100000, 'EUR' ) ).toEqual( '€1,000.00' );
 	} );
+
+	test( 'format export amounts', () => {
+		expect( utils.formatExportAmount( 1000, 'USD' ) ).toEqual( 10 );
+		expect( utils.formatExportAmount( 1250, 'USD' ) ).toEqual( 12.5 );
+		expect( utils.formatExportAmount( 1000, 'JPY' ) ).toEqual( 1000 );
+		expect( utils.formatExportAmount( 3450, 'JPY' ) ).toEqual( 3450 );
+	} );
 } );


### PR DESCRIPTION
Fixes #7834

#### Changes proposed in this Pull Request
This PR addresses the issue of incorrect amounts in Transactions, Deposits, and Disputes on CSV exports when there are fewer than 25 products. It specifically resolves discrepancies with zero-decimal currencies like the Japanese Yen (JPY), ensuring that the amounts are no longer displayed 100 times lower than intended.

**Amounts before the changes**
<img width="792" alt="Screenshot 2023-12-08 at 17 23 51" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/80f2fc72-7b00-4c19-9201-4f048340badb">

**Amounts after the changes**
<img width="788" alt="Screenshot 2023-12-08 at 17 24 07" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/559cf00e-804c-4a6a-a70d-0d5c24200ae9">

**Demo**
https://github.com/Automattic/woocommerce-payments/assets/8667118/7fef0481-d4a6-4e69-9e5c-793bbe9e252b

#### Testing instructions
**Prerequisites**
- Link a Japanese account to your store. You can use acct_1NlSbfQrGWYVdtTz
- Place an order for a product in Japanese Yen. ( If using the above account you shouldn't create a new order )

**Case 1**
- Go to Payments -> Transactions.
- Click the Download button to export the CSV.
- Verify that the amount and fees are no longer displayed 100 times lower than intended.

**Case 2**
- Go to Payments -> Deposits.
- Click the Download button to export the CSV.
- Verify that the amount and fees are no longer displayed 100 times lower than intended.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
