### PR TITLE
Fix account status error messages with JSX

### DIFF
--- a/changelog/fix-jsx-account-status-error-messages
+++ b/changelog/fix-jsx-account-status-error-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix account status error messages with links.

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -26,7 +26,7 @@ export const getUpdateBusinessDetailsTask = (
 	const hasMultipleErrors = 1 < errorMessages.length;
 	const hasSingleError = 1 === errorMessages.length;
 
-	let accountDetailsTaskDescription = '',
+	let accountDetailsTaskDescription: React.ReactElement | string = '',
 		errorMessageDescription,
 		accountDetailsUpdateByDescription;
 
@@ -45,9 +45,11 @@ export const getUpdateBusinessDetailsTask = (
 
 		if ( hasSingleError ) {
 			errorMessageDescription = errorMessages[ 0 ];
-			accountDetailsTaskDescription = errorMessageDescription.concat(
-				' ',
-				accountDetailsUpdateByDescription
+			accountDetailsTaskDescription = (
+				<>
+					{ errorMessageDescription }{ ' ' }
+					{ accountDetailsUpdateByDescription }
+				</>
 			);
 		} else {
 			accountDetailsTaskDescription = accountDetailsUpdateByDescription;

--- a/client/overview/task-list/types.d.ts
+++ b/client/overview/task-list/types.d.ts
@@ -17,4 +17,6 @@ export interface TaskItemProps extends React.ComponentProps< typeof TaskItem > {
 	 * Whether the task is dismissable.
 	 */
 	isDismissable?: boolean;
+
+	content: string | React.ReactElement;
 }


### PR DESCRIPTION
Fixes p1703252483654569-slack-C7U3Y3VMY

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Some task list error messages includes JSX which cause blank screen errors when running the `.concat` (a string method) on `accountDetailsUpdateByDescription`, this PR fixes that by always using JSX to append the error message.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Below [this line](https://github.com/Automattic/woocommerce-payments/blob/e2a574a7e6eb94fbc65aad77fe5ef8f937cd86cb/includes/admin/class-wc-payments-admin.php#L798) append the following code:

```
$account_status_data['status'] = 'restricted_soon';
$account_status_data['currentDeadline'] = 1705003534;
$account_status_data['requirements']['errors'] = [
    [
        'code' => 'verification_document_type_not_supported',
        'detailed_code' => 'verification_document_type_not_supported',
    ]
];
```
* Access the `Payments > Overview` page.
* The error message should be shown as expected (it will cause a blank screen on `trunk`).
* Test with [other error codes](https://github.com/Automattic/woocommerce-payments/blob/fix/jsx-account-status-error-messages/client/overview/task-list/strings.tsx#L198).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.