### PR TITLE
Fix currency negative sign position on JS rendered amounts

### DIFF
--- a/changelog/fix-6700-remove-currency-sign-modification-code
+++ b/changelog/fix-6700-remove-currency-sign-modification-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix currency negative sign position on JS rendered amounts

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -343,7 +343,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -654,7 +654,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -914,7 +914,7 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -1174,7 +1174,7 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -1456,7 +1456,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -1742,16 +1742,16 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
             >
               <p>
                 Refunded: 
-                $-20.00
+                -$20.00
               </p>
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
                 Net: 
-                $-0.70
+                -$0.70
               </p>
             </div>
           </div>
@@ -2238,11 +2238,11 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             >
               <p>
                 Refunded: 
-                $-12.00
+                -$12.00
               </p>
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -2502,7 +2502,7 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>
@@ -2762,7 +2762,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
               
               <p>
                 Fees: 
-                $-0.70
+                -$0.70
               </p>
               
               <p>

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -251,7 +251,7 @@ describe( 'PaymentDetailsSummary', () => {
 		} );
 
 		const container = renderCharge( charge );
-		screen.getByText( /Refunded: \$-20.00/i );
+		screen.getByText( /Refunded: -\$20.00/i );
 		expect( container ).toMatchSnapshot();
 	} );
 

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -1494,7 +1494,7 @@ exports[`PaymentDetailsTimeline renders subscription fee correctly 1`] = `
                   >
                     <span />
                     <span>
-                      Fee (3.9% + $0.30): $-0.34
+                      Fee (3.9% + $0.30): -$0.34
                     </span>
                     <span>
                       <ul

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -26,7 +26,7 @@ Array [
   Object {
     "body": Array [
       "1.00 EUR → 1.19944 USD: $21.59 USD",
-      "Fee (2.9% + $0.30): $-0.62",
+      "Fee (2.9% + $0.30): -$0.62",
       undefined,
       "Net deposit: $20.97 USD",
     ],
@@ -389,7 +389,7 @@ Array [
   Object {
     "body": Array [
       undefined,
-      "Fee (1.95% + $0.15): $-3.50",
+      "Fee (1.95% + $0.15): -$3.50",
       <ul
         className="fee-breakdown-list"
       >
@@ -412,7 +412,7 @@ Array [
               Variable fee: -4.9%
             </li>
             <li>
-              Fixed fee: £-0.20
+              Fixed fee: -£0.20
             </li>
           </ul>
         </li>
@@ -455,7 +455,7 @@ Array [
   Object {
     "body": Array [
       undefined,
-      "Base fee (1.95% + $0.15): $-3.50",
+      "Base fee (1.95% + $0.15): -$3.50",
       undefined,
       "Net deposit: $59.50 USD",
     ],
@@ -695,7 +695,7 @@ Array [
   Object {
     "body": Array [
       undefined,
-      "Fee (2.6% + $0.20): $-0.61",
+      "Fee (2.6% + $0.20): -$0.61",
       <ul
         className="fee-breakdown-list"
       >
@@ -745,7 +745,7 @@ Array [
   Object {
     "body": Array [
       undefined,
-      "Fee (1.95% + $0.15): $-3.50",
+      "Fee (1.95% + $0.15): -$3.50",
       undefined,
       "Net deposit: $59.50 USD",
     ],

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -542,7 +542,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -723,7 +723,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -871,7 +871,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_rskkmpe46yu&transaction_id=txn_mmtr89gjh5&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.75
+                      -$0.75
                     </a>
                   </td>
                   <td
@@ -1531,7 +1531,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -1712,7 +1712,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -1860,7 +1860,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_rskkmpe46yu&transaction_id=txn_mmtr89gjh5&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.75
+                      -$0.75
                     </a>
                   </td>
                   <td
@@ -2524,7 +2524,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -3210,7 +3210,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -3401,7 +3401,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -3552,7 +3552,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_rskkmpe46yu&transaction_id=txn_mmtr89gjh5&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.75
+                      -$0.75
                     </a>
                   </td>
                   <td
@@ -4257,7 +4257,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -4438,7 +4438,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -4586,7 +4586,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_rskkmpe46yu&transaction_id=txn_mmtr89gjh5&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.75
+                      -$0.75
                     </a>
                   </td>
                   <td
@@ -5288,7 +5288,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -5469,7 +5469,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.50
+                      -$0.50
                     </a>
                   </td>
                   <td
@@ -5617,7 +5617,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_rskkmpe46yu&transaction_id=txn_mmtr89gjh5&transaction_type=charge"
                       tabindex="-1"
                     >
-                      $-0.75
+                      -$0.75
                     </a>
                   </td>
                   <td

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -119,19 +119,38 @@ export const formatCurrency = (
 		amount /= 100;
 	}
 
+	const isNegative = amount < 0;
+	const positiveAmount = isNegative ? -1 * amount : amount;
 	const currency = getCurrency( currencyCode, baseCurrencyCode );
 
 	if ( currency === null ) {
-		return composeFallbackCurrency( amount, currencyCode, isZeroDecimal );
+		return (
+			( isNegative ? '-' : '' ) +
+			composeFallbackCurrency(
+				positiveAmount,
+				currencyCode,
+				isZeroDecimal
+			)
+		);
 	}
 
 	try {
-		return typeof currency.formatAmount === 'function'
-			? htmlDecode( currency.formatAmount( amount ) )
-			: htmlDecode( currency.formatCurrency( amount ) );
+		return (
+			( isNegative ? '-' : '' ) +
+			( typeof currency.formatAmount === 'function'
+				? htmlDecode( currency.formatAmount( positiveAmount ) )
+				: htmlDecode( currency.formatCurrency( positiveAmount ) ) )
+		);
 	} catch ( err ) {
-		return htmlDecode(
-			composeFallbackCurrency( amount, currencyCode, isZeroDecimal )
+		return (
+			( isNegative ? '-' : '' ) +
+			htmlDecode(
+				composeFallbackCurrency(
+					positiveAmount,
+					currencyCode,
+					isZeroDecimal
+				)
+			)
 		);
 	}
 };

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -121,11 +121,12 @@ export const formatCurrency = (
 
 	const isNegative = amount < 0;
 	const positiveAmount = isNegative ? -1 * amount : amount;
+	const prefix = isNegative ? '-' : '';
 	const currency = getCurrency( currencyCode, baseCurrencyCode );
 
 	if ( currency === null ) {
 		return (
-			( isNegative ? '-' : '' ) +
+			prefix +
 			composeFallbackCurrency(
 				positiveAmount,
 				currencyCode,
@@ -136,14 +137,14 @@ export const formatCurrency = (
 
 	try {
 		return (
-			( isNegative ? '-' : '' ) +
+			prefix +
 			( typeof currency.formatAmount === 'function'
 				? htmlDecode( currency.formatAmount( positiveAmount ) )
 				: htmlDecode( currency.formatCurrency( positiveAmount ) ) )
 		);
 	} catch ( err ) {
 		return (
-			( isNegative ? '-' : '' ) +
+			prefix +
 			htmlDecode(
 				composeFallbackCurrency(
 					positiveAmount,

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -829,15 +829,7 @@ class WC_Payments_Utils {
 			)
 		);
 
-		if ( $amount >= 0 ) {
-			return $formatted;
-		}
-
-		// Handle the subtle display difference for the negative amount between PHP wc_price `-$0.74` vs JavaScript formatCurrency `$-0.74` for the same input.
-		// Remove the minus sign, and then move it right before the number.
-		$formatted = str_replace( '-', '', $formatted );
-
-		return preg_replace( '/([0-9,\.]+)/', '-$1', $formatted );
+		return $formatted;
 	}
 
 	/**

--- a/tests/fixtures/captured-payments/discount.json
+++ b/tests/fixtures/captured-payments/discount.json
@@ -61,7 +61,7 @@
       "discount": {
         "label": "Discount",
         "variable": "Variable fee: -4.9%",
-        "fixed": "Fixed fee: $-0.30"
+        "fixed": "Fixed fee: -$0.30"
       }
     },
     "netString": "Net deposit: $105.48 USD"

--- a/tests/fixtures/captured-payments/foreign-card.json
+++ b/tests/fixtures/captured-payments/foreign-card.json
@@ -49,7 +49,7 @@
   },
   "expectation": {
     "fxString": "1.00 CAD → 0.774692 USD: $100.71 USD",
-    "feeString": "Fee (4.9% + $0.30): $-5.24",
+    "feeString": "Fee (4.9% + $0.30): -$5.24",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-international": "International card fee: 1%",

--- a/tests/fixtures/captured-payments/fx-decimal.json
+++ b/tests/fixtures/captured-payments/fx-decimal.json
@@ -42,7 +42,7 @@
     },
   "expectation": {
     "fxString": "1.00 EUR → 1.0504 USD: $105.04 USD",
-    "feeString": "Fee (3.9% + $0.30): $-4.39",
+    "feeString": "Fee (3.9% + $0.30): -$4.39",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-fx": "Foreign exchange fee: 1%"

--- a/tests/fixtures/captured-payments/fx-foreign-card.json
+++ b/tests/fixtures/captured-payments/fx-foreign-card.json
@@ -42,7 +42,7 @@
     }
   },
   "expectation": {
-    "feeString": "Fee (3.9% + $0.30): $-3.20",
+    "feeString": "Fee (3.9% + $0.30): -$3.20",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-international": "International card fee: 1%"

--- a/tests/fixtures/captured-payments/fx-with-capped-fee.json
+++ b/tests/fixtures/captured-payments/fx-with-capped-fee.json
@@ -51,7 +51,7 @@
   },
   "expectation": {
     "fxString": "1.00 EUR → 1.05483 USD: $1,002.09 USD",
-    "feeString": "Fee (2.5% + $6.00): $-31.05",
+    "feeString": "Fee (2.5% + $6.00): -$31.05",
     "feeBreakdown": {
       "base": "Base fee: capped at $6.00",
       "additional-international": "International card fee: 1.5%",

--- a/tests/fixtures/captured-payments/fx.json
+++ b/tests/fixtures/captured-payments/fx.json
@@ -43,7 +43,7 @@
     },
   "expectation": {
     "fxString": "1 VND → 0.000044 USD: $100.04 USD",
-    "feeString": "Fee (3.9% + $0.30): $-4.20",
+    "feeString": "Fee (3.9% + $0.30): -$4.20",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-fx": "Foreign exchange fee: 1%"

--- a/tests/fixtures/captured-payments/jpy-payment.json
+++ b/tests/fixtures/captured-payments/jpy-payment.json
@@ -50,7 +50,7 @@
 	},
 	"expectation": {
 		"fxString": "1.00 EUR → 159.13333 JPY: ¥4,774 JPY",
-		"feeString": "Fee (7.6% + ¥0): ¥-267",
+		"feeString": "Fee (7.6% + ¥0): -¥267",
 		"feeBreakdown": {
 			"base": "Base fee: 3.6%",
 			"additional-international": "International card fee: 2%",

--- a/tests/fixtures/captured-payments/only-base-fee.json
+++ b/tests/fixtures/captured-payments/only-base-fee.json
@@ -34,7 +34,7 @@
     }
   },
   "expectation": {
-    "feeString": "Base fee (2.9% + $0.30): $-0.74",
+    "feeString": "Base fee (2.9% + $0.30): -$0.74",
     "netString": "Net deposit: $14.26 USD"
   }
 }

--- a/tests/fixtures/captured-payments/subscription.json
+++ b/tests/fixtures/captured-payments/subscription.json
@@ -50,7 +50,7 @@
   },
   "expectation": {
     "fxString": "1.00 EUR → 1.05491 USD: $55.91 USD",
-    "feeString": "Fee (4.9% + $0.30): $-3.04",
+    "feeString": "Fee (4.9% + $0.30): -$3.04",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-fx": "Foreign exchange fee: 1%",

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -518,7 +518,7 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 	public function provider_format_currency(): array {
 		return [
 			'US dollar'                      => [ 123.456, 'USD', '$123.46' ],
-			'US dollar with negative amount' => [ -123.456, 'USD', '$-123.46' ],
+			'US dollar with negative amount' => [ -123.456, 'USD', '-$123.46' ],
 			'Euro'                           => [ 12000, 'EUR', '12.000,00 €' ],
 			'CHF - no currency symbol'       => [ 123, 'CHF', 'CHF 123.00' ],
 			'VND - decimal currency'         => [ 123456, 'VND', '123.456 ₫' ],


### PR DESCRIPTION
Fixes #6700

#### Changes proposed in this Pull Request

This fixes the discrepancy between JS rendered negative amounts versus PHP rendered amounts with putting the negative sign in front of the rendered amount including the currency code.  JS side was rendering the amount with putting the currency code before the negative amount because of `sprintf`, whereas PHP was converting the price to positive and prepending the negativity sign after `sprintf` ([link](https://github.com/woocommerce/woocommerce/blob/7768ef5b5c08c063bf8270387eb2bc9963eb0beb/plugins/woocommerce/includes/wc-formatting-functions.php#L611-L612)). Used the same approach on the JS side to fix the difference in rendering.

This equalizes the negative format application for those three places:

- [#](https://github.com/woocommerce/woocommerce/blob/7768ef5b5c08c063bf8270387eb2bc9963eb0beb/plugins/woocommerce/includes/wc-formatting-functions.php#L611-L612) Core `wc_price` formatting of negative amounts
- [#](https://github.com/Automattic/woocommerce-payments/pull/7935/files#diff-fdf97bb0bd6043ee97d2ab4f058059c59d2b7173a076398fe8441824dc7b5e35) Removes the extra mod for fee formatter
- [#](https://github.com/Automattic/woocommerce-payments/pull/7935/files#diff-d6d2898493a58a1d7c4e36bdfc2edbab82b2d1241a7d81f7988f68f20f75c513) Moves the negative amount handling outside the sprintf call

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch, build the client assets with `npm run build:client`
* Go to Payments > Transactions screen and see the fees are rendered with negative sign in front of the whole representation, not after the currency symbol.
* Sell something and do a refund
* See that the refund prices are shown correctly with the negative sign before the currency sign.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.