### PR TITLE
Compatibility Service: Send the post type count

### DIFF
--- a/changelog/add-server-3944-compatibility-service-include-post-types
+++ b/changelog/add-server-3944-compatibility-service-include-post-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add post_types and their counts as an array to compatibility data.

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -83,7 +83,7 @@ class Compatibility_Service {
 			$post_types_count[ $post_type ] = wp_count_posts( $post_type )->publish;
 		}
 
-		return $post_types_count;
+		return (array) $post_types_count;
 
 	}
 }

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -47,15 +47,39 @@ class Compatibility_Service {
 	 * @return void
 	 */
 	public function update_compatibility_data() {
+		$post_types_count = $this->get_post_types_count();
 		try {
 			$this->payments_api_client->update_compatibility_data(
 				[
 					'woopayments_version' => WCPAY_VERSION_NUMBER,
 					'woocommerce_version' => WC_VERSION,
+					'post_types_count'    => $post_types_count,
 				]
 			);
 		} catch ( API_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// The exception is already logged if logging is on, nothing else needed.
 		}
+	}
+
+	/**
+	 * Gets the count of public posts for each post type.
+	 *
+	 * @return array
+	 */
+	private function get_post_types_count(): array {
+		$post_types = get_post_types(
+			[
+				'public' => true,
+			]
+		);
+
+		$post_types_count = [];
+
+		foreach ( $post_types as $post_type ) {
+			$post_types_count[ $post_type ] = wp_count_posts( $post_type )->publish;
+		}
+
+		return $post_types_count;
+
 	}
 }

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -68,7 +68,7 @@ class Compatibility_Service {
 	/**
 	 * Gets the count of public posts for each post type.
 	 *
-	 * @return array
+	 * @return array<\WP_Post_Type|string, string>
 	 */
 	private function get_post_types_count(): array {
 		$post_types = get_post_types(
@@ -80,7 +80,7 @@ class Compatibility_Service {
 		$post_types_count = [];
 
 		foreach ( $post_types as $post_type ) {
-			$post_types_count[ $post_type ] = (string) wp_count_posts( $post_type )->publish;
+			$post_types_count[ $post_type ] = wp_count_posts( $post_type )->publish;
 		}
 
 		return $post_types_count;

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -80,10 +80,10 @@ class Compatibility_Service {
 		$post_types_count = [];
 
 		foreach ( $post_types as $post_type ) {
-			$post_types_count[ $post_type ] = wp_count_posts( $post_type )->publish;
+			$post_types_count[ $post_type ] = (string) wp_count_posts( $post_type )->publish;
 		}
 
-		return (array) $post_types_count;
+		return $post_types_count;
 
 	}
 }

--- a/tests/unit/test-class-compatibility-service.php
+++ b/tests/unit/test-class-compatibility-service.php
@@ -47,6 +47,12 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 		$expected = [
 			'woopayments_version' => WCPAY_VERSION_NUMBER,
 			'woocommerce_version' => WC_VERSION,
+			'post_types_count'    => [
+				'post'       => 0,
+				'page'       => 0,
+				'attachment' => 0,
+				'product'    => 0,
+			],
 		];
 
 		// Arrange/Assert: Set the expectations for update_compatibility_data.

--- a/tests/unit/test-class-compatibility-service.php
+++ b/tests/unit/test-class-compatibility-service.php
@@ -59,12 +59,15 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 			'woocommerce_version' => WC_VERSION,
 			'blog_theme'          => $stylesheet,
 			'post_types_count'    => [
-				'post'       => 0,
-				'page'       => 0,
+				'post'       => 1,
+				'page'       => 6,
 				'attachment' => 0,
-				'product'    => 0,
+				'product'    => 12,
 			],
 		];
+
+		// Arrange: Insert test posts.
+		$post_ids = $this->insert_test_posts( $expected['post_types_count'] );
 
 		// Arrange/Assert: Set the expectations for update_compatibility_data.
 		$this->mock_api_client
@@ -74,5 +77,45 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 
 		// Act: Call the method we're testing.
 		$this->compatibility_service->update_compatibility_data();
+
+		// Clean up: Delete the test posts.
+		$this->delete_test_posts( $post_ids );
+	}
+
+	/**
+	 * Insert test posts for use during a unit test.
+	 *
+	 * @param  array $post_types  Assoc array of post types as keys and the number of posts to create for each.
+	 *
+	 * @return array Array of post IDs that were created.
+	 */
+	private function insert_test_posts( array $post_types ): array {
+		$post_ids = [];
+		foreach ( $post_types as $post_type => $count ) {
+			$title_content = 'This is a ' . $post_type . ' test post';
+			for ( $i = 0; $i < $count; $i++ ) {
+				$post_ids[] = (int) wp_insert_post(
+					[
+						'post_title'   => $title_content,
+						'post_content' => $title_content,
+						'post_type'    => $post_type,
+						'post_status'  => 'publish',
+					]
+				);
+			}
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Delete test posts that were created during a unit test.
+	 *
+	 * @param array $post_ids Array of post IDs to delete.
+	 */
+	private function delete_test_posts( array $post_ids ) {
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( (int) $post_id, true );
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments-server/issues/3944

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR adds an array of the counts of the public post types published posts. The array keys are the post types and the value is the count of published posts for that post type.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing instructions are on: https://github.com/Automattic/woocommerce-payments-server/pull/4437

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
