### PR TITLE
Add e2e test for dispute flow: viewing dispute details via the order notice

### DIFF
--- a/changelog/add-7397-e2e-disputed-order-notice
+++ b/changelog/add-7397-e2e-disputed-order-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not user-facing: add e2e test for viewing the dispute details via the disputed order notice
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
@@ -38,7 +38,13 @@ describe( 'Disputes > View dispute details via disputed order notice', () => {
 	} );
 
 	it( 'should click the disputed order notice and view the dispute details', async () => {
-		// TODO: if WC < 7.9, skip this test.
+		// If WC < 7.9, return early since the order dispute notice is not present.
+		const orderPaymentDetailsContainer = await page.$(
+			'#wcpay-order-payment-details-container'
+		);
+		if ( ! orderPaymentDetailsContainer ) {
+			return;
+		}
 
 		// Click the order dispute notice.
 		await expect( page ).toClick( '[type="button"]', {

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
@@ -37,7 +37,7 @@ describe( 'Disputes > View dispute details via disputed order notice', () => {
 		await merchant.logout();
 	} );
 
-	it( 'should click the disputed order notice and view the dispute details', async () => {
+	it( 'should navigate to dispute details when disputed order notice button clicked', async () => {
 		// If WC < 7.9, return early since the order dispute notice is not present.
 		const orderPaymentDetailsContainer = await page.$(
 			'#wcpay-order-payment-details-container'

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import { fillCardDetails, setupProductCheckout } from '../../../utils/payments';
+
+const { merchant, shopper } = require( '@woocommerce/e2e-utils' );
+
+describe( 'Disputes > View dispute details via disputed order notice', () => {
+	beforeAll( async () => {
+		await page.goto( config.get( 'url' ), { waitUntil: 'networkidle0' } );
+
+		// Place an order to dispute later
+		await setupProductCheckout(
+			config.get( 'addresses.customer.billing' )
+		);
+		const card = config.get( 'cards.disputed-fraudulent' );
+		await fillCardDetails( page, card );
+		await shopper.placeOrder();
+		await expect( page ).toMatch( 'Order received' );
+
+		// Get the order ID
+		const orderIdField = await page.$(
+			'.woocommerce-order-overview__order.order > strong'
+		);
+		const orderId = await orderIdField.evaluate( ( el ) => el.innerText );
+
+		await merchant.login();
+		await merchant.goToOrder( orderId );
+	} );
+
+	afterAll( async () => {
+		await merchant.logout();
+	} );
+
+	it( 'should click the disputed order notice and view the dispute details', async () => {
+		// TODO: if WC < 7.9, skip this test.
+
+		// Click the order dispute notice.
+		await expect( page ).toClick( '[type="button"]', {
+			text: 'Respond now',
+		} );
+
+		await page.waitForNavigation( {
+			waitUntil: 'networkidle0',
+		} );
+
+		// Verify we see the dispute details on the transaction details page.
+		await expect( page ).toMatchElement( '.dispute-notice', {
+			text: 'The cardholder claims this is an unauthorized transaction',
+		} );
+	} );
+} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-view-details-via-order-notice.spec.js
@@ -43,6 +43,10 @@ describe( 'Disputes > View dispute details via disputed order notice', () => {
 			'#wcpay-order-payment-details-container'
 		);
 		if ( ! orderPaymentDetailsContainer ) {
+			// eslint-disable-next-line no-console
+			console.log(
+				'Skipping test since the order dispute notice is not present in WC < 7.9'
+			);
 			return;
 		}
 


### PR DESCRIPTION
Fixes #7397 

#### Changes proposed in this Pull Request

This PR adds an e2e test for the dispute flow: viewing dispute details via the order notice. 

This test only runs with WC v7.9+, since disputed order notices are only supported from this version onwards.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Ensure `merchant` e2e `merchant` test suites pass on this PR's GH checks
1. Run e2e tests with WC 7.7 and ensure `merchant` test suites pass.
	1. This can be done in a local environment (`npm run test:e2e tests/e2e/specs/wcpay/merchant/merchant-disputes-*`) or by
	2. Running the GH action ["E2E tests - All"](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml) against this branch. I've manually run this [here](https://github.com/Automattic/woocommerce-payments/actions/runs/7487624539).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
