### PR TITLE
chore: remove unused checkout API functions

### DIFF
--- a/changelog/chore-remove-unused-checkout-api-methods
+++ b/changelog/chore-remove-unused-checkout-api-methods
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+chore: remove unused checkout API methods

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -565,49 +565,4 @@ export default class WCPayAPI {
 			...paymentData,
 		} );
 	}
-
-	/**
-	 * Log Payment Errors via Ajax.
-	 *
-	 * @param {string} chargeId Stripe Charge ID
-	 * @return {boolean} Returns true irrespective of result.
-	 */
-	logPaymentError( chargeId ) {
-		return this.request(
-			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'log_payment_error' ),
-			{
-				charge_id: chargeId,
-				_ajax_nonce: getConfig( 'logPaymentErrorNonce' ),
-			}
-		).then( () => {
-			// There is not any action to take or harm caused by a failed update, so just returning true.
-			return true;
-		} );
-	}
-
-	/**
-	 * Redirect to the order-received page for duplicate payments.
-	 *
-	 * @param {Object} response Response data to check if doing the redirect.
-	 * @return {boolean} Returns true if doing the redirection.
-	 */
-	handleDuplicatePayments( {
-		wcpay_upe_paid_for_previous_order: previouslyPaid,
-		wcpay_upe_previous_successful_intent: previousSuccessfulIntent,
-		redirect,
-	} ) {
-		if ( redirect ) {
-			// Another order has the same cart content and was paid.
-			if ( previouslyPaid ) {
-				return ( window.location = redirect );
-			}
-
-			// Another intent has the equivalent successful status for the order.
-			if ( previousSuccessfulIntent ) {
-				return ( window.location = redirect );
-			}
-		}
-
-		return false;
-	}
 }

--- a/includes/class-duplicate-payment-prevention-service.php
+++ b/includes/class-duplicate-payment-prevention-service.php
@@ -120,9 +120,8 @@ class Duplicate_Payment_Prevention_Service {
 		$return_url = $this->gateway->get_return_url( $order );
 		$return_url = add_query_arg( self::FLAG_PREVIOUS_SUCCESSFUL_INTENT, 'yes', $return_url );
 		return [ // nosemgrep: audit.php.wp.security.xss.query-arg -- https://woocommerce.github.io/code-reference/classes/WC-Payment-Gateway.html#method_get_return_url is passed in.
-			'result'                               => 'success',
-			'redirect'                             => $return_url,
-			'wcpay_upe_previous_successful_intent' => 'yes', // This flag is needed for UPE flow.
+			'result'   => 'success',
+			'redirect' => $return_url,
 		];
 	}
 
