### PR TITLE
Fix WooPay Adapted Extensions initialization

### DIFF
--- a/changelog/fix-woopay-adapted-extensions
+++ b/changelog/fix-woopay-adapted-extensions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix WooPay adapted extensions initialization.
+
+

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -462,6 +462,7 @@ class WooPay_Session {
 			WC()->customer->set_billing_email( $email );
 			WC()->customer->save();
 
+			$woopay_adapted_extensions->init();
 			$request['adapted_extensions'] = $woopay_adapted_extensions->get_adapted_extensions_data( $email );
 
 			if ( ! is_user_logged_in() && count( $request['adapted_extensions'] ) > 0 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
After changed the WooPay Adapted Extensions hooks to be initialized from the `init` method instead of `__construct` we didn't call the `init` method before getting adapted extension data, this disabled adapted extensions for the time being, this PR fixes that.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set [this line](https://github.com/Automattic/woocommerce-payments/blob/7a924525708974318a2dc1a312ab1ecf148872a1/includes/woopay/class-woopay-adapted-extensions.php#L37) to `$enabled_adapted_extensions = [self::POINTS_AND_REWARDS_PLUGIN];` (this way we don't need to modify WCPay Server and run the daily hook).
* Set [this line](https://github.com/Automattic/woocommerce-payments/blob/c26e9e5761768a75cf50d43c88f78b8fe0fa3599/includes/woopay/class-woopay-scheduler.php#L192) to `$plugins_in_list = [WooPay_Adapted_Extensions::POINTS_AND_REWARDS_PLUGIN];` (this way we don't need to modify WCPay Server and run the daily hook).
* Install Points and Rewards extension.
* On merchant store wp-admin, access WooCommerce > Points & Rewards.
* Add points to an user that has a unverified WooPay account.
* As a guest user on merchant store, add items in the cart and checkout with WooPay with the email you added points to.
* On WooPay you should see the verify email alert.

![252517777-00e3aff7-496e-4b5e-9363-b1606c130132](https://github.com/Automattic/woocommerce-payments/assets/1693223/c7748cb7-92fa-4701-bda7-62bec54e8d30)

* Comment out [these lines](https://github.com/Automattic/woopay/blob/feat/design-refresh/src/OTP/OTPSender.php#L207-212) to prevent getting an error because you are on the development environment.
* Verify your email.
* You should see the available points fields.

![252518331-0e09621d-258a-42bc-8529-2056474796a3](https://github.com/Automattic/woocommerce-payments/assets/1693223/97e6dff1-81a8-4173-85f1-8ccef5d5ccdd)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
