### PR TITLE
Restock order items when refunding in full from transaction details page

### DIFF
--- a/changelog/fix-7969-restock-items-when-refund-from-transaction-page
+++ b/changelog/fix-7969-restock-items-when-refund-from-transaction-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restock order items when performing full refund from transaction details page

--- a/includes/admin/class-wc-rest-payments-refunds-controller.php
+++ b/includes/admin/class-wc-rest-payments-refunds-controller.php
@@ -57,6 +57,7 @@ class WC_REST_Payments_Refunds_Controller extends WC_Payments_REST_Controller {
 						'reason'         => $reason,
 						'order_id'       => $order_id,
 						'refund_payment' => true,
+						'restock_items'  => true,
 					]
 				);
 


### PR DESCRIPTION
Fixes #7969 

#### Changes proposed in this Pull Request

When performing full refund from transaction detail page restock the items

#### Testing instructions

1. Place any order for a product with tracked inventory. The inventory should be reduced, evidenced in the order notes.
2. Refund the order via the Transaction screen.
3. Go to "Edit order" page and assert that stock is restored, and the 'Refund' button is no longer available.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
