### PR TITLE
Avoid WooPay duplicate charges when order cannot be completely processed

### DIFF
--- a/changelog/fix-2199-woopay-duplicate-payments
+++ b/changelog/fix-2199-woopay-duplicate-payments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix WooPay duplicate charges.
+
+

--- a/includes/class-duplicate-payment-prevention-service.php
+++ b/includes/class-duplicate-payment-prevention-service.php
@@ -102,9 +102,13 @@ class Duplicate_Payment_Prevention_Service {
 			return;
 		}
 
-		$intent_meta_order_id_raw = $intent->get_metadata()['order_id'] ?? '';
-		$intent_meta_order_id     = is_numeric( $intent_meta_order_id_raw ) ? intval( $intent_meta_order_id_raw ) : 0;
-		if ( $intent_meta_order_id !== $order->get_id() ) {
+		$intent_meta_order_id_raw     = $intent->get_metadata()['order_id'] ?? '';
+		$intent_meta_order_id         = is_numeric( $intent_meta_order_id_raw ) ? intval( $intent_meta_order_id_raw ) : 0;
+		$intent_meta_order_number_raw = $intent->get_metadata()['order_number'] ?? '';
+		$intent_meta_order_number     = is_numeric( $intent_meta_order_number_raw ) ? intval( $intent_meta_order_number_raw ) : 0;
+		$paid_on_woopay               = filter_var( $intent->get_metadata()['paid_on_woopay'] ?? false, FILTER_VALIDATE_BOOLEAN );
+		$is_woopay_order              = $order->get_id() === $intent_meta_order_number;
+		if ( ! ( $paid_on_woopay && $is_woopay_order ) && $intent_meta_order_id !== $order->get_id() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2199

#### Changes proposed in this Pull Request

Adds a check for WooPay orders in the duplicate payment prevention service. This check is needed because the WooPay order IDs doesn't match the order ID in the context, but the order number instead.

See https://github.com/Automattic/woopay/issues/2199 and https://github.com/Automattic/woopay/pull/2408 for more context.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Pre-requisite**

You will need to apply these changes directly to WooPay in `docker/wordpress/wp-content/plugins/woocommerce-payments/includes/class-duplicate-payment-prevention-service.php`. Building the plugin is not an alternative because the WCPay version on WooPay is different and that might break things.

**Tests**

Run the same tests described in https://github.com/Automattic/woopay/pull/2408, including the pre-requisite.

The only difference is in the last three steps of the `Test: the fix prevent duplicate charges`, which should be

10. You should see an error alert saying "Merchant store order creation failed with the following error: We're not able to process this payment. Please try again later.".
11. Go to the merchant site WP Admin and confirm a new order has been created. This new order should have a failed charge attempt and order status `Failed`.
12. Go to the WooPay WP Admin and confirm two things: a) there's no new order, only the one created in step 3, and b) this order was updated, but it's still with status `Failed` and with just a single charge.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
