### PR TITLE
Add new Tracks around WooPay Save My Info checkbox

### DIFF
--- a/changelog/add-save-my-info-tracks
+++ b/changelog/add-save-my-info-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add new Tracks events to WooPay Save My Info checkbox

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -404,8 +404,7 @@ export const handleWooPayEmailInput = async (
 				} else if ( data.code !== 'rest_invalid_param' ) {
 					wcpayTracks.recordUserEvent(
 						wcpayTracks.events.WOOPAY_OFFERED,
-						[],
-						true
+						[]
 					);
 				}
 			} )

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -119,6 +119,15 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	};
 
 	useEffect( () => {
+		// Record Tracks event when the mobile number is entered.
+		if ( isPhoneValid ) {
+			wcpayTracks.recordUserEvent(
+				wcpayTracks.events.WOOPAY_SAVE_MY_INFO_MOBILE_ENTER
+			);
+		}
+	}, [ isPhoneValid ] );
+
+	useEffect( () => {
 		// Record Tracks event when user clicks on the info icon for the first time.
 		if ( isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
 			setHasShownInfoFlyout( true );

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -92,6 +92,12 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		[ isSaveDetailsChecked, phoneNumber, viewportWidth, viewportHeight ]
 	);
 
+	const handleCountryDropdownClick = useCallback( () => {
+		wcpayTracks.recordUserEvent(
+			wcpayTracks.events.WOOPAY_SAVE_MY_INFO_COUNTRY_CLICK
+		);
+	}, [] );
+
 	const handleCheckboxClick = ( e ) => {
 		const isChecked = e.target.checked;
 		if ( isChecked ) {
@@ -305,6 +311,9 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							value={ phoneNumber }
 							onValueChange={ setPhoneNumber }
 							onValidationChange={ onPhoneValidationChange }
+							onCountryDropdownClick={
+								handleCountryDropdownClick
+							}
 							inputProps={ {
 								name:
 									'woopay_user_phone_field[no-country-code]',

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -15,6 +15,7 @@ interface PhoneNumberInputProps {
 	value: string;
 	onValidationChange: ( isValid: boolean ) => void;
 	onValueChange: ( value: string ) => void;
+	onCountryDropdownClick?: () => void;
 	inputProps: {
 		label: string;
 		ariaLabel: string;
@@ -27,6 +28,7 @@ const PhoneNumberInput = ( {
 	onValueChange,
 	value,
 	onValidationChange = ( validation ) => validation,
+	onCountryDropdownClick,
 	inputProps = {
 		label: '',
 		ariaLabel: '',
@@ -101,6 +103,13 @@ const PhoneNumberInput = ( {
 			setInputInstance( iti );
 
 			currentRef.addEventListener( 'countrychange', handleCountryChange );
+
+			const countryList = currentRef
+				.closest( '.iti' )
+				?.querySelector( '.iti__flag-container' );
+			if ( countryList && onCountryDropdownClick ) {
+				countryList.addEventListener( 'click', onCountryDropdownClick );
+			}
 		}
 
 		return () => {
@@ -113,9 +122,20 @@ const PhoneNumberInput = ( {
 						handleCountryChange
 					);
 				}
+
+				// Cleanup for country dropdown click event
+				const countryList = currentRef
+					?.closest( '.iti' )
+					?.querySelector( '.iti__flag-container' );
+				if ( countryList && onCountryDropdownClick ) {
+					countryList.removeEventListener(
+						'click',
+						onCountryDropdownClick
+					);
+				}
 			}
 		};
-	}, [ onValueChange, onValidationChange ] );
+	}, [ onValueChange, onValidationChange, onCountryDropdownClick ] );
 
 	useEffect( () => {
 		if ( inputInstance && inputRef.current ) {

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -108,12 +108,16 @@ const events = {
 		'wcpay_subscriptions_account_not_connected_product_modal_dismiss',
 	TRANSACTIONS_DOWNLOAD_CSV_CLICK: 'wcpay_transactions_download_csv_click',
 	WOOPAY_EMAIL_CHECK: 'checkout_email_address_woopay_check',
-	WOOPAY_OFFERED: 'woopay_offered',
+	WOOPAY_OFFERED: 'checkout_woopay_save_my_info_offered',
 	WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
 	WOOPAY_SKIPPED: 'woopay_skipped',
 	WOOPAY_BUTTON_LOAD: 'woopay_button_load',
 	WOOPAY_BUTTON_CLICK: 'woopay_button_click',
+	WOOPAY_SAVE_MY_INFO_COUNTRY_CLICK:
+		'checkout_woopay_save_my_info_country_click',
 	WOOPAY_SAVE_MY_INFO_CLICK: 'checkout_save_my_info_click',
+	WOOPAY_SAVE_MY_INFO_MOBILE_ENTER:
+		'checkout_woopay_save_my_info_mobile_enter',
 	WOOPAY_SAVE_MY_INFO_TOS_CLICK: 'checkout_save_my_info_tos_click',
 	WOOPAY_SAVE_MY_INFO_PRIVACY_CLICK:
 		'checkout_save_my_info_privacy_policy_click',


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This PR improves Tracks coverage around WooPay Save My Info usage. 
- `woocommerceanalytics_woopay_offered` event was renamed to `wcpay_checkout_woopay_save_my_info_offered` to remove the ambiguity around the source.
- Following two events are added
  - `wcpay_checkout_woopay_save_my_info_country_click`
  - `wcpay_checkout_woopay_save_my_info_mobile_enter`


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a shopper, add a product to the cart.
* Go to the classic checkout page.
* Enter an email that's not already registered with WooPay.
* Wait for the "Save My info" checkbox to appear
* In ~5 minutes, check Tracks Live view for the `wcpay_checkout_woopay_save_my_info_offered` event
* Enter a valid phone number in the input box under the "Save My info" section.
* In ~5 minutes, check Tracks Live view for the `checkout_woopay_save_my_info_mobile_enter` event
* Click the dropdown menu to change the country code.
* In ~5 minutes, check Tracks Live view for the `wcpay_checkout_woopay_save_my_info_country_click` event

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
