### PR TITLE
chore: remove isOrderPage return value

### DIFF
--- a/changelog/chore-remove-unused-isOrderPage-return-value
+++ b/changelog/chore-remove-unused-isOrderPage-return-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+chore: remove unused isOrderPage return value from confirmIntent

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -207,7 +207,7 @@ export default class WCPayAPI {
 	 *
 	 * @param {string} redirectUrl The redirect URL, returned from the server.
 	 * @param {string} paymentMethodToSave The ID of a Payment Method if it should be saved (optional).
-	 * @return {string|boolean} A redirect URL on success, or `true` if no confirmation is needed.
+	 * @return {Promise<string>|boolean} A redirect URL on success, or `true` if no confirmation is needed.
 	 */
 	confirmIntent( redirectUrl, paymentMethodToSave ) {
 		const partials = redirectUrl.match(

--- a/client/checkout/blocks/confirm-card-payment.js
+++ b/client/checkout/blocks/confirm-card-payment.js
@@ -16,26 +16,22 @@ export default async function confirmCardPayment(
 	const { redirect, payment_method: paymentMethod } = paymentDetails;
 
 	try {
-		const confirmation = api.confirmIntent(
+		const confirmationRequest = api.confirmIntent(
 			redirect,
 			shouldSavePayment ? paymentMethod : null
 		);
 
 		// `true` means there is no intent to confirm.
-		if ( confirmation === true ) {
+		if ( confirmationRequest === true ) {
 			return {
 				type: 'success',
 				redirectUrl: redirect,
 			};
 		}
 
-		// `confirmIntent` also returns `isOrderPage`, but that's not supported in blocks yet.
-		const { request } = confirmation;
-
-		const finalRedirect = await request;
 		return {
 			type: 'success',
-			redirectUrl: finalRedirect,
+			redirectUrl: await confirmationRequest,
 		};
 	} catch ( error ) {
 		return {

--- a/client/checkout/classic/3ds-flow-handling.js
+++ b/client/checkout/classic/3ds-flow-handling.js
@@ -25,20 +25,19 @@ export const showAuthenticationModalIfRequired = ( api ) => {
 	const paymentMethodId = document.querySelector( '#wcpay-payment-method' )
 		?.value;
 
-	const confirmation = api.confirmIntent(
+	const confirmationRequest = api.confirmIntent(
 		window.location.href,
 		shouldSavePaymentPaymentMethod() ? paymentMethodId : null
 	);
 
 	// Boolean `true` means that there is nothing to confirm.
-	if ( confirmation === true ) {
+	if ( confirmationRequest === true ) {
 		return Promise.resolve();
 	}
 
-	const { request } = confirmation;
 	cleanupURL();
 
-	return request
+	return confirmationRequest
 		.then( ( redirectUrl ) => {
 			window.location = redirectUrl;
 		} )

--- a/client/checkout/classic/test/3ds-flow-handling.test.js
+++ b/client/checkout/classic/test/3ds-flow-handling.test.js
@@ -27,11 +27,7 @@ describe( 'showAuthenticationModalIfRequired', () => {
 		const mockedRequest = Promise.resolve( 'https://example.com/checkout' );
 
 		const apiMock = {
-			confirmIntent: jest.fn( () => {
-				return {
-					request: mockedRequest,
-				};
-			} ),
+			confirmIntent: jest.fn( () => mockedRequest ),
 		};
 
 		showAuthenticationModalIfRequired( apiMock );

--- a/client/payment-request/event-handlers.js
+++ b/client/payment-request/event-handlers.js
@@ -55,16 +55,15 @@ const paymentResponseHandler = async (
 	}
 
 	try {
-		const confirmation = api.confirmIntent( response.redirect );
+		const confirmationRequest = api.confirmIntent( response.redirect );
 		// We need to call `complete` outside of `completePayment` to close the dialog for 3DS.
 		event.complete( 'success' );
 
 		// `true` means there is no intent to confirm.
-		if ( confirmation === true ) {
+		if ( confirmationRequest === true ) {
 			completePayment( response.redirect );
 		} else {
-			const { request } = confirmation;
-			const redirectUrl = await request;
+			const redirectUrl = await confirmationRequest;
 
 			completePayment( redirectUrl );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The `isOrderPage` attribute returned by the `confirmIntent` method is never used anywhere by the method's consumers.
Let's simplify & clean up the logic, so that the function doesn't return an object with unused attributes.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Perform the following actions with a 3DS card:
  - Create an order to be paid by a customer
  - Perform a checkout
  - Add a payment method via the customer's "My Account" page
- In all the cases above, there should be no change in behavior.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
