### PR TITLE
Ensure coupon usage counts remain unchanged in WooPay preflight request

### DIFF
--- a/changelog/fix-woopay-coupon-limit
+++ b/changelog/fix-woopay-coupon-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay coupon usage count in preflight request

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -61,7 +61,6 @@ use WCPay\Payment_Methods\P24_Payment_Method;
 use WCPay\Payment_Methods\Sepa_Payment_Method;
 use WCPay\Payment_Methods\Sofort_Payment_Method;
 use WCPay\Payment_Methods\UPE_Payment_Method;
-use Automattic\WooCommerce\Utilities\StringUtil;
 
 /**
  * Gateway class for WooPayments
@@ -1095,7 +1094,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		if ( count( $order->get_coupon_codes() ) > 0 ) {
 			foreach ( $order->get_coupon_codes() as $code ) {
-				if ( StringUtil::is_null_or_whitespace( $code ) ) {
+				// Skip empty coupon codes.
+				if ( is_null( $code ) || '' === $code || ctype_space( $code ) ) {
 					continue;
 				}
 

--- a/tests/unit/helpers/class-wc-helper-coupon.php
+++ b/tests/unit/helpers/class-wc-helper-coupon.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Coupon helpers.
+ *
+ * @package WooCommerce/Tests
+ */
+
+/**
+ * Class WC_Helper_Coupon.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Helper_Coupon {
+
+	/**
+	 * Create a dummy coupon.
+	 *
+	 * @param string $coupon_code
+	 * @param array  $meta
+	 *
+	 * @return WC_Coupon
+	 */
+	public static function create_coupon( $coupon_code = 'dummycoupon', $meta = [] ) {
+		// Insert post.
+		$coupon_id = wp_insert_post(
+			[
+				'post_title'   => $coupon_code,
+				'post_type'    => 'shop_coupon',
+				'post_status'  => 'publish',
+				'post_excerpt' => 'This is a dummy coupon',
+			]
+		);
+
+		$meta = wp_parse_args(
+			$meta,
+			[
+				'discount_type'              => 'fixed_cart',
+				'coupon_amount'              => '1',
+				'individual_use'             => 'no',
+				'product_ids'                => '',
+				'exclude_product_ids'        => '',
+				'usage_limit'                => '',
+				'usage_limit_per_user'       => '',
+				'limit_usage_to_x_items'     => '',
+				'expiry_date'                => '',
+				'free_shipping'              => 'no',
+				'exclude_sale_items'         => 'no',
+				'product_categories'         => [],
+				'exclude_product_categories' => [],
+				'minimum_amount'             => '',
+				'maximum_amount'             => '',
+				'customer_email'             => [],
+				'usage_count'                => '0',
+			]
+		);
+
+		// Update meta.
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $coupon_id, $key, $value );
+		}
+
+		return new WC_Coupon( $coupon_code );
+	}
+
+}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2993,7 +2993,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	public function test_coupon_decrement_exits_early_if_no_preflight_check() {
 		$_POST['is-woopay-preflight-check'] = null;
 		$mock_order                         = WC_Helper_Order::create_order();
-		$response                           = $this->wcpay_gateway->maybe_decrement_coupon_counts( $mock_order );
+		$response                           = $this->card_gateway->maybe_decrement_coupon_counts( $mock_order );
 		$this->assertNull( $response );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2439

#### Changes proposed in this Pull Request
This is a workaround for an issue where WooPay's preflight request prematurely increases the coupon usage count. This addresses it (for the lack of a better solution) by decreasing the coupon usage later in the request.

Refer https://github.com/Automattic/woopay/issues/2439#issuecomment-1898027833 for more details.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
#### Happy path
1. Create a coupon with usage limit set to 1.
2. In woopay checkout apply the coupon.
3. Place the order.
4. You should be able to place the order without any errors.
5. As the merchant, go back to the Coupon dashboard (Marketing -> Coupons) and ensure coupon usage/limit field shows up as 1/1

#### Test multiple coupons
1. Create two coupons with usage limit set to 1.
2. Apply both at WooPay checkout.
3. Place the order and ensure no errors appear.
4. Merchant site's Coupon dashboard should reflect the correct usage counts.

#### Test with usage limit > 1
1. Create a coupon with a usage limit set to 10.
2. Place a WooPay order using the coupon.
3. Ensure that the merchant site's Coupon dashboard reflects the correct usage counts.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
