### PR TITLE
Show Payments → Overview waiting period notice for new accounts that have completed one or more transactions

### DIFF
--- a/changelog/fix-8040-new-account-waiting-period-notice
+++ b/changelog/fix-8040-new-account-waiting-period-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+On Payments Overview, show the first deposit waiting period notice for new accounts that have transacted

--- a/changelog/fix-8040-new-account-waiting-period-notice
+++ b/changelog/fix-8040-new-account-waiting-period-notice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-On Payments Overview, show the first deposit waiting period notice for new accounts that have transacted
+Reinstate first deposit waiting period notice in payments overview (fix bug)

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -88,11 +88,6 @@ const DepositsOverview: React.FC = () => {
 		);
 	}
 
-	// This card isn't shown if there are no deposits, so we can bail early.
-	if ( ! isLoading && deposits.length === 0 ) {
-		return null;
-	}
-
 	return (
 		<Card className="wcpay-deposits-overview">
 			<CardHeader>

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -94,7 +94,8 @@ const DepositsOverview: React.FC = () => {
 		availableFunds === 0 &&
 		pendingFunds === 0
 	) {
-		// If the account has not received any transactions before completing the waiting period, don't show the deposits overview section.
+		// If still in new account waiting period and account has no transactions,
+		// don't render deposits card (nothing to show).
 		return null;
 	}
 

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -89,6 +89,15 @@ const DepositsOverview: React.FC = () => {
 		);
 	}
 
+	if (
+		! hasCompletedWaitingPeriod &&
+		availableFunds === 0 &&
+		pendingFunds === 0
+	) {
+		// If the account has not received any transactions before completing the waiting period, don't show the deposits overview section.
+		return null;
+	}
+
 	return (
 		<Card className="wcpay-deposits-overview">
 			<CardHeader>
@@ -139,6 +148,7 @@ const DepositsOverview: React.FC = () => {
 					<RecentDepositsList deposits={ deposits } />
 				</>
 			) }
