### PR TITLE
Allow subscription purchase via Payment Request when no shipping methods are present

### DIFF
--- a/changelog/fix-2493-filter-subscriptions-payment-request
+++ b/changelog/fix-2493-filter-subscriptions-payment-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow subscription purchase via Payment Request when no shipping methods are present.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -878,7 +878,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @param boolean $needs_shipping_address Whether the cart needs a shipping address.
 	 */
 	public function filter_cart_needs_shipping_address( $needs_shipping_address ) {
-		if ( $this->has_subscription_product() && $this->get_shipping_method_count( true, true ) === 0 ) {
+		if ( $this->has_subscription_product() && wc_get_shipping_method_count( true, true ) === 0 ) {
 			return false;
 		}
 
@@ -1576,16 +1576,5 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		// Normally there should be a single tax, but `calc_tax` returns an array, let's use it.
 		return WC_Tax::calc_tax( $price, $rates, false );
-	}
-
-	/**
-	 * Wrapper for `wc_get_shipping_method_count` to allow mocking.
-	 *
-	 * @param boolean $include_legacy Whether to include legacy shipping methods.
-	 * @param boolean $enabled_only   Whether to include only enabled shipping methods.
-	 * @return int                    The number of shipping methods.
-	 */
-	public function get_shipping_method_count( $include_legacy = false, $enabled_only = false ) {
-		return wc_get_shipping_method_count( $include_legacy, $enabled_only );
 	}
 }

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -94,6 +94,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'add_order_meta' ], 10, 2 );
 		add_filter( 'woocommerce_login_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
 		add_filter( 'woocommerce_registration_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
+		add_filter( 'woocommerce_cart_needs_shipping_address', [ $this, 'filter_cart_needs_shipping_address' ], 11, 1 );
 
 		// Add a filter for the value of `wcpay_is_apple_pay_enabled`.
 		// This option does not get stored in the database at all, and this function
@@ -872,6 +873,19 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
+	 * Determine wether to filter the cart needs shipping address.
+	 *
+	 * @param boolean $needs_shipping_address Whether the cart needs a shipping address.
+	 */
+	public function filter_cart_needs_shipping_address( $needs_shipping_address ) {
+		if ( $this->has_subscription_product() && $this->get_shipping_method_count( true, true ) === 0 ) {
+			return false;
+		}
+
+		return $needs_shipping_address;
+	}
+
+	/**
 	 * Get cart details.
 	 */
 	public function ajax_get_cart_details() {
@@ -1562,5 +1576,16 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		// Normally there should be a single tax, but `calc_tax` returns an array, let's use it.
 		return WC_Tax::calc_tax( $price, $rates, false );
+	}
+
+	/**
+	 * Wrapper for `wc_get_shipping_method_count` to allow mocking.
+	 *
+	 * @param boolean $include_legacy Whether to include legacy shipping methods.
+	 * @param boolean $enabled_only   Whether to include only enabled shipping methods.
+	 * @return int                    The number of shipping methods.
+	 */
+	public function get_shipping_method_count( $include_legacy = false, $enabled_only = false ) {
+		return wc_get_shipping_method_count( $include_legacy, $enabled_only );
 	}
 }

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -551,25 +551,18 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 	}
 
 	public function test_filter_cart_needs_shipping_address_returns_false() {
-		$mock_pr = $this->getMockBuilder( WC_Payments_Payment_Request_Button_Handler::class )
-			->setConstructorArgs( [ $this->mock_wcpay_account, $this->mock_wcpay_gateway, $this->express_checkout_helper ] )
-			->setMethods( [ 'has_subscription_product', 'get_shipping_method_count' ] )
-			->getMock();
+		sleep( 1 );
+		$this->zone->delete_shipping_method( $this->flat_rate_id );
+		$this->zone->delete_shipping_method( $this->local_pickup_id );
 
-		$mock_pr->method( 'has_subscription_product' )->willReturn( true );
-		$mock_pr->method( 'get_shipping_method_count' )->willReturn( 0 );
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
-		$this->assertFalse( $mock_pr->filter_cart_needs_shipping_address( true ) );
+		$this->assertFalse( $this->pr->filter_cart_needs_shipping_address( true ) );
 	}
 
 	public function test_filter_cart_needs_shipping_address_returns_true() {
-		$mock_pr = $this->getMockBuilder( WC_Payments_Payment_Request_Button_Handler::class )
-			->setConstructorArgs( [ $this->mock_wcpay_account, $this->mock_wcpay_gateway, $this->express_checkout_helper ] )
-			->setMethods( [ 'has_subscription_product', 'get_shipping_method_count' ] )
-			->getMock();
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
-		$mock_pr->method( 'has_subscription_product' )->willReturn( true );
-
-		$this->assertTrue( $mock_pr->filter_cart_needs_shipping_address( true ) );
+		$this->assertTrue( $this->pr->filter_cart_needs_shipping_address( true ) );
 	}
 }

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -549,4 +549,27 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 			'Failed asserting total amount are the same for get_product_data and build_display_items'
 		);
 	}
