### PR TITLE
Show deposit schedule message if account's deposits are unrestricted

### DIFF
--- a/changelog/fix-7874-show-deposit-schedule-when-zero-available-balance
+++ b/changelog/fix-7874-show-deposit-schedule-when-zero-available-balance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show deposit schedule message when available balance is zero or negative

--- a/changelog/fix-7874-show-deposit-schedule-when-zero-available-balance
+++ b/changelog/fix-7874-show-deposit-schedule-when-zero-available-balance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Show deposit schedule message when available balance is zero or negative
+Show deposit schedule message when deposits are unrestricted

--- a/client/components/deposits-overview/deposit-schedule.tsx
+++ b/client/components/deposits-overview/deposit-schedule.tsx
@@ -17,6 +17,7 @@ import type * as AccountOverview from 'wcpay/types/account-overview';
 
 interface DepositScheduleProps {
 	depositsSchedule: AccountOverview.Account[ 'deposits_schedule' ];
+	showNextDepositDate?: boolean;
 }
 /**
  * Renders the Deposit Schedule details component.
@@ -25,19 +26,30 @@ interface DepositScheduleProps {
  */
 const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 	depositsSchedule,
+	showNextDepositDate,
 } ) => {
 	const nextDepositDate = getNextDepositDate( depositsSchedule );
+	const nextDepositDateString = showNextDepositDate
+		? sprintf(
+				/** translators: %s: is the date of the next deposit, e.g. "January 1st, 2023". */
+				__(
+					' – your next deposit is scheduled for {{strong}}%s{{/strong}}',
+					'woocommerce-payments'
+				),
+				nextDepositDate
+		  )
+		: '';
 
 	switch ( depositsSchedule.interval ) {
 		case 'daily':
 			return interpolateComponents( {
 				mixedString: sprintf(
-					/** translators: {{strong}}: placeholders are opening and closing strong tags. %s: is the date of the next deposit, e.g. "January 1st, 2023". */
+					/** translators: {{strong}}: placeholders are opening and closing strong tags. %s: is an optional next deposit date message. */
 					__(
-						'Available funds are automatically dispatched {{strong}}every day{{/strong}} – your next deposit is scheduled for {{strong}}%s{{/strong}}.',
+						'Available funds are automatically dispatched {{strong}}every day{{/strong}}%s.',
 						'woocommerce-payments'
 					),
-					nextDepositDate
+					nextDepositDateString
 				),
 				components: {
 					strong: <strong />,
@@ -52,13 +64,13 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 
 			return interpolateComponents( {
 				mixedString: sprintf(
-					/** translators: %1$s: is the day of the week. eg "Friday". %2$s: is the date of the next deposit, e.g. "January 1st, 2023". {{strong}}: placeholders are opening and closing strong tags. */
+					/** translators: %1$s: is the day of the week. eg "Friday". %2$s: is an optional next deposit date message. {{strong}}: placeholders are opening and closing strong tags. */
 					__(
-						'Available funds are automatically dispatched {{strong}}every %1$s{{/strong}} – your next deposit is scheduled for {{strong}}%2$s{{/strong}}.',
+						'Available funds are automatically dispatched {{strong}}every %1$s{{/strong}}%2$s.',
 						'woocommerce-payments'
 					),
 					dayOfWeek,
-					nextDepositDate
+					nextDepositDateString
 				),
 				components: {
 					strong: <strong />,
@@ -71,12 +83,12 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 			if ( monthlyAnchor === 31 ) {
 				return interpolateComponents( {
 					mixedString: sprintf(
-						/** translators: {{strong}}: placeholders are opening and closing strong tags. %s: is the date of the next deposit, e.g. "January 1st, 2023". */
+						/** translators: {{strong}}: placeholders are opening and closing strong tags. %s: is an optional next deposit date message. */
 						__(
-							'Available funds are automatically dispatched {{strong}}on the last day of every month{{/strong}} – your next deposit is scheduled for {{strong}}%s{{/strong}}.',
+							'Available funds are automatically dispatched {{strong}}on the last day of every month{{/strong}}%s.',
 							'woocommerce-payments'
 						),
-						nextDepositDate
+						nextDepositDateString
 					),
 					components: {
 						strong: <strong />,
@@ -86,16 +98,16 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 
 			return interpolateComponents( {
 				mixedString: sprintf(
-					/** translators: {{strong}}: placeholders are opening and closing strong tags. %1$s: is the day of the month. eg "31st". %2$s: is the date of the next deposit, e.g. "January 1st, 2023". */
+					/** translators: {{strong}}: placeholders are opening and closing strong tags. %1$s: is the day of the month. eg "31st". %2$s: is an optional next deposit date message. */
 					__(
-						'Available funds are automatically dispatched {{strong}}on the %1$s of every month{{/strong}} – your next deposit is scheduled for {{strong}}%2$s{{/strong}}.',
+						'Available funds are automatically dispatched {{strong}}on the %1$s of every month{{/strong}}%2$s.',
 						'woocommerce-payments'
 					),
 					getDepositMonthlyAnchorLabel( {
 						monthlyAnchor: monthlyAnchor,
 						capitalize: false,
 					} ),
-					nextDepositDate
+					nextDepositDateString
 				),
 				components: {
 					strong: <strong />,

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -45,9 +45,8 @@ const DepositsOverview: React.FC = () => {
 
 	const availableFunds = overview?.available?.amount ?? 0;
 
-	// If the account has deposits blocked, there is no available balance or it is negative, there is no future deposit expected.
-	const isNextDepositExpected =
-		! account?.deposits_blocked && availableFunds > 0;
+	// If the account has deposits blocked, there is no future deposit expected.
+	const isNextDepositExpected = ! account?.deposits_blocked;
 	// If the available balance is negative, deposits may be paused.
 	const isNegativeBalanceDepositsPaused = availableFunds < 0;
 	const hasCompletedWaitingPeriod =

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -99,6 +99,7 @@ const DepositsOverview: React.FC = () => {
 				<CardBody className="wcpay-deposits-overview__schedule__container">
 					<DepositSchedule
 						depositsSchedule={ account.deposits_schedule }
+						showNextDepositDate={ availableFunds !== 0 }
 					/>
 				</CardBody>
 			) }

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -54,10 +54,7 @@ const DepositsOverview: React.FC = () => {
 		wcpaySettings.accountStatus.deposits?.completed_waiting_period;
 	// Only show the deposit history section if the page is finished loading and there are deposits. */ }
 	const showRecentDeposits =
-		! isLoading &&
-		deposits?.length > 0 &&
-		!! account &&
-		isDepositsUnrestricted;
+		! isLoading && deposits?.length > 0 && !! account;
 
 	// Show a loading state if the page is still loading.
 	if ( isLoading ) {

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -35,6 +35,9 @@ const DepositsOverview: React.FC = () => {
 		overview,
 		isLoading: isLoadingOverview,
 	} = useSelectedCurrencyOverview();
+	const isDepositsUnrestricted =
+		wcpaySettings.accountStatus.deposits?.restrictions ===
+		'deposits_unrestricted';
 	const selectedCurrency =
 		overview?.currency || wcpaySettings.accountDefaultCurrency;
 	const { isLoading: isLoadingDeposits, deposits } = useRecentDeposits(
@@ -45,8 +48,6 @@ const DepositsOverview: React.FC = () => {
 
 	const availableFunds = overview?.available?.amount ?? 0;
 
-	// If the account has deposits blocked, there is no future deposit expected.
-	const isNextDepositExpected = ! account?.deposits_blocked;
 	// If the available balance is negative, deposits may be paused.
 	const isNegativeBalanceDepositsPaused = availableFunds < 0;
 	const hasCompletedWaitingPeriod =
@@ -56,7 +57,7 @@ const DepositsOverview: React.FC = () => {
 		! isLoading &&
 		deposits?.length > 0 &&
 		!! account &&
-		! account?.deposits_blocked;
+		isDepositsUnrestricted;
 
 	// Show a loading state if the page is still loading.
 	if ( isLoading ) {
@@ -97,7 +98,7 @@ const DepositsOverview: React.FC = () => {
 			</CardHeader>
 
 			{ /* Deposit schedule message */ }
-			{ isNextDepositExpected && !! account && (
+			{ isDepositsUnrestricted && !! account && (
 				<CardBody className="wcpay-deposits-overview__schedule__container">
 					<DepositSchedule
 						depositsSchedule={ account.deposits_schedule }
@@ -111,7 +112,7 @@ const DepositsOverview: React.FC = () => {
 					<SuspendedDepositNotice />
 				) : (
 					<>
-						{ isNextDepositExpected && (
+						{ isDepositsUnrestricted && (
 							<DepositTransitDaysNotice />
 						) }
 						{ ! hasCompletedWaitingPeriod && (

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -99,7 +99,7 @@ const DepositsOverview: React.FC = () => {
 				<CardBody className="wcpay-deposits-overview__schedule__container">
 					<DepositSchedule
 						depositsSchedule={ account.deposits_schedule }
-						showNextDepositDate={ availableFunds !== 0 }
+						showNextDepositDate={ availableFunds > 0 }
 					/>
 				</CardBody>
 			) }

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -26,10 +26,6 @@ exports[`Deposits Overview information Component Renders 1`] = `
         <strong>
           every Monday
         </strong>
-         – your next deposit is scheduled for 
-        <strong>
-          December 18th, 2023
-        </strong>
         .
       </div>
       <div

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -18,10 +18,68 @@ exports[`Deposits Overview information Component Renders 1`] = `
         Deposits
       </div>
       <div
+        class="components-card__body components-card-body wcpay-deposits-overview__schedule__container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="CardBody"
+      >
+        Available funds are automatically dispatched 
+        <strong>
+          every Monday
+        </strong>
+         – your next deposit is scheduled for 
+        <strong>
+          December 18th, 2023
+        </strong>
+        .
+      </div>
+      <div
         class="components-card__body components-card-body wcpay-deposits-overview__notices__container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
-      />
+      >
+        <div
+          class="wcpay-inline-notice wcpay-inline-undefined-notice wcpay-deposit-transit-days-notice components-notice is-info"
+        >
+          <div
+            class="components-notice__content"
+          >
+            <div
+              class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Flex"
+            >
+              <div
+                class="components-flex-item wcpay-inline-notice__icon wcpay-inline-undefined-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="FlexItem"
+              >
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8 6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="components-flex-item wcpay-inline-notice__content wcpay-inline-undefined-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="FlexItem"
+              >
+                It may take 1-3 business days for deposits to reach your bank account.
+              </div>
+            </div>
+            <div
+              class="components-notice__actions"
+            />
+          </div>
+        </div>
+      </div>
       <div
         class="components-card__body components-card-body wcpay-deposits-overview__heading css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -51,6 +51,7 @@ declare const global: {
 	wcpaySettings: {
 		accountStatus: {
 			deposits: {
+				restrictions: string;
 				completed_waiting_period: boolean;
 			};
 		};
@@ -210,6 +211,7 @@ describe( 'Deposits Overview information', () => {
 		global.wcpaySettings = {
 			accountStatus: {
 				deposits: {
+					restrictions: 'deposits_unrestricted',
 					completed_waiting_period: true,
 				},
 			},

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -30,7 +30,7 @@ declare global {
 			country?: string;
 			paymentsEnabled?: boolean;
 			deposits?: {
-				status;
+				status: string;
 				restrictions:
 					| 'deposits_unrestricted'
 					| 'deposits_blocked'

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -30,7 +30,11 @@ declare global {
 			country?: string;
 			paymentsEnabled?: boolean;
 			deposits?: {
-				status: string;
+				status;
+				restrictions:
+					| 'deposits_unrestricted'
+					| 'deposits_blocked'
+					| 'schedule_restricted';
 				interval: string;
 				weekly_anchor: string;
 				monthly_anchor: null | number;


### PR DESCRIPTION
Fixes #7874

#### Changes proposed in this Pull Request

1. Renders the deposit schedule message on the Payments → Overview screen unless the account's deposits are blocked or restricted.

This helps communicate to merchants that they have an expected upcoming deposit, even if their available balance <= 0.

2. The "next deposit is scheduled" part of the message will only be rendered if there is available balance. Without available balance, this part of the message will not render. (in the future, this will only render if above the minimum automatic deposit threshold #6774)

<img width="703" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/e7b63276-c11a-460d-8c13-7719bcc6f647">



#### Testing instructions

* Check that the message is rendered for accounts without deposit restrictions (use MC tools to add/remove restrictions to account)
	* With an available balance of 0
	* With a negative available balance
* Check that the message is not rendered
	* Deposits blocked
	* Deposits restricted

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
