### PR TITLE
chore: update BNPL settings sorting for consistency with onboarding

### DIFF
--- a/changelog/fix-6810-bnpl-sorting
+++ b/changelog/fix-6810-bnpl-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updated BNPL sorting in settings for consistency with onboarding.

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -75,8 +75,8 @@ const PaymentMethods = () => {
 
 	const orderedAvailablePaymentMethodIds = [
 		PAYMENT_METHOD_IDS.CARD,
-		...availablePayLaterMethods,
 		...availableNonPayLaterMethods,
+		...availablePayLaterMethods,
 	];
 
 	const availableMethods = orderedAvailablePaymentMethodIds.map(


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/6810

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Updated the sorting of BNPL options to be consistent with onboarding.
I noticed that BNPL is also displayed at the bottom on checkout, so it made sense to update the settings this way:
![Screenshot 2024-01-12 at 9 29 08 AM](https://github.com/Automattic/woocommerce-payments/assets/273592/2d194c5a-a927-45db-88eb-6562922eec8b)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WooPayment's settings page
* BNPL should be displayed at the bottom
![Screenshot 2024-01-12 at 9 30 39 AM](https://github.com/Automattic/woocommerce-payments/assets/273592/8a94d8d3-2d05-4c0e-ad14-28f6db694071)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
