### PR TITLE
Fix JS error when purchasing free products

### DIFF
--- a/changelog/fix-place-order-js-error
+++ b/changelog/fix-place-order-js-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes a JS error introduced in an unreleased change
+
+

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -62,7 +62,7 @@ jQuery( function ( $ ) {
 	$( 'form.checkout' ).on( 'click', '#place_order', function () {
 		const isWCPay = document.getElementById(
 			'payment_method_woocommerce_payments'
-		).checked;
+		)?.checked;
 
 		if ( ! isWCPay ) {
 			return;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7980

#### Changes proposed in this Pull Request
Check for the presence of the WCPay payment method before trying to record "Place Order" Tracks event.



<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Make sure `shopper-checkout-free-cart.spec.js` e2e test is passing ✅ 

Manual test (optional)
1. As a merchant, create a 100% off coupon.
2. As a shopper, add a product to the cart.
3. Apply the coupon created in step 2.
4. Proceed to the classic checkout page.
5. Open dev tools console.
6. Click the Place Order button.
7. There should not be a console error.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
