### PR TITLE
Bump WC tested up to version to 8.4.0

### DIFF
--- a/changelog/dev-bump-wc-version-8-4-0
+++ b/changelog/dev-bump-wc-version-8-4-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump WC tested up to version to 8.4.0.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -9,7 +9,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 8.3.1
+ * WC tested up to: 8.4.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 6.9.2


### PR DESCRIPTION
Context: https://github.com/Automattic/woocommerce-payments/issues/7451#issuecomment-1802197703

8.4.0 is the [latest stable release](https://github.com/woocommerce/woocommerce/releases/latest) of WooCommerce.