### PR TITLE
Fix incorrect test mode notice when left KYC early after going live from builder mode

### DIFF
--- a/changelog/fix-7819-incorrect-test-mode-notice
+++ b/changelog/fix-7819-incorrect-test-mode-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect test mode notice when left KYC early after going live from builder mode

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1499,18 +1499,18 @@ class WC_Payments_Account {
 			$event_properties
 		);
 
-		wp_safe_redirect(
-			add_query_arg(
-				[
-					'wcpay-state'                => false,
-					'wcpay-account-id'           => false,
-					'wcpay-live-publishable-key' => false,
-					'wcpay-test-publishable-key' => false,
-					'wcpay-mode'                 => false,
-					'wcpay-connection-success'   => '1',
-				]
-			)
-		);
+		$params = [
+			'wcpay-state'                => false,
+			'wcpay-account-id'           => false,
+			'wcpay-live-publishable-key' => false,
+			'wcpay-test-publishable-key' => false,
+			'wcpay-mode'                 => false,
+		];
+		if ( empty( $_GET['wcpay-connection-error'] ) ) {
+			$params['wcpay-connection-success'] = '1';
+		}
+
+		wp_safe_redirect( add_query_arg( $params ) );
 		exit;
 	}
 


### PR DESCRIPTION
Fixes #7819

#### Changes proposed in this Pull Request

* Check if there is wcpay-connection-error in the URL before adding the redirect to wcpay-connection-success

#### Testing instructions

* Should be tested in https://github.com/Automattic/woocommerce-payments-server/pull/4503

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
