### PR TITLE
fix: pay for order 3DS handling

### DIFF
--- a/changelog/fix-7799-pay-for-order-error-message
+++ b/changelog/fix-7799-pay-for-order-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix pay-for-order quirks and 3DS behavior

--- a/client/checkout/classic/3ds-flow-handling.js
+++ b/client/checkout/classic/3ds-flow-handling.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getConfig } from 'wcpay/utils/checkout';
+import { getConfig, getUPEConfig } from 'wcpay/utils/checkout';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 
 export const shouldSavePaymentPaymentMethod = () => {
@@ -22,12 +22,11 @@ const cleanupURL = () => {
 };
 
 export const showAuthenticationModalIfRequired = ( api ) => {
-	const url = window.location.href;
 	const paymentMethodId = document.querySelector( '#wcpay-payment-method' )
 		?.value;
 
 	const confirmation = api.confirmIntent(
-		url,
+		window.location.href,
 		shouldSavePaymentPaymentMethod() ? paymentMethodId : null
 	);
 
@@ -39,11 +38,16 @@ export const showAuthenticationModalIfRequired = ( api ) => {
 	const { request } = confirmation;
 	cleanupURL();
 
+	if ( getUPEConfig( 'isOrderPay' ) ) {
+		// TODO: block UI
+	}
+
 	request
 		.then( ( redirectUrl ) => {
 			window.location = redirectUrl;
 		} )
 		.catch( ( error ) => {
+			// TODO: the checkout form might not be present on pay for order or add payment method pages
 			document
 				.querySelector( 'form.checkout' )
 				.classList.remove( 'processing' );

--- a/client/checkout/classic/3ds-flow-handling.js
+++ b/client/checkout/classic/3ds-flow-handling.js
@@ -1,12 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	getConfig,
-	getUPEConfig,
-	blockUi,
-	unblockUi,
-} from 'wcpay/utils/checkout';
+import { getConfig } from 'wcpay/utils/checkout';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 
 export const shouldSavePaymentPaymentMethod = () => {

--- a/client/checkout/classic/3ds-flow-handling.js
+++ b/client/checkout/classic/3ds-flow-handling.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { getConfig, getUPEConfig } from 'wcpay/utils/checkout';
+import {
+	getConfig,
+	getUPEConfig,
+	blockUi,
+	unblockUi,
+} from 'wcpay/utils/checkout';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 
 export const shouldSavePaymentPaymentMethod = () => {
@@ -32,31 +37,17 @@ export const showAuthenticationModalIfRequired = ( api ) => {
 
 	// Boolean `true` means that there is nothing to confirm.
 	if ( confirmation === true ) {
-		return;
+		return Promise.resolve();
 	}
 
 	const { request } = confirmation;
 	cleanupURL();
 
-	if ( getUPEConfig( 'isOrderPay' ) ) {
-		// TODO: block UI
-	}
-
-	request
+	return request
 		.then( ( redirectUrl ) => {
 			window.location = redirectUrl;
 		} )
 		.catch( ( error ) => {
-			// TODO: the checkout form might not be present on pay for order or add payment method pages
-			document
-				.querySelector( 'form.checkout' )
-				.classList.remove( 'processing' );
-
-			const elements = document.getElementsByClassName( 'blockUI' );
-			Array.from( elements ).forEach( ( element ) => {
-				element.parentNode.removeChild( element );
-			} );
-
 			let errorMessage = error.message;
 
 			// If this is a generic error, we probably don't want to display the error message to the user,

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -12,8 +12,6 @@ import {
 	isPaymentMethodRestrictedToLocation,
 	isUsingSavedPaymentMethod,
 	togglePaymentMethodForCountry,
-	blockUI,
-	unblockUI,
 } from '../utils/upe';
 import {
 	processPayment,
@@ -21,6 +19,8 @@ import {
 	renderTerms,
 	createAndConfirmSetupIntent,
 	maybeEnableStripeLink,
+	blockUI,
+	unblockUI,
 } from './payment-processing';
 import enqueueFraudScripts from 'fraud-scripts';
 import { showAuthenticationModalIfRequired } from './3ds-flow-handling';

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -12,6 +12,8 @@ import {
 	isPaymentMethodRestrictedToLocation,
 	isUsingSavedPaymentMethod,
 	togglePaymentMethodForCountry,
+	blockUI,
+	unblockUI,
 } from '../utils/upe';
 import {
 	processPayment,
@@ -19,8 +21,6 @@ import {
 	renderTerms,
 	createAndConfirmSetupIntent,
 	maybeEnableStripeLink,
-	blockUI,
-	unblockUI,
 } from './payment-processing';
 import enqueueFraudScripts from 'fraud-scripts';
 import { showAuthenticationModalIfRequired } from './3ds-flow-handling';
@@ -41,11 +41,12 @@ jQuery( function ( $ ) {
 
 	const $checkoutForm = $( 'form.checkout' );
 	const $addPaymentMethodForm = $( 'form#add_payment_method' );
-	const $orderReviewForm = $( 'form#order_review' );
+	const $payForOrderForm = $( 'form#order_review' );
 
+	// creating a new jQuery object containing all the forms that need to be updated on submit, failure, or other events.
 	const $forms = jQuery( $checkoutForm )
 		.add( $addPaymentMethodForm )
-		.add( $orderReviewForm );
+		.add( $payForOrderForm );
 
 	const api = new WCPayAPI(
 		{
@@ -103,7 +104,7 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	if ( $addPaymentMethodForm.length || $orderReviewForm.length ) {
+	if ( $addPaymentMethodForm.length || $payForOrderForm.length ) {
 		maybeMountStripePaymentElement();
 	}
 
@@ -128,8 +129,8 @@ jQuery( function ( $ ) {
 		);
 	} );
 
-	$orderReviewForm.on( 'submit', function () {
-		return processPaymentIfNotUsingSavedMethod( $orderReviewForm );
+	$payForOrderForm.on( 'submit', function () {
+		return processPaymentIfNotUsingSavedMethod( $payForOrderForm );
 	} );
 
 	if (

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -60,9 +60,9 @@ jQuery( function ( $ ) {
 		apiRequest
 	);
 
-	blockUI( $form );
+	blockUI( $forms );
 	showAuthenticationModalIfRequired( api ).finally( () => {
-		unblockUI( $form );
+		unblockUI( $forms );
 	} );
 
 	$( document.body ).on( 'updated_checkout', () => {
@@ -87,9 +87,9 @@ jQuery( function ( $ ) {
 
 	window.addEventListener( 'hashchange', () => {
 		if ( window.location.hash.startsWith( '#wcpay-confirm-' ) ) {
-			blockUI( $form );
+			blockUI( $forms );
 			showAuthenticationModalIfRequired( api, $forms ).finally( () => {
-				unblockUI( $form );
+				unblockUI( $forms );
 			} );
 		}
 	} );

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -37,6 +37,10 @@ jQuery( function ( $ ) {
 		return;
 	}
 
+	const $checkoutForm = $( 'form.checkout' );
+	const $addPaymentMethodForm = $( 'form#add_payment_method' );
+	const $orderReviewForm = $( 'form#order_review' );
+
 	const api = new WCPayAPI(
 		{
 			publishableKey: publishableKey,
@@ -55,11 +59,11 @@ jQuery( function ( $ ) {
 		maybeMountStripePaymentElement();
 	} );
 
-	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
+	$checkoutForm.on( generateCheckoutEventNames(), function () {
 		return processPaymentIfNotUsingSavedMethod( $( this ) );
 	} );
 
-	$( 'form.checkout' ).on( 'click', '#place_order', function () {
+	$checkoutForm.on( 'click', '#place_order', function () {
 		const isWCPay = document.getElementById(
 			'payment_method_woocommerce_payments'
 		).checked;
@@ -86,35 +90,33 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	if (
-		$( 'form#add_payment_method' ).length ||
-		$( 'form#order_review' ).length
-	) {
+	if ( $addPaymentMethodForm.length || $orderReviewForm.length ) {
 		maybeMountStripePaymentElement();
 	}
 
-	$( 'form#add_payment_method' ).on( 'submit', function () {
+	$addPaymentMethodForm.on( 'submit', function () {
 		if (
-			$(
-				"#add_payment_method input:checked[name='payment_method']"
-			).val() !== 'woocommerce_payments'
+			$addPaymentMethodForm
+				.find( "input:checked[name='payment_method']" )
+				.val() !== 'woocommerce_payments'
 		) {
 			return;
 		}
+
 		// WC core calls block() when add_payment_method form is submitted, so we need to enable the ignore flag here to avoid
 		// the overlay blink when the form is blocked twice.
 		$.blockUI.defaults.ignoreIfBlocked = true;
 
 		return processPayment(
 			api,
-			$( 'form#add_payment_method' ),
+			$addPaymentMethodForm,
 			getSelectedUPEGatewayPaymentMethod(),
 			createAndConfirmSetupIntent
 		);
 	} );
 
-	$( 'form#order_review' ).on( 'submit', function () {
-		return processPaymentIfNotUsingSavedMethod( $( 'form#order_review' ) );
+	$orderReviewForm.on( 'submit', function () {
+		return processPaymentIfNotUsingSavedMethod( $orderReviewForm );
 	} );
 
 	if (
@@ -148,6 +150,8 @@ jQuery( function ( $ ) {
 	function restrictPaymentMethodToLocation( upeElement ) {
 		if ( isPaymentMethodRestrictedToLocation( upeElement ) ) {
 			togglePaymentMethodForCountry( upeElement );
+
+			// this event only applies to the checkout form, but not "place order" or "add payment method" pages.
 			$( '#billing_country' ).on( 'change', function () {
 				togglePaymentMethodForCountry( upeElement );
 			} );

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -64,6 +64,7 @@ export function blockUI( $form ) {
 		},
 	} );
 }
+
 /**
  * Unblocks the UI to allow payment processing.
  *

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -15,6 +15,8 @@ import {
 	getTerms,
 	getUpeSettings,
 	isLinkEnabled,
+	blockUI,
+	unblockUI,
 } from 'wcpay/checkout/utils/upe';
 import enableStripeLinkPaymentMethod from 'wcpay/checkout/stripe-link';
 import {
@@ -48,29 +50,6 @@ function initializeAppearance( api ) {
 		api.saveUPEAppearance( appearance );
 	}
 	return appearance;
-}
-
-/**
- * Block the UI to indicate processing and avoid duplicate submission.
- *
- * @param {Object} $form The jQuery object for the form.
- */
-export function blockUI( $form ) {
-	$form.addClass( 'processing' ).block( {
-		message: null,
-		overlayCSS: {
-			background: '#fff',
-			opacity: 0.6,
-		},
-	} );
-}
-/**
- * Unblocks the UI to allow payment processing.
- *
- * @param {Object} $form The jQuery object for the form.
- */
-export function unblockUI( $form ) {
-	$form.removeClass( 'processing' ).unblock();
 }
 
 /**

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -51,7 +51,7 @@ function initializeAppearance( api ) {
 }
 
 /**
- * Block UI to indicate processing and avoid duplicate submission.
+ * Block the UI to indicate processing and avoid duplicate submission.
  *
  * @param {Object} $form The jQuery object for the form.
  */
@@ -63,6 +63,14 @@ function blockUI( $form ) {
 			opacity: 0.6,
 		},
 	} );
+}
+/**
+ * Unblocks the UI to allow payment processing.
+ *
+ * @param {Object} $form The jQuery object for the form.
+ */
+function unblockUI( $form ) {
+	$form.removeClass( 'processing' ).unblock();
 }
 
 /**
@@ -375,7 +383,7 @@ export const processPayment = (
 			submitForm( $form );
 		} catch ( err ) {
 			hasCheckoutCompleted = false;
-			$form.removeClass( 'processing' ).unblock();
+			unblockUI( $form );
 			showErrorCheckout( err.message );
 		}
 	} )();

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -53,10 +53,10 @@ function initializeAppearance( api ) {
 /**
  * Block UI to indicate processing and avoid duplicate submission.
  *
- * @param {Object} jQueryForm The jQuery object for the jQueryForm.
+ * @param {Object} $form The jQuery object for the form.
  */
-function blockUI( jQueryForm ) {
-	jQueryForm.addClass( 'processing' ).block( {
+function blockUI( $form ) {
+	$form.addClass( 'processing' ).block( {
 		message: null,
 		overlayCSS: {
 			background: '#fff',
@@ -339,16 +339,16 @@ export function renderTerms( event ) {
 let hasCheckoutCompleted;
 export const processPayment = (
 	api,
-	jQueryForm,
+	$form,
 	paymentMethodType,
-	additionalActionsHandler = () => {}
+	additionalActionsHandler = () => Promise.resolve()
 ) => {
 	if ( hasCheckoutCompleted ) {
 		hasCheckoutCompleted = false;
 		return;
 	}
 
-	blockUI( jQueryForm );
+	blockUI( $form );
 
 	const elements = gatewayUPEComponents[ paymentMethodType ].elements;
 
@@ -358,24 +358,24 @@ export const processPayment = (
 			const paymentMethodObject = await createStripePaymentMethod(
 				api,
 				elements,
-				jQueryForm,
+				$form,
 				paymentMethodType
 			);
-			appendFingerprintInputToForm( jQueryForm, fingerprint );
+			appendFingerprintInputToForm( $form, fingerprint );
 			appendPaymentMethodIdToForm(
-				jQueryForm,
+				$form,
 				paymentMethodObject.paymentMethod.id
 			);
 			await additionalActionsHandler(
 				paymentMethodObject.paymentMethod,
-				jQueryForm,
+				$form,
 				api
 			);
 			hasCheckoutCompleted = true;
-			submitForm( jQueryForm );
+			submitForm( $form );
 		} catch ( err ) {
 			hasCheckoutCompleted = false;
-			jQueryForm.removeClass( 'processing' ).unblock();
+			$form.removeClass( 'processing' ).unblock();
 			showErrorCheckout( err.message );
 		}
 	} )();

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -116,7 +116,7 @@ function createStripePaymentMethod(
 ) {
 	/* global wcpayCustomerData */
 	let params = {};
-	if ( wcpayCustomerData ) {
+	if ( window.wcpayCustomerData ) {
 		params = {
 			billing_details: {
 				name: wcpayCustomerData.name || undefined,

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -15,8 +15,6 @@ import {
 	getTerms,
 	getUpeSettings,
 	isLinkEnabled,
-	blockUI,
-	unblockUI,
 } from 'wcpay/checkout/utils/upe';
 import enableStripeLinkPaymentMethod from 'wcpay/checkout/stripe-link';
 import {
@@ -50,6 +48,29 @@ function initializeAppearance( api ) {
 		api.saveUPEAppearance( appearance );
 	}
 	return appearance;
+}
+
+/**
+ * Block the UI to indicate processing and avoid duplicate submission.
+ *
+ * @param {Object} $form The jQuery object for the form.
+ */
+export function blockUI( $form ) {
+	$form.addClass( 'processing' ).block( {
+		message: null,
+		overlayCSS: {
+			background: '#fff',
+			opacity: 0.6,
+		},
+	} );
+}
+/**
+ * Unblocks the UI to allow payment processing.
+ *
+ * @param {Object} $form The jQuery object for the form.
+ */
+export function unblockUI( $form ) {
+	$form.removeClass( 'processing' ).unblock();
 }
 
 /**

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -55,7 +55,7 @@ function initializeAppearance( api ) {
  *
  * @param {Object} $form The jQuery object for the form.
  */
-function blockUI( $form ) {
+export function blockUI( $form ) {
 	$form.addClass( 'processing' ).block( {
 		message: null,
 		overlayCSS: {
@@ -69,7 +69,7 @@ function blockUI( $form ) {
  *
  * @param {Object} $form The jQuery object for the form.
  */
-function unblockUI( $form ) {
+export function unblockUI( $form ) {
 	$form.removeClass( 'processing' ).unblock();
 }
 

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -106,22 +106,36 @@ function createStripePaymentMethod(
 	jQueryForm,
 	paymentMethodType
 ) {
+	/* global wcpayCustomerData */
 	let params = {};
+	if ( wcpayCustomerData ) {
+		params = {
+			billing_details: {
+				name: wcpayCustomerData.name || undefined,
+				email: wcpayCustomerData.email,
+				address: {
+					country: wcpayCustomerData.billing_country,
+				},
+			},
+		};
+	}
+
 	if ( jQueryForm.attr( 'name' ) === 'checkout' ) {
 		params = {
 			billing_details: {
-				name: document.querySelector( '#billing_first_name' )
-					? (
-							document.querySelector( '#billing_first_name' )
-								?.value +
-							' ' +
-							document.querySelector( '#billing_last_name' )
-								?.value
-					  ).trim()
-					: undefined,
+				...params.billing_details,
+				name:
+					`${
+						document.querySelector( '#billing_first_name' )
+							?.value || ''
+					} ${
+						document.querySelector( '#billing_last_name' )?.value ||
+						''
+					}`.trim() || undefined,
 				email: document.querySelector( '#billing_email' )?.value,
 				phone: document.querySelector( '#billing_phone' )?.value,
 				address: {
+					...params.billing_details?.address,
 					city: document.querySelector( '#billing_city' )?.value,
 					country: document.querySelector( '#billing_country' )
 						?.value,

--- a/client/checkout/utils/fingerprint.js
+++ b/client/checkout/utils/fingerprint.js
@@ -27,14 +27,14 @@ export const getFingerprint = async () => {
 /**
  * Appends a hidden input with the user fingerprint to the checkout form.
  *
- * @param {Object} form        The jQuery Checkout form object.
+ * @param {Object} $form        The jQuery Checkout form object.
  * @param {string} fingerprint User fingerprint.
  */
-export const appendFingerprintInputToForm = ( form, fingerprint = '' ) => {
+export const appendFingerprintInputToForm = ( $form, fingerprint = '' ) => {
 	// Remove any existing wcpay-fingerprint input.
-	form.find( 'input[name="wcpay-fingerprint"]' ).remove();
+	$form.find( 'input[name="wcpay-fingerprint"]' ).remove();
 
 	// Append an input with the correct fingerprint to the form.
 	const fingerprintInput = `<input type="hidden" name="wcpay-fingerprint" value="${ fingerprint }" />`;
-	form.append( fingerprintInput );
+	$form.append( fingerprintInput );
 };

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -166,8 +166,8 @@ export const generateCheckoutEventNames = () => {
 		.join( ' ' );
 };
 
-export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
-	form.append(
+export const appendPaymentMethodIdToForm = ( $form, paymentMethodId ) => {
+	$form.append(
 		`<input type="hidden" id="wcpay-payment-method" name="wcpay-payment-method" value="${ paymentMethodId }" />`
 	);
 };
@@ -431,26 +431,3 @@ export const togglePaymentMethodForCountry = ( upeElement ) => {
 		upeContainer.style.display = 'none';
 	}
 };
-
-/**
- * Block the UI to indicate processing and avoid duplicate submission.
- *
- * @param {Object} $form The jQuery object for the form.
- */
-export function blockUI( $form ) {
-	$form.addClass( 'processing' ).block( {
-		message: null,
-		overlayCSS: {
-			background: '#fff',
-			opacity: 0.6,
-		},
-	} );
-}
-/**
- * Unblocks the UI to allow payment processing.
- *
- * @param {Object} $form The jQuery object for the form.
- */
-export function unblockUI( $form ) {
-	$form.removeClass( 'processing' ).unblock();
-}

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -431,3 +431,26 @@ export const togglePaymentMethodForCountry = ( upeElement ) => {
 		upeContainer.style.display = 'none';
 	}
 };
+
+/**
+ * Block the UI to indicate processing and avoid duplicate submission.
+ *
+ * @param {Object} $form The jQuery object for the form.
+ */
+export function blockUI( $form ) {
+	$form.addClass( 'processing' ).block( {
+		message: null,
+		overlayCSS: {
+			background: '#fff',
+			opacity: 0.6,
+		},
+	} );
+}
+/**
+ * Unblocks the UI to allow payment processing.
+ *
+ * @param {Object} $form The jQuery object for the form.
+ */
+export function unblockUI( $form ) {
+	$form.removeClass( 'processing' ).unblock();
+}

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -410,19 +410,17 @@ export const isPaymentMethodRestrictedToLocation = ( upeElement ) => {
  * @param {Object} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
  **/
 export const togglePaymentMethodForCountry = ( upeElement ) => {
-	// in the case of "pay for order", there is no "billing country" input
-	// if there is no input, we'll assume that the payment method has already been restricted by the backend
-	const billingCountryElement = document.getElementById( 'billing_country' );
-	if ( ! billingCountryElement || getUPEConfig( 'isOrderPay' ) ) {
-		return;
-	}
-
 	const paymentMethodsConfig = getUPEConfig( 'paymentMethodsConfig' );
 	const paymentMethodType = upeElement.dataset.paymentMethodType;
 	const supportedCountries =
 		paymentMethodsConfig[ paymentMethodType ].countries;
 
-	const billingCountry = billingCountryElement.value;
+	/* global wcpayCustomerData */
+	// in the case of "pay for order", there is no "billing country" input, so we need to rely on backend data.
+	const billingCountry =
+		document.getElementById( 'billing_country' )?.value ||
+		wcpayCustomerData?.billing_country ||
+		'';
 	const upeContainer = document.querySelector(
 		'.payment_method_woocommerce_payments_' + paymentMethodType
 	);

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -410,12 +410,19 @@ export const isPaymentMethodRestrictedToLocation = ( upeElement ) => {
  * @param {Object} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
  **/
 export const togglePaymentMethodForCountry = ( upeElement ) => {
+	// in the case of "pay for order", there is no "billing country" input
+	// if there is no input, we'll assume that the payment method has already been restricted by the backend
+	const billingCountryElement = document.getElementById( 'billing_country' );
+	if ( ! billingCountryElement || getUPEConfig( 'isOrderPay' ) ) {
+		return;
+	}
+
 	const paymentMethodsConfig = getUPEConfig( 'paymentMethodsConfig' );
 	const paymentMethodType = upeElement.dataset.paymentMethodType;
 	const supportedCountries =
 		paymentMethodsConfig[ paymentMethodType ].countries;
 
-	const billingCountry = document.getElementById( 'billing_country' ).value;
+	const billingCountry = billingCountryElement.value;
 	const upeContainer = document.querySelector(
 		'.payment_method_woocommerce_payments_' + paymentMethodType
 	);

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -421,6 +421,7 @@ export const togglePaymentMethodForCountry = ( upeElement ) => {
 		document.getElementById( 'billing_country' )?.value ||
 		wcpayCustomerData?.billing_country ||
 		'';
+
 	const upeContainer = document.querySelector(
 		'.payment_method_woocommerce_payments_' + paymentMethodType
 	);

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -714,7 +714,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
-        // checks on the backend
 		$processing_payment_method = $this->payment_methods[ $this->payment_method->get_id() ];
 		if ( ! $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) ) {
 			return false;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -714,6 +714,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
+        // checks on the backend
 		$processing_payment_method = $this->payment_methods[ $this->payment_method->get_id() ];
 		if ( ! $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) ) {
 			return false;

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -346,12 +346,11 @@ class WC_Payments_Checkout {
 			 * before `$this->saved_payment_methods()`.
 			 */
 			$payment_fields  = $this->get_payment_fields_js_config();
-			$upe_object_name = 'wcpay_upe_config';
 			wp_enqueue_script( 'wcpay-upe-checkout' );
 			add_action(
 				'wp_footer',
-				function() use ( $payment_fields, $upe_object_name ) {
-					wp_localize_script( 'wcpay-upe-checkout', $upe_object_name, $payment_fields );
+				function() use ( $payment_fields) {
+					wp_localize_script( 'wcpay-upe-checkout', 'wcpay_upe_config', $payment_fields );
 				}
 			);
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -278,15 +278,6 @@ class WC_Payments_Checkout {
 	}
 
 	/**
-	 * Checks if WooPay is enabled.
-	 *
-	 * @return bool - True if WooPay enabled, false otherwise.
-	 */
-	private function is_woopay_enabled() {
-		return WC_Payments_Features::is_woopay_eligible() && 'yes' === $this->gateway->get_option( 'platform_checkout', 'no' ) && WC_Payments_Features::is_woopay_express_checkout_enabled();
-	}
-
-	/**
 	 * Gets payment method settings to pass to client scripts
 	 *
 	 * @return array

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -345,11 +345,11 @@ class WC_Payments_Checkout {
 			 * but we need `$this->get_payment_fields_js_config` to be called
 			 * before `$this->saved_payment_methods()`.
 			 */
-			$payment_fields  = $this->get_payment_fields_js_config();
+			$payment_fields = $this->get_payment_fields_js_config();
 			wp_enqueue_script( 'wcpay-upe-checkout' );
 			add_action(
 				'wp_footer',
-				function() use ( $payment_fields) {
+				function() use ( $payment_fields ) {
 					wp_localize_script( 'wcpay-upe-checkout', 'wcpay_upe_config', $payment_fields );
 				}
 			);

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -520,6 +520,7 @@ class WC_Payments_Customer_Service {
 		$user_email = '';
 		$firstname  = '';
 		$lastname   = '';
+		$billing_country = '';
 
 		if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$order_id = absint( $wp->query_vars['order-pay'] );
@@ -529,6 +530,7 @@ class WC_Payments_Customer_Service {
 				$firstname  = $order->get_billing_first_name();
 				$lastname   = $order->get_billing_last_name();
 				$user_email = $order->get_billing_email();
+				$billing_country = $order->get_billing_country();
 			}
 		}
 
@@ -539,14 +541,15 @@ class WC_Payments_Customer_Service {
 				$firstname  = $user->user_firstname;
 				$lastname   = $user->user_lastname;
 				$user_email = get_user_meta( $user->ID, 'billing_email', true );
-				$user_email = $user_email ? $user_email : $user->user_email;
+				$user_email = $user_email ?: $user->user_email;
+				$billing_country = get_user_meta( $user->ID, 'billing_country', true );
 			}
 		}
-		$prepared_customer_data = [
+
+		return [
 			'name'  => $firstname . ' ' . $lastname,
 			'email' => $user_email,
+			'billing_country' => $billing_country,
 		];
-
-		return $prepared_customer_data;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7799
Fixes https://github.com/Automattic/woocommerce-payments/issues/7871
Fixes https://github.com/Automattic/woocommerce-payments/issues/7788

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a manual order via the merchant's backend (in WooCommerce > Orders)
* Click the "Customer payment page" link on the newly created order
* Use a 3DS card & decline (`4000000000003220`) or use the "generic decline" card (`4000000000000002`)
* The error message should be displayed upon redirection
* Enter new card details, make a successful payment
* The details should be displayed in the merchant's backend, in Payments > Transactions
![Screenshot 2024-01-11 at 6 27 36 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/c245fa13-d428-4384-9dfe-3a645105076f)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
