### PR TITLE
Rerender Woopay Button on jQuery Events

### DIFF
--- a/changelog/fix-2395-rerender-woopay-button-on-cart-update
+++ b/changelog/fix-2395-rerender-woopay-button-on-cart-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Re-render WooPay button when cart updates, when checkout updates.

--- a/client/checkout/woopay/express-button/index.js
+++ b/client/checkout/woopay/express-button/index.js
@@ -1,3 +1,4 @@
+/* global jQuery */
 /**
  * External dependencies
  */
@@ -57,17 +58,17 @@ const renderWooPayExpressCheckoutButtonWithCallbacks = () => {
 	renderWooPayExpressCheckoutButton( listenForCartChanges );
 };
 
-document.addEventListener( 'DOMContentLoaded', () => {
+jQuery( ( $ ) => {
 	listenForCartChanges = {
 		start: () => {
-			document.body.addEventListener(
-				'updated_cart_totals',
+			$( document.body ).on(
+				'updated_cart_totals updated_checkout',
 				renderWooPayExpressCheckoutButtonWithCallbacks
 			);
 		},
 		stop: () => {
-			document.body.removeEventListener(
-				'updated_cart_totals',
+			$( document.body ).off(
+				'updated_cart_totals updated_checkout',
 				renderWooPayExpressCheckoutButtonWithCallbacks
 			);
 		},


### PR DESCRIPTION
Fixes:
* 2395-gh-Automattic/woopay
* 2398-gh-Automattic/woopay

#### Changes proposed in this Pull Request

<!--
Title: A descriptive yet concise title.
-->

<!--
Description: Write a brief summary of this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR adds jQuery listeners for the following events: `updated_cart_totals` and `updated_checkout`. 

Previously, there were DOM element listeners (e.g. `document.body.addEventListener( ... )` ), but it seems the `jQuery.trigger( ... )` wasn't always calling the `dispatchEvent(...)`. 

This was causing the issue where the WooPay button would not receive the event and, therefore, would not re-render the WooPay button.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**2395-gh-Automattic/woopay**

**Confirm: WooPay Button Does Not Re-render On `trunk`**
* In the terminal, checkout to the `trunk` branch.
* As a shopper, navigate to the merchant's shop and add a product to your cart.
* Navigate to the cart.
* Update the quantity of your product and click the `Update cart` button.
* Confirm that the WooPay button does *not* re-render.

**Test: WooPay Button Re-renders When Updating Cart Totals**
* In the terminal, checkout to the `2395-rerender-woopay-button-on-cart-update` branch.
* As a shopper, navigate to the merchant's shop and add a product to your cart.
* Navigate to the cart.
* Update the quantity of your product and click the `Update cart` button.
* Confirm that the WooPay button re-renders as expected.

**Regression Test: WooPay Button Navigates to Woopay**
* In the terminal, checkout to the `2395-rerender-woopay-button-on-cart-update` branch.
* As a shopper, navigate to the merchant's shop and add a product to your cart.
* Navigate to the cart and click the `Buy with WooPay` button.
* Confirm that the WooPay button navigates to WooPay as expected.
* Confirm that in WooPay, the cart shows the expected products.

**Regression Test: WooPay Button Navigates to Woopay, Even After Re-render**
* In the terminal, checkout to the `2395-rerender-woopay-button-on-cart-update` branch.
* As a shopper, navigate to the merchant's shop and add a product to your cart.
* Navigate to the cart.
* Update the quantity of your product and click the `Update cart` button. Repeat this step twice.
* Confirm that the WooPay button navigates to WooPay as expected.
* Confirm that in WooPay, the cart shows the expected products.

**2398-gh-Automattic/woopay**

**Confirm: Implemented Solution Matches Suggested Solution**
* Compare implemented solution to suggested solution in 18798-gh-Automattic/woocommerce.com.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
