### PR TITLE
Hide the transaction details refund menu for non-refundable disputes

### DIFF
--- a/changelog/fix-7960-transaction-refund-eligible-disputes-only
+++ b/changelog/fix-7960-transaction-refund-eligible-disputes-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide the transaction details refund menu for ineligble disputed transactions

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -72,6 +72,11 @@ export const isInquiry = ( dispute: Pick< Dispute, 'status' > ): boolean => {
 	return dispute.status.startsWith( 'warning' );
 };
 
+export const isRefundable = ( status: DisputeStatus ): boolean => {
+	// Refundable dispute statuses are one of `warning_needs_response`, `warning_under_review`, `warning_closed` or `won`.
+	return isInquiry( { status } ) || 'won' === status;
+};
+
 /**
  * Returns the dispute fee balance transaction for a dispute if it exists
  * and the deduction has not been reversed.

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -48,6 +48,7 @@ import DisputeStatusChip from 'components/dispute-status-chip';
 import {
 	getDisputeFeeFormatted,
 	isAwaitingResponse,
+	isRefundable,
 } from 'wcpay/disputes/utils';
 import { useAuthorization } from 'wcpay/data';
 import CaptureAuthorizationButton from 'wcpay/components/capture-authorization-button';
@@ -207,6 +208,14 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 
 	const disputeFee =
 		charge.dispute && getDisputeFeeFormatted( charge.dispute );
+
+	// If this transaction is disputed, check if it is refundable.  If not, we should hide the refund menu.
+	const isDisputeRefundable = charge.dispute
+		? isRefundable( charge.dispute.status )
+		: true;
+
+	const showRefundMenu =
+		charge.captured && ! charge.refunded && isDisputeRefundable;
 
 	// Use the balance_transaction fee if available. If not (e.g. authorized but not captured), use the application_fee_amount.
 	const transactionFee = charge.balance_transaction
@@ -484,7 +493,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 						</div>
 					</div>
 					<div className="payment-details__refund-controls">
-						{ ! charge?.refunded && charge?.captured && (
+						{ showRefundMenu && (
 							<Loadable
 								isLoading={ isLoading }
 								placeholder={ moreVertical }

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -209,12 +209,13 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 	const disputeFee =
 		charge.dispute && getDisputeFeeFormatted( charge.dispute );
 
-	// If this transaction is disputed, check if it is refundable.  If not, we should hide the refund menu.
+	// If this transaction is disputed, check if it is refundable.
 	const isDisputeRefundable = charge.dispute
 		? isRefundable( charge.dispute.status )
 		: true;
 
-	const showRefundMenu =
+	// Control menu only shows refund actions for now. In the future, it may show other actions.
+	const showControlMenu =
 		charge.captured && ! charge.refunded && isDisputeRefundable;
 
 	// Use the balance_transaction fee if available. If not (e.g. authorized but not captured), use the application_fee_amount.
@@ -493,7 +494,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 						</div>
 					</div>
 					<div className="payment-details__refund-controls">
-						{ showRefundMenu && (
+						{ showControlMenu && (
 							<Loadable
 								isLoading={ isLoading }
 								placeholder={ moreVertical }

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -427,6 +427,13 @@ describe( 'PaymentDetailsSummary', () => {
 		screen.getByRole( 'button', {
 			name: /Accept dispute/,
 		} );
+
+		// Refund menu is not rendered
+		expect(
+			screen.queryByRole( 'button', {
+				name: /Translation actions/i,
+			} )
+		).toBeNull();
 	} );
 
 	test( 'renders the information of a disputed charge when the store/charge currency differ', () => {
@@ -684,6 +691,11 @@ describe( 'PaymentDetailsSummary', () => {
 				name: /Accept/i,
 			} )
 		).toBeNull();
+
+		// Refund menu is rendered
+		screen.getByRole( 'button', {
+			name: /Translation actions/i,
+		} );
 	} );
 
 	test( 'correctly renders dispute details for "under_review" disputes', () => {
@@ -710,6 +722,13 @@ describe( 'PaymentDetailsSummary', () => {
 		expect(
 			screen.queryByRole( 'button', {
 				name: /Accept/i,
+			} )
+		).toBeNull();
+
+		// Refund menu is not rendered
+		expect(
+			screen.queryByRole( 'button', {
+				name: /Translation actions/i,
 			} )
 		).toBeNull();
 	} );
@@ -742,6 +761,13 @@ describe( 'PaymentDetailsSummary', () => {
 		expect(
 			screen.queryByRole( 'button', {
 				name: /Accept/i,
+			} )
+		).toBeNull();
+
+		// Refund menu is not rendered
+		expect(
+			screen.queryByRole( 'button', {
+				name: /Translation actions/i,
 			} )
 		).toBeNull();
 	} );
@@ -777,6 +803,13 @@ describe( 'PaymentDetailsSummary', () => {
 				name: /Accept/i,
 			} )
 		).toBeNull();
+
+		// Refund menu is not rendered
+		expect(
+			screen.queryByRole( 'button', {
+				name: /Translation actions/i,
+			} )
+		).toBeNull();
 	} );
 
 	test( 'correctly renders dispute details for "warning_needs_response" inquiry disputes', () => {
@@ -807,6 +840,11 @@ describe( 'PaymentDetailsSummary', () => {
 		screen.getByRole( 'button', {
 			name: /Issue refund/i,
 		} );
+
+		// Refund menu is rendered
+		screen.getByRole( 'button', {
+			name: /Translation actions/i,
+		} );
 	} );
 
 	test( 'correctly renders dispute details for "warning_under_review" inquiry disputes', () => {
@@ -834,6 +872,11 @@ describe( 'PaymentDetailsSummary', () => {
 				name: /Accept/i,
 			} )
 		).toBeNull();
+
+		// Refund menu is rendered
+		screen.getByRole( 'button', {
+			name: /Translation actions/i,
+		} );
 	} );
 
 	test( 'correctly renders dispute details for "warning_closed" inquiry disputes', () => {
@@ -862,6 +905,11 @@ describe( 'PaymentDetailsSummary', () => {
 				name: /Accept/i,
 			} )
 		).toBeNull();
+
+		// Refund menu is rendered
+		screen.getByRole( 'button', {
+			name: /Translation actions/i,
+		} );
 	} );
 
 	describe( 'order missing notice', () => {


### PR DESCRIPTION
Fixes #7960

### Changes proposed in this Pull Request

This PR hides the refund menu on the transaction details screen when it has a non-refundable dispute.

It introduces a new dispute utility function `isRefundable()` to determine if a dispute status is eligible or not. Dispute statuses that are refundable and should show the refund dropdown: `won`, `warning_needs_response`, `warning_under_review`, `warning_closed`.

https://github.com/Automattic/woocommerce-payments/blob/b864c62b4745919980f364bc459856e41096d7ff/client/disputes/utils.ts#L75-L78

**Transaction with a dispute not eligible for refund – refund menu is not rendered**

![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/2bfab240-e2e9-4c51-8c91-2210cd508080)


**Transaction with a dispute eligible for refund – refund menu is rendered**

![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/bdc59a07-17b9-48f3-9368-ee18d82ecfc0)


### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Ensure the refund menu does not appear on the transaction details screen:**
* Active or lost disputes – as a shopper, use the card `4000000000000259` at checkout.

**Ensure the refund menu appears on the transaction details screen:**
* Any non-disputed transactions.
* Inquiries – as a shopper, use the card `4000000000001976` at checkout.
* "Won" disputes – as a merchant, provide winning evidence by submitting the challenge form with `winning_evidence` in the “Additional details” field.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
