### PR TITLE
Fix unnecessary gateway import warning in BNPL messaging element class

### DIFF
--- a/changelog/fix-unnecessary-import-warning
+++ b/changelog/fix-unnecessary-import-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove unnecessary import statement which leads to a warning when first loaded

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -34,7 +34,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 	 * @param  WC_Payment_Gateway_WCPay $gateway Gateway instance.
 	 * @return void
 	 */
-	public function __construct( WC_Payments_Account $account, $gateway ) {
+	public function __construct( WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway ) {
 		$this->account = $account;
 		$this->gateway = $gateway;
 	}

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -10,7 +10,6 @@ use WCPay\Constants\Payment_Method;
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-use WC_Payment_Gateway_WCPay;
 /**
  * WC_Payments_Payment_Method_Messaging_Element class.
  */


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7975

#### Changes proposed in this Pull Request
Class `WC_Payments_Payment_Method_Messaging_Element` is defined within the global namespace. Thus, it doesn't need imports for classes located in the global namespace. One such class is `WC_Payment_Gateway_WCPay`, which is currently being imported in `WC_Payments_Payment_Method_Messaging_Element.` Because of the unnecessary import, PHP echoes a warning when the class is loaded for the first time. This happens on the product details page only. 

This PR fixes the warning by removing the unnecessary import. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checkout `develop` branch
* enable Klarna _and/or_ Affirm _and/or_ Afterpay
* set your store currency and product price to match any of the requirements ([afterpay requirements](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/payment-methods/class-afterpay-payment-method.php#L33-L64), [affirm requirements](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/payment-methods/class-affirm-payment-method.php#L35-L47), [klarna requirements](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/payment-methods/class-klarna-payment-method.php#L35-L100)) of the BNPL you're using (currency + minimum amount, e.g. USD & $50)
* navigate to the chosen product details page
* confirm the warning is present
* refresh the page and confirm the warning is gone
* checkout `fix/unnecessary-import-warning` and run `npm run down && npm run up`
* perform the previous steps once more and confirm the warning doesn't appear on the first page load for product details page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
