### PR TITLE
Fix e2e tests on WC 7.7

### DIFF
--- a/changelog/dev-fix-e2e-tests-on-wc-7-7
+++ b/changelog/dev-fix-e2e-tests-on-wc-7-7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix e2e tests on WC 7.7.
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
@@ -106,6 +106,7 @@ describe( 'Shopper Multi-Currency widget', () => {
 				);
 				// Change it back to USD for the other tests.
 				await page.select( '.widget select[name=currency]', 'USD' );
+				await page.reload( { waitUntil: 'networkidle0' } );
 			} );
 		}
 	);

--- a/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
@@ -95,6 +95,7 @@ describe( 'Shopper Multi-Currency widget', () => {
 				await setupTest();
 				await page.waitForSelector( '.widget select[name=currency]', {
 					visible: true,
+					timeout: 5000,
 				} );
 				await page.select( '.widget select[name=currency]', 'EUR' );
 				await expect( page.url() ).toContain(

--- a/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
@@ -180,5 +180,6 @@ describe( 'Shopper Multi-Currency widget', () => {
 			'.widget select[name=currency]'
 		);
 		expect( currencySwitcher ).toBeNull();
+		await merchant.logout();
 	} );
 } );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -691,7 +691,7 @@ export const merchantWCP = {
 		await merchant.openNewOrder();
 		await page.click( 'button.add-line-item' );
 		await page.click( 'button.add-order-item' );
-		await page.click( 'select.wc-product-search' );
+		await page.click( 'select[name="item_id"]' );
 		await page.type(
 			'.select2-search--dropdown > input',
 			config.get( 'products.simple.name' ),

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -671,7 +671,11 @@ export const merchantWCP = {
 			searchInput.type( 'switcher', { delay: 20 } );
 
 			await page.waitForSelector(
-				'button.components-button[role="option"]'
+				'button.components-button[role="option"]',
+				{
+					visible: true,
+					timeout: 5000,
+				}
 			);
 			await page.click( 'button.components-button[role="option"]' );
 			await page.waitFor( 2000 );


### PR DESCRIPTION
Fixes #7892.

#### Changes proposed in this Pull Request

It fixes the e2e tests that are failing on the WooCommerce 7.7.0.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Pre-requisites**

1. Set up a clean e2e test environment: `npm run test:e2e-reset`, then `npm run test:e2e-setup`.
2. Run `npm run build:client` to build the assets.

**Test: reproduce the issue**

1. Checkout to the `develop` branch.
2. Run `docker exec -it wcp_e2e_wordpress /bin/bash` to ssh into the merchant site.
3. After ssh'ed, run `wp plugin update woocommerce --version="7.7.0" --allow-root` within the container to downgrade WooCommerce to 7.7.0.
4. Exit from the container bash session.
5. Run `npm run test:e2e -- multi-currency-widget shopper-myaccount-payment-methods-add-delete-success` and confirm both suites fail and the output/errors are similar to [this run](https://github.com/Automattic/woocommerce-payments/actions/runs/7185934402/job/19571633541). There should be 7 tests failed.

**Test: all tests pass on WC 7.7.0**

1. Switch to this branch.
2. Run `npm run test:e2e -- multi-currency-widget shopper-myaccount-payment-methods-add-delete-success` again and confirm all tests pass.

**Test: all tests still pass on the latest WC**

1. Via WP Admin or WP CLI (as shown above), update the WooCommerce version to the latest.
2. Run `npm run test:e2e -- multi-currency-widget shopper-myaccount-payment-methods-add-delete-success` again and confirm all tests pass.

**Test: all CI checks pass**

1. Confirm all e2e tests checks pass for this PR.
2. Confirm all e2e tests checks pass after this is merged to `develop`.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
