### PR TITLE
Fix multi-currency e2e tests

### DIFF
--- a/changelog/dev-fix-multi-currency-e2e-tests
+++ b/changelog/dev-fix-multi-currency-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix multi-currency e2e tests.
+
+

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -24,6 +24,9 @@ const ERROR_MESSAGES_TO_IGNORE = [
 	'Scripts that have a dependency on',
 	'was preloaded using link preload but not used within a few seconds',
 	'No UI will be shown. CanMakePayment and hasEnrolledInstrument',
+	'Failed to load resource: the server responded with a status of 404 (Not Found)',
+	'Store "wc/payments" is already registered.',
+	'Preflight request for request with keepalive specified is currently not supported',
 ];
 
 ERROR_MESSAGES_TO_IGNORE.forEach( ( errorMessage ) => {

--- a/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
@@ -64,6 +64,7 @@ describe( 'Shopper Multi-Currency widget', () => {
 
 	it( 'should display currency switcher widget if multi-currency is enabled', async () => {
 		await merchantWCP.addMulticurrencyWidget();
+		await merchant.logout();
 		await shopper.goToShop();
 		await page.waitForSelector( '.widget select[name=currency]', {
 			visible: true,
@@ -72,6 +73,7 @@ describe( 'Shopper Multi-Currency widget', () => {
 	} );
 
 	it( 'should not display currency switcher widget if multi-currency is disabled', async () => {
+		await merchant.login();
 		await merchantWCP.openWCPSettings();
 		await merchantWCP.deactivateMulticurrency();
 		await shopper.goToShop();


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

It fixes the multi-currency failing e2e tests.

It also adds a couple of errors/warnings to the error suppression list. Those errors are not errors caused by the e2e tests, but rather errors that pop up because of the developer environment, or are simply developer warnings.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Confirm all multi-currency-related e2e tests pass in this PR (you can search for "multi-currency" in the GitHub run).
- Confirm all multi-currency-related e2e tests pass on `develop` after this is merged.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
