### PR TITLE
Improve consistency of tooltip text style

### DIFF
--- a/changelog/fix-7905-transactions-list-tooltip-styles
+++ b/changelog/fix-7905-transactions-list-tooltip-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Improving consitency of tooltip styles, part of previous PR adding transaction list tooltip
+
+

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -37,6 +37,9 @@
 		z-index: 100010;
 		// Initial left position is set to 0 to fix a positioning bug in mobile Safari.
 		left: 0;
+		white-space: normal;
+		font-size: 12px;
+		font-weight: 400;
 
 		&.is-hiding {
 			opacity: 0 !important;

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -46,11 +46,6 @@ $space-header-item: 12px;
 		top: 3px;
 		left: 8px;
 	}
-	.woocommerce-table__item {
-		.wcpay-tooltip__content-wrapper {
-			white-space: normal;
-		}
-	}
 }
 
 /**


### PR DESCRIPTION
Fixes #7905

#### Changes proposed in this Pull Request

This PR adds CSS to tooltip component in order to improve consistency of text rendering across the WooPayments UI.

The tooltip component now uses a `font-size: 12px`, `font-weight: 400` and `white-space: normal` to match the Payments Overview tooltip styles.

This inconsistency was made apparent by the transaction list screen tooltips, but was also inconsistent across the WooPaymants settings screen tooltips.



**Before**

<img width="294" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/dcfcb891-5442-4de4-a2a6-2c01c28ee74f">

<img width="292" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/62df3bd1-ca2e-423b-ae96-a3073b1f5f0b">

<img width="421" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/bde4ca6b-1e77-422d-9fc9-d5e22c9869ce">

**After**

<img width="345" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/5547f0c6-5bd8-4eed-a04d-60e8d6bf49de">


<img width="358" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/19d862b9-ee16-4f21-9d15-93f6d560b7dc">

<img width="370" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/5b1167f3-9b5c-40c9-b6c4-37262c12e9e4">


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and check the font style rendering for tooltips throughout the WooPayments admin UI. Tooltips are used primarily on the settings screen, transaction list screen and Payments Overview screen.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
