### PR TITLE
Fix WooPay tablet breakpoint

### DIFF
--- a/changelog/fix-woopay-tablet-breakpoint
+++ b/changelog/fix-woopay-tablet-breakpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update WooPay tablet breakpoint.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -116,7 +116,7 @@ export const handleWooPayEmailInput = async (
 		}
 
 		// If the window width is less than the breakpoint, reset the styles and return.
-		if ( fullScreenModalBreakpoint >= window.innerWidth ) {
+		if ( fullScreenModalBreakpoint > window.innerWidth ) {
 			iframe.style.left = '0';
 			iframe.style.right = '';
 			return;

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -75,7 +75,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 
 		// If the window width is less than the breakpoint, set iframe to full window
-		if ( fullScreenModalBreakpoint >= window.innerWidth ) {
+		if ( fullScreenModalBreakpoint > window.innerWidth ) {
 			iframe.style.left = '0';
 			iframe.style.right = '';
 			iframe.style.top = '0';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
This PR fixes the WooPay iframe position on screens with 768 pixels width (usually used on tablets like old iPads and iPad Mini in vertical mode).

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="589" alt="Screenshot 2024-01-05 at 11 55 03 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1693223/d2187020-e06f-4333-a16a-7d0e8bb33918">
</td>
<td>
<img width="589" alt="Screenshot 2024-01-05 at 11 55 32 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1693223/06e9a171-5147-4cf6-b121-ae11733e866d">
</td>
</tr>
<tr>
<td>
<img width="589" alt="Screenshot 2024-01-05 at 11 54 34 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1693223/6be4c82b-d012-446f-8947-2e313f4e6efc">
</td>
<td>
<img width="589" alt="Screenshot 2024-01-05 at 11 53 33 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1693223/586f3ae6-a5b6-4436-9ff8-ac8a719800d5">
</td>
</tr>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On browser DevTools, simulate a 768 pixels width screen (iPad Mini).
* Add products in the cart.
* Access checkout page.
* Wait for WooPay iframe.
* The iframe should be right positioned.
* Enable Gift Cards or Points & Rewards extension to disable first party auth flow.
* Reload the page and click the WooPay express checkout button.
* The iframe should be right positioned.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
