### PR TITLE
Fix Dropdown menu border defect

### DIFF
--- a/changelog/fix-7991-blank-square-in-the-upper-left-corner-of-basic-filter-dropdowns-on-analytics-pages
+++ b/changelog/fix-7991-blank-square-in-the-upper-left-corner-of-basic-filter-dropdowns-on-analytics-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reverting to manual styling over native WordPress components to fix CSS defects on Analytics page

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -21,10 +21,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 import _ from 'lodash';
 
-// This is a workaround for the position of the dropdown menu. At the same time underlines the need for a better solution.
-import '../../../node_modules/@wordpress/components/src/dropdown-menu/style.scss';
-import '../../../node_modules/@wordpress/components/src/popover/style.scss';
-
 /**
  * Internal dependencies.
  */
@@ -512,6 +508,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 									popoverProps={ {
 										position: 'bottom left',
 									} }
+									className="refund-controls__dropdown-menu"
 								>
 									{ ( { onClose } ) => (
 										<MenuGroup>

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -98,4 +98,30 @@
 
 .payment-details__refund-controls {
 	flex: 0 0 auto;
+
+	.refund-controls__dropdown-menu {
+		/**
+		 * HACK: The following styles are needed to make the dropdown menu
+		 * appear in its expected position. The dropdown menu is positioned absolutely, so we need to make sure
+		 * that the parent container is positioned relatively.
+		 * This should be taken care of by the dropdown menu component's CSS, but we seem to be relying in outdated
+		 * wordpress/components styles.
+		 * TODO: link to GH issue.
+		 */
+		.components-popover {
+			position: fixed;
+		}
+		.components-popover__content {
+			position: absolute;
+			right: 100%;
+		}
+
+		.components-tooltip {
+			.components-popover__content {
+				position: relative;
+				right: 0;
+			}
+		}
+		// END HACK
+	}
 }

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -106,7 +106,8 @@
 		 * that the parent container is positioned relatively.
 		 * This should be taken care of by the dropdown menu component's CSS, but we seem to be relying in outdated
 		 * wordpress/components styles.
-		 * TODO: link to GH issue.
+		 *
+		 * Github issue: https://github.com/Automattic/woocommerce-payments/issues/8012
 		 */
 		.components-popover {
 			position: fixed;

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -701,7 +701,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button
@@ -996,7 +996,7 @@ exports[`PaymentDetailsSummary order missing notice does not render notice if or
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button
@@ -1291,7 +1291,7 @@ exports[`PaymentDetailsSummary order missing notice renders notice if order miss
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button
@@ -1609,7 +1609,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button
@@ -2448,7 +2448,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button
@@ -2743,7 +2743,7 @@ exports[`PaymentDetailsSummary renders the Tap to Pay channel from metadata 1`] 
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button
@@ -3038,7 +3038,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             class="payment-details__refund-controls"
           >
             <div
-              class="components-dropdown components-dropdown-menu"
+              class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
               tabindex="-1"
             >
               <button

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -538,7 +538,7 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               class="payment-details__refund-controls"
             >
               <div
-                class="components-dropdown components-dropdown-menu"
+                class="components-dropdown components-dropdown-menu refund-controls__dropdown-menu"
                 tabindex="-1"
               >
                 <button


### PR DESCRIPTION
Fixes #7991

In a previous PR, we started to import the styles from `wordpress/components` so the dropdown menu was correctly positioned. Unfortunately, this had a side effect: other instances of the dropdown menu started to display the following defect on the popover border:

<img width="508" alt="294973697-bce0095b-98d9-42eb-a5a9-9557c9c96298" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/bc349f5f-910c-4748-b2e9-36f5fff573be">



#### Changes proposed in this Pull Request

* Remove specific SCSS imports for dropdown-menu and popover from @wordpress/components in `client/payment-details/summary/index.tsx`
* Added custom styles to handle the positioning of dropdown menus in `client/payment-details/summary/style.scss`. 
* Updated snapshots

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
We need to test that the undesired side effects are fixed and, at the same time, the refunds dropdown menu is displayed correctly.

1. Navigate to WP Admin > Analytics page.
2. Click on Products menu item.
3. Click on Date range or Show filters
4. Check that the popover menu does not display a blank square:
<img width="873" alt="Screenshot 2024-01-11 at 15 56 34" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/be1061b0-ddd8-47af-9ddf-bd5fb5f5622e">
6. Navigate to WP Admin > Payments > Transactions and click on one transactions.
7. On the payment details page, check that the refund menu is displayed properly
<img width="547" alt="Screenshot 2024-01-11 at 16 01 03" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/eb6305b3-06af-4688-adb6-8a121e1f0e13">




<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
