### PR TITLE
Format fee description pill for zero fixed rate

### DIFF
--- a/changelog/fix-6531-calculate-zero-fees-in-settings-pill
+++ b/changelog/fix-6531-calculate-zero-fees-in-settings-pill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Format fee descriptions for iDeal payment method without percentage rate

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -15,7 +15,7 @@ import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants'
 import { useManualCapture } from 'wcpay/data';
 import { FeeStructure } from 'wcpay/types/fees';
 import {
-	formatMethodFeesDescription,
+	formatMethodMinimalFee,
 	formatMethodFeesTooltip,
 } from 'wcpay/utils/account-fees';
 import WCPaySettingsContext from '../../settings/wcpay-settings-context';
@@ -319,13 +319,13 @@ const PaymentMethod = ( {
 												'Base transaction fees: %s',
 												'woocommerce-payments'
 											),
-											formatMethodFeesDescription(
+											formatMethodMinimalFee(
 												accountFees[ id ]
 											)
 										) }
 									>
 										<span>
-											{ formatMethodFeesDescription(
+											{ formatMethodMinimalFee(
 												accountFees[ id ]
 											) }
 										</span>

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -104,6 +104,12 @@ const getFeeDescriptionString = (
 	return '';
 };
 
+function calculateDiscountAdjustedFeeRate( accountFees: FeeStructure ) {
+	return accountFees.discount.length && accountFees.discount[ 0 ].discount
+		? 1 - accountFees.discount[ 0 ].discount
+		: 1;
+}
+
 export const getCurrentBaseFee = (
 	accountFees: FeeStructure
 ): BaseFee | DiscountFee => {
@@ -117,10 +123,9 @@ export const formatMethodFeesTooltip = (
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
 
-	const discountAdjustedFeeRate: number =
-		accountFees.discount.length && accountFees.discount[ 0 ].discount
-			? 1 - accountFees.discount[ 0 ].discount
-			: 1;
+	const discountAdjustedFeeRate: number = calculateDiscountAdjustedFeeRate(
+		accountFees
+	);
 
 	const total = {
 		percentage_rate:
@@ -363,13 +368,11 @@ export const formatAccountFeesDescription = (
 };
 
 export const formatMethodMinimalFee = ( accountFees: FeeStructure ): string => {
-	const discountAdjustedFeeRate: number =
-		accountFees.discount.length && accountFees.discount[ 0 ].discount
-			? 1 - accountFees.discount[ 0 ].discount
-			: 1;
+	const discountAdjustedFeeRate: number = calculateDiscountAdjustedFeeRate(
+		accountFees
+	);
 
 	return sprintf(
-		// eslint-disable-next-line max-len
 		/* translators: %1 Base fee */
 		__( 'From %1$s', 'woocommerce-payments' ),
 		getFeeDescriptionString( accountFees.base, discountAdjustedFeeRate )

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -362,6 +362,20 @@ export const formatAccountFeesDescription = (
 	return feeDescription;
 };
 
+export const formatMethodMinimalFee = ( accountFees: FeeStructure ): string => {
+	const discountAdjustedFeeRate: number =
+		accountFees.discount.length && accountFees.discount[ 0 ].discount
+			? 1 - accountFees.discount[ 0 ].discount
+			: 1;
+
+	return sprintf(
+		// eslint-disable-next-line max-len
+		/* translators: %1 Base fee */
+		__( 'From %1$s', 'woocommerce-payments' ),
+		getFeeDescriptionString( accountFees.base, discountAdjustedFeeRate )
+	);
+};
+
 export const formatMethodFeesDescription = (
 	methodFees: FeeStructure | undefined
 ): string | JSX.Element => {

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -12,6 +12,7 @@ import {
 	formatAccountFeesDescription,
 	formatMethodFeesDescription,
 	formatMethodFeesTooltip,
+	formatMethodMinimalFee,
 	getCurrentBaseFee,
 } from '../account-fees';
 import { formatCurrency } from '../currency';
@@ -69,6 +70,41 @@ const mockAccountFees = (
 };
 
 describe( 'Account fees utility functions', () => {
+	describe( 'formatMethodMinimalFee()', () => {
+		it( 'formats base fee with both fixed and percentage parts', () => {
+			const accountFees = mockAccountFees( {
+				percentage_rate: 0.123,
+				fixed_rate: 456.78,
+				currency: 'USD',
+			} );
+			expect( formatMethodMinimalFee( accountFees ) ).toEqual(
+				'From 12.3% + $4.57'
+			);
+		} );
+
+		it( 'formats base fee with only fixed part', () => {
+			const accountFees = mockAccountFees( {
+				percentage_rate: 0,
+				fixed_rate: 456.78,
+				currency: 'USD',
+			} );
+			expect( formatMethodMinimalFee( accountFees ) ).toEqual(
+				'From $4.57'
+			);
+		} );
+
+		it( 'formats base fee with only percentage part', () => {
+			const accountFees = mockAccountFees( {
+				percentage_rate: 0.123,
+				fixed_rate: 0,
+				currency: 'USD',
+			} );
+			expect( formatMethodMinimalFee( accountFees ) ).toEqual(
+				'From 12.3%'
+			);
+		} );
+	} );
+
 	describe( 'getCurrentBaseFee()', () => {
 		it( 'returns first discount regardless of amount', () => {
 			const accountFees = mockAccountFees(


### PR DESCRIPTION
Fixes #6531 

#### Changes proposed in this Pull Request

Right now we use `formatMethodFeesDescription` method to format fee description in the settings pill. The info in the Pill is very simple, just a  "From {fixed} + {percentage}" however the `formatMethodFeesDescription` contains long and complicated logic which is used in `payments->overview` (see https://github.com/Automattic/woocommerce-payments/pull/6949) and potentially other places.

This PR introduces a simple one-use function to perform the simple formatting for the pill. 

#### Testing instructions

- Open `Payments->settings`
- Observe that iDeal pill says "From $0.80" without the percentage part.


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
