### PR TITLE
Include level3 data when capturing an authorization.

### DIFF
--- a/changelog/fix-6806-authorizations-level-3-data-error-while-trying-to-capture-partial-amount
+++ b/changelog/fix-6806-authorizations-level-3-data-error-while-trying-to-capture-partial-amount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a Level 3 error occurring during the capture of an authorization for amounts lower than the initial authorization amount.

--- a/client/payment-methods-map.tsx
+++ b/client/payment-methods-map.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/payment-methods/capability-request/index.tsx
+++ b/client/payment-methods/capability-request/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { __ } from '@wordpress/i18n';
 
 import CapabilityRequestList from './capability-request-map';
 import CapabilityNotice from './capability-request-notice';

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -658,9 +658,7 @@ export const TransactionsList = (
 				window.confirm( confirmMessage )
 			) {
 				try {
-					const {
-						exported_transactions: exportedTransactions,
-					} = await apiFetch( {
+					await apiFetch( {
 						path: getTransactionsCSV( {
 							userEmail,
 							dateAfter,

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -289,7 +289,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 
 			$this->add_fraud_outcome_manual_entry( $order, 'approve' );
 
-			$result = $this->gateway->capture_charge( $order, false, $intent_metadata );
+			$result = $this->gateway->capture_charge( $order, true, $intent_metadata );
 
 			if ( Intent_Status::SUCCEEDED !== $result['status'] ) {
 				return new WP_Error(


### PR DESCRIPTION
Fixes #6806 

The bug was happening because we were not sending level3 data when capturing an authorization, but relying on the level3 data sent when the authorization was created. If the order was modified after the initial authorization to let's say, remove one item or modify shipping costs, Stripe would throw an error because the level 3 data was not updated. 

#### Changes proposed in this Pull Request

* Include level3 data when capturing and authorization by calling the `capture_charge` method with `include_level3` param set to `true` 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

_To test manually you'll need a way to edit the order after it has been authorized. Here's one way:_

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable manual capture in merchant settings.
2. As a shopper add 2 products to the cart and checkout.
3. As a merchant, go to the order detail, reduce the quantity of products in the order and save it (hint: use the "pencil" icon to edit quantity).
4. Navigate to the payment details page and Capture the payment.
5. Check that the payment is captured without errors.
6. Check that the payment transitions to Partial refund status.
7. Go back to the order details page and you should not see any error in the Order notes.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
