### PR TITLE
Updating title and name with country on init

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -497,7 +497,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return void
 	 */
 	public function init_hooks() {
-		add_action( 'init', [ $this, 'update_properties_with_country' ] );
+		add_action( 'init', [ $this, 'maybe_update_properties_with_country' ] );
 		// Only add certain actions/filter if this is the main gateway (i.e. not split UPE).
 		if ( self::GATEWAY_ID === $this->id ) {
 			add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
@@ -534,7 +534,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @return void
 	 */
-	public function update_properties_with_country(): void {
+	public function maybe_update_properties_with_country(): void {
+		if ( Afterpay_Payment_Method::PAYMENT_METHOD_STRIPE_ID !== $this->stripe_id ) {
+			return;
+		}
 		$account_country = $this->get_account_country();
 		$this->icon      = $this->payment_method->get_icon( $account_country );
 		$this->title     = $this->payment_method->get_title( $account_country );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -268,14 +268,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->localization_service                 = $localization_service;
 		$this->fraud_service                        = $fraud_service;
 
-		$account_country          = $this->get_account_country();
 		$this->id                 = static::GATEWAY_ID;
-		$this->icon               = $payment_method->get_icon( $account_country );
+		$this->icon               = $payment_method->get_icon();
 		$this->has_fields         = true;
 		$this->method_title       = 'WooPayments';
 		$this->method_description = __( 'Payments made simple, with no monthly fees - designed exclusively for WooCommerce stores. Accept credit cards, debit cards, and other popular payment methods.', 'woocommerce-payments' );
 
-		$this->title       = $payment_method->get_title( $account_country );
+		$this->title       = $payment_method->get_title();
 		$this->description = '';
 		$this->supports    = [
 			'products',
@@ -498,6 +497,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return void
 	 */
 	public function init_hooks() {
+		add_action( 'init', [ $this, 'update_properties_with_country' ] );
 		// Only add certain actions/filter if this is the main gateway (i.e. not split UPE).
 		if ( self::GATEWAY_ID === $this->id ) {
 			add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
@@ -525,6 +525,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		$this->maybe_init_subscriptions_hooks();
+	}
+
+	/**
+	 * Updates icon and title using the account country.
+	 * This method runs on init is not in the controller because get_account_country might
+	 * make a request to the API if the account data is not cached.
+	 *
+	 * @return void
+	 */
+	public function update_properties_with_country(): void {
+		$account_country = $this->get_account_country();
+		$this->icon      = $this->payment_method->get_icon( $account_country );
+		$this->title     = $this->payment_method->get_title( $account_country );
 	}
 
 	/**

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -68,11 +68,11 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 	/**
 	 * Returns payment method title.
 	 *
-	 * @param string      $account_country Country of merchants account.
+	 * @param string|null $account_country Country of merchants account.
 	 * @param array|false $payment_details Optional payment details from charge object.
 	 * @return string|null
 	 */
-	public function get_title( string $account_country, $payment_details = false ) {
+	public function get_title( string $account_country = null, $payment_details = false ) {
 		if ( 'GB' === $account_country ) {
 			return __( 'Clearpay', 'woocommerce-payments' );
 		}
@@ -83,10 +83,10 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 	/**
 	 * Returns payment method icon.
 	 *
-	 * @param string $account_country Country of merchants account.
+	 * @param string|null $account_country Country of merchants account.
 	 * @return string|null
 	 */
-	public function get_icon( string $account_country ) {
+	public function get_icon( string $account_country = null ) {
 		if ( 'GB' === $account_country ) {
 			return plugins_url( 'assets/images/payment-methods/clearpay.svg', WCPAY_PLUGIN_FILE );
 		}

--- a/includes/payment-methods/class-cc-payment-method.php
+++ b/includes/payment-methods/class-cc-payment-method.php
@@ -33,11 +33,11 @@ class CC_Payment_Method extends UPE_Payment_Method {
 	/**
 	 * Returns payment method title
 	 *
-	 * @param string      $account_country Account country.
+	 * @param string|null $account_country Account country.
 	 * @param array|false $payment_details Payment details.
 	 * @return string
 	 */
-	public function get_title( string $account_country, $payment_details = false ) {
+	public function get_title( string $account_country = null, $payment_details = false ) {
 		if ( ! $payment_details ) {
 			return $this->title;
 		}

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -113,12 +113,12 @@ abstract class UPE_Payment_Method {
 	/**
 	 * Returns payment method title
 	 *
-	 * @param string      $account_country Country of merchants account.
+	 * @param string|null $account_country Country of merchants account.
 	 * @param array|false $payment_details Optional payment details from charge object.
 	 *
 	 * @return string
 	 */
-	public function get_title( string $account_country, $payment_details = false ) {
+	public function get_title( string $account_country = null, $payment_details = false ) {
 		return $this->title;
 	}
 
@@ -225,10 +225,10 @@ abstract class UPE_Payment_Method {
 	/**
 	 * Returns the payment method icon URL or an empty string.
 	 *
-	 * @param string $account_country Optional account country.
+	 * @param string|null $account_country Optional account country.
 	 * @return string
 	 */
-	public function get_icon( string $account_country ) {
+	public function get_icon( string $account_country = null ) {
 		return isset( $this->icon_url ) ? $this->icon_url : '';
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -573,70 +573,76 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( 'card', $card_method->get_id() );
 		$this->assertEquals( 'Credit card / debit card', $card_method->get_title() );
-		$this->assertEquals( 'Visa debit card', $card_method->get_title( $mock_visa_details ) );
-		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( $mock_mastercard_details ) );
+		$this->assertEquals( 'Visa debit card', $card_method->get_title( 'US', $mock_visa_details ) );
+		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( 'US', $mock_mastercard_details ) );
 		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertTrue( $card_method->is_reusable() );
 		$this->assertEquals( $mock_token, $card_method->get_payment_token_for_user( $mock_user, $mock_payment_method_id ) );
 
 		$this->assertEquals( 'giropay', $giropay_method->get_id() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title() );
-		$this->assertEquals( 'giropay', $giropay_method->get_title( $mock_giropay_details ) );
+		$this->assertEquals( 'giropay', $giropay_method->get_title( 'US', $mock_giropay_details ) );
 		$this->assertTrue( $giropay_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $giropay_method->is_reusable() );
 
 		$this->assertEquals( 'p24', $p24_method->get_id() );
 		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title() );
-		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title( $mock_p24_details ) );
+		$this->assertEquals( 'Przelewy24 (P24)', $p24_method->get_title( 'US', $mock_p24_details ) );
 		$this->assertTrue( $p24_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $p24_method->is_reusable() );
 
 		$this->assertEquals( 'sofort', $sofort_method->get_id() );
 		$this->assertEquals( 'Sofort', $sofort_method->get_title() );
-		$this->assertEquals( 'Sofort', $sofort_method->get_title( $mock_sofort_details ) );
+		$this->assertEquals( 'Sofort', $sofort_method->get_title( 'US', $mock_sofort_details ) );
 		$this->assertTrue( $sofort_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $sofort_method->is_reusable() );
 
 		$this->assertEquals( 'bancontact', $bancontact_method->get_id() );
 		$this->assertEquals( 'Bancontact', $bancontact_method->get_title() );
-		$this->assertEquals( 'Bancontact', $bancontact_method->get_title( $mock_bancontact_details ) );
+		$this->assertEquals( 'Bancontact', $bancontact_method->get_title( 'US', $mock_bancontact_details ) );
 		$this->assertTrue( $bancontact_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $bancontact_method->is_reusable() );
 
 		$this->assertEquals( 'eps', $eps_method->get_id() );
 		$this->assertEquals( 'EPS', $eps_method->get_title() );
-		$this->assertEquals( 'EPS', $eps_method->get_title( $mock_eps_details ) );
+		$this->assertEquals( 'EPS', $eps_method->get_title( 'US', $mock_eps_details ) );
 		$this->assertTrue( $eps_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $eps_method->is_reusable() );
 
 		$this->assertEquals( 'sepa_debit', $sepa_method->get_id() );
 		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title() );
-		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title( $mock_sepa_details ) );
+		$this->assertEquals( 'SEPA Direct Debit', $sepa_method->get_title( 'US', $mock_sepa_details ) );
 		$this->assertTrue( $sepa_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $sepa_method->is_reusable() );
 
 		$this->assertEquals( 'ideal', $ideal_method->get_id() );
 		$this->assertEquals( 'iDEAL', $ideal_method->get_title() );
-		$this->assertEquals( 'iDEAL', $ideal_method->get_title( $mock_ideal_details ) );
+		$this->assertEquals( 'iDEAL', $ideal_method->get_title( 'US', $mock_ideal_details ) );
 		$this->assertTrue( $ideal_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $ideal_method->is_reusable() );
 
 		$this->assertEquals( 'au_becs_debit', $becs_method->get_id() );
 		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title() );
-		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title( $mock_becs_details ) );
+		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title( 'US', $mock_becs_details ) );
 		$this->assertTrue( $becs_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $becs_method->is_reusable() );
 
 		$this->assertSame( 'affirm', $affirm_method->get_id() );
 		$this->assertSame( 'Affirm', $affirm_method->get_title() );
-		$this->assertSame( 'Affirm', $affirm_method->get_title( $mock_affirm_details ) );
+		$this->assertSame( 'Affirm', $affirm_method->get_title( 'US', $mock_affirm_details ) );
 		$this->assertTrue( $affirm_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertFalse( $affirm_method->is_reusable() );
 
 		$this->assertSame( 'afterpay_clearpay', $afterpay_method->get_id() );
 		$this->assertSame( 'Afterpay', $afterpay_method->get_title() );
-		$this->assertSame( 'Afterpay', $afterpay_method->get_title( $mock_afterpay_details ) );
+		$this->assertSame( 'Afterpay', $afterpay_method->get_title( 'US', $mock_afterpay_details ) );
 		$this->assertTrue( $afterpay_method->is_enabled_at_checkout( 'US' ) );
+		$this->assertFalse( $afterpay_method->is_reusable() );
+
+		$this->assertSame( 'afterpay_clearpay', $afterpay_method->get_id() );
+		$this->assertSame( 'Clearpay', $afterpay_method->get_title( 'GB' ) );
+		$this->assertSame( 'Clearpay', $afterpay_method->get_title( 'GB', $mock_afterpay_details ) );
+		$this->assertTrue( $afterpay_method->is_enabled_at_checkout( 'GB' ) );
 		$this->assertFalse( $afterpay_method->is_reusable() );
 	}
 


### PR DESCRIPTION
Refactors #8046

#### Changes proposed in this Pull Request

This PR refactors how we update the address to avoid making a request to the API before init.
More details: p1705939522850039/1705510123.965239-slack-C0208C3BXHP

#### Testing instructions

Follow testing instructions from #8046

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
