### PR TITLE
Pass additional data to the intent authentication exception

### DIFF
--- a/changelog/fix-pass-additional-data-to-intent-authentication-exception
+++ b/changelog/fix-pass-additional-data-to-intent-authentication-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass additional data to the intent authentication exception

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1033,7 +1033,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			// Re-throw the exception after setting everything up.
 			// This makes the error notice show up both in the regular and block checkout.
-			throw new Exception( WC_Payments_Utils::get_filtered_error_message( $e ) );
+			$additional_data = method_exists( $e, 'getAdditionalData' ) ? $e->getAdditionalData() : [];
+			throw new Process_Payment_Exception( WC_Payments_Utils::get_filtered_error_message( $e ), 'process_payment_error', 0, null, $additional_data );
 		}
 	}
 
@@ -1272,7 +1273,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( $intent_meta_order_id !== $order_id ) {
 					throw new Intent_Authentication_Exception(
 						__( "We're not able to process this payment. Please try again later.", 'woocommerce-payments' ),
-						'order_id_mismatch'
+						'order_id_mismatch',
+						0,
+						null,
+						[
+							'intent_meta_data' => $intent->get_metadata(),
+							'order_id'         => $order_id,
+						]
 					);
 				}
 			}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -881,7 +881,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 * @throws Process_Payment_Exception Error processing the payment.
-	 * @throws Exception Error processing the payment.
 	 */
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
@@ -944,7 +943,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$payment_information = $this->prepare_payment_information( $order );
 			return $this->process_payment_for_order( WC()->cart, $payment_information );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			// We set this variable to be used in following checks.
 			$blocked_due_to_fraud_rules = $e instanceof API_Exception && 'wcpay_blocked_by_fraud_rule' === $e->get_error_code();
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -945,6 +945,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_information = $this->prepare_payment_information( $order );
 			return $this->process_payment_for_order( WC()->cart, $payment_information );
 		} catch ( Exception $e ) {
+			// error_log(print_r($e,true));
 			// We set this variable to be used in following checks.
 			$blocked_due_to_fraud_rules = $e instanceof API_Exception && 'wcpay_blocked_by_fraud_rule' === $e->get_error_code();
 
@@ -1277,6 +1278,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						0,
 						null,
 						[
+							'error_code'       => 'order_id_mismatch',
 							'intent_meta_data' => $intent->get_metadata(),
 							'order_id'         => $order_id,
 						]

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -945,7 +945,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_information = $this->prepare_payment_information( $order );
 			return $this->process_payment_for_order( WC()->cart, $payment_information );
 		} catch ( Exception $e ) {
-			// error_log(print_r($e,true));
 			// We set this variable to be used in following checks.
 			$blocked_due_to_fraud_rules = $e instanceof API_Exception && 'wcpay_blocked_by_fraud_rule' === $e->get_error_code();
 
@@ -1278,9 +1277,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						0,
 						null,
 						[
-							'error_code'       => 'order_id_mismatch',
-							'intent_meta_data' => $intent->get_metadata(),
-							'order_id'         => $order_id,
+							'error_code'           => 'order_id_mismatch',
+							'intent_meta_order_id' => $intent_meta_order_id,
+							'order_id'             => $order_id,
 						]
 					);
 				}

--- a/includes/exceptions/class-base-exception.php
+++ b/includes/exceptions/class-base-exception.php
@@ -24,16 +24,25 @@ abstract class Base_Exception extends Exception {
 	private $error_code;
 
 	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
 	 * Constructor, including the usual $message, $code, and $previous,
 	 * and a new parameter $error_code.
 	 *
-	 * @param string     $message    The Exception message to throw.
-	 * @param string     $error_code String error code.
-	 * @param int        $code       The Exception code.
-	 * @param \Throwable $previous   The previous exception used for the exception chaining.
+	 * @param string     $message         The Exception message to throw.
+	 * @param string     $error_code      String error code.
+	 * @param int        $code            The Exception code.
+	 * @param \Throwable $previous        The previous exception used for the exception chaining.
+	 * @param array      $additional_data The additional data.
 	 */
-	public function __construct( $message, $error_code, $code = 0, $previous = null ) {
-		$this->error_code = $error_code;
+	public function __construct( $message, $error_code, $code = 0, $previous = null, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->additional_data = $additional_data;
 
 		parent::__construct( $message, $code, $previous );
 	}
@@ -45,5 +54,14 @@ abstract class Base_Exception extends Exception {
 	 */
 	public function get_error_code() {
 		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
 	}
 }

--- a/includes/exceptions/class-base-exception.php
+++ b/includes/exceptions/class-base-exception.php
@@ -28,7 +28,7 @@ abstract class Base_Exception extends Exception {
 	 *
 	 * @var array
 	 */
-	public $additional_data = [];
+	private $additional_data = [];
 
 	/**
 	 * Constructor, including the usual $message, $code, and $previous,
@@ -53,6 +53,15 @@ abstract class Base_Exception extends Exception {
 	 * @return string Error code, for example 'order_not_found'.
 	 */
 	public function get_error_code() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string Error code, for example 'order_not_found'.
+	 */
+	public function getErrorCode() {
 		return $this->error_code;
 	}
 


### PR DESCRIPTION
Slack discussion p1702070481324349/1702053239.912509-slack-C022WMN88KG

Currently, we only throw an exception message `We're not able to process this payment. Please try again later.` and don't have further information for debugging.


#### Changes proposed in this Pull Request
Throw additional data `intent_meta_data` and `order_id` to the intent authentication exception so we have more information for the failed order. 

#### Testing instructions
1. Test with https://github.com/woocommerce/woocommerce/pull/42685
2. Update the [condition](https://github.com/Automattic/woocommerce-payments/blob/0d3bd80bca2f10a6a75b35b01d0f6004bc88436e/includes/class-wc-payment-gateway-wcpay.php#L1273) to `true`
3. Add a log `error_log(print_r($e,true));` behind the [catch](https://github.com/Automattic/woocommerce-payments/blob/0d3bd80bca2f10a6a75b35b01d0f6004bc88436e/includes/class-wc-payment-gateway-wcpay.php#L947) to see the additional data
4. Place an order via WooPay
5. Check the additional data in the debug log

#### If test with WooPay
See the test instruction https://github.com/Automattic/woopay/pull/2394

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.