### PR TITLE
Address QIT security errors

### DIFF
--- a/changelog/fix-8059-qit-security-test-failed-in-develop-branch
+++ b/changelog/fix-8059-qit-security-test-failed-in-develop-branch
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix QIT security tests errors.
+Comment: Fix QIT security tests errors.

--- a/changelog/fix-8059-qit-security-test-failed-in-develop-branch
+++ b/changelog/fix-8059-qit-security-test-failed-in-develop-branch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix QIT security tests errors.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1358,7 +1358,7 @@ class WC_Payments {
 							'WooPayments'
 						),
 						[
-							'a1' => '<a href="' . admin_url( 'plugins.php' ) . '">',
+							'a1' => '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">',
 						]
 					)
 					?>
@@ -1724,10 +1724,10 @@ class WC_Payments {
 					$notice,
 					'WooCommerce',
 					'WooPayments',
-					WC_VERSION
+					esc_html( WC_VERSION )
 				),
 				[
-					'a1' => '<a href="' . admin_url( 'plugins.php' ) . '">',
+					'a1' => '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">',
 				]
 			)
 			?>

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1021,7 +1021,7 @@ class MultiCurrency {
 		echo \WC_Payments_Utils::esc_interpolated_html(
 			$message,
 			[
-				'a' => '<a href="?currency=' . $store_currency . '">',
+				'a' => '<a href="?currency=' . esc_attr( $store_currency ) . '">',
 			]
 		);
 		echo ' <a href="#" class="woocommerce-store-notice__dismiss-link">' . esc_html__( 'Dismiss', 'woocommerce-payments' ) . '</a></p>';


### PR DESCRIPTION
Fixes #8059 

#### Changes proposed in this Pull Request
Address QIT security test failures.

- Use escaping functions for URL and attributes
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout locally, and make sure QIT tests pass in the branch
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
