### PR TITLE
Deposits List - Hide the next deposit notice if account witin the new account waiting period

### DIFF
--- a/changelog/fix-7904-hide-next-deposit-notice-within-waiting-period
+++ b/changelog/fix-7904-hide-next-deposit-notice-within-waiting-period
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: No changelog for this change, part of previous changelog entry adding the next deposit notice

--- a/client/deposits/index.tsx
+++ b/client/deposits/index.tsx
@@ -49,8 +49,12 @@ const NextDepositNotice: React.FC = () => {
 		wcpaySettings.accountStatus.deposits?.restrictions ===
 		'deposits_unrestricted';
 
+	const hasCompletedWaitingPeriod =
+		wcpaySettings.accountStatus.deposits?.completed_waiting_period;
+
 	if (
 		! isDepositsUnrestricted ||
+		! hasCompletedWaitingPeriod ||
 		! account ||
 		isNextDepositNoticeDismissed
 	) {


### PR DESCRIPTION
Fixes #7904

> [!warning]
> This is a fix for a merged change for the patch release `6.9.2`


#### Changes proposed in this Pull Request

This PR hides the deposit notice while accounts are within the new account waiting period.


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For an account within the new account waiting period, ensure the Deposits List → Next deposit notice **is not** shown.
* For an account outside the new account waiting period, ensure the Deposits List → Next deposit notice **is** shown.
* This can be mocked by [adjusting the `completed_waiting_period`](https://github.com/Automattic/woocommerce-payments-server/blob/debf8141341d66da68d6d84fcdf89e41b23133ab/server/wp-content/rest-api-plugins/endpoints/wcpay/class-accounts-controller.php#L820) to `true` or `false` on local server. Remember to clear account cache in WCPay dev tools.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
