### PR TITLE
Add empty file to avoid fatals

### DIFF
--- a/changelog/revert-file-needed-for-plugin-update
+++ b/changelog/revert-file-needed-for-plugin-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This is the file revert to avoid failures on plugin update. This is a temporary solution. Both removal & revert happen on develop meaning there is no change to the outside world.
+
+

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -9,4 +9,5 @@
  * REST controller for UPE feature flag. Needs to stay in the codebase to avoid error on plugin update for versions 6.9.2 or earlier.
  */
 class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
+    public function register_routes() {}
 }

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -9,5 +9,8 @@
  * REST controller for UPE feature flag. Needs to stay in the codebase to avoid error on plugin update for versions 6.9.2 or earlier.
  */
 class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
-    public function register_routes() {}
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {}
 }

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Class WC_REST_UPE_Flag_Toggle_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+/**
+ * REST controller for UPE feature flag. Needs to stay in the codebase to avoid error on plugin update for versions 6.9.2 or earlier.
+ */
+class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
+}


### PR DESCRIPTION
Based on p1703066593001019-slack-CGGCLBN58 

#### Changes proposed in this Pull Request
Due to some unexpected way of performing operations during the plugin update, some errors might pop up. paJDYF-aZa-p2 is all about it. When `class-wc-rest-upe-flag-toggle-controller.php` was removed in https://github.com/Automattic/woocommerce-payments/pull/7821 together with its invocation in `class-wc-payments.php`, we faced another issue of the same nature (p1702991864368429/1702991804.354289-slack-C011ENB20Q1).

This error is not fatal (doesn't prevent from plugin update) nor is it shown to the merchants because they don't have debug log mode enabled on their sites. But since we previously approached same problem by reverting (https://github.com/Automattic/woocommerce-payments/pull/6303 as example), this PR also reverts the file so that the error doesn't appear. 

The file can be empty. p1703073471085769/1703066593.001019-slack-CGGCLBN58


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions


> 💡 If you want to save a bit of time by skipping (1) and (2) below, reach out to @timur27 to get credentials to `https://rough-butterfly.jurassic.ninja/wp-admin`, which has WooPayments & DevTools configured

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Create a JN site with DevTools & WooPayments, which will be of version `6.9.2` by default
2. Set up WooPayments, navigate to `Payments -> Settings -> Advanced settings` and confirm Debug mode is enabled 
3. Attempt to update the plugin from to the version from [here](https://github.com/Automattic/woocommerce-payments/releases/tag/7.0.0-test-1) and confirm that you're getting [the error during this process](https://github.com/Automattic/woocommerce-payments/assets/22319444/cfca0f67-29c7-4218-9a70-8c134789fe50)
4. Downgrade back to [`6.9.2`](https://github.com/Automattic/woocommerce-payments/releases/tag/6.9.2)
5. Download [`7.0.0` version with the fix](https://github.com/Automattic/woocommerce-payments/actions/runs/7277917845) (in other words zip based on this PR) and use it to update the plugin version
6. Confirm no errors during the plugin update this time 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.