@@ -178,9 +177,8 @@ class Duplicate_Payment_Prevention_Service {
 		$return_url = add_query_arg( self::FLAG_PREVIOUS_ORDER_PAID, 'yes', $return_url );
 
 		return [ // nosemgrep: audit.php.wp.security.xss.query-arg -- https://woocommerce.github.io/code-reference/classes/WC-Payment-Gateway.html#method_get_return_url is passed in.
-			'result'                            => 'success',
-			'redirect'                          => $return_url,
-			'wcpay_upe_paid_for_previous_order' => 'yes', // This flag is needed for UPE flow.
+			'result'   => 'success',
+			'redirect' => $return_url,
 		];
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -898,59 +898,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Log payment errors on Checkout.
-	 *
-	 * @throws Exception If nonce is not present or invalid or charge ID is empty or order not found.
-	 */
-	public function log_payment_error_ajax() {
-		try {
-			$is_nonce_valid = check_ajax_referer( 'wcpay_log_payment_error_nonce', false, false );
-			if ( ! $is_nonce_valid ) {
-				throw new Exception( 'Invalid request.' );
-			}
-
-			$charge_id = isset( $_POST['charge_id'] ) ? wc_clean( wp_unslash( $_POST['charge_id'] ) ) : '';
-			if ( empty( $charge_id ) ) {
-				throw new Exception( 'Charge ID cannot be empty.' );
-			}
-
-			// Get charge data from WCPay Server.
-			$request = Get_Charge::create( $charge_id );
-			$request->set_hook_args( $charge_id );
-			$charge_data = $request->send();
-			$order_id    = $charge_data['metadata']['order_id'];
-
-			// Validate Order ID and proceed with logging errors and updating order status.
-			$order = wc_get_order( $order_id );
-			if ( ! $order ) {
-				throw new Exception( 'Order not found. Unable to log error.' );
-			}
-
-			$intent_id = $charge_data['payment_intent'] ?? $order->get_meta( '_intent_id' );
-
-			$request = Get_Intention::create( $intent_id );
-			$request->set_hook_args( $order );
-			$intent = $request->send();
-
-			$intent_status = $intent->get_status();
-			$error_message = esc_html( rtrim( $charge_data['failure_message'], '.' ) );
-
-			$this->order_service->mark_payment_failed( $order, $intent_id, $intent_status, $charge_id, $error_message );
-
-			wp_send_json_success();
-		} catch ( Exception $e ) {
-			wp_send_json_error(
-				[
-					'error' => [
-						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
-					],
-				],
-				WC_Payments_Utils::get_filtered_error_status_code( $e ),
-			);
-		}
-	}
-
-	/**
 	 * Displays the save to account checkbox.
 	 *
 	 * @param bool $force_checked True if the checkbox must be forced to "checked" state (and invisible).

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -96,12 +96,10 @@ class WC_Payments_Checkout {
 		add_action( 'wc_payments_set_gateway', [ $this, 'set_gateway' ] );
 		add_action( 'wc_payments_add_upe_payment_fields', [ $this, 'payment_fields' ] );
 		add_action( 'wp', [ $this->gateway, 'maybe_process_upe_redirect' ] );
-		add_action( 'wc_ajax_wcpay_log_payment_error', [ $this->gateway, 'log_payment_error_ajax' ] );
 		add_action( 'wp_ajax_save_upe_appearance', [ $this->gateway, 'save_upe_appearance_ajax' ] );
 		add_action( 'wp_ajax_nopriv_save_upe_appearance', [ $this->gateway, 'save_upe_appearance_ajax' ] );
 		add_action( 'switch_theme', [ $this->gateway, 'clear_upe_appearance_transient' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ $this->gateway, 'clear_upe_appearance_transient' ] );
-		add_action( 'wc_ajax_wcpay_log_payment_error', [ $this->gateway, 'log_payment_error_ajax' ] );
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts_for_zero_order_total' ], 11 );
@@ -179,7 +177,6 @@ class WC_Payments_Checkout {
 			'ajaxUrl'                        => admin_url( 'admin-ajax.php' ),
 			'wcAjaxUrl'                      => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'createSetupIntentNonce'         => wp_create_nonce( 'wcpay_create_setup_intent_nonce' ),
-			'logPaymentErrorNonce'           => wp_create_nonce( 'wcpay_log_payment_error_nonce' ),
 			'initWooPayNonce'                => wp_create_nonce( 'wcpay_init_woopay_nonce' ),
 			'saveUPEAppearanceNonce'         => wp_create_nonce( 'wcpay_save_upe_appearance_nonce' ),
 			'genericErrorMessage'            => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),

--- a/tests/unit/test-class-duplicate-payment-prevention-service.php
+++ b/tests/unit/test-class-duplicate-payment-prevention-service.php
@@ -77,7 +77,6 @@ class Duplicate_Payment_Prevention_Service_Test extends WCPAY_UnitTestCase {
 		$result = $this->service->check_against_session_processing_order( $current_order );
 
 		// Assert: the result of check_against_session_processing_order.
-		$this->assertSame( 'yes', $result['wcpay_upe_paid_for_previous_order'] );
 		$this->assertSame( 'success', $result['result'] );
 		$this->assertStringContainsString( $return_url, $result['redirect'] );
 
@@ -267,7 +266,6 @@ class Duplicate_Payment_Prevention_Service_Test extends WCPAY_UnitTestCase {
 		$result = $this->service->check_payment_intent_attached_to_order_succeeded( $order );
 
 		// Assert: the result of check_intent_attached_to_order_succeeded.
-		$this->assertSame( 'yes', $result['wcpay_upe_previous_successful_intent'] );
 		$this->assertSame( 'success', $result['result'] );
 		$this->assertStringContainsString( $return_url, $result['redirect'] );
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the `logPaymentError` and the `handleDuplicatePayments` functions on the `client/checkout/api/index.js` were not used anywhere.
It was first introduced in https://github.com/Automattic/woocommerce-payments/pull/3019

Since `logPaymentError` is not used, I deleted the `log_payment_error` handler (`log_payment_error_ajax` method) and the `logPaymentErrorNonce` nonce.


Since `handleDuplicatePayments` is not used, I deleted references to its arguments: `wcpay_upe_paid_for_previous_order` & `wcpay_upe_previous_successful_intent`.
It was first introduced in https://github.com/Automattic/woocommerce-payments/pull/5346

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