+
+	public function test_filter_cart_needs_shipping_address_returns_false() {
+		$mock_pr = $this->getMockBuilder( WC_Payments_Payment_Request_Button_Handler::class )
+			->setConstructorArgs( [ $this->mock_wcpay_account, $this->mock_wcpay_gateway, $this->express_checkout_helper ] )
+			->setMethods( [ 'has_subscription_product', 'get_shipping_method_count' ] )
+			->getMock();
+
+		$mock_pr->method( 'has_subscription_product' )->willReturn( true );
+		$mock_pr->method( 'get_shipping_method_count' )->willReturn( 0 );
+
+		$this->assertFalse( $mock_pr->filter_cart_needs_shipping_address( true ) );
+	}
+
+	public function test_filter_cart_needs_shipping_address_returns_true() {
+		$mock_pr = $this->getMockBuilder( WC_Payments_Payment_Request_Button_Handler::class )
+			->setConstructorArgs( [ $this->mock_wcpay_account, $this->mock_wcpay_gateway, $this->express_checkout_helper ] )
+			->setMethods( [ 'has_subscription_product', 'get_shipping_method_count' ] )
+			->getMock();
+
+		$mock_pr->method( 'has_subscription_product' )->willReturn( true );
+
+		$this->assertTrue( $mock_pr->filter_cart_needs_shipping_address( true ) );
+	}
 }

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -153,6 +153,7 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 
 	public function tear_down() {
 		parent::tear_down();
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 		WC()->cart->empty_cart();
 		WC()->session->cleanup_sessions();
 		$this->zone->delete();


### PR DESCRIPTION
Fixes #2493 

#### Changes proposed in this Pull Request

Subscriptions require shipping by default. When a store has no shipping methods configured in any shipping zone, purchases via Google Pay will fail and, as mentioned in #2493, an error is added to the page behind the Google Pay modal.

I was initially working under the assumption that subscriptions simply couldn't be purchased when the store had no shipping methods enabled and [worked out a solution](https://github.com/Automattic/woocommerce-payments/compare/develop...fix/2493-payment-request-button-shipping-zones) that hides the payment request button in this scenario. With further testing, it turns out that subscriptions can indeed be purchased when no shipping methods are enabled, via normal checkout flows.

This purpose of this PR is to allow subscription purchases to complete via Google Pay when the store has no shipping methods. This is done via the `woocommerce_cart_needs_shipping_address`, [the same as Woo Subscriptions is doing](https://github.com/Automattic/woocommerce-subscriptions-core/blob/5abcf9aac4e53ad9bdcf3752a34a04ae42261bac/includes/class-wc-subscriptions-cart.php#L83) to require shipping.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before - Reproducing the error**

<img src="https://user-images.githubusercontent.com/41110392/126347654-aea24f90-a1ee-4340-b852-5192cb5427aa.png" width="500" />

* Enable Payment Request buttons
* On `develop`, remove all shipping methods from the store
* Add a subscription product to the cart
* Navigate to the cart page
* Attempt to pay with Google Pay
* Upon clicking pay, notice the error added above the cart, behind the modal

**After**

* Checkout this branch
* Remove all shipping methods from the store
* Add a subscription product to the cart
* Navigate to the cart page
* Pay with Google Pay
* The purchase should complete the error should no longer appear
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
