### PR TITLE
Deposits: Remove unnecessary notice when account is in new account waiting period

### DIFF
--- a/changelog/fix-7901-excess-deposit-notices
+++ b/changelog/fix-7901-excess-deposit-notices
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Removing unneccessary notice when merchant is in new account waiting period.
+
+

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -122,9 +122,10 @@ const DepositsOverview: React.FC = () => {
 						{ ! hasCompletedWaitingPeriod && (
 							<NewAccountWaitingPeriodNotice />
 						) }
-						{ isDepositAwaitingPendingFunds && (
-							<NoFundsAvailableForDepositNotice />
-						) }
+						{ hasCompletedWaitingPeriod &&
+							isDepositAwaitingPendingFunds && (
+								<NoFundsAvailableForDepositNotice />
+							) }
 						{ isNegativeBalanceDepositsPaused && (
 							<NegativeBalanceDepositsPausedNotice />
 						) }


### PR DESCRIPTION
Fixes #7901

#### Changes proposed in this Pull Request

> **Warning**
> This is a fix for a merged change for the patch release `6.9.2`

This PR removes the `You have no funds available to deposit` notice when an account is in the new account waiting period.

**Before**

![image](https://github.com/Automattic/woocommerce-payments/assets/57298/b40d045b-b2aa-4429-b580-c3f2d87bb6e7)

**After**

![image](https://github.com/Automattic/woocommerce-payments/assets/57298/5cf3eded-eaba-40dc-b50b-0bfa463d4972)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
