### PR TITLE
Verify that order exists before offering "Partial refund" option on transaction details page

### DIFF
--- a/changelog/fix-transaction-refund-options-for-missing-order
+++ b/changelog/fix-transaction-refund-options-for-missing-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Verify that order exists before offering "Partial refund" option on transaction details page.

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -214,6 +214,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 		? isRefundable( charge.dispute.status )
 		: true;
 
+	const isPartiallyRefundable = charge.order && charge.order.number;
+
 	// Control menu only shows refund actions for now. In the future, it may show other actions.
 	const showControlMenu =
 		charge.captured && ! charge.refunded && isDisputeRefundable;
@@ -531,7 +533,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 													'woocommerce-payments'
 												) }
 											</MenuItem>
-											{ charge.order && (
+											{ isPartiallyRefundable && (
 												<MenuItem
 													onClick={ () => {
 														wcpayTracks.recordEvent(

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -214,6 +214,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 		? isRefundable( charge.dispute.status )
 		: true;
 
+	// Partial refunds are done through the order page. If order number is not
+	// present, partial refund is not possible.
 	const isPartiallyRefundable = charge.order && charge.order.number;
 
 	// Control menu only shows refund actions for now. In the future, it may show other actions.


### PR DESCRIPTION
Fixes #7983

#### Changes proposed in this Pull Request

 - Verify that order exists before offering "Partial refund" option on transaction details page

#### Testing instructions

 - Create an orphaned transaction, either deleting an order placed with WooPayments, or by manually adding a payment in the Stripe dashboard on the connected account.
 - View the transaction in Payments → Transactions. The 'Order' field will be blank.
 - Click on the three dots.
 - Only "Refund in full" option should be present.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
