### PR TITLE
Correct the `AccountOverview.OverviewsResponse` TS interface `account` type to show it is nullable

### DIFF
--- a/changelog/fix-7920-correct-account-overview-account-type-nullable
+++ b/changelog/fix-7920-correct-account-overview-account-type-nullable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: No changelog entry required – minor TS interface fix with no user-facing changes
+
+

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -115,7 +115,7 @@ const AccountBalances: React.FC = () => {
 			currencyCode: overview.currency,
 			availableFunds: overview.available?.amount ?? 0,
 			pendingFunds: overview.pending?.amount ?? 0,
-			delayDays: account.deposits_schedule.delay_days,
+			delayDays: account?.deposits_schedule.delay_days,
 			instantBalance: overview.instant,
 		} )
 	);

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -115,7 +115,7 @@ const AccountBalances: React.FC = () => {
 			currencyCode: overview.currency,
 			availableFunds: overview.available?.amount ?? 0,
 			pendingFunds: overview.pending?.amount ?? 0,
-			delayDays: account?.deposits_schedule.delay_days,
+			delayDays: account?.deposits_schedule.delay_days ?? 0,
 			instantBalance: overview.instant,
 		} )
 	);

--- a/client/overview/hooks.ts
+++ b/client/overview/hooks.ts
@@ -46,7 +46,7 @@ export const useSelectedCurrency = (): UseSelectedCurrencyResult => {
 };
 
 type SelectedCurrencyOverview = {
-	account?: AccountOverview.Account;
+	account?: AccountOverview.Account | null;
 	overview?: AccountOverview.Overview;
 	isLoading: boolean;
 };

--- a/client/types/account-overview.d.ts
+++ b/client/types/account-overview.d.ts
@@ -68,8 +68,8 @@ export interface Overview {
 
 export interface OverviewsResponse {
 	overviews: {
-		account: Account;
-		currencies: Array< Overview >;
+		account: Account | null;
+		currencies: Overview[];
 	};
 	isLoading: boolean;
 }


### PR DESCRIPTION
Fixes #7920

> [!note]
> This is a small, dev-facing change. I hope this requires minimal effort to review!

#### Changes proposed in this Pull Request


This PR fixes a mismatch between the `OverviewsResponse` TS interface and data returned from `getAllDepositsOverviews()` while the fetch request is in progress:

https://github.com/Automattic/woocommerce-payments/blob/b37d805915d680220c63a6b323dceed6c2def7ad/client/data/deposits/selectors.js#L58-L64

`OverviewsResponse` has been corrected to define the `overviews.account` type as `Account | null`:

```ts
export interface OverviewsResponse {
	overviews: {
		account: Account | null;
		currencies: Overview[];
	};
	isLoading: boolean;
}
```

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npx tsc --noEmit` and ensure no TS errors are returned.
* Ensure relevant GH checks tests pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
