### PR TITLE
Fix broken dispute details UI

### DIFF
--- a/changelog/fix-7958-transaction-details-dispute-details-broken-ui
+++ b/changelog/fix-7958-transaction-details-dispute-details-broken-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Not user-facing: fixes styling bug introduced in develop branch
+
+

--- a/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
@@ -20,55 +20,61 @@ exports[`Order details page should match the snapshot - Charge without payment i
           data-wp-component="CardBody"
         >
           <div
-            class="payment-details-summary"
+            class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
           >
             <div
-              class="payment-details-summary__section"
+              class="payment-details-summary"
             >
-              <p
-                class="payment-details-summary__amount"
-              >
-                $15.00
-                <span
-                  class="payment-details-summary__amount-currency"
-                >
-                  USD
-                </span>
-                <span
-                  class="chip chip-light"
-                >
-                  Pending
-                </span>
-              </p>
               <div
-                class="payment-details-summary__breakdown"
+                class="payment-details-summary__section"
               >
-                
-                <p>
-                  Fees: 
-                  -$0.00
-                </p>
-                
-                <p>
-                  Net: 
+                <p
+                  class="payment-details-summary__amount"
+                >
                   $15.00
+                  <span
+                    class="payment-details-summary__amount-currency"
+                  >
+                    USD
+                  </span>
+                  <span
+                    class="chip chip-light"
+                  >
+                    Pending
+                  </span>
                 </p>
+                <div
+                  class="payment-details-summary__breakdown"
+                >
+                  
+                  <p>
+                    Fees: 
+                    -$0.00
+                  </p>
+                  
+                  <p>
+                    Net: 
+                    $15.00
+                  </p>
+                </div>
+              </div>
+              <div
+                class="payment-details-summary__section"
+              >
+                <div
+                  class="payment-details-summary__id"
+                >
+                  Payment ID: 
+                  776
+                </div>
               </div>
             </div>
             <div
-              class="payment-details-summary__section"
-            >
-              <div
-                class="payment-details-summary__id"
-              >
-                Payment ID: 
-                776
-              </div>
-            </div>
+              class="payment-details__refund-controls"
+            />
           </div>
-          <div
-            class="payment-details__refund-controls"
-          />
         </div>
         <hr
           aria-orientation="horizontal"

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -243,307 +243,314 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 	return (
 		<Card>
 			<CardBody>
-				<div className="payment-details-summary">
-					<div className="payment-details-summary__section">
-						<p className="payment-details-summary__amount">
-							<Loadable
-								isLoading={ isLoading }
-								placeholder="Amount placeholder"
-							>
-								{ formattedAmount }
-								<span className="payment-details-summary__amount-currency">
-									{ charge.currency || 'USD' }
-								</span>
-								{ charge.dispute ? (
-									<DisputeStatusChip
-										status={ charge.dispute.status }
-										dueBy={
-											charge.dispute.evidence_details
-												?.due_by
-										}
-										prefixDisputeType={ true }
-									/>
-								) : (
-									<PaymentStatusChip
-										status={ getChargeStatus(
-											charge,
-											paymentIntent
-										) }
-									/>
-								) }
-							</Loadable>
-						</p>
-						<div className="payment-details-summary__breakdown">
-							{ renderStorePrice ? (
-								<p>
-									{ formatExplicitCurrency(
-										balance.amount,
-										balance.currency
-									) }
-								</p>
-							) : null }
-							{ balance.refunded ? (
-								<p>
-									{ `${
-										disputeFee
-											? __(
-													'Deducted',
-													'woocommerce-payments'
-											  )
-											: __(
-													'Refunded',
-													'woocommerce-payments'
-											  )
-									}: ` }
-									{ formatExplicitCurrency(
-										-balance.refunded,
-										balance.currency
-									) }
-								</p>
-							) : (
-								''
-							) }
-							<p>
+				<Flex direction="row" align="start">
+					<div className="payment-details-summary">
+						<div className="payment-details-summary__section">
+							<p className="payment-details-summary__amount">
 								<Loadable
 									isLoading={ isLoading }
-									placeholder="Fee amount"
+									placeholder="Amount placeholder"
 								>
-									{ `${ __(
-										'Fees',
-										'woocommerce-payments'
-									) }: ` }
-									{ formatCurrency(
-										-balance.fee,
-										balance.currency
-									) }
-									{ disputeFee && (
-										<ClickTooltip
-											className="payment-details-summary__breakdown__fee-tooltip"
-											buttonIcon={ <HelpOutlineIcon /> }
-											buttonLabel={ __(
-												'Fee breakdown',
-												'woocommerce-payments'
-											) }
-											content={
-												<>
-													<Flex>
-														<label>
-															{ __(
-																'Transaction fee',
-																'woocommerce-payments'
-															) }
-														</label>
-														<span aria-label="Transaction fee">
-															{ formatCurrency(
-																transactionFee.fee,
-																transactionFee.currency
-															) }
-														</span>
-													</Flex>
-													<Flex>
-														<label>
-															{ __(
-																'Dispute fee',
-																'woocommerce-payments'
-															) }
-														</label>
-														<span aria-label="Dispute fee">
-															{ disputeFee }
-														</span>
-													</Flex>
-													<Flex>
-														<label>
-															{ __(
-																'Total fees',
-																'woocommerce-payments'
-															) }
-														</label>
-														<span aria-label="Total fees">
-															{ formatCurrency(
-																balance.fee,
-																balance.currency
-															) }
-														</span>
-													</Flex>
-												</>
+									{ formattedAmount }
+									<span className="payment-details-summary__amount-currency">
+										{ charge.currency || 'USD' }
+									</span>
+									{ charge.dispute ? (
+										<DisputeStatusChip
+											status={ charge.dispute.status }
+											dueBy={
+												charge.dispute.evidence_details
+													?.due_by
 											}
+											prefixDisputeType={ true }
+										/>
+									) : (
+										<PaymentStatusChip
+											status={ getChargeStatus(
+												charge,
+												paymentIntent
+											) }
 										/>
 									) }
 								</Loadable>
 							</p>
-							{ charge.paydown ? (
+							<div className="payment-details-summary__breakdown">
+								{ renderStorePrice ? (
+									<p>
+										{ formatExplicitCurrency(
+											balance.amount,
+											balance.currency
+										) }
+									</p>
+								) : null }
+								{ balance.refunded ? (
+									<p>
+										{ `${
+											disputeFee
+												? __(
+														'Deducted',
+														'woocommerce-payments'
+												  )
+												: __(
+														'Refunded',
+														'woocommerce-payments'
+												  )
+										}: ` }
+										{ formatExplicitCurrency(
+											-balance.refunded,
+											balance.currency
+										) }
+									</p>
+								) : (
+									''
+								) }
 								<p>
-									{ `${ __(
-										'Loan repayment',
-										'woocommerce-payments'
-									) }: ` }
-									{ formatExplicitCurrency(
-										charge.paydown.amount,
-										balance.currency
-									) }
+									<Loadable
+										isLoading={ isLoading }
+										placeholder="Fee amount"
+									>
+										{ `${ __(
+											'Fees',
+											'woocommerce-payments'
+										) }: ` }
+										{ formatCurrency(
+											-balance.fee,
+											balance.currency
+										) }
+										{ disputeFee && (
+											<ClickTooltip
+												className="payment-details-summary__breakdown__fee-tooltip"
+												buttonIcon={
+													<HelpOutlineIcon />
+												}
+												buttonLabel={ __(
+													'Fee breakdown',
+													'woocommerce-payments'
+												) }
+												content={
+													<>
+														<Flex>
+															<label>
+																{ __(
+																	'Transaction fee',
+																	'woocommerce-payments'
+																) }
+															</label>
+															<span aria-label="Transaction fee">
+																{ formatCurrency(
+																	transactionFee.fee,
+																	transactionFee.currency
+																) }
+															</span>
+														</Flex>
+														<Flex>
+															<label>
+																{ __(
+																	'Dispute fee',
+																	'woocommerce-payments'
+																) }
+															</label>
+															<span aria-label="Dispute fee">
+																{ disputeFee }
+															</span>
+														</Flex>
+														<Flex>
+															<label>
+																{ __(
+																	'Total fees',
+																	'woocommerce-payments'
+																) }
+															</label>
+															<span aria-label="Total fees">
+																{ formatCurrency(
+																	balance.fee,
+																	balance.currency
+																) }
+															</span>
+														</Flex>
+													</>
+												}
+											/>
+										) }
+									</Loadable>
 								</p>
-							) : (
-								''
+								{ charge.paydown ? (
+									<p>
+										{ `${ __(
+											'Loan repayment',
+											'woocommerce-payments'
+										) }: ` }
+										{ formatExplicitCurrency(
+											charge.paydown.amount,
+											balance.currency
+										) }
+									</p>
+								) : (
+									''
+								) }
+								<p>
+									<Loadable
+										isLoading={ isLoading }
+										placeholder="Net amount"
+									>
+										{ `${ __(
+											'Net',
+											'woocommerce-payments'
+										) }: ` }
+										{ formatExplicitCurrency(
+											charge.paydown
+												? balance.net -
+														Math.abs(
+															charge.paydown
+																.amount
+														)
+												: balance.net,
+											balance.currency
+										) }
+									</Loadable>
+								</p>
+							</div>
+						</div>
+						<div className="payment-details-summary__section">
+							{ ! isLoading && isFraudOutcomeReview && (
+								<div className="payment-details-summary__fraud-outcome-action">
+									<CancelAuthorizationButton
+										orderId={ charge.order?.number || 0 }
+										paymentIntentId={
+											charge.payment_intent || ''
+										}
+										onClick={ () => {
+											wcpayTracks.recordEvent(
+												'wcpay_fraud_protection_transaction_reviewed_merchant_blocked',
+												{
+													payment_intent_id:
+														charge.payment_intent,
+												}
+											);
+											wcpayTracks.recordEvent(
+												'payments_transactions_details_cancel_charge_button_click',
+												{
+													payment_intent_id:
+														charge.payment_intent,
+												}
+											);
+										} }
+									>
+										{ __( 'Block transaction' ) }
+									</CancelAuthorizationButton>
+
+									<CaptureAuthorizationButton
+										buttonIsPrimary
+										orderId={ charge.order?.number || 0 }
+										paymentIntentId={
+											charge.payment_intent || ''
+										}
+										buttonIsSmall={ false }
+										onClick={ () => {
+											wcpayTracks.recordEvent(
+												'wcpay_fraud_protection_transaction_reviewed_merchant_approved',
+												{
+													payment_intent_id:
+														charge.payment_intent,
+												}
+											);
+											wcpayTracks.recordEvent(
+												'payments_transactions_details_capture_charge_button_click',
+												{
+													payment_intent_id:
+														charge.payment_intent,
+												}
+											);
+										} }
+									>
+										{ __( 'Approve Transaction' ) }
+									</CaptureAuthorizationButton>
+								</div>
 							) }
-							<p>
+							<div className="payment-details-summary__id">
 								<Loadable
 									isLoading={ isLoading }
-									placeholder="Net amount"
+									placeholder="Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx"
 								>
 									{ `${ __(
-										'Net',
+										'Payment ID',
 										'woocommerce-payments'
 									) }: ` }
-									{ formatExplicitCurrency(
-										charge.paydown
-											? balance.net -
-													Math.abs(
-														charge.paydown.amount
-													)
-											: balance.net,
-										balance.currency
-									) }
+									{ charge.payment_intent
+										? charge.payment_intent
+										: charge.id }
 								</Loadable>
-							</p>
+							</div>
 						</div>
 					</div>
-					<div className="payment-details-summary__section">
-						{ ! isLoading && isFraudOutcomeReview && (
-							<div className="payment-details-summary__fraud-outcome-action">
-								<CancelAuthorizationButton
-									orderId={ charge.order?.number || 0 }
-									paymentIntentId={
-										charge.payment_intent || ''
-									}
-									onClick={ () => {
-										wcpayTracks.recordEvent(
-											'wcpay_fraud_protection_transaction_reviewed_merchant_blocked',
-											{
-												payment_intent_id:
-													charge.payment_intent,
-											}
-										);
-										wcpayTracks.recordEvent(
-											'payments_transactions_details_cancel_charge_button_click',
-											{
-												payment_intent_id:
-													charge.payment_intent,
-											}
-										);
-									} }
-								>
-									{ __( 'Block transaction' ) }
-								</CancelAuthorizationButton>
-
-								<CaptureAuthorizationButton
-									buttonIsPrimary
-									orderId={ charge.order?.number || 0 }
-									paymentIntentId={
-										charge.payment_intent || ''
-									}
-									buttonIsSmall={ false }
-									onClick={ () => {
-										wcpayTracks.recordEvent(
-											'wcpay_fraud_protection_transaction_reviewed_merchant_approved',
-											{
-												payment_intent_id:
-													charge.payment_intent,
-											}
-										);
-										wcpayTracks.recordEvent(
-											'payments_transactions_details_capture_charge_button_click',
-											{
-												payment_intent_id:
-													charge.payment_intent,
-											}
-										);
-									} }
-								>
-									{ __( 'Approve Transaction' ) }
-								</CaptureAuthorizationButton>
-							</div>
-						) }
-						<div className="payment-details-summary__id">
+					<div className="payment-details__refund-controls">
+						{ ! charge?.refunded && charge?.captured && (
 							<Loadable
 								isLoading={ isLoading }
-								placeholder="Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx"
+								placeholder={ moreVertical }
 							>
-								{ `${ __(
-									'Payment ID',
-									'woocommerce-payments'
-								) }: ` }
-								{ charge.payment_intent
-									? charge.payment_intent
-									: charge.id }
-							</Loadable>
-						</div>
-					</div>
-				</div>
-				<div className="payment-details__refund-controls">
-					{ ! charge?.refunded && charge?.captured && (
-						<Loadable
-							isLoading={ isLoading }
-							placeholder={ moreVertical }
-						>
-							<DropdownMenu
-								icon={ moreVertical }
-								label={ __(
-									'Translation actions',
-									'woocommerce-payments'
-								) }
-								popoverProps={ {
-									position: 'bottom left',
-								} }
-							>
-								{ ( { onClose } ) => (
-									<MenuGroup>
-										<MenuItem
-											onClick={ () => {
-												setIsRefundModalOpen( true );
-												wcpayTracks.recordEvent(
-													'payments_transactions_details_refund_modal_open',
-													{
-														payment_intent_id:
-															charge.payment_intent,
-													}
-												);
-												onClose();
-											} }
-										>
-											{ __(
-												'Refund in full',
-												'woocommerce-payments'
-											) }
-										</MenuItem>
-										{ charge.order && (
+								<DropdownMenu
+									icon={ moreVertical }
+									label={ __(
+										'Translation actions',
+										'woocommerce-payments'
+									) }
+									popoverProps={ {
+										position: 'bottom left',
+									} }
+								>
+									{ ( { onClose } ) => (
+										<MenuGroup>
 											<MenuItem
 												onClick={ () => {
+													setIsRefundModalOpen(
+														true
+													);
 													wcpayTracks.recordEvent(
-														'payments_transactions_details_partial_refund',
+														'payments_transactions_details_refund_modal_open',
 														{
 															payment_intent_id:
 																charge.payment_intent,
-															order_id:
-																charge.order
-																	?.number,
 														}
 													);
-													window.location =
-														charge.order?.url;
+													onClose();
 												} }
 											>
 												{ __(
-													'Partial refund',
+													'Refund in full',
 													'woocommerce-payments'
 												) }
 											</MenuItem>
-										) }
-									</MenuGroup>
-								) }
-							</DropdownMenu>
-						</Loadable>
-					) }
-				</div>
+											{ charge.order && (
+												<MenuItem
+													onClick={ () => {
+														wcpayTracks.recordEvent(
+															'payments_transactions_details_partial_refund',
+															{
+																payment_intent_id:
+																	charge.payment_intent,
+																order_id:
+																	charge.order
+																		?.number,
+															}
+														);
+														window.location =
+															charge.order?.url;
+													} }
+												>
+													{ __(
+														'Partial refund',
+														'woocommerce-payments'
+													) }
+												</MenuItem>
+											) }
+										</MenuGroup>
+									) }
+								</DropdownMenu>
+							</Loadable>
+						) }
+					</div>
+				</Flex>
 			</CardBody>
 			<CardDivider />
 			<CardBody>

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -25,6 +25,7 @@
 		padding: 0;
 		margin: 0;
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
 
 		.payment-details-summary__amount-currency {

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -8,11 +8,6 @@
 	margin-bottom: 24px;
 }
 
-.components-card__body:first-of-type {
-	display: flex;
-	flex-direction: row;
-}
-
 .payment-details-summary {
 	display: flex;
 	flex: 1;

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -16,55 +16,61 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-primary"
-              >
-                Payment authorized
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-primary"
+                >
+                  Payment authorized
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
-          >
-            <div
-              class="payment-details-summary__id"
-            >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
+            class="payment-details__refund-controls"
+          />
         </div>
-        <div
-          class="payment-details__refund-controls"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -320,71 +326,77 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-warning"
-              >
-                Needs review
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-warning"
+                >
+                  Needs review
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__fraud-outcome-action"
+              >
+                <button
+                  class="components-button is-destructive"
+                  type="button"
+                >
+                  Block transaction
+                </button>
+                <button
+                  class="components-button is-primary"
+                  type="button"
+                >
+                  Approve Transaction
+                </button>
+              </div>
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
-          >
-            <div
-              class="payment-details-summary__fraud-outcome-action"
-            >
-              <button
-                class="components-button is-destructive"
-                type="button"
-              >
-                Block transaction
-              </button>
-              <button
-                class="components-button is-primary"
-                type="button"
-              >
-                Approve Transaction
-              </button>
-            </div>
-            <div
-              class="payment-details-summary__id"
-            >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
+            class="payment-details__refund-controls"
+          />
         </div>
-        <div
-          class="payment-details__refund-controls"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -634,79 +646,85 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-success"
-              >
-                Paid
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-success"
+                >
+                  Paid
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -923,79 +941,85 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-success"
-              >
-                Paid
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-success"
+                >
+                  Paid
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -1212,79 +1236,85 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-success"
-              >
-                Paid
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-success"
+                >
+                  Paid
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -1524,79 +1554,85 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-success"
-              >
-                Paid
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-success"
+                >
+                  Paid
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -1840,58 +1876,64 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-light"
-              >
-                Refunded
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              <p>
-                Refunded: 
-                -$20.00
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-light"
+                >
+                  Refunded
+                </span>
               </p>
-              <p>
-                Fees: 
-                -$0.70
-              </p>
-              
-              <p>
-                Net: 
-                -$0.70
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                <p>
+                  Refunded: 
+                  -$20.00
+                </p>
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  -$0.70
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
-          >
-            <div
-              class="payment-details-summary__id"
-            >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
+            class="payment-details__refund-controls"
+          />
         </div>
-        <div
-          class="payment-details__refund-controls"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -2106,52 +2148,58 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                USD
-              </span>
-              <span
-                class="chip chip-light"
-              />
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                $0.00
+              <p
+                class="payment-details-summary__amount"
+              >
+                
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  USD
+                </span>
+                <span
+                  class="chip chip-light"
+                />
               </p>
-              
-              <p>
-                Net: 
-                $0.00
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  $0.00
+                </p>
+                
+                <p>
+                  Net: 
+                  $0.00
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
-          >
-            <div
-              class="payment-details-summary__id"
-            >
-              Payment ID: 
-            </div>
-          </div>
+            class="payment-details__refund-controls"
+          />
         </div>
-        <div
-          class="payment-details__refund-controls"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -2342,82 +2390,88 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-light"
-              >
-                Partial refund
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              <p>
-                Refunded: 
-                -$12.00
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-light"
+                >
+                  Partial refund
+                </span>
               </p>
-              <p>
-                Fees: 
-                -$0.70
-              </p>
-              
-              <p>
-                Net: 
-                $7.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                <p>
+                  Refunded: 
+                  -$12.00
+                </p>
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $7.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -2634,79 +2688,85 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-success"
-              >
-                Paid
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-success"
+                >
+                  Paid
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -2923,79 +2983,85 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
         data-wp-component="CardBody"
       >
         <div
-          class="payment-details-summary"
+          class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
         >
           <div
-            class="payment-details-summary__section"
+            class="payment-details-summary"
           >
-            <p
-              class="payment-details-summary__amount"
-            >
-              $20.00
-              <span
-                class="payment-details-summary__amount-currency"
-              >
-                usd
-              </span>
-              <span
-                class="chip chip-success"
-              >
-                Disputed: Won
-              </span>
-            </p>
             <div
-              class="payment-details-summary__breakdown"
+              class="payment-details-summary__section"
             >
-              
-              <p>
-                Fees: 
-                -$0.70
+              <p
+                class="payment-details-summary__amount"
+              >
+                $20.00
+                <span
+                  class="payment-details-summary__amount-currency"
+                >
+                  usd
+                </span>
+                <span
+                  class="chip chip-success"
+                >
+                  Disputed: Won
+                </span>
               </p>
-              
-              <p>
-                Net: 
-                $19.30
-              </p>
+              <div
+                class="payment-details-summary__breakdown"
+              >
+                
+                <p>
+                  Fees: 
+                  -$0.70
+                </p>
+                
+                <p>
+                  Net: 
+                  $19.30
+                </p>
+              </div>
+            </div>
+            <div
+              class="payment-details-summary__section"
+            >
+              <div
+                class="payment-details-summary__id"
+              >
+                Payment ID: 
+                ch_38jdHA39KKA
+              </div>
             </div>
           </div>
           <div
-            class="payment-details-summary__section"
+            class="payment-details__refund-controls"
           >
             <div
-              class="payment-details-summary__id"
+              class="components-dropdown components-dropdown-menu"
+              tabindex="-1"
             >
-              Payment ID: 
-              ch_38jdHA39KKA
-            </div>
-          </div>
-        </div>
-        <div
-          class="payment-details__refund-controls"
-        >
-          <div
-            class="components-dropdown components-dropdown-menu"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Translation actions"
-              class="components-button components-dropdown-menu__toggle has-icon"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Translation actions"
+                class="components-button components-dropdown-menu__toggle has-icon"
+                type="button"
               >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -20,77 +20,83 @@ exports[`Payment details page should match the snapshot - Charge query param 1`]
           data-wp-component="CardBody"
         >
           <div
-            class="payment-details-summary"
+            class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
           >
             <div
-              class="payment-details-summary__section"
+              class="payment-details-summary"
             >
-              <p
-                class="payment-details-summary__amount"
-              >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Amount placeholder
-                </span>
-              </p>
               <div
-                class="payment-details-summary__breakdown"
+                class="payment-details-summary__section"
               >
-                
-                <p>
+                <p
+                  class="payment-details-summary__amount"
+                >
                   <span
                     aria-busy="true"
                     class="is-loadable-placeholder"
                   >
-                    Fee amount
+                    Amount placeholder
                   </span>
                 </p>
-                
-                <p>
+                <div
+                  class="payment-details-summary__breakdown"
+                >
+                  
+                  <p>
+                    <span
+                      aria-busy="true"
+                      class="is-loadable-placeholder"
+                    >
+                      Fee amount
+                    </span>
+                  </p>
+                  
+                  <p>
+                    <span
+                      aria-busy="true"
+                      class="is-loadable-placeholder"
+                    >
+                      Net amount
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                class="payment-details-summary__section"
+              >
+                <div
+                  class="payment-details-summary__id"
+                >
                   <span
                     aria-busy="true"
                     class="is-loadable-placeholder"
                   >
-                    Net amount
+                    Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx
                   </span>
-                </p>
+                </div>
               </div>
             </div>
             <div
-              class="payment-details-summary__section"
+              class="payment-details__refund-controls"
             >
-              <div
-                class="payment-details-summary__id"
+              <span
+                aria-busy="true"
+                class="is-loadable-placeholder"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx
-                </span>
-              </div>
+                  <path
+                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                  />
+                </svg>
+              </span>
             </div>
-          </div>
-          <div
-            class="payment-details__refund-controls"
-          >
-            <span
-              aria-busy="true"
-              class="is-loadable-placeholder"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                />
-              </svg>
-            </span>
           </div>
         </div>
         <hr
@@ -477,79 +483,85 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
           data-wp-component="CardBody"
         >
           <div
-            class="payment-details-summary"
+            class="components-flex css-175m5nr-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
           >
             <div
-              class="payment-details-summary__section"
+              class="payment-details-summary"
             >
-              <p
-                class="payment-details-summary__amount"
-              >
-                $1,500.00
-                <span
-                  class="payment-details-summary__amount-currency"
-                >
-                  usd
-                </span>
-                <span
-                  class="chip chip-success"
-                >
-                  Paid
-                </span>
-              </p>
               <div
-                class="payment-details-summary__breakdown"
+                class="payment-details-summary__section"
               >
-                
-                <p>
-                  Fees: 
-                  -$74.00
+                <p
+                  class="payment-details-summary__amount"
+                >
+                  $1,500.00
+                  <span
+                    class="payment-details-summary__amount-currency"
+                  >
+                    usd
+                  </span>
+                  <span
+                    class="chip chip-success"
+                  >
+                    Paid
+                  </span>
                 </p>
-                
-                <p>
-                  Net: 
-                  $1,426.00
-                </p>
+                <div
+                  class="payment-details-summary__breakdown"
+                >
+                  
+                  <p>
+                    Fees: 
+                    -$74.00
+                  </p>
+                  
+                  <p>
+                    Net: 
+                    $1,426.00
+                  </p>
+                </div>
+              </div>
+              <div
+                class="payment-details-summary__section"
+              >
+                <div
+                  class="payment-details-summary__id"
+                >
+                  Payment ID: 
+                  pi_mock
+                </div>
               </div>
             </div>
             <div
-              class="payment-details-summary__section"
+              class="payment-details__refund-controls"
             >
               <div
-                class="payment-details-summary__id"
+                class="components-dropdown components-dropdown-menu"
+                tabindex="-1"
               >
-                Payment ID: 
-                pi_mock
-              </div>
-            </div>
-          </div>
-          <div
-            class="payment-details__refund-controls"
-          >
-            <div
-              class="components-dropdown components-dropdown-menu"
-              tabindex="-1"
-            >
-              <button
-                aria-expanded="false"
-                aria-haspopup="true"
-                aria-label="Translation actions"
-                class="components-button components-dropdown-menu__toggle has-icon"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  focusable="false"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Translation actions"
+                  class="components-button components-dropdown-menu__toggle has-icon"
+                  type="button"
                 >
-                  <path
-                    d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes #7958

Note: see #7742 for the original implementation of the transaction refund menu & modal.

#### Changes proposed in this Pull Request

This PR fixes the dispute details UI within the Transaction Details screen.

It removes a global CSS declaration that inadvertently changes the styles of the dispute details. Using the `Flex` component will apply the intended `flex-direction: row` style directly to the top card on this page without impacting other page components.

Also, the payment status chip has been allowed to wrap on small viewports.

**Before**
![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/2282e8c0-2299-4421-8fe3-2dfab330969a)

<img width="300" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/edf960a6-dc19-4880-a002-76e7e061e326" />


**After**

![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/db2dcd37-e5f9-46e3-920a-a4bc16c11e3c)


<img width="300" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/2345fc4a-c3b2-4307-974c-3dedcf718183" />


Related: I've opened #7960 since disputed transactions should not show the refund dropdown if they are not refundable.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* As a shopper, create a disputed order by purchasing a test product using the card `4000000000000259` at checkout.
* As a merchant, navigate to Payments -> Disputes and click the row for the dispute you just created. You will be taken to the "Transaction Details" screen.
* Ensure the dispute details are rendered correctly.
* Ensure the refund dropdown menu is rendered correctly.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