+
 			{ ( hasRecentDeposits || canChangeDepositSchedule ) && (
 				<CardFooter className="wcpay-deposits-overview__footer">
 					{ hasRecentDeposits && (

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -57,6 +57,8 @@ const DepositsOverview: React.FC = () => {
 		availableFunds === 0 && pendingFunds > 0;
 	const hasCompletedWaitingPeriod =
 		wcpaySettings.accountStatus.deposits?.completed_waiting_period;
+	const canChangeDepositSchedule =
+		! account?.deposits_blocked && hasCompletedWaitingPeriod;
 	// Only show the deposit history section if the page is finished loading and there are deposits. */ }
 	const hasRecentDeposits = ! isLoading && deposits?.length > 0 && !! account;
 
@@ -137,53 +139,54 @@ const DepositsOverview: React.FC = () => {
 					<RecentDepositsList deposits={ deposits } />
 				</>
 			) }
+			{ ( hasRecentDeposits || canChangeDepositSchedule ) && (
+				<CardFooter className="wcpay-deposits-overview__footer">
+					{ hasRecentDeposits && (
+						<Button
+							variant="secondary"
+							href={ getAdminUrl( {
+								page: 'wc-admin',
+								path: '/payments/deposits',
+							} ) }
+							onClick={ () =>
+								wcpayTracks.recordEvent(
+									wcpayTracks.events
+										.OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK
+								)
+							}
+						>
+							{ __(
+								'View full deposits history',
+								'woocommerce-payments'
+							) }
+						</Button>
+					) }
 
-			<CardFooter className="wcpay-deposits-overview__footer">
-				{ hasRecentDeposits && (
-					<Button
-						variant="secondary"
-						href={ getAdminUrl( {
-							page: 'wc-admin',
-							path: '/payments/deposits',
-						} ) }
-						onClick={ () =>
-							wcpayTracks.recordEvent(
-								wcpayTracks.events
-									.OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK
-							)
-						}
-					>
-						{ __(
-							'View full deposits history',
-							'woocommerce-payments'
-						) }
-					</Button>
-				) }
-
-				{ ! account?.deposits_blocked && (
-					<Button
-						variant="tertiary"
-						href={
-							getAdminUrl( {
-								page: 'wc-settings',
-								tab: 'checkout',
-								section: 'woocommerce_payments',
-							} ) + '#deposit-schedule'
-						}
-						onClick={ () =>
-							wcpayTracks.recordEvent(
-								wcpayTracks.events
-									.OVERVIEW_DEPOSITS_CHANGE_SCHEDULE_CLICK
-							)
-						}
-					>
-						{ __(
-							'Change deposit schedule',
-							'woocommerce-payments'
-						) }
-					</Button>
-				) }
-			</CardFooter>
+					{ canChangeDepositSchedule && (
+						<Button
+							variant="tertiary"
+							href={
+								getAdminUrl( {
+									page: 'wc-settings',
+									tab: 'checkout',
+									section: 'woocommerce_payments',
+								} ) + '#deposit-schedule'
+							}
+							onClick={ () =>
+								wcpayTracks.recordEvent(
+									wcpayTracks.events
+										.OVERVIEW_DEPOSITS_CHANGE_SCHEDULE_CLICK
+								)
+							}
+						>
+							{ __(
+								'Change deposit schedule',
+								'woocommerce-payments'
+							) }
+						</Button>
+					) }
+				</CardFooter>
+			) }
 		</Card>
 	);
 };

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -58,8 +58,7 @@ const DepositsOverview: React.FC = () => {
 	const hasCompletedWaitingPeriod =
 		wcpaySettings.accountStatus.deposits?.completed_waiting_period;
 	// Only show the deposit history section if the page is finished loading and there are deposits. */ }
-	const showRecentDeposits =
-		! isLoading && deposits?.length > 0 && !! account;
+	const hasRecentDeposits = ! isLoading && deposits?.length > 0 && !! account;
 
 	// Show a loading state if the page is still loading.
 	if ( isLoading ) {
@@ -128,7 +127,7 @@ const DepositsOverview: React.FC = () => {
 				) }
 			</CardBody>
 
-			{ showRecentDeposits && (
+			{ hasRecentDeposits && (
 				<>
 					<CardBody className="wcpay-deposits-overview__heading">
 						<span className="wcpay-deposits-overview__heading__title">
@@ -140,24 +139,26 @@ const DepositsOverview: React.FC = () => {
 			) }
 
 			<CardFooter className="wcpay-deposits-overview__footer">
-				<Button
-					variant="secondary"
-					href={ getAdminUrl( {
-						page: 'wc-admin',
-						path: '/payments/deposits',
-					} ) }
-					onClick={ () =>
-						wcpayTracks.recordEvent(
-							wcpayTracks.events
-								.OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK
-						)
-					}
-				>
-					{ __(
-						'View full deposits history',
-						'woocommerce-payments'
-					) }
-				</Button>
+				{ hasRecentDeposits && (
+					<Button
+						variant="secondary"
+						href={ getAdminUrl( {
+							page: 'wc-admin',
+							path: '/payments/deposits',
+						} ) }
+						onClick={ () =>
+							wcpayTracks.recordEvent(
+								wcpayTracks.events
+									.OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK
+							)
+						}
+					>
+						{ __(
+							'View full deposits history',
+							'woocommerce-payments'
+						) }
+					</Button>
+				) }
 
 				{ ! account?.deposits_blocked && (
 					<Button

--- a/client/components/deposits-overview/style.scss
+++ b/client/components/deposits-overview/style.scss
@@ -30,8 +30,12 @@
 	// so table CardDivider is full width.
 	.components-card__body.wcpay-deposits-overview__table__container,
 	.components-card__body.wcpay-deposits-overview__notices__container {
-		padding-bottom: 0;
 		padding-top: 0;
+
+		// If the CardFooter is rendered, remove the bottom padding
+		&:not( :last-child ) {
+			padding-bottom: 0;
+		}
 	}
 
 	// Override display:block on the first FlexItem with the date and icon

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -268,7 +268,8 @@ describe( 'Deposits Overview information', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	test( `Component doesn't render for new account`, () => {
+	test( `Component doesn't render for new accounts with no pending funds`, () => {
+		global.wcpaySettings.accountStatus.deposits.completed_waiting_period = false;
 		mockOverviews( [ createMockNewAccountOverview( 'eur' ) ] );
 		mockDepositOverviews( [ createMockNewAccountOverview( 'eur' ) ] );
 		mockUseDeposits.mockReturnValue( {
@@ -284,7 +285,8 @@ describe( 'Deposits Overview information', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	test( `Component doesn't render for new accounts with pending funds but no available funds`, () => {
+	test( `Component renders for new accounts with pending funds but no available funds`, () => {
+		global.wcpaySettings.accountStatus.deposits.completed_waiting_period = false;
 		mockOverviews( [ createMockNewAccountOverview( 'eur', 5000, 0 ) ] );
 		mockDepositOverviews( [
 			createMockNewAccountOverview( 'eur', 5000, 0 ),
@@ -298,8 +300,12 @@ describe( 'Deposits Overview information', () => {
 			selectedCurrency: 'eur',
 			setSelectedCurrency: mockSetSelectedCurrency,
 		} );
-		const { container } = render( <DepositsOverview /> );
-		expect( container ).toBeEmptyDOMElement();
+		const { getByText, queryByText } = render( <DepositsOverview /> );
+		getByText( /Your first deposit is held for seven business days/, {
+			ignore: '.a11y-speak-region',
+		} );
+		expect( queryByText( 'Change deposit schedule' ) ).toBeFalsy();
+		expect( queryByText( 'View full deposits history' ) ).toBeFalsy();
 	} );
 
 	test( 'Confirm notice renders if deposits blocked', () => {
@@ -402,7 +408,7 @@ describe( 'Deposits Overview information', () => {
 		).toBeFalsy();
 	} );
 
-	test( 'Confirm new account waiting period notice does not show', () => {
+	test( 'Confirm new account waiting period notice does not show if outside waiting period', () => {
 		global.wcpaySettings.accountStatus.deposits.completed_waiting_period = true;
 		const accountOverview = createMockNewAccountOverview(
 			'eur',
@@ -422,7 +428,7 @@ describe( 'Deposits Overview information', () => {
 		).toBeFalsy();
 	} );
 
-	test( 'Confirm new account waiting period notice shows', () => {
+	test( 'Confirm new account waiting period notice shows if within waiting period', () => {
 		global.wcpaySettings.accountStatus.deposits.completed_waiting_period = false;
 		const accountOverview = createMockNewAccountOverview(
 			'eur',


### PR DESCRIPTION
Fixes #8040

#### Changes proposed in this Pull Request

This PR shows the new account waiting period deposit notice on the Payments → Overview screen for new accounts within the waiting period who have received a transaction (have a pending or available balance).

<img width="706" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/f37650cb-0aae-431d-bc62-8a0cd27017de">

Accounts that have not received any transactions (no pending or available balance) will not see the notice on the Payments → Overview screen.

<img width="720" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/081eeca7-a874-4272-8bdf-c91975376c72">

Note: the wording of this notice is being updated in #8030

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a new account that has not received any transactions
* On the Payments → Overview screen, you should not see the deposits card or the new account waiting period notice
* Complete a transaction to accrue some pending funds
* On the Payments → Overview screen, you should see the deposits card and the new account waiting period notice

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : __QA Testing Not Applicable__
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **N/A**
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. **N/A**
