### PR TITLE
Fix missing transaction error when viewing orders placed in mismatched test mode

### DIFF
--- a/changelog/fix-7967-disputed-order-notice-test-mode-check
+++ b/changelog/fix-7967-disputed-order-notice-test-mode-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix network error that occurs when viewing an test mode order with test mode disabled, and vice versa.

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -60,7 +60,7 @@ jQuery( function ( $ ) {
 	const disableManualRefunds = getConfig( 'disableManualRefunds' ) ?? false;
 	const manualRefundsTip = getConfig( 'manualRefundsTip' ) ?? '';
 	const chargeId = getConfig( 'chargeId' );
-	const testMode = getConfig( 'testMode' );
+	const orderTestMode = getConfig( 'testMode' );
 
 	maybeShowOrderNotices();
 
@@ -175,6 +175,10 @@ jQuery( function ( $ ) {
 			'#wcpay-order-payment-details-container'
 		);
 
+		// Check if the order's test mode meta matches the site's current test mode setting.
+		// E.g. order and site are both in test mode, or both in live mode.
+		const isOrderTestModeMatch = orderTestMode === wcpaySettings.testMode;
+
 		// If the container doesn't exist (WC < 7.9), or the charge ID isn't present, don't render the notice.
 		if ( ! container ) {
 			return;
@@ -182,9 +186,9 @@ jQuery( function ( $ ) {
 
 		ReactDOM.render(
 			<>
-				{ testMode && <TestModeNotice /> }
+				{ orderTestMode && <TestModeNotice /> }
 
-				{ chargeId && (
+				{ isOrderTestModeMatch && chargeId && (
 					<DisputedOrderNoticeHandler
 						chargeId={ chargeId }
 						onDisableOrderRefund={ disableWooOrderRefundButton }

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -179,7 +179,7 @@ jQuery( function ( $ ) {
 		// E.g. order and site are both in test mode, or both in live mode.
 		const isOrderTestModeMatch = orderTestMode === wcpaySettings.testMode;
 
-		// If the container doesn't exist (WC < 7.9), or the charge ID isn't present, don't render the notice.
+		// If the container doesn't exist (WC < 7.9) don't render the notice.
 		if ( ! container ) {
 			return;
 		}

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -60,7 +60,10 @@ jQuery( function ( $ ) {
 	const disableManualRefunds = getConfig( 'disableManualRefunds' ) ?? false;
 	const manualRefundsTip = getConfig( 'manualRefundsTip' ) ?? '';
 	const chargeId = getConfig( 'chargeId' );
-	const orderTestMode = getConfig( 'testMode' );
+	const testMode = getConfig( 'testMode' );
+	// Order and site are both in test mode, or both in live mode.
+	// '1' = true, '' = false, null = the order was created before the test mode meta was added, so we assume it matches.
+	const orderTestModeMatch = getConfig( 'orderTestModeMatch' ) !== '';
 
 	maybeShowOrderNotices();
 
@@ -175,20 +178,16 @@ jQuery( function ( $ ) {
 			'#wcpay-order-payment-details-container'
 		);
 
-		// Check if the order's test mode meta matches the site's current test mode setting.
-		// E.g. order and site are both in test mode, or both in live mode.
-		const isOrderTestModeMatch = orderTestMode === wcpaySettings.testMode;
-
-		// If the container doesn't exist (WC < 7.9) don't render the notice.
+		// If the container doesn't exist (WC < 7.9) don't render notices.
 		if ( ! container ) {
 			return;
 		}
 
 		ReactDOM.render(
 			<>
-				{ orderTestMode && <TestModeNotice /> }
+				{ testMode && <TestModeNotice /> }
 
-				{ isOrderTestModeMatch && chargeId && (
+				{ chargeId && orderTestModeMatch && (
 					<DisputedOrderNoticeHandler
 						chargeId={ chargeId }
 						onDisableOrderRefund={ disableWooOrderRefundButton }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -728,7 +728,7 @@ class WC_Payments_Admin {
 				// E.g. order and site are both in test mode, or both in live mode.
 				$order_mode = $order->get_meta( WC_Payments_Order_Service::WCPAY_MODE_META_KEY );
 				if ( '' === $order_mode ) {
-					// If the order doesn't have a mode set, assume it was created before the order mode meta was added and return null.
+					// If the order doesn't have a mode set, assume it was created before the order mode meta was added (< 6.9 PR#7651) and return null.
 					$order_test_mode_match = null;
 				} else {
 					$order_test_mode_match = (

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -723,6 +723,23 @@ class WC_Payments_Admin {
 
 			if ( $order && WC_Payment_Gateway_WCPay::GATEWAY_ID === $order->get_payment_method() ) {
 				$refund_amount = $order->get_remaining_refund_amount();
+
+				// Check if the order's test mode meta matches the site's current test mode state.
+				// E.g. order and site are both in test mode, or both in live mode.
+				$order_mode = $order->get_meta( WC_Payments_Order_Service::WCPAY_MODE_META_KEY );
+				if ( '' === $order_mode ) {
+					// If the order doesn't have a mode set, assume it was created before the order mode meta was added and return null.
+					$order_test_mode_match = null;
+				} else {
+					$order_test_mode_match = (
+						\WCPay\Constants\Order_Mode::PRODUCTION === $order_mode &&
+						WC_Payments::mode()->is_live()
+					) || (
+						\WCPay\Constants\Order_Mode::TEST === $order_mode &&
+						WC_Payments::mode()->is_test()
+					);
+				}
+
 				wp_localize_script(
 					'WCPAY_ADMIN_ORDER_ACTIONS',
 					'wcpay_order_config',
@@ -736,6 +753,7 @@ class WC_Payments_Admin {
 						'chargeId'              => $this->order_service->get_charge_id_for_order( $order ),
 						'hasOpenAuthorization'  => $this->order_service->has_open_authorization( $order ),
 						'testMode'              => \WCPay\Constants\Order_Mode::TEST === $order->get_meta( WC_Payments_Order_Service::WCPAY_MODE_META_KEY ),
+						'orderTestModeMatch'    => $order_test_mode_match,
 					]
 				);
 				wp_localize_script(


### PR DESCRIPTION
Fixes #7967 
Fixes #7076

#### Changes proposed in this Pull Request

This PR checks to see if the order and site test mode match before rendering the disputed order notice and subsequently fetching charge data.

This prevents the error `Error: No such charge: 'ch_abcde';` from being returned by the server and the `Error retrieving transaction.` snackbar from rendering.

To ensure the notice continues to render for orders created prior to 6.9 (which added the `wcpay_mode` order meta #7651), the disputed order notice will always render if no `wcpay_mode` order meta is defined.

Tradeoffs of this approach:
1. The disputed order notice will not show for disputed orders when the order was created in test mode but the site is in live mode (or vice versa).


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Use a store setup in live mode during KYC. (I've set one up, search Secret Store for `ej-wcpay-aus` with a live-mode order [here](https://ej-woo.mystagingwebsite.com/wp-admin/post.php?post=361&action=edit)).
* Enable test mode.
* Place a test order.
* Disable test mode.
* View the order as merchant.
* On `develop`, you will notice a network request error and a `Error retrieving transaction` snackbar.
* On this branch, the `/charges` network request will not occur and there should not be an error snackbar.


**Disputed orders**
* Use a store setup in live mode during KYC.
* Enable test mode.
* Place a disputed test order with the card `4000000000000259`.
* View the order as merchant.
* You should see the disputed order notice, since the disputed order was created in test mode.
* Disable test mode.
* View the disputed order as merchant.
* You will no longer see the disputed order notice, since the order/site test mode is mismatched.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
