### PR TITLE
Getting settings directly from the db in Mode

### DIFF
--- a/changelog/refactor-mode-class
+++ b/changelog/refactor-mode-class
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: It just changes how we get the same data from the database
+
+

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -538,7 +538,7 @@ class WC_Payments {
 		self::$card_gateway->init_hooks();
 		self::$wc_payments_checkout->init_hooks();
 
-		self::$mode = new Mode( self::$card_gateway );
+		self::$mode = new Mode();
 
 		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::get_gateway(), self::$customer_service, self::$database_cache );
 		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -29,13 +29,6 @@ class Mode {
 	private $dev_mode;
 
 	/**
-	 * Holds the gateway class for settings.
-	 *
-	 * @var WC_Payment_Gateway_WCPay
-	 */
-	private $gateway;
-
-	/**
 	 * Indicates the WCPay version which introduced the class.
 	 *
 	 * @var string
@@ -54,15 +47,6 @@ class Mode {
 	];
 
 	/**
-	 * Stores the gateway for later retrieval of options.
-	 *
-	 * @param WC_Payment_Gateway_WCPay $gateway The active gateway.
-	 */
-	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
-		$this->gateway = $gateway;
-	}
-
-	/**
 	 * Initializes the working mode of WooPayments.
 	 *
 	 * @throws Exception In case the class has not been initialized yet.
@@ -71,11 +55,6 @@ class Mode {
 		// The object is only initialized once.
 		if ( isset( $this->dev_mode ) && isset( $this->test_mode ) ) {
 			return;
-		}
-
-		// We need the gateway settings in order to determine test mode.
-		if ( ! isset( $this->gateway ) || empty( $this->gateway->settings ) ) {
-			throw new Exception( 'WooPayments\' working mode is not initialized yet. Wait for the `init` action.' );
 		}
 
 		$dev_mode = (
@@ -94,8 +73,11 @@ class Mode {
 		 */
 		$this->dev_mode = (bool) apply_filters( 'wcpay_dev_mode', $dev_mode );
 
-		$test_mode_setting = 'yes' === $this->gateway->get_option( 'test_mode' );
-		$test_mode         = $this->dev_mode || $test_mode_setting;
+		// Getting the gateway settings directly from the database so the gateway doesn't need to be initialized.
+		$settings_option_name = 'woocommerce_' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '_settings';
+		$wcpay_settings       = get_option( $settings_option_name );
+		$test_mode_setting    = 'yes' === ( $wcpay_settings['test_mode'] ?? false );
+		$test_mode            = $this->dev_mode || $test_mode_setting;
 
 		/**
 		 * Allows WooCommerce to enter test mode.

--- a/tests/unit/core/test-class-mode.php
+++ b/tests/unit/core/test-class-mode.php
@@ -28,11 +28,7 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 	public function setUp() : void {
 		parent::setUp();
 
-		$this->mock_gateway           = $this->createMock( WC_Payment_Gateway_WCPay::class );
-		$this->mock_gateway->settings = [ 'empty' => false ];
-
 		$this->mode = $this->getMockBuilder( Mode::class )
-			->setConstructorArgs( [ $this->mock_gateway ] )
 			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type' ] )
 			->getMock();
 	}
@@ -44,17 +40,8 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 		parent::tearDown();
 	}
 
-	public function test_throw_exception_if_uninitialized() {
-		$this->mock_gateway->settings = [];
-		$this->expectException( Exception::class );
-		$this->mode->is_live();
-	}
-
 	public function test_init_defaults_to_live_mode() {
-		$this->mock_gateway->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'test_mode' )
-			->willReturn( 'no' );
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'test_mode' => 'no' ] );
 
 		$this->assertTrue( $this->mode->is_live() );
 	}
@@ -76,10 +63,7 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_init_enters_test_mode_with_gateway_test_mode_settings() {
-		$this->mock_gateway->expects( $this->once() )
-			->method( 'get_option' )
-			->with( 'test_mode' )
-			->willReturn( 'yes' );
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'test_mode' => 'yes' ] );
 
 		// Reset and check.
 		$this->assertFalse( $this->mode->is_dev() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the dependency of an instance of WC_Payment_Gateway_WCPay from the Mode class, allowing it to be used before init.
Because this class is used by the Logger, trying to log something before init resulted in a Fatal error when trying to call `->is_dev()`.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke tests and ensures everything still works fine.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
