### PR TITLE
Modify the test support phone numbers

### DIFF
--- a/changelog/fix-test-support-phone
+++ b/changelog/fix-test-support-phone
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Modified the test phone numbers supported by Stripe.
+
+

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -25,9 +25,7 @@ const SupportPhoneInput = ( { setInputVallid } ) => {
 	const isEmptyPhoneValid = supportPhone === '' && currentPhone === '';
 	const isDevModeEnabled = useDevMode();
 	const isTestPhoneValid =
-		isDevModeEnabled &&
-		( supportPhone === '+1000-000-0000' ||
-			supportPhone === '+10000000000' );
+		isDevModeEnabled && supportPhone === '+10000000000';
 
 	const [ isPhoneValid, setPhoneValidity ] = useState( true );
 	if ( ! isTestPhoneValid && ! isPhoneValid && ! isEmptyPhoneValid ) {
@@ -53,7 +51,7 @@ const SupportPhoneInput = ( { setInputVallid } ) => {
 	let labelText = __( 'Support phone number', 'woocommerce-payments' );
 	if ( isDevModeEnabled ) {
 		labelText += __(
-			' (+1 000-000-0000 can be used in dev mode)',
+			' (+1 0000000000 can be used in dev mode)',
 			'woocommerce-payments'
 		);
 	}


### PR DESCRIPTION
Fixes #6782 
#### Changes proposed in this Pull Request
- Changed the text to reflect that support phone number +10000000000  is only supported.

#### Testing instructions
Same as PR #7851 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
