### PR TITLE
Fix the typo for transaction controls label

### DIFF
--- a/changelog/fix-7964-typo-for-transaction-actions
+++ b/changelog/fix-7964-typo-for-transaction-actions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixed a typo
+
+

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -502,7 +502,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 								<DropdownMenu
 									icon={ moreVertical }
 									label={ __(
-										'Translation actions',
+										'Transaction actions',
 										'woocommerce-payments'
 									) }
 									popoverProps={ {

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -707,7 +707,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >
@@ -1002,7 +1002,7 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >
@@ -1297,7 +1297,7 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >
@@ -1615,7 +1615,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >
@@ -2454,7 +2454,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >
@@ -2749,7 +2749,7 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >
@@ -3044,7 +3044,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-label="Translation actions"
+                aria-label="Transaction actions"
                 class="components-button components-dropdown-menu__toggle has-icon"
                 type="button"
               >

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -431,7 +431,7 @@ describe( 'PaymentDetailsSummary', () => {
 		// Refund menu is not rendered
 		expect(
 			screen.queryByRole( 'button', {
-				name: /Translation actions/i,
+				name: /Transaction actions/i,
 			} )
 		).toBeNull();
 	} );
@@ -694,7 +694,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 		// Refund menu is rendered
 		screen.getByRole( 'button', {
-			name: /Translation actions/i,
+			name: /Transaction actions/i,
 		} );
 	} );
 
@@ -728,7 +728,7 @@ describe( 'PaymentDetailsSummary', () => {
 		// Refund menu is not rendered
 		expect(
 			screen.queryByRole( 'button', {
-				name: /Translation actions/i,
+				name: /Transaction actions/i,
 			} )
 		).toBeNull();
 	} );
@@ -767,7 +767,7 @@ describe( 'PaymentDetailsSummary', () => {
 		// Refund menu is not rendered
 		expect(
 			screen.queryByRole( 'button', {
-				name: /Translation actions/i,
+				name: /Transaction actions/i,
 			} )
 		).toBeNull();
 	} );
@@ -807,7 +807,7 @@ describe( 'PaymentDetailsSummary', () => {
 		// Refund menu is not rendered
 		expect(
 			screen.queryByRole( 'button', {
-				name: /Translation actions/i,
+				name: /Transaction actions/i,
 			} )
 		).toBeNull();
 	} );
@@ -843,7 +843,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 		// Refund menu is rendered
 		screen.getByRole( 'button', {
-			name: /Translation actions/i,
+			name: /Transaction actions/i,
 		} );
 	} );
 
@@ -875,7 +875,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 		// Refund menu is rendered
 		screen.getByRole( 'button', {
-			name: /Translation actions/i,
+			name: /Transaction actions/i,
 		} );
 	} );
 
@@ -908,7 +908,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 		// Refund menu is rendered
 		screen.getByRole( 'button', {
-			name: /Translation actions/i,
+			name: /Transaction actions/i,
 		} );
 	} );
 

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -544,7 +544,7 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  aria-label="Translation actions"
+                  aria-label="Transaction actions"
                   class="components-button components-dropdown-menu__toggle has-icon"
                   type="button"
                 >


### PR DESCRIPTION
Fixes #7964 

#### Changes proposed in this Pull Request

Fix the typo for transaction controls label

This PR updates "Translation actions" to correct "Transaction actions"

#### Testing instructions

1. Go to a transaction details screen
2. Mouse over the three-dot menu icon in the top-right.
2. Assert the popover text showing "Transaction actions"

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
