### PR TITLE
chore: unused gateway methods marked as deprecated

### DIFF
--- a/changelog/chore-deprecate-gateway-methods
+++ b/changelog/chore-deprecate-gateway-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+chore: deprecate is_account_partially_onboarded, get_transaction_url, get_settings_url gateway methods.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -676,6 +676,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Checks if the account has not completed onboarding due to users abandoning the process half way.
 	 * Also used by WC Core to complete the task "Set up WooPayments".
 	 *
+	 * @deprecated 7.1.0
+	 *
 	 * @return bool
 	 */
 	public function is_account_partially_onboarded(): bool {
@@ -3738,6 +3740,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Add a url to the admin order page that links directly to the transactions detail view.
 	 *
 	 * @since 1.4.0
+	 * @deprecated 7.1.0
 	 *
 	 * @param WC_Order $order The context passed into this function when the user view the order details page in WordPress admin.
 	 * @return string
@@ -4228,6 +4231,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
+	 *
+	 * @deprecated 7.1.0
 	 *
 	 * @return string URL of the configuration screen for this gateway
 	 */

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -679,6 +679,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool
 	 */
 	public function is_account_partially_onboarded(): bool {
+		wc_deprecated_function( __FUNCTION__, '7.1.0' );
 		return $this->account->is_stripe_connected() && ! $this->account->is_details_submitted();
 	}
 
@@ -3742,6 +3743,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string
 	 */
 	public function get_transaction_url( $order ) {
+		wc_deprecated_function( __FUNCTION__, '7.1.0', 'WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id )' );
 		$intent_id = $this->order_service->get_intent_id_for_order( $order );
 		$charge_id = $this->order_service->get_charge_id_for_order( $order );
 
@@ -4230,6 +4232,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string URL of the configuration screen for this gateway
 	 */
 	public static function get_settings_url() {
+		wc_deprecated_function( __FUNCTION__, '7.1.0', 'WC_Payments_Admin_Settings::get_settings_url()' );
 		return WC_Payments_Admin_Settings::get_settings_url();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

There are a few methods in the gateway class that are not used anywhere.
It looks like when they were introduced they might have been used, but now it's no longer the case.

Marking them as deprecated.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Search for `is_account_partially_onboarded()`, `get_transaction_url(`, `WC_Payment_Gateway_WCPay::get_settings_url()` in the codebase
- There should be no usages

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
