### PR TITLE
Fix WooPay integration with AutomateWoo - Refer a Friend extension

### DIFF
--- a/changelog/fix-7913-woopay-automatewoo-referrals-integration
+++ b/changelog/fix-7913-woopay-automatewoo-referrals-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay integration with AutomateWoo - Refer a Friend extension.

--- a/includes/woopay/class-woopay-adapted-extensions.php
+++ b/includes/woopay/class-woopay-adapted-extensions.php
@@ -259,9 +259,7 @@ class WooPay_Adapted_Extensions extends IntegrationRegistry {
 		method_exists( AW_Referrals(), 'options' ) &&
 		AW_Referrals()->options()->type === 'link' &&
 		class_exists( '\AutomateWoo\Referrals\Referral_Manager' ) &&
-		method_exists( \AutomateWoo\Referrals\Referral_Manager::class, 'get_advocate_key_from_cookie' ) && class_exists( 'AFWC_API' ) &&
-		method_exists( 'AFWC_API', 'get_instance' ) &&
-		method_exists( 'AFWC_API', 'track_conversion' );
+		method_exists( \AutomateWoo\Referrals\Referral_Manager::class, 'get_advocate_key_from_cookie' );
 	}
 
 	/**

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -262,7 +262,15 @@ class WooPay_Session {
 	 * Fix for AutomateWoo - Refer A Friend Add-on
 	 * plugin when using link referrals.
 	 */
-	public static function automatewoo_refer_a_friend_referral_from_parameter() {
+	public static function automatewoo_refer_a_friend_referral_from_parameter( $advocate_id ) {
+		if ( ! self::is_request_from_woopay() || ! self::is_store_api_request() ) {
+			return $advocate_id;
+		}
+
+		if ( ! self::is_woopay_enabled() ) {
+			return $advocate_id;
+		}
+
 		if ( empty( $_GET['automatewoo_referral_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}


### PR DESCRIPTION
Fixes #7913

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
This PR fixes a bug on #7300 implementation caused by not checking if the request comes from WooPay before applying the AutomateWoo - Refer a Friend extension filters.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow https://github.com/Automattic/woocommerce-payments/pull/7300 testing instructions with WooPay checkout flow.
* Follow https://github.com/Automattic/woocommerce-payments/pull/7300 testing instructions with shortcode and blocks based checkout flow.
* All referrals should be computed as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
