### PR TITLE
Don't instantiate `Fraud_Prevention_Service` in checkout if processing an authorized WooPay request

### DIFF
--- a/changelog/fix-fraud-service-woopay
+++ b/changelog/fix-fraud-service-woopay
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Don't instantiate `Fraud_Prevention_Service` in checkout if it's an authorized WooPay request.
+Don't instantiate `Fraud_Prevention_Service` in checkout if processing an authorized WooPay request.

--- a/changelog/fix-fraud-service-woopay
+++ b/changelog/fix-fraud-service-woopay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Don't instantiate `Fraud_Prevention_Service` in checkout if it's an authorized WooPay request.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1161,8 +1161,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'invalid_phone_number'
 				);
 			}
-			// Check if session exists before instantiating Fraud_Prevention_Service.
-			if ( WC()->session ) {
+			// Check if session exists and is not WooPay request before instantiating Fraud_Prevention_Service.
+			if ( WC()->session && ! apply_filters( 'wcpay_is_woopay_store_api_request', false ) ) {
 				$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $_POST['wcpay-fraud-prevention-token'] ?? null ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1161,7 +1161,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'invalid_phone_number'
 				);
 			}
-			// Check if session exists and is not WooPay request before instantiating Fraud_Prevention_Service.
+			// Check if session exists and we're currently not processing a WooPay request before instantiating `Fraud_Prevention_Service`.
 			if ( WC()->session && ! apply_filters( 'wcpay_is_woopay_store_api_request', false ) ) {
 				$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -111,6 +111,8 @@ class WooPay_Session {
 			wp_die( esc_html__( 'WooPay request is not signed correctly.', 'woocommerce-payments' ), 401 );
 		}
 
+		add_filter( 'wcpay_is_woopay_store_api_request', '__return_true', 20 );
+
 		$cart_token_user_id = self::get_user_id_from_cart_token();
 		if ( null === $cart_token_user_id ) {
 			return $user;

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -111,7 +111,7 @@ class WooPay_Session {
 			wp_die( esc_html__( 'WooPay request is not signed correctly.', 'woocommerce-payments' ), 401 );
 		}
 
-		add_filter( 'wcpay_is_woopay_store_api_request', '__return_true', 20 );
+		add_filter( 'wcpay_is_woopay_store_api_request', '__return_true' );
 
 		$cart_token_user_id = self::get_user_id_from_cart_token();
 		if ( null === $cart_token_user_id ) {


### PR DESCRIPTION
**Context:** paJDYF-bQ1-p2

#### Changes proposed in this Pull Request

This PR fixes an issue where WooPay doesn't send a currently expected `wcpay-fraud-prevention-token` at checkout when fraud prevention service is enabled at the merchant's account.

WooPay checkouts rely on saved payment methods, so the token is not useful since the customer cannot enter a new card at checkout.

To fix this issue, we're introducing a new filter: `wcpay_is_woopay_store_api_request`, which gets set to `true` only if these criteria are met early in the request:
1. [The request is coming from WooPay](https://github.com/Automattic/woocommerce-payments/blob/fe1c56c94d1657ec6c8bb0886903c41d8848b423/includes/woopay/class-woopay-session.php#L100).
2. [It's a store API request](https://github.com/Automattic/woocommerce-payments/blob/fe1c56c94d1657ec6c8bb0886903c41d8848b423/includes/woopay/class-woopay-session.php#L100).
3. [WooPay is enabled](https://github.com/Automattic/woocommerce-payments/blob/fe1c56c94d1657ec6c8bb0886903c41d8848b423/includes/woopay/class-woopay-session.php#L104).
4. [Request comes from WPCOM and is signed by Jetpack](https://github.com/Automattic/woocommerce-payments/blob/fe1c56c94d1657ec6c8bb0886903c41d8848b423/includes/woopay/class-woopay-session.php#L109).

**Note:** The 4th step here is what makes it secure, as it's not possible to simulate a request from WooPay.

So, whenever we have a request from WooPay, `apply_filters( 'wcpay_is_woopay_store_api_request' )` should return `true`.

#### Testing instructions

1. Enable `fraud_services` on the merchant's account.
2. Ensure the WooPay checkout works.
3. Ensure the fraud prevention service still works for other regular checkouts.

- More tests TBD.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.