### PR TITLE
Standardise Tracking Calls on the Client

### DIFF
--- a/changelog/8075-standardise-tracking
+++ b/changelog/8075-standardise-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Refactoring the tracking logic

--- a/client/card-readers/settings/file-upload.tsx
+++ b/client/card-readers/settings/file-upload.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
@@ -71,12 +71,9 @@ const BrandingFileUpload: React.FunctionComponent< CardReaderFileUploadProps > =
 
 		setLoading( true );
 
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.SETTINGS_FILE_UPLOAD_STARTED,
-			{
-				type: key,
-			}
-		);
+		recordEvent( events.SETTINGS_FILE_UPLOAD_STARTED, {
+			type: key,
+		} );
 
 		const body = new FormData();
 		body.append( 'file', file );
@@ -99,19 +96,13 @@ const BrandingFileUpload: React.FunctionComponent< CardReaderFileUploadProps > =
 			setLoading( false );
 			setUploadError( false );
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.SETTINGS_FILE_UPLOAD_SUCCESS,
-				{
-					type: key,
-				}
-			);
+			recordEvent( events.SETTINGS_FILE_UPLOAD_SUCCESS, {
+				type: key,
+			} );
 		} catch ( { err } ) {
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.SETTINGS_FILE_UPLOAD_FAILED,
-				{
-					message: ( err as Error ).message,
-				}
-			);
+			recordEvent( events.SETTINGS_FILE_UPLOAD_FAILED, {
+				message: ( err as Error ).message,
+			} );
 
 			// Remove file ID
 			updateFileID( '' );

--- a/client/card-readers/settings/file-upload.tsx
+++ b/client/card-readers/settings/file-upload.tsx
@@ -72,7 +72,7 @@ const BrandingFileUpload: React.FunctionComponent< CardReaderFileUploadProps > =
 		setLoading( true );
 
 		wcpayTracks.recordEvent(
-			'wcpay_merchant_settings_file_upload_started',
+			wcpayTracks.events.SETTINGS_FILE_UPLOAD_STARTED,
 			{
 				type: key,
 			}
@@ -100,15 +100,18 @@ const BrandingFileUpload: React.FunctionComponent< CardReaderFileUploadProps > =
 			setUploadError( false );
 
 			wcpayTracks.recordEvent(
-				'wcpay_merchant_settings_file_upload_success',
+				wcpayTracks.events.SETTINGS_FILE_UPLOAD_SUCCESS,
 				{
 					type: key,
 				}
 			);
 		} catch ( { err } ) {
-			wcpayTracks.recordEvent( 'wcpay_merchant_settings_upload_failed', {
-				message: ( err as Error ).message,
-			} );
+			wcpayTracks.recordEvent(
+				wcpayTracks.events.SETTINGS_FILE_UPLOAD_FAILED,
+				{
+					message: ( err as Error ).message,
+				}
+			);
 
 			// Remove file ID
 			updateFileID( '' );

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -34,7 +34,7 @@ import {
 } from '../constants.js';
 import { getDeferredIntentCreationUPEFields } from './payment-elements';
 import { handleWooPayEmailInput } from '../woopay/email-input-iframe';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 import wooPayExpressCheckoutPaymentMethod from '../woopay/express-button/woopay-express-checkout-payment-method';
 import { isPreviewing } from '../preview';
 
@@ -127,7 +127,7 @@ const addCheckoutTracking = () => {
 				return;
 			}
 
-			wcpayTracks.recordUserEvent( wcpayTracks.events.PLACE_ORDER_CLICK );
+			recordUserEvent( events.PLACE_ORDER_CLICK );
 		} );
 	}
 };

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -28,7 +28,7 @@ import WCPayAPI from 'wcpay/checkout/api';
 import apiRequest from '../utils/request';
 import { handleWooPayEmailInput } from 'wcpay/checkout/woopay/email-input-iframe';
 import { isPreviewing } from 'wcpay/checkout/preview';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 
 jQuery( function ( $ ) {
 	enqueueFraudScripts( getUPEConfig( 'fraudServices' ) );
@@ -83,7 +83,7 @@ jQuery( function ( $ ) {
 			return;
 		}
 
-		wcpayTracks.recordUserEvent( wcpayTracks.events.PLACE_ORDER_CLICK );
+		recordUserEvent( events.PLACE_ORDER_CLICK );
 	} );
 
 	window.addEventListener( 'hashchange', () => {

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -403,8 +403,7 @@ export const handleWooPayEmailInput = async (
 					openIframe( email );
 				} else if ( data.code !== 'rest_invalid_param' ) {
 					wcpayTracks.recordUserEvent(
-						wcpayTracks.events.WOOPAY_OFFERED,
-						[]
+						wcpayTracks.events.WOOPAY_OFFERED
 					);
 				}
 			} )
@@ -627,7 +626,7 @@ export const handleWooPayEmailInput = async (
 
 		wcpayTracks.recordUserEvent(
 			wcpayTracks.events.WOOPAY_SKIPPED,
-			[],
+			{},
 			true
 		);
 

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getConfig } from 'wcpay/utils/checkout';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 import request from '../utils/request';
 import { buildAjaxURL } from '../../payment-request/utils';
 import {
@@ -340,7 +340,7 @@ export const handleWooPayEmailInput = async (
 			parentDiv.removeChild( errorMessage );
 		}
 
-		wcpayTracks.recordUserEvent( wcpayTracks.events.WOOPAY_EMAIL_CHECK );
+		recordUserEvent( events.WOOPAY_EMAIL_CHECK );
 
 		request(
 			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'get_woopay_signature' ),
@@ -402,9 +402,7 @@ export const handleWooPayEmailInput = async (
 				if ( data[ 'user-exists' ] ) {
 					openIframe( email );
 				} else if ( data.code !== 'rest_invalid_param' ) {
-					wcpayTracks.recordUserEvent(
-						wcpayTracks.events.WOOPAY_OFFERED
-					);
+					recordUserEvent( events.WOOPAY_OFFERED );
 				}
 			} )
 			.catch( ( err ) => {
@@ -501,9 +499,7 @@ export const handleWooPayEmailInput = async (
 								'woopay-login-session-iframe-wrapper'
 							);
 							loginSessionIframe.classList.add( 'open' );
-							wcpayTracks.recordUserEvent(
-								wcpayTracks.events.WOOPAY_AUTO_REDIRECT
-							);
+							recordUserEvent( events.WOOPAY_AUTO_REDIRECT );
 							spinner.remove();
 							// Do nothing if the iframe has been closed.
 							if (
@@ -624,11 +620,7 @@ export const handleWooPayEmailInput = async (
 			dispatchUserExistEvent( true );
 		}, 2000 );
 
-		wcpayTracks.recordUserEvent(
-			wcpayTracks.events.WOOPAY_SKIPPED,
-			{},
-			true
-		);
+		recordUserEvent( events.WOOPAY_SKIPPED, {}, true );
 
 		searchParams.delete( 'skip_woopay' );
 

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -12,7 +12,6 @@ import { expressCheckoutIframe } from '../express-checkout-iframe';
 import WCPayAPI from 'wcpay/checkout/api';
 import request from 'wcpay/checkout/utils/request';
 import { getConfig } from 'utils/checkout';
-import wcpayTracks from 'tracks';
 import useExpressCheckoutProductHandler from '../use-express-checkout-product-handler';
 
 jest.mock( 'wcpay/checkout/utils/request', () => ( {
@@ -30,7 +29,27 @@ jest.mock( '../express-checkout-iframe', () => ( {
 } ) );
 
 jest.mock( 'tracks', () => ( {
-	recordUserEvent: jest.fn(),
+	recordUserEvent: jest.fn().mockReturnValue( true ),
+	events: {
+		WOOPAY_EMAIL_CHECK: 'checkout_email_address_woopay_check',
+		WOOPAY_OFFERED: 'checkout_woopay_save_my_info_offered',
+		WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
+		WOOPAY_SKIPPED: 'woopay_skipped',
+		WOOPAY_BUTTON_LOAD: 'woopay_button_load',
+		WOOPAY_BUTTON_CLICK: 'woopay_button_click',
+		WOOPAY_SAVE_MY_INFO_COUNTRY_CLICK:
+			'checkout_woopay_save_my_info_country_click',
+		WOOPAY_SAVE_MY_INFO_CLICK: 'checkout_save_my_info_click',
+		WOOPAY_SAVE_MY_INFO_MOBILE_ENTER:
+			'checkout_woopay_save_my_info_mobile_enter',
+		WOOPAY_SAVE_MY_INFO_TOS_CLICK: 'checkout_save_my_info_tos_click',
+		WOOPAY_SAVE_MY_INFO_PRIVACY_CLICK:
+			'checkout_save_my_info_privacy_policy_click',
+		WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK:
+			'checkout_save_my_info_tooltip_click',
+		WOOPAY_SAVE_MY_INFO_TOOLTIP_LEARN_MORE_CLICK:
+			'checkout_save_my_info_tooltip_learn_more_click',
+	},
 } ) );
 
 jest.mock( '../use-express-checkout-product-handler', () => jest.fn() );
@@ -53,10 +72,6 @@ describe( 'WoopayExpressCheckoutButton', () => {
 	beforeEach( () => {
 		expressCheckoutIframe.mockImplementation( () => jest.fn() );
 		getConfig.mockReturnValue( 'foo' );
-		wcpayTracks.recordUserEvent.mockReturnValue( true );
-		wcpayTracks.events = {
-			WOOPAY_EXPRESS_BUTTON_OFFERED: 'woopay_express_button_offered',
-		};
 		useExpressCheckoutProductHandler.mockImplementation( () => ( {
 			addToCart: mockAddToCart,
 		} ) );

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -12,7 +12,7 @@ import WoopayIcon from './woopay-icon';
 import WoopayIconLight from './woopay-icon-light';
 import { expressCheckoutIframe } from './express-checkout-iframe';
 import useExpressCheckoutProductHandler from './use-express-checkout-product-handler';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 import { getConfig } from 'wcpay/utils/checkout';
 import request from 'wcpay/checkout/utils/request';
 import { showErrorMessage } from 'wcpay/checkout/woopay/express-button/utils';
@@ -77,12 +77,9 @@ export const WoopayExpressCheckoutButton = ( {
 
 	useEffect( () => {
 		if ( ! isPreview ) {
-			wcpayTracks.recordUserEvent(
-				wcpayTracks.events.WOOPAY_BUTTON_LOAD,
-				{
-					source: context,
-				}
-			);
+			recordUserEvent( events.WOOPAY_BUTTON_LOAD, {
+				source: context,
+			} );
 		}
 	}, [ isPreview, context ] );
 
@@ -154,12 +151,9 @@ export const WoopayExpressCheckoutButton = ( {
 				return; // eslint-disable-line no-useless-return
 			}
 
-			wcpayTracks.recordUserEvent(
-				wcpayTracks.events.WOOPAY_BUTTON_CLICK,
-				{
-					source: context,
-				}
-			);
+			recordUserEvent( events.WOOPAY_BUTTON_CLICK, {
+				source: context,
+			} );
 
 			if ( ! canAddProductToCart() ) {
 				return;
@@ -240,12 +234,9 @@ export const WoopayExpressCheckoutButton = ( {
 					return;
 				}
 
-				wcpayTracks.recordUserEvent(
-					wcpayTracks.events.WOOPAY_BUTTON_CLICK,
-					{
-						source: context,
-					}
-				);
+				recordUserEvent( events.WOOPAY_BUTTON_CLICK, {
+					source: context,
+				} );
 
 				if ( ! canAddProductToCart() ) {
 					return;

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -16,7 +16,7 @@ import BalanceBlock from './balance-block';
 import BalanceTooltip from './balance-tooltip';
 import { documentationUrls, fundLabelStrings } from './strings';
 import InstantDepositButton from 'deposits/instant-deposits';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import type * as AccountOverview from 'wcpay/types/account-overview';
 import './style.scss';
 
@@ -57,12 +57,9 @@ const AccountBalances: React.FC = () => {
 
 	const onTabSelect = ( tabName: BalanceTabProps[ 'name' ] ) => {
 		setSelectedCurrency( tabName );
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.OVERVIEW_BALANCES_CURRENCY_CLICK,
-			{
-				selected_currency: tabName,
-			}
-		);
+		recordEvent( events.OVERVIEW_BALANCES_CURRENCY_CLICK, {
+			selected_currency: tabName,
+		} );
 	};
 
 	if ( isLoading ) {

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { getAdminUrl } from 'wcpay/utils';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import Loadable from 'components/loadable';
 import { useSelectedCurrencyOverview } from 'wcpay/overview/hooks';
 import RecentDepositsList from './recent-deposits-list';
@@ -160,9 +160,8 @@ const DepositsOverview: React.FC = () => {
 								path: '/payments/deposits',
 							} ) }
 							onClick={ () =>
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK
+								recordEvent(
+									events.OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK
 								)
 							}
 						>
@@ -184,9 +183,8 @@ const DepositsOverview: React.FC = () => {
 								} ) + '#deposit-schedule'
 							}
 							onClick={ () =>
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.OVERVIEW_DEPOSITS_CHANGE_SCHEDULE_CLICK
+								recordEvent(
+									events.OVERVIEW_DEPOSITS_CHANGE_SCHEDULE_CLICK
 								)
 							}
 						>

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -18,7 +18,7 @@ import {
 	isUnderReview,
 } from 'wcpay/disputes/utils';
 import { useCharge } from 'wcpay/data';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import './style.scss';
 
 const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
@@ -201,7 +201,7 @@ const DisputeNeedsResponseNotice = ( {
 	disputeDetailsUrl,
 } ) => {
 	useEffect( () => {
-		wcpayTracks.recordEvent( wcpayTracks.events.DISPUTE_NOTICE_VIEW, {
+		recordEvent( events.DISPUTE_NOTICE_VIEW, {
 			is_inquiry: isPreDisputeInquiry,
 			dispute_reason: disputeReason,
 			due_by_days: countdownDays,
@@ -241,12 +241,9 @@ const DisputeNeedsResponseNotice = ( {
 					label: buttonLabel,
 					variant: 'secondary',
 					onClick: () => {
-						wcpayTracks.recordEvent(
-							wcpayTracks.events.DISPUTE_NOTICE_CLICK,
-							{
-								due_by_days: countdownDays,
-							}
-						);
+						recordEvent( events.DISPUTE_NOTICE_CLICK, {
+							due_by_days: countdownDays,
+						} );
 						window.location = disputeDetailsUrl;
 					},
 				},

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -201,7 +201,7 @@ const DisputeNeedsResponseNotice = ( {
 	disputeDetailsUrl,
 } ) => {
 	useEffect( () => {
-		wcpayTracks.recordEvent( 'wcpay_order_dispute_notice_view', {
+		wcpayTracks.recordEvent( wcpayTracks.events.DISPUTE_NOTICE_VIEW, {
 			is_inquiry: isPreDisputeInquiry,
 			dispute_reason: disputeReason,
 			due_by_days: countdownDays,
@@ -242,7 +242,7 @@ const DisputeNeedsResponseNotice = ( {
 					variant: 'secondary',
 					onClick: () => {
 						wcpayTracks.recordEvent(
-							'wcpay_order_dispute_notice_action_click',
+							wcpayTracks.events.DISPUTE_NOTICE_CLICK,
 							{
 								due_by_days: countdownDays,
 							}

--- a/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
+++ b/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
@@ -19,8 +19,7 @@ const BannerActions: React.FC< BannerActionsProps > = ( {
 } ) => {
 	const handleLearnMoreButtonClick = () => {
 		wcpayTracks.recordEvent(
-			'wcpay_fraud_protection_banner_learn_more_button_clicked',
-			{}
+			wcpayTracks.events.FRAUD_PROTECTION_BANNER_LEARN_MORE_CLICKED
 		);
 	};
 

--- a/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
+++ b/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
@@ -8,7 +8,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 interface BannerActionsProps {
 	handleDontShowAgainOnClick: () => void;
@@ -18,9 +18,7 @@ const BannerActions: React.FC< BannerActionsProps > = ( {
 	handleDontShowAgainOnClick,
 } ) => {
 	const handleLearnMoreButtonClick = () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.FRAUD_PROTECTION_BANNER_LEARN_MORE_CLICKED
-		);
+		recordEvent( events.FRAUD_PROTECTION_BANNER_LEARN_MORE_CLICKED );
 	};
 
 	return (

--- a/client/components/fraud-risk-tools-banner/index.tsx
+++ b/client/components/fraud-risk-tools-banner/index.tsx
@@ -11,7 +11,7 @@ import { useDispatch } from '@wordpress/data';
  */
 import { BannerBody, NewPill, BannerActions } from './components';
 import './style.scss';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 interface BannerSettings {
 	dontShowAgain: boolean;
@@ -35,9 +35,7 @@ const FRTDiscoverabilityBanner: React.FC = () => {
 	};
 
 	useEffect( () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.FRAUD_PROTECTION_BANNER_RENDERED
-		);
+		recordEvent( events.FRAUD_PROTECTION_BANNER_RENDERED );
 
 		const stringifiedSettings = JSON.stringify( settings );
 

--- a/client/components/fraud-risk-tools-banner/index.tsx
+++ b/client/components/fraud-risk-tools-banner/index.tsx
@@ -35,7 +35,9 @@ const FRTDiscoverabilityBanner: React.FC = () => {
 	};
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( 'wcpay_fraud_protection_banner_rendered', {} );
+		wcpayTracks.recordEvent(
+			wcpayTracks.events.FRAUD_PROTECTION_BANNER_RENDERED
+		);
 
 		const stringifiedSettings = JSON.stringify( settings );
 

--- a/client/components/woopay/save-user/agreement.js
+++ b/client/components/woopay/save-user/agreement.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 
 const Agreement = () => {
 	return (
@@ -21,9 +21,8 @@ const Agreement = () => {
 							href="https://wordpress.com/tos/"
 							rel="noopener noreferrer"
 							onClick={ () => {
-								wcpayTracks.recordUserEvent(
-									wcpayTracks.events
-										.WOOPAY_SAVE_MY_INFO_TOS_CLICK
+								recordUserEvent(
+									events.WOOPAY_SAVE_MY_INFO_TOS_CLICK
 								);
 							} }
 						>
@@ -36,9 +35,8 @@ const Agreement = () => {
 							href="https://automattic.com/privacy/"
 							rel="noopener noreferrer"
 							onClick={ () => {
-								wcpayTracks.recordUserEvent(
-									wcpayTracks.events
-										.WOOPAY_SAVE_MY_INFO_PRIVACY_CLICK
+								recordUserEvent(
+									events.WOOPAY_SAVE_MY_INFO_PRIVACY_CLICK
 								);
 							} }
 						>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -21,7 +21,7 @@ import Container from './container';
 import useWooPayUser from '../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../hooks/use-selected-payment-method';
 import WooPayIcon from 'assets/images/woopay.svg?asset';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 import './style.scss';
 
 const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
@@ -93,9 +93,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	);
 
 	const handleCountryDropdownClick = useCallback( () => {
-		wcpayTracks.recordUserEvent(
-			wcpayTracks.events.WOOPAY_SAVE_MY_INFO_COUNTRY_CLICK
-		);
+		recordUserEvent( events.WOOPAY_SAVE_MY_INFO_COUNTRY_CLICK );
 	}, [] );
 
 	const handleCheckboxClick = ( e ) => {
@@ -110,20 +108,15 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		}
 		setIsSaveDetailsChecked( isChecked );
 
-		wcpayTracks.recordUserEvent(
-			wcpayTracks.events.WOOPAY_SAVE_MY_INFO_CLICK,
-			{
-				status: isChecked ? 'checked' : 'unchecked',
-			}
-		);
+		recordUserEvent( events.WOOPAY_SAVE_MY_INFO_CLICK, {
+			status: isChecked ? 'checked' : 'unchecked',
+		} );
 	};
 
 	useEffect( () => {
 		// Record Tracks event when the mobile number is entered.
 		if ( isPhoneValid ) {
-			wcpayTracks.recordUserEvent(
-				wcpayTracks.events.WOOPAY_SAVE_MY_INFO_MOBILE_ENTER
-			);
+			recordUserEvent( events.WOOPAY_SAVE_MY_INFO_MOBILE_ENTER );
 		}
 	}, [ isPhoneValid ] );
 
@@ -131,9 +124,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		// Record Tracks event when user clicks on the info icon for the first time.
 		if ( isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
 			setHasShownInfoFlyout( true );
-			wcpayTracks.recordUserEvent(
-				wcpayTracks.events.WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK
-			);
+			recordUserEvent( events.WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK );
 		} else if ( ! isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
 			setHasShownInfoFlyout( false );
 		}
@@ -282,9 +273,8 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 											href="https://woo.com/document/woopay-customer-documentation/"
 											rel="noopener noreferrer"
 											onClick={ () => {
-												wcpayTracks.recordUserEvent(
-													wcpayTracks.events
-														.WOOPAY_SAVE_MY_INFO_TOOLTIP_LEARN_MORE_CLICK
+												recordUserEvent(
+													events.WOOPAY_SAVE_MY_INFO_TOOLTIP_LEARN_MORE_CLICK
 												);
 											} }
 										>

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -6,7 +6,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // eslint-disable-next-line import/no-unresolved
 import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
-import wcpayTracks from 'tracks';
 
 /**
  * Internal dependencies
@@ -36,7 +35,27 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 jest.mock( 'tracks', () => ( {
-	recordUserEvent: jest.fn(),
+	recordUserEvent: jest.fn().mockReturnValue( true ),
+	events: {
+		WOOPAY_EMAIL_CHECK: 'checkout_email_address_woopay_check',
+		WOOPAY_OFFERED: 'checkout_woopay_save_my_info_offered',
+		WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
+		WOOPAY_SKIPPED: 'woopay_skipped',
+		WOOPAY_BUTTON_LOAD: 'woopay_button_load',
+		WOOPAY_BUTTON_CLICK: 'woopay_button_click',
+		WOOPAY_SAVE_MY_INFO_COUNTRY_CLICK:
+			'checkout_woopay_save_my_info_country_click',
+		WOOPAY_SAVE_MY_INFO_CLICK: 'checkout_save_my_info_click',
+		WOOPAY_SAVE_MY_INFO_MOBILE_ENTER:
+			'checkout_woopay_save_my_info_mobile_enter',
+		WOOPAY_SAVE_MY_INFO_TOS_CLICK: 'checkout_save_my_info_tos_click',
+		WOOPAY_SAVE_MY_INFO_PRIVACY_CLICK:
+			'checkout_save_my_info_privacy_policy_click',
+		WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK:
+			'checkout_save_my_info_tooltip_click',
+		WOOPAY_SAVE_MY_INFO_TOOLTIP_LEARN_MORE_CLICK:
+			'checkout_save_my_info_tooltip_learn_more_click',
+	},
 } ) );
 
 const BlocksCheckoutEnvironmentMock = ( { children } ) => (
@@ -64,11 +83,6 @@ describe( 'CheckoutPageSaveUser', () => {
 		getConfig.mockImplementation(
 			( setting ) => setting === 'forceNetworkSavedCards'
 		);
-
-		wcpayTracks.recordUserEvent.mockReturnValue( true );
-		wcpayTracks.events = {
-			WOOPAY_SAVE_MY_INFO_CLICK: 'woopay_express_button_offered',
-		};
 
 		window.wcpaySettings = {
 			accountStatus: {

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -21,7 +21,7 @@ import scheduled from 'gridicons/dist/scheduled';
 /**
  * Internal dependencies
  */
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import Page from 'components/page';
 import BannerNotice from 'components/banner-notice';
 import PaymentMethods from './payment-methods';
@@ -50,7 +50,7 @@ const ConnectAccountPage: React.FC = () => {
 	const isCountrySupported = !! availableCountries[ country ];
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( wcpayTracks.events.CONNECT_ACCOUNT_VIEW, {
+		recordEvent( events.CONNECT_ACCOUNT_VIEW, {
 			path: 'payments_connect_v2',
 			...( incentive && {
 				incentive_id: incentive.id,
@@ -98,7 +98,7 @@ const ConnectAccountPage: React.FC = () => {
 	const handleSetup = async () => {
 		setSubmitted( true );
 
-		wcpayTracks.recordEvent( wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
+		recordEvent( events.CONNECT_ACCOUNT_CLICKED, {
 			wpcom_connection: wcpaySettings.isJetpackConnected ? 'Yes' : 'No',
 			is_new_onboarding_flow: isNewFlowEnabled,
 			...( incentive && {

--- a/client/connect-account-page/info-notice-modal.tsx
+++ b/client/connect-account-page/info-notice-modal.tsx
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import TipBox from 'components/tip-box';
 import strings from './strings';
 import './style.scss';
@@ -32,9 +32,7 @@ const InfoNoticeModal: React.FC = () => {
 				<Button
 					variant="link"
 					onClick={ () => {
-						wcpayTracks.recordEvent(
-							wcpayTracks.events.CONNECT_ACCOUNT_KYC_MODAL_OPENED
-						);
+						recordEvent( events.CONNECT_ACCOUNT_KYC_MODAL_OPENED );
 						setModalOpen( true );
 					} }
 				>

--- a/client/data/multi-currency/actions.js
+++ b/client/data/multi-currency/actions.js
@@ -6,7 +6,7 @@
 import { apiFetch } from '@wordpress/data-controls';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 /**
  * Internal Dependencies
@@ -82,13 +82,10 @@ export function* submitEnabledCurrenciesUpdate( currencies ) {
 			__( 'Enabled currencies updated.', 'woocommerce-payments' )
 		);
 
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED,
-			{
-				added_currencies: addedCurrencies,
-				removed_currencies: removedCurrencies,
-			}
-		);
+		recordEvent( events.MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED, {
+			added_currencies: addedCurrencies,
+			removed_currencies: removedCurrencies,
+		} );
 	} catch ( e ) {
 		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error updating enabled currencies.', 'woocommerce-payments' )

--- a/client/deposits/list/index.tsx
+++ b/client/deposits/list/index.tsx
@@ -5,7 +5,7 @@
  */
 import { DepositsTableHeader } from 'wcpay/types/deposits';
 import React, { useState } from 'react';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { useMemo } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -104,11 +104,7 @@ export const DepositsList = (): JSX.Element => {
 		const clickable = ( children: React.ReactNode ): JSX.Element => (
 			<ClickableCell
 				href={ getDetailsURL( deposit.id, 'deposits' ) }
-				onClick={ () =>
-					wcpayTracks.recordEvent(
-						wcpayTracks.events.DEPOSITS_ROW_CLICK
-					)
-				}
+				onClick={ () => recordEvent( events.DEPOSITS_ROW_CLICK ) }
 			>
 				{ children }
 			</ClickableCell>
@@ -120,11 +116,7 @@ export const DepositsList = (): JSX.Element => {
 		const dateDisplay = (
 			<Link
 				href={ getDetailsURL( deposit.id, 'deposits' ) }
-				onClick={ () =>
-					wcpayTracks.recordEvent(
-						wcpayTracks.events.DEPOSITS_ROW_CLICK
-					)
-				}
+				onClick={ () => recordEvent( events.DEPOSITS_ROW_CLICK ) }
 			>
 				{ dateI18n(
 					'M j, Y',
@@ -275,14 +267,11 @@ export const DepositsList = (): JSX.Element => {
 						)
 					);
 
-					wcpayTracks.recordEvent(
-						wcpayTracks.events.DEPOSITS_DOWNLOAD_CSV_CLICK,
-						{
-							exported_deposits: exportedDeposits,
-							total_deposits: exportedDeposits,
-							download_type: 'endpoint',
-						}
-					);
+					recordEvent( events.DEPOSITS_DOWNLOAD_CSV_CLICK, {
+						exported_deposits: exportedDeposits,
+						total_deposits: exportedDeposits,
+						download_type: 'endpoint',
+					} );
 				} catch {
 					createNotice(
 						'error',
@@ -322,14 +311,11 @@ export const DepositsList = (): JSX.Element => {
 				generateCSVDataFromTable( csvColumns, csvRows )
 			);
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.DEPOSITS_DOWNLOAD_CSV_CLICK,
-				{
-					exported_deposits: rows.length,
-					total_deposits: depositsSummary.count,
-					download_type: 'browser',
-				}
-			);
+			recordEvent( events.DEPOSITS_DOWNLOAD_CSV_CLICK, {
+				exported_deposits: rows.length,
+				total_deposits: depositsSummary.count,
+				download_type: 'browser',
+			} );
 		}
 
 		setIsDownloading( false );

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -548,9 +548,12 @@ export default ( { query } ) => {
 			return;
 		}
 
-		wcpayTracks.recordEvent( 'wcpay_dispute_file_upload_started', {
-			type: key,
-		} );
+		wcpayTracks.recordEvent(
+			wcpayTracks.events.DISPUTE_FILE_UPLOAD_STARTED,
+			{
+				type: key,
+			}
+		);
 
 		const body = new FormData();
 		body.append( 'file', file );
@@ -580,13 +583,19 @@ export default ( { query } ) => {
 			} );
 			updateEvidence( key, uploadedFile.id );
 
-			wcpayTracks.recordEvent( 'wcpay_dispute_file_upload_success', {
-				type: key,
-			} );
+			wcpayTracks.recordEvent(
+				wcpayTracks.events.DISPUTE_FILE_UPLOAD_SUCCESS,
+				{
+					type: key,
+				}
+			);
 		} catch ( err ) {
-			wcpayTracks.recordEvent( 'wcpay_dispute_file_upload_failed', {
-				message: err.message,
-			} );
+			wcpayTracks.recordEvent(
+				wcpayTracks.events.DISPUTE_FILE_UPLOAD_FAILED,
+				{
+					message: err.message,
+				}
+			);
 
 			updateDispute( {
 				metadata: { [ key ]: '' },
@@ -611,8 +620,8 @@ export default ( { query } ) => {
 
 		wcpayTracks.recordEvent(
 			submit
-				? 'wcpay_dispute_submit_evidence_success'
-				: 'wcpay_dispute_save_evidence_success'
+				? wcpayTracks.events.DISPUTE_SUBMIT_EVIDENCE_SUCCESS
+				: wcpayTracks.events.DISPUTE_SAVE_EVIDENCE_SUCCESS
 		);
 		/*
 			We rely on WC-Admin Transient notices to display success message.
@@ -645,8 +654,8 @@ export default ( { query } ) => {
 	const handleSaveError = ( err, submit ) => {
 		wcpayTracks.recordEvent(
 			submit
-				? 'wcpay_dispute_submit_evidence_failed'
-				: 'wcpay_dispute_save_evidence_failed'
+				? wcpayTracks.events.DISPUTE_SUBMIT_EVIDENCE_FAILED
+				: wcpayTracks.events.DISPUTE_SAVE_EVIDENCE_FAILED
 		);
 
 		const message = submit
@@ -674,8 +683,8 @@ export default ( { query } ) => {
 		try {
 			wcpayTracks.recordEvent(
 				submit
-					? 'wcpay_dispute_submit_evidence_clicked'
-					: 'wcpay_dispute_save_evidence_clicked'
+					? wcpayTracks.events.DISPUTE_SUBMIT_EVIDENCE_CLICK
+					: wcpayTracks.events.DISPUTE_SAVE_EVIDENCE_CLICK
 			);
 
 			const { metadata } = dispute;
@@ -705,7 +714,10 @@ export default ( { query } ) => {
 		const properties = {
 			selection: newProductType,
 		};
-		wcpayTracks.recordEvent( 'wcpay_dispute_product_selected', properties );
+		wcpayTracks.recordEvent(
+			wcpayTracks.events.DISPUTE_PRODUCT_SELECTED,
+			properties
+		);
 		updateDispute( {
 			metadata: { [ PRODUCT_TYPE_META_KEY ]: newProductType },
 		} );

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -33,7 +33,7 @@ import Page from 'components/page';
 import ErrorBoundary from 'components/error-boundary';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import useConfirmNavigation from 'utils/use-confirm-navigation';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { getAdminUrl } from 'wcpay/utils';
 
 const DISPUTE_EVIDENCE_MAX_LENGTH = 150000;
@@ -548,12 +548,9 @@ export default ( { query } ) => {
 			return;
 		}
 
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.DISPUTE_FILE_UPLOAD_STARTED,
-			{
-				type: key,
-			}
-		);
+		recordEvent( events.DISPUTE_FILE_UPLOAD_STARTED, {
+			type: key,
+		} );
 
 		const body = new FormData();
 		body.append( 'file', file );
@@ -583,19 +580,13 @@ export default ( { query } ) => {
 			} );
 			updateEvidence( key, uploadedFile.id );
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.DISPUTE_FILE_UPLOAD_SUCCESS,
-				{
-					type: key,
-				}
-			);
+			recordEvent( events.DISPUTE_FILE_UPLOAD_SUCCESS, {
+				type: key,
+			} );
 		} catch ( err ) {
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.DISPUTE_FILE_UPLOAD_FAILED,
-				{
-					message: err.message,
-				}
-			);
+			recordEvent( events.DISPUTE_FILE_UPLOAD_FAILED, {
+				message: err.message,
+			} );
 
 			updateDispute( {
 				metadata: { [ key ]: '' },
@@ -618,10 +609,10 @@ export default ( { query } ) => {
 			filter: 'awaiting_response',
 		} );
 
-		wcpayTracks.recordEvent(
+		recordEvent(
 			submit
-				? wcpayTracks.events.DISPUTE_SUBMIT_EVIDENCE_SUCCESS
-				: wcpayTracks.events.DISPUTE_SAVE_EVIDENCE_SUCCESS
+				? events.DISPUTE_SUBMIT_EVIDENCE_SUCCESS
+				: events.DISPUTE_SAVE_EVIDENCE_SUCCESS
 		);
 		/*
 			We rely on WC-Admin Transient notices to display success message.
@@ -652,10 +643,10 @@ export default ( { query } ) => {
 	};
 
 	const handleSaveError = ( err, submit ) => {
-		wcpayTracks.recordEvent(
+		recordEvent(
 			submit
-				? wcpayTracks.events.DISPUTE_SUBMIT_EVIDENCE_FAILED
-				: wcpayTracks.events.DISPUTE_SAVE_EVIDENCE_FAILED
+				? events.DISPUTE_SUBMIT_EVIDENCE_FAILED
+				: events.DISPUTE_SAVE_EVIDENCE_FAILED
 		);
 
 		const message = submit
@@ -681,10 +672,10 @@ export default ( { query } ) => {
 		setLoading( true );
 
 		try {
-			wcpayTracks.recordEvent(
+			recordEvent(
 				submit
-					? wcpayTracks.events.DISPUTE_SUBMIT_EVIDENCE_CLICK
-					: wcpayTracks.events.DISPUTE_SAVE_EVIDENCE_CLICK
+					? events.DISPUTE_SUBMIT_EVIDENCE_CLICK
+					: events.DISPUTE_SAVE_EVIDENCE_CLICK
 			);
 
 			const { metadata } = dispute;
@@ -714,10 +705,7 @@ export default ( { query } ) => {
 		const properties = {
 			selection: newProductType,
 		};
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.DISPUTE_PRODUCT_SELECTED,
-			properties
-		);
+		recordEvent( events.DISPUTE_PRODUCT_SELECTED, properties );
 		updateDispute( {
 			metadata: { [ PRODUCT_TYPE_META_KEY ]: newProductType },
 		} );

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { dateI18n } from '@wordpress/date';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
@@ -315,9 +315,7 @@ export const DisputesList = (): JSX.Element => {
 						) => {
 							// Use client-side routing to avoid page refresh.
 							e.preventDefault();
-							wcpayTracks.recordEvent(
-								wcpayTracks.events.DISPUTES_ROW_ACTION_CLICK
-							);
+							recordEvent( events.DISPUTES_ROW_ACTION_CLICK );
 							const history = getHistory();
 							history.push(
 								getDetailsURL(
@@ -405,14 +403,11 @@ export const DisputesList = (): JSX.Element => {
 						)
 					);
 
-					wcpayTracks.recordEvent(
-						wcpayTracks.events.DISPUTE_DOWNLOAD_CSV_CLICK,
-						{
-							exported_disputes: exportedDisputes,
-							total_disputes: exportedDisputes,
-							download_type: 'endpoint',
-						}
-					);
+					recordEvent( events.DISPUTE_DOWNLOAD_CSV_CLICK, {
+						exported_disputes: exportedDisputes,
+						total_disputes: exportedDisputes,
+						download_type: 'endpoint',
+					} );
 				} catch {
 					createNotice(
 						'error',
@@ -474,14 +469,11 @@ export const DisputesList = (): JSX.Element => {
 				generateCSVDataFromTable( csvColumns, csvRows )
 			);
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.DISPUTE_DOWNLOAD_CSV_CLICK,
-				{
-					exported_disputes: csvRows.length,
-					total_disputes: disputesSummary.count,
-					download_type: 'browser',
-				}
-			);
+			recordEvent( events.DISPUTE_DOWNLOAD_CSV_CLICK, {
+				exported_disputes: csvRows.length,
+				total_disputes: disputesSummary.count,
+				download_type: 'browser',
+			} );
 		}
 
 		setIsDownloading( false );

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -405,11 +405,14 @@ export const DisputesList = (): JSX.Element => {
 						)
 					);
 
-					wcpayTracks.recordEvent( 'wcpay_disputes_download', {
-						exported_disputes: exportedDisputes,
-						total_disputes: exportedDisputes,
-						download_type: 'endpoint',
-					} );
+					wcpayTracks.recordEvent(
+						wcpayTracks.events.DISPUTE_DOWNLOAD_CSV_CLICK,
+						{
+							exported_disputes: exportedDisputes,
+							total_disputes: exportedDisputes,
+							download_type: 'endpoint',
+						}
+					);
 				} catch {
 					createNotice(
 						'error',
@@ -471,11 +474,14 @@ export const DisputesList = (): JSX.Element => {
 				generateCSVDataFromTable( csvColumns, csvRows )
 			);
 
-			wcpayTracks.recordEvent( 'wcpay_disputes_download', {
-				exported_disputes: csvRows.length,
-				total_disputes: disputesSummary.count,
-				download_type: 'browser',
-			} );
+			wcpayTracks.recordEvent(
+				wcpayTracks.events.DISPUTE_DOWNLOAD_CSV_CLICK,
+				{
+					exported_disputes: csvRows.length,
+					total_disputes: disputesSummary.count,
+					download_type: 'browser',
+				}
+			);
 		}
 
 		setIsDownloading( false );

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -123,7 +123,22 @@ declare global {
 		isNextDepositNoticeDismissed: boolean;
 	};
 
-	const wcTracks: any;
+	const wc: {
+		tracks: {
+			recordEvent: (
+				eventName: string,
+				eventProperties: Record< string, unknown >
+			) => void;
+		};
+	};
+
+	const wcTracks: {
+		isEnabled: boolean;
+		recordEvent: (
+			eventName: string,
+			eventProperties: Record< string, unknown >
+		) => void;
+	};
 
 	const wcSettings: Record< string, any >;
 }

--- a/client/onboarding/tracking.ts
+++ b/client/onboarding/tracking.ts
@@ -10,7 +10,7 @@ import { useEffect } from 'react';
 import { useStepperContext } from 'components/stepper';
 import { useOnboardingContext } from './context';
 import { OnboardingFields } from './types';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 const trackedSteps: Set< string > = new Set();
 let startTime: number;
@@ -26,11 +26,11 @@ const stepElapsed = () => {
 export const trackStarted = (): void => {
 	startTime = stepStartTime = Date.now();
 
-	wcpayTracks.recordEvent( wcpayTracks.events.ONBOARDING_FLOW_STARTED, {} );
+	recordEvent( events.ONBOARDING_FLOW_STARTED, {} );
 };
 
 export const trackModeSelected = ( mode: string ): void => {
-	wcpayTracks.recordEvent( wcpayTracks.events.ONBOARDING_FLOW_MODE_SELECTED, {
+	recordEvent( events.ONBOARDING_FLOW_MODE_SELECTED, {
 		mode,
 		elapsed: stepElapsed(),
 	} );
@@ -40,33 +40,27 @@ export const trackStepCompleted = ( step: string ): void => {
 	// We only track a completed step once.
 	if ( trackedSteps.has( step ) ) return;
 
-	wcpayTracks.recordEvent(
-		wcpayTracks.events.ONBOARDING_FLOW_STEP_COMPLETED,
-		{
-			step,
-			elapsed: stepElapsed(),
-		}
-	);
+	recordEvent( events.ONBOARDING_FLOW_STEP_COMPLETED, {
+		step,
+		elapsed: stepElapsed(),
+	} );
 	trackedSteps.add( step );
 };
 
 export const trackRedirected = ( isEligible: boolean ): void => {
-	wcpayTracks.recordEvent( wcpayTracks.events.ONBOARDING_FLOW_REDIRECTED, {
+	recordEvent( events.ONBOARDING_FLOW_REDIRECTED, {
 		is_po_eligible: isEligible,
 		elapsed: elapsed( startTime ),
 	} );
 };
 
 export const trackAccountReset = (): void =>
-	wcpayTracks.recordEvent( wcpayTracks.events.ONBOARDING_FLOW_RESET, {} );
+	recordEvent( events.ONBOARDING_FLOW_RESET, {} );
 
 export const trackEligibilityModalClosed = (
 	action: 'dismiss' | 'setup_deposits' | 'enable_payments_only'
 ): void =>
-	wcpayTracks.recordEvent(
-		wcpayTracks.events.ONBOARDING_FLOW_ELIGIBILITY_MODAL_CLOSED,
-		{ action }
-	);
+	recordEvent( events.ONBOARDING_FLOW_ELIGIBILITY_MODAL_CLOSED, { action } );
 
 export const useTrackAbandoned = (): {
 	trackAbandoned: ( method: 'hide' | 'exit' ) => void;
@@ -78,13 +72,13 @@ export const useTrackAbandoned = (): {
 	const trackEvent = ( method = 'hide' ) => {
 		const event =
 			method === 'hide'
-				? wcpayTracks.events.ONBOARDING_FLOW_HIDDEN
-				: wcpayTracks.events.ONBOARDING_FLOW_EXITED;
+				? events.ONBOARDING_FLOW_HIDDEN
+				: events.ONBOARDING_FLOW_EXITED;
 		const errored = Object.keys( errors ).filter(
 			( field ) => touched[ field as keyof OnboardingFields ]
 		);
 
-		wcpayTracks.recordEvent( event, {
+		recordEvent( event, {
 			step,
 			errored,
 			elapsed: elapsed( startTime ),

--- a/client/overview/inbox-notifications/index.js
+++ b/client/overview/inbox-notifications/index.js
@@ -63,7 +63,7 @@ function hasValidNotes( notes ) {
 }
 
 const onBodyLinkClick = ( note, innerLink ) => {
-	wcpayTracks.recordEvent( 'wcpay_inbox_action_click', {
+	wcpayTracks.recordEvent( wcpayTracks.events.INBOX_ACTION_CLICK, {
 		note_name: note.name,
 		note_title: note.title,
 		note_content_inner_link: innerLink,
@@ -87,7 +87,7 @@ const renderNotes = ( {
 	}
 
 	const onNoteVisible = ( note ) => {
-		wcpayTracks.recordEvent( 'wcpay_inbox_note_view', {
+		wcpayTracks.recordEvent( wcpayTracks.events.INBOX_NOTE_VIEW, {
 			note_content: note.content,
 			note_name: note.name,
 			note_title: note.title,
@@ -207,7 +207,7 @@ const InboxPanel = () => {
 	const closeDismissModal = async ( confirmed = false ) => {
 		const noteNameDismissAll = dismiss.type === 'all';
 
-		wcpayTracks.recordEvent( 'wcpay_inbox_action_dismiss', {
+		wcpayTracks.recordEvent( wcpayTracks.events.INBOX_ACTION_DISMISSED, {
 			note_name: dismiss.note.name,
 			note_title: dismiss.note.title,
 			note_name_dismiss_all: noteNameDismissAll,

--- a/client/overview/inbox-notifications/index.js
+++ b/client/overview/inbox-notifications/index.js
@@ -16,7 +16,7 @@ import {
 /**
  * Internal dependencies
  */
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { updateWoocommerceUserMeta } from 'utils/update-woocommerce-user-meta';
 import './index.scss';
 
@@ -63,7 +63,7 @@ function hasValidNotes( notes ) {
 }
 
 const onBodyLinkClick = ( note, innerLink ) => {
-	wcpayTracks.recordEvent( wcpayTracks.events.INBOX_ACTION_CLICK, {
+	recordEvent( events.INBOX_ACTION_CLICK, {
 		note_name: note.name,
 		note_title: note.title,
 		note_content_inner_link: innerLink,
@@ -87,7 +87,7 @@ const renderNotes = ( {
 	}
 
 	const onNoteVisible = ( note ) => {
-		wcpayTracks.recordEvent( wcpayTracks.events.INBOX_NOTE_VIEW, {
+		recordEvent( events.INBOX_NOTE_VIEW, {
 			note_content: note.content,
 			note_name: note.name,
 			note_title: note.title,
@@ -207,7 +207,7 @@ const InboxPanel = () => {
 	const closeDismissModal = async ( confirmed = false ) => {
 		const noteNameDismissAll = dismiss.type === 'all';
 
-		wcpayTracks.recordEvent( wcpayTracks.events.INBOX_ACTION_DISMISSED, {
+		recordEvent( events.INBOX_ACTION_DISMISSED, {
 			note_name: dismiss.note.name,
 			note_title: dismiss.note.title,
 			note_name_dismiss_all: noteNameDismissAll,

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -13,7 +13,7 @@ import type { TaskItemProps } from '../types';
 import type { CachedDispute } from 'wcpay/types/disputes';
 import { formatCurrency } from 'wcpay/utils/currency';
 import { getAdminUrl } from 'wcpay/utils';
-import wcpayTracks from 'wcpay/tracks';
+import { recordEvent, events } from 'wcpay/tracks';
 import { isDueWithin } from 'wcpay/disputes/utils';
 
 /**
@@ -50,7 +50,7 @@ export const getDisputeResolutionTask = (
 	}
 
 	const handleClick = () => {
-		wcpayTracks.recordEvent( wcpayTracks.events.OVERVIEW_TASK_CLICK, {
+		recordEvent( events.OVERVIEW_TASK_CLICK, {
 			task: 'dispute-resolution-task',
 			active_dispute_count: activeDisputeCount,
 		} );

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -25,7 +25,7 @@ import {
  */
 import type { Dispute } from 'wcpay/types/disputes';
 import type { ChargeBillingDetails } from 'wcpay/types/charges';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { useDisputeAccept } from 'wcpay/data';
 import { getDisputeFeeFormatted, isInquiry } from 'wcpay/disputes/utils';
 import { getAdminUrl } from 'wcpay/utils';
@@ -93,8 +93,7 @@ function getAcceptDisputeProps( {
 	if ( isInquiry( dispute ) ) {
 		return {
 			acceptButtonLabel: __( 'Issue refund', 'woocommerce-payments' ),
-			acceptButtonTracksEvent:
-				wcpayTracks.events.DISPUTE_INQUIRY_REFUND_MODAL_VIEW,
+			acceptButtonTracksEvent: events.DISPUTE_INQUIRY_REFUND_MODAL_VIEW,
 			modalTitle: __( 'Issue a refund?', 'woocommerce-payments' ),
 			modalLines: [
 				{
@@ -116,14 +115,13 @@ function getAcceptDisputeProps( {
 				'View order to issue refund',
 				'woocommerce-payments'
 			),
-			modalButtonTracksEvent:
-				wcpayTracks.events.DISPUTE_INQUIRY_REFUND_CLICK,
+			modalButtonTracksEvent: events.DISPUTE_INQUIRY_REFUND_CLICK,
 		};
 	}
 
 	return {
 		acceptButtonLabel: __( 'Accept dispute', 'woocommerce-payments' ),
-		acceptButtonTracksEvent: wcpayTracks.events.DISPUTE_ACCEPT_MODAL_VIEW,
+		acceptButtonTracksEvent: events.DISPUTE_ACCEPT_MODAL_VIEW,
 		modalTitle: __( 'Accept the dispute?', 'woocommerce-payments' ),
 		modalLines: [
 			{
@@ -153,7 +151,7 @@ function getAcceptDisputeProps( {
 		modalButtonLabel: isDisputeAcceptRequestPending
 			? __( 'Accepting…', 'woocommerce-payments' )
 			: __( 'Accept dispute', 'woocommerce-payments' ),
-		modalButtonTracksEvent: wcpayTracks.events.DISPUTE_ACCEPT_CLICK,
+		modalButtonTracksEvent: events.DISPUTE_ACCEPT_CLICK,
 	};
 }
 
@@ -270,9 +268,8 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 									data-testid="challenge-dispute-button"
 									disabled={ isDisputeAcceptRequestPending }
 									onClick={ () => {
-										wcpayTracks.recordEvent(
-											wcpayTracks.events
-												.DISPUTE_CHALLENGE_CLICKED,
+										recordEvent(
+											events.DISPUTE_CHALLENGE_CLICKED,
 											{
 												dispute_status: dispute.status,
 												on_page: 'transaction_details',
@@ -294,7 +291,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 								disabled={ isDisputeAcceptRequestPending }
 								data-testid="open-accept-dispute-modal-button"
 								onClick={ () => {
-									wcpayTracks.recordEvent(
+									recordEvent(
 										disputeAcceptAction.acceptButtonTracksEvent,
 										{
 											dispute_status: dispute.status,
@@ -362,7 +359,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 											}
 											data-testid="accept-dispute-button"
 											onClick={ () => {
-												wcpayTracks.recordEvent(
+												recordEvent(
 													disputeAcceptAction.modalButtonTracksEvent,
 													{
 														dispute_status:

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -13,7 +13,7 @@ import { Button, CardFooter, Flex, FlexItem } from '@wordpress/components';
  * Internal dependencies
  */
 import type { Dispute } from 'wcpay/types/disputes';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { getAdminUrl } from 'wcpay/utils';
 import { getDisputeFeeFormatted } from 'wcpay/disputes/utils';
 import './style.scss';
@@ -68,9 +68,8 @@ const DisputeUnderReviewFooter: React.FC< {
 						<Button
 							variant="secondary"
 							onClick={ () => {
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
+								recordEvent(
+									events.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
 										on_page: 'transaction_details',
@@ -140,9 +139,8 @@ const DisputeWonFooter: React.FC< {
 						<Button
 							variant="secondary"
 							onClick={ () => {
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
+								recordEvent(
+									events.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
 										on_page: 'transaction_details',
@@ -250,9 +248,8 @@ const DisputeLostFooter: React.FC< {
 							<Button
 								variant="secondary"
 								onClick={ () => {
-									wcpayTracks.recordEvent(
-										wcpayTracks.events
-											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
+									recordEvent(
+										events.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 										{
 											dispute_status: dispute.status,
 											on_page: 'transaction_details',
@@ -323,9 +320,8 @@ const InquiryUnderReviewFooter: React.FC< {
 						<Button
 							variant="secondary"
 							onClick={ () => {
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
+								recordEvent(
+									events.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 									{
 										dispute_status: dispute.status,
 										on_page: 'transaction_details',
@@ -398,9 +394,8 @@ const InquiryClosedFooter: React.FC< {
 							<Button
 								variant="secondary"
 								onClick={ () => {
-									wcpayTracks.recordEvent(
-										wcpayTracks.events
-											.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
+									recordEvent(
+										events.PAYMENT_DETAILS_VIEW_DISPUTE_EVIDENCE_BUTTON_CLICKED,
 										{
 											dispute_status: dispute.status,
 											on_page: 'transaction_details',

--- a/client/payment-details/index.tsx
+++ b/client/payment-details/index.tsx
@@ -24,7 +24,7 @@ const PaymentDetails: React.FC< PaymentDetailsProps > = ( { query } ) => {
 
 	if ( statusIs && typeIs ) {
 		wcpayTracks.recordEvent(
-			'wcpay_fraud_protection_order_details_link_clicked',
+			wcpayTracks.events.FRAUD_PROTECTION_ORDER_DETAILS_LINK_CLICKED,
 			{ status: statusIs, type: typeIs }
 		);
 		// Remove the tracking queries on page load so we don't track refreshes or back button reloads.

--- a/client/payment-details/index.tsx
+++ b/client/payment-details/index.tsx
@@ -11,7 +11,7 @@ import PaymentCardReaderChargeDetails from './readers';
 import { PaymentDetailsProps } from './types';
 import PaymentOrderDetails from './order-details';
 import PaymentChargeDetails from './charge-details';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 const PaymentDetails: React.FC< PaymentDetailsProps > = ( { query } ) => {
 	const {
@@ -23,10 +23,10 @@ const PaymentDetails: React.FC< PaymentDetailsProps > = ( { query } ) => {
 	const { status_is: statusIs, type_is: typeIs } = getQuery();
 
 	if ( statusIs && typeIs ) {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.FRAUD_PROTECTION_ORDER_DETAILS_LINK_CLICKED,
-			{ status: statusIs, type: typeIs }
-		);
+		recordEvent( events.FRAUD_PROTECTION_ORDER_DETAILS_LINK_CLICKED, {
+			status: statusIs,
+			type: typeIs,
+		} );
 		// Remove the tracking queries on page load so we don't track refreshes or back button reloads.
 		updateQueryString( {
 			status_is: undefined,

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -50,7 +50,7 @@ import { useAuthorization } from 'wcpay/data';
 import CaptureAuthorizationButton from 'wcpay/components/capture-authorization-button';
 import './style.scss';
 import { Charge } from 'wcpay/types/charges';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import WCPaySettingsContext from '../../settings/wcpay-settings-context';
 import { FraudOutcome } from '../../types/fraud-outcome';
 import CancelAuthorizationButton from '../../components/cancel-authorization-button';
@@ -430,17 +430,15 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 											charge.payment_intent || ''
 										}
 										onClick={ () => {
-											wcpayTracks.recordEvent(
-												wcpayTracks.events
-													.FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_BLOCKED,
+											recordEvent(
+												events.FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_BLOCKED,
 												{
 													payment_intent_id:
 														charge.payment_intent,
 												}
 											);
-											wcpayTracks.recordEvent(
-												wcpayTracks.events
-													.TRANSACTIONS_DETAILS_CANCEL_CHARGE_BUTTON_CLICK,
+											recordEvent(
+												events.TRANSACTIONS_DETAILS_CANCEL_CHARGE_BUTTON_CLICK,
 												{
 													payment_intent_id:
 														charge.payment_intent,
@@ -459,17 +457,15 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 										}
 										buttonIsSmall={ false }
 										onClick={ () => {
-											wcpayTracks.recordEvent(
-												wcpayTracks.events
-													.FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_APPROVED,
+											recordEvent(
+												events.FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_APPROVED,
 												{
 													payment_intent_id:
 														charge.payment_intent,
 												}
 											);
-											wcpayTracks.recordEvent(
-												wcpayTracks.events
-													.TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK,
+											recordEvent(
+												events.TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK,
 												{
 													payment_intent_id:
 														charge.payment_intent,
@@ -521,9 +517,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 													setIsRefundModalOpen(
 														true
 													);
-													wcpayTracks.recordEvent(
-														wcpayTracks.events
-															.TRANSACTIONS_DETAILS_REFUND_MODAL_OPEN,
+													recordEvent(
+														events.TRANSACTIONS_DETAILS_REFUND_MODAL_OPEN,
 														{
 															payment_intent_id:
 																charge.payment_intent,
@@ -540,9 +535,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 											{ isPartiallyRefundable && (
 												<MenuItem
 													onClick={ () => {
-														wcpayTracks.recordEvent(
-															wcpayTracks.events
-																.TRANSACTION_DETAILS_PARTIAL_REFUND,
+														recordEvent(
+															events.TRANSACTION_DETAILS_PARTIAL_REFUND,
 															{
 																payment_intent_id:
 																	charge.payment_intent,
@@ -601,9 +595,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 					formattedAmount={ formattedAmount }
 					onModalClose={ () => {
 						setIsRefundModalOpen( false );
-						wcpayTracks.recordEvent(
-							wcpayTracks.events
-								.TRANSACTIONS_DETAILS_REFUND_MODAL_CLOSE,
+						recordEvent(
+							events.TRANSACTIONS_DETAILS_REFUND_MODAL_CLOSE,
 							{
 								payment_intent_id: charge.payment_intent,
 							}
@@ -633,9 +626,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 										buttonIsPrimary={ true }
 										buttonIsSmall={ false }
 										onClick={ () => {
-											wcpayTracks.recordEvent(
-												wcpayTracks.events
-													.TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK,
+											recordEvent(
+												events.TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK,
 												{
 													payment_intent_id:
 														charge.payment_intent,

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -431,14 +431,16 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 										}
 										onClick={ () => {
 											wcpayTracks.recordEvent(
-												'wcpay_fraud_protection_transaction_reviewed_merchant_blocked',
+												wcpayTracks.events
+													.FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_BLOCKED,
 												{
 													payment_intent_id:
 														charge.payment_intent,
 												}
 											);
 											wcpayTracks.recordEvent(
-												'payments_transactions_details_cancel_charge_button_click',
+												wcpayTracks.events
+													.TRANSACTIONS_DETAILS_CANCEL_CHARGE_BUTTON_CLICK,
 												{
 													payment_intent_id:
 														charge.payment_intent,
@@ -458,14 +460,16 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 										buttonIsSmall={ false }
 										onClick={ () => {
 											wcpayTracks.recordEvent(
-												'wcpay_fraud_protection_transaction_reviewed_merchant_approved',
+												wcpayTracks.events
+													.FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_APPROVED,
 												{
 													payment_intent_id:
 														charge.payment_intent,
 												}
 											);
 											wcpayTracks.recordEvent(
-												'payments_transactions_details_capture_charge_button_click',
+												wcpayTracks.events
+													.TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK,
 												{
 													payment_intent_id:
 														charge.payment_intent,
@@ -518,7 +522,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 														true
 													);
 													wcpayTracks.recordEvent(
-														'payments_transactions_details_refund_modal_open',
+														wcpayTracks.events
+															.TRANSACTIONS_DETAILS_REFUND_MODAL_OPEN,
 														{
 															payment_intent_id:
 																charge.payment_intent,
@@ -536,7 +541,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 												<MenuItem
 													onClick={ () => {
 														wcpayTracks.recordEvent(
-															'payments_transactions_details_partial_refund',
+															wcpayTracks.events
+																.TRANSACTION_DETAILS_PARTIAL_REFUND,
 															{
 																payment_intent_id:
 																	charge.payment_intent,
@@ -596,7 +602,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 					onModalClose={ () => {
 						setIsRefundModalOpen( false );
 						wcpayTracks.recordEvent(
-							'payments_transactions_details_refund_modal_close',
+							wcpayTracks.events
+								.TRANSACTIONS_DETAILS_REFUND_MODAL_CLOSE,
 							{
 								payment_intent_id: charge.payment_intent,
 							}
@@ -627,7 +634,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 										buttonIsSmall={ false }
 										onClick={ () => {
 											wcpayTracks.recordEvent(
-												'payments_transactions_details_capture_charge_button_click',
+												wcpayTracks.events
+													.TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK,
 												{
 													payment_intent_id:
 														charge.payment_intent,

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -46,9 +46,12 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 	};
 
 	const handleRefund = async () => {
-		wcpayTracks.recordEvent( 'payments_transactions_details_refund_full', {
-			payment_intent_id: charge.payment_intent,
-		} );
+		wcpayTracks.recordEvent(
+			wcpayTracks.events.TRANSACTIONS_DETAILS_REFUND_FULL,
+			{
+				payment_intent_id: charge.payment_intent,
+			}
+		);
 		setIsRefundInProgress( true );
 		await doRefund( charge, reason === 'other' ? null : reason );
 		setIsRefundInProgress( false );

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -18,7 +18,7 @@ import ConfirmationModal from 'wcpay/components/confirmation-modal';
 import { Charge } from 'wcpay/types/charges';
 import { usePaymentIntentWithChargeFallback } from 'wcpay/data';
 import { PaymentChargeDetailsResponse } from 'wcpay/payment-details/types';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 interface RefundModalProps {
 	charge: Charge;
@@ -46,12 +46,9 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 	};
 
 	const handleRefund = async () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.TRANSACTIONS_DETAILS_REFUND_FULL,
-			{
-				payment_intent_id: charge.payment_intent,
-			}
-		);
+		recordEvent( events.TRANSACTIONS_DETAILS_REFUND_FULL, {
+			payment_intent_id: charge.payment_intent,
+		} );
 		setIsRefundInProgress( true );
 		await doRefund( charge, reason === 'other' ? null : reason );
 		setIsRefundInProgress( false );

--- a/client/payment-request/blocks/payment-request-express.js
+++ b/client/payment-request/blocks/payment-request-express.js
@@ -10,7 +10,7 @@ import { Elements, PaymentRequestButtonElement } from '@stripe/react-stripe-js';
  */
 import { useInitialization } from './use-initialization';
 import { getPaymentRequestData } from '../utils';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 import { useEffect, useState } from 'react';
 
 /**
@@ -79,13 +79,13 @@ const PaymentRequestExpressComponent = ( {
 		onButtonClick();
 
 		const paymentRequestTypeEvents = {
-			google_pay: wcpayTracks.events.GOOGLEPAY_BUTTON_CLICK,
-			apple_pay: wcpayTracks.events.APPLEPAY_BUTTON_CLICK,
+			google_pay: events.GOOGLEPAY_BUTTON_CLICK,
+			apple_pay: events.APPLEPAY_BUTTON_CLICK,
 		};
 
 		if ( paymentRequestTypeEvents.hasOwnProperty( paymentRequestType ) ) {
 			const event = paymentRequestTypeEvents[ paymentRequestType ];
-			wcpayTracks.recordUserEvent( event, {
+			recordUserEvent( event, {
 				source: wcpayPaymentRequestParams?.button_context,
 			} );
 		}
@@ -120,15 +120,15 @@ export const PaymentRequestExpress = ( props ) => {
 	useEffect( () => {
 		if ( paymentRequestType ) {
 			const paymentRequestTypeEvents = {
-				google_pay: wcpayTracks.events.GOOGLEPAY_BUTTON_LOAD,
-				apple_pay: wcpayTracks.events.APPLEPAY_BUTTON_LOAD,
+				google_pay: events.GOOGLEPAY_BUTTON_LOAD,
+				apple_pay: events.APPLEPAY_BUTTON_LOAD,
 			};
 
 			if (
 				paymentRequestTypeEvents.hasOwnProperty( paymentRequestType )
 			) {
 				const event = paymentRequestTypeEvents[ paymentRequestType ];
-				wcpayTracks.recordUserEvent( event, {
+				recordUserEvent( event, {
 					source: wcpayPaymentRequestParams?.button_context,
 				} );
 			}

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -17,7 +17,7 @@ import {
 	payForOrderHandler,
 } from './event-handlers.js';
 import '../checkout/express-checkout-buttons.scss';
-import wcpayTracks from 'tracks';
+import { recordUserEvent, events } from 'tracks';
 
 import { getPaymentRequest, displayLoginConfirmation } from './utils';
 
@@ -56,26 +56,26 @@ jQuery( ( $ ) => {
 	// Track the payment request button click event.
 	const trackPaymentRequestButtonClick = ( source ) => {
 		const paymentRequestTypeEvents = {
-			google_pay: wcpayTracks.events.GOOGLEPAY_BUTTON_CLICK,
-			apple_pay: wcpayTracks.events.APPLEPAY_BUTTON_CLICK,
+			google_pay: events.GOOGLEPAY_BUTTON_CLICK,
+			apple_pay: events.APPLEPAY_BUTTON_CLICK,
 		};
 
 		if ( paymentRequestTypeEvents.hasOwnProperty( paymentRequestType ) ) {
 			const event = paymentRequestTypeEvents[ paymentRequestType ];
-			wcpayTracks.recordUserEvent( event, { source } );
+			recordUserEvent( event, { source } );
 		}
 	};
 
 	// Track the payment request button load event.
 	const trackPaymentRequestButtonLoad = debounce( ( source ) => {
 		const paymentRequestTypeEvents = {
-			google_pay: wcpayTracks.events.GOOGLEPAY_BUTTON_LOAD,
-			apple_pay: wcpayTracks.events.APPLEPAY_BUTTON_LOAD,
+			google_pay: events.GOOGLEPAY_BUTTON_LOAD,
+			apple_pay: events.APPLEPAY_BUTTON_LOAD,
 		};
 
 		if ( paymentRequestTypeEvents.hasOwnProperty( paymentRequestType ) ) {
 			const event = paymentRequestTypeEvents[ paymentRequestType ];
-			wcpayTracks.recordUserEvent( event, { source } );
+			recordUserEvent( event, { source } );
 		}
 	}, 1000 );
 

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -23,7 +23,7 @@ import {
 	useDepositRestrictions,
 } from '../../data';
 import './style.scss';
-import wcpayTracks from 'wcpay/tracks';
+import { recordEvent, events } from 'wcpay/tracks';
 import InlineNotice from 'components/inline-notice';
 
 const daysOfWeek = [
@@ -227,9 +227,8 @@ const Deposits = () => {
 						<ExternalLink
 							href={ accountLink }
 							onClick={ () =>
-								wcpayTracks.recordEvent(
-									wcpayTracks.events
-										.SETTINGS_DEPOSITS_MANAGE_IN_STRIPE_CLICK,
+								recordEvent(
+									events.SETTINGS_DEPOSITS_MANAGE_IN_STRIPE_CLICK,
 									{}
 								)
 							}

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
@@ -74,12 +74,9 @@ const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = (
 
 		setLoading( true );
 
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.SETTINGS_FILE_UPLOAD_STARTED,
-			{
-				type: key,
-			}
-		);
+		recordEvent( events.SETTINGS_FILE_UPLOAD_STARTED, {
+			type: key,
+		} );
 
 		const body = new FormData();
 		body.append( 'file', file );
@@ -100,19 +97,13 @@ const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = (
 			setLoading( false );
 			setUploadError( false );
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.SETTINGS_FILE_UPLOAD_SUCCESS,
-				{
-					type: key,
-				}
-			);
+			recordEvent( events.SETTINGS_FILE_UPLOAD_SUCCESS, {
+				type: key,
+			} );
 		} catch ( { err } ) {
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.SETTINGS_FILE_UPLOAD_FAILED,
-				{
-					message: ( err as Error ).message,
-				}
-			);
+			recordEvent( events.SETTINGS_FILE_UPLOAD_FAILED, {
+				message: ( err as Error ).message,
+			} );
 
 			// Remove file ID
 			updateFileID( '' );

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -75,7 +75,7 @@ const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = (
 		setLoading( true );
 
 		wcpayTracks.recordEvent(
-			'wcpay_merchant_settings_file_upload_started',
+			wcpayTracks.events.SETTINGS_FILE_UPLOAD_STARTED,
 			{
 				type: key,
 			}
@@ -101,15 +101,18 @@ const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = (
 			setUploadError( false );
 
 			wcpayTracks.recordEvent(
-				'wcpay_merchant_settings_file_upload_success',
+				wcpayTracks.events.SETTINGS_FILE_UPLOAD_SUCCESS,
 				{
 					type: key,
 				}
 			);
 		} catch ( { err } ) {
-			wcpayTracks.recordEvent( 'wcpay_merchant_settings_upload_failed', {
-				message: ( err as Error ).message,
-			} );
+			wcpayTracks.recordEvent(
+				wcpayTracks.events.SETTINGS_FILE_UPLOAD_FAILED,
+				{
+					message: ( err as Error ).message,
+				}
+			);
 
 			// Remove file ID
 			updateFileID( '' );

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -175,7 +175,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			saveSettings();
 
 			wcpayTracks.recordEvent(
-				'wcpay_fraud_protection_advanced_settings_saved',
+				wcpayTracks.events.FRAUD_PROTECTION_ADVANCED_SETTINGS_SAVED,
 				{ settings: JSON.stringify( settings ) }
 			);
 		} else {

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -36,7 +36,7 @@ import './../style.scss';
 
 import { ProtectionLevel } from './constants';
 import { readRuleset, writeRuleset } from './utils';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import {
 	CurrentProtectionLevelHook,
 	AdvancedFraudPreventionSettingsHook,
@@ -174,10 +174,9 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 
 			saveSettings();
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.FRAUD_PROTECTION_ADVANCED_SETTINGS_SAVED,
-				{ settings: JSON.stringify( settings ) }
-			);
+			recordEvent( events.FRAUD_PROTECTION_ADVANCED_SETTINGS_SAVED, {
+				settings: JSON.stringify( settings ),
+			} );
 		} else {
 			window.scrollTo( {
 				top: 0,
@@ -208,7 +207,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				const event = observerEventMapping[ id ] || null;
 
 				if ( event ) {
-					wcpayTracks.recordEvent( event, {} );
+					recordEvent( event, {} );
 				}
 
 				const element = document.getElementById( id );

--- a/client/settings/fraud-protection/components/protection-levels/index.tsx
+++ b/client/settings/fraud-protection/components/protection-levels/index.tsx
@@ -18,7 +18,7 @@ import { FraudProtectionHelpText, BasicFraudProtectionModal } from '../index';
 import { getAdminUrl } from 'wcpay/utils';
 import { ProtectionLevel } from '../../advanced-settings/constants';
 import InlineNotice from 'components/inline-notice';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import { CurrentProtectionLevelHook } from '../../interfaces';
 
 const ProtectionLevels: React.FC = () => {
@@ -38,18 +38,14 @@ const ProtectionLevels: React.FC = () => {
 		0 < advancedFraudProtectionSettings.length;
 
 	const handleLevelChange = ( level: string ) => () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.FRAUD_PROTECTION_RISK_LEVEL_PRESET_ENABLED,
-			{ preset: level }
-		);
+		recordEvent( events.FRAUD_PROTECTION_RISK_LEVEL_PRESET_ENABLED, {
+			preset: level,
+		} );
 		updateProtectionLevel( level );
 	};
 
 	const handleBasicModalOpen = () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.FRAUD_PROTECTION_BASIC_MODAL_VIEWED,
-			{}
-		);
+		recordEvent( events.FRAUD_PROTECTION_BASIC_MODAL_VIEWED, {} );
 		setBasicModalOpen( true );
 	};
 

--- a/client/settings/fraud-protection/components/protection-levels/index.tsx
+++ b/client/settings/fraud-protection/components/protection-levels/index.tsx
@@ -39,7 +39,7 @@ const ProtectionLevels: React.FC = () => {
 
 	const handleLevelChange = ( level: string ) => () => {
 		wcpayTracks.recordEvent(
-			'wcpay_fraud_protection_risk_level_preset_enabled',
+			wcpayTracks.events.FRAUD_PROTECTION_RISK_LEVEL_PRESET_ENABLED,
 			{ preset: level }
 		);
 		updateProtectionLevel( level );
@@ -47,7 +47,7 @@ const ProtectionLevels: React.FC = () => {
 
 	const handleBasicModalOpen = () => {
 		wcpayTracks.recordEvent(
-			'wcpay_fraud_protection_basic_modal_viewed',
+			wcpayTracks.events.FRAUD_PROTECTION_BASIC_MODAL_VIEWED,
 			{}
 		);
 		setBasicModalOpen( true );

--- a/client/settings/fraud-protection/tour/index.tsx
+++ b/client/settings/fraud-protection/tour/index.tsx
@@ -10,7 +10,7 @@ import { TourKit } from '@woocommerce/components';
  */
 import { useSettings } from '../../../data';
 import { steps } from './steps';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 const [ firstStep ] = steps;
 const { desktop: firstStepId } = firstStep.referenceElements;
@@ -72,15 +72,9 @@ const FraudProtectionTour: React.FC = () => {
 		setShowTour( false );
 
 		if ( 'done-btn' === element ) {
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.FRAUD_PROTECTION_TOUR_CLICKED_THROUGH,
-				{}
-			);
+			recordEvent( events.FRAUD_PROTECTION_TOUR_CLICKED_THROUGH, {} );
 		} else {
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.FRAUD_PROTECTION_TOUR_ABANDONED,
-				{}
-			);
+			recordEvent( events.FRAUD_PROTECTION_TOUR_ABANDONED, {} );
 		}
 	};
 

--- a/client/settings/fraud-protection/tour/index.tsx
+++ b/client/settings/fraud-protection/tour/index.tsx
@@ -73,12 +73,12 @@ const FraudProtectionTour: React.FC = () => {
 
 		if ( 'done-btn' === element ) {
 			wcpayTracks.recordEvent(
-				'wcpay_fraud_protection_tour_clicked_through',
+				wcpayTracks.events.FRAUD_PROTECTION_TOUR_CLICKED_THROUGH,
 				{}
 			);
 		} else {
 			wcpayTracks.recordEvent(
-				'wcpay_fraud_protection_tour_abandoned',
+				wcpayTracks.events.FRAUD_PROTECTION_TOUR_ABANDONED,
 				{}
 			);
 		}

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useGetSettings, useSettings } from '../../data';
-import wcpayTracks from '../../tracks';
+import { recordEvent, events } from '../../tracks';
 import SettingsSection from '../settings-section';
 import './style.scss';
 import WooPayDisableFeedback from '../woopay-disable-feedback';
@@ -66,12 +66,9 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 			initialIsPaymentRequestEnabled !==
 			settings.is_payment_request_enabled
 		) {
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.PAYMENT_REQUEST_SETTINGS_CHANGE,
-				{
-					enabled: settings.is_payment_request_enabled ? 'yes' : 'no',
-				}
-			);
+			recordEvent( events.PAYMENT_REQUEST_SETTINGS_CHANGE, {
+				enabled: settings.is_payment_request_enabled ? 'yes' : 'no',
+			} );
 
 			// Update the "initial" value to properly track consecutive saves.
 			setInitialIsPaymentRequestEnabled(

--- a/client/subscription-product-onboarding/modal.js
+++ b/client/subscription-product-onboarding/modal.js
@@ -12,7 +12,7 @@ import {
 import { registerPlugin } from '@wordpress/plugins';
 import { removeQueryArgs } from '@wordpress/url';
 import { __, sprintf } from '@wordpress/i18n';
-import wcpayTracks from '../tracks';
+import { recordEvent, events } from '../tracks';
 
 import './style.scss';
 
@@ -31,9 +31,8 @@ const FinishSetupButton = () => {
 			isBusy={ isFinishingSetup }
 			isPrimary
 			onClick={ () => {
-				wcpayTracks.recordEvent(
-					wcpayTracks.events
-						.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_FINISH_SETUP
+				recordEvent(
+					events.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_FINISH_SETUP
 				);
 				setIsFinishingSetup( true );
 			} }
@@ -47,9 +46,8 @@ const SubscriptionProductOnboardingModalContent = ( {
 	onRequestClose = () => {},
 } ) => {
 	useEffect( () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events
-				.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_VIEW
+		recordEvent(
+			events.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_VIEW
 		);
 	}, [] );
 
@@ -57,9 +55,8 @@ const SubscriptionProductOnboardingModalContent = ( {
 		<Modal
 			className="wcpay-subscription-product-modal"
 			onRequestClose={ () => {
-				wcpayTracks.recordEvent(
-					wcpayTracks.events
-						.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_DISMISS
+				recordEvent(
+					events.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_DISMISS
 				);
 				onRequestClose();
 			} }

--- a/client/subscriptions-empty-state/index.js
+++ b/client/subscriptions-empty-state/index.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement, render, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 
-import wcpayTracks from '../tracks';
+import { recordEvent, events } from '../tracks';
 import UnconnectedImage from 'assets/images/subscriptions-empty-state-unconnected.svg?asset';
 
 import './style.scss';
@@ -64,9 +64,8 @@ const ActionButtons = () => {
 				isBusy={ isFinishingSetup }
 				isPrimary
 				onClick={ () => {
-					wcpayTracks.recordEvent(
-						wcpayTracks.events
-							.SUBSCRIPTIONS_EMPTY_STATE_FINISH_SETUP
+					recordEvent(
+						events.SUBSCRIPTIONS_EMPTY_STATE_FINISH_SETUP
 					);
 					setIsFinishingSetup( true );
 				} }
@@ -79,9 +78,8 @@ const ActionButtons = () => {
 				isBusy={ isCreatingProduct }
 				isSecondary
 				onClick={ () => {
-					wcpayTracks.recordEvent(
-						wcpayTracks.events
-							.SUBSCRIPTIONS_EMPTY_STATE_CREATE_PRODUCT
+					recordEvent(
+						events.SUBSCRIPTIONS_EMPTY_STATE_CREATE_PRODUCT
 					);
 					setIsCreatingProduct( true );
 				} }
@@ -108,12 +106,9 @@ const emptyStateContainer = document.querySelector(
 );
 
 if ( emptyStateContainer ) {
-	wcpayTracks.recordEvent(
-		wcpayTracks.events.SUBSCRIPTIONS_EMPTY_STATE_VIEW,
-		{
-			is_connected: isConnected ? 'yes' : 'no',
-		}
-	);
+	recordEvent( events.SUBSCRIPTIONS_EMPTY_STATE_VIEW, {
+		is_connected: isConnected ? 'yes' : 'no',
+	} );
 
 	if ( ! isConnected ) {
 		render( <EmptyState />, emptyStateContainer );

--- a/client/tos/request.js
+++ b/client/tos/request.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import wcpayTracks from 'tracks';
+import { isEnabled, recordEvent, events } from 'tracks';
 
 export const makeTosAcceptanceRequest = async ( { accept } ) =>
 	apiFetch( {
@@ -25,17 +25,14 @@ export const enableGatewayAfterTosDecline = async () =>
  */
 export const maybeTrackStripeConnected = async () => {
 	const trackStripeConnected = wcpay_tos_settings.trackStripeConnected;
-	if ( ! wcpayTracks.isEnabled() || ! trackStripeConnected ) {
+	if ( ! isEnabled() || ! trackStripeConnected ) {
 		return;
 	}
 
-	wcpayTracks.recordEvent(
-		wcpayTracks.events.CONNECT_ACCOUNT_STRIPE_CONNECTED,
-		{
-			is_existing_stripe_account:
-				trackStripeConnected.is_existing_stripe_account,
-		}
-	);
+	recordEvent( events.CONNECT_ACCOUNT_STRIPE_CONNECTED, {
+		is_existing_stripe_account:
+			trackStripeConnected.is_existing_stripe_account,
+	} );
 
 	apiFetch( {
 		path: '/wc/v3/payments/tos/stripe_track_connected',

--- a/client/tracks/events.ts
+++ b/client/tracks/events.ts
@@ -53,6 +53,16 @@ export default {
 	INBOX_ACTION_DISMISSED: 'wcpay_inbox_action_dismissed',
 	INBOX_ACTION_CLICK: 'wcpay_inbox_action_click',
 	INBOX_NOTE_VIEW: 'wcpay_inbox_note_view',
+	// Onboarding flow.
+	ONBOARDING_FLOW_STARTED: 'wcpay_onboarding_flow_started',
+	ONBOARDING_FLOW_MODE_SELECTED: 'wcpay_onboarding_flow_mode_selected',
+	ONBOARDING_FLOW_STEP_COMPLETED: 'wcpay_onboarding_flow_step_completed',
+	ONBOARDING_FLOW_HIDDEN: 'wcpay_onboarding_flow_hidden',
+	ONBOARDING_FLOW_EXITED: 'wcpay_onboarding_flow_exited',
+	ONBOARDING_FLOW_REDIRECTED: 'wcpay_onboarding_flow_redirected',
+	ONBOARDING_FLOW_RESET: 'wcpay_onboarding_flow_reset',
+	ONBOARDING_FLOW_ELIGIBILITY_MODAL_CLOSED:
+		'wcpay_onboarding_flow_eligibility_modal_closed',
 	OVERVIEW_BALANCES_CURRENCY_CLICK:
 		'wcpay_overview_balances_currency_tab_click',
 	OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK:
@@ -119,14 +129,4 @@ export default {
 	WOOPAY_SAVE_MY_INFO_TOOLTIP_CLICK: 'checkout_save_my_info_tooltip_click',
 	WOOPAY_SAVE_MY_INFO_TOOLTIP_LEARN_MORE_CLICK:
 		'checkout_save_my_info_tooltip_learn_more_click',
-	// Onboarding flow.
-	ONBOARDING_FLOW_STARTED: 'wcpay_onboarding_flow_started',
-	ONBOARDING_FLOW_MODE_SELECTED: 'wcpay_onboarding_flow_mode_selected',
-	ONBOARDING_FLOW_STEP_COMPLETED: 'wcpay_onboarding_flow_step_completed',
-	ONBOARDING_FLOW_HIDDEN: 'wcpay_onboarding_flow_hidden',
-	ONBOARDING_FLOW_EXITED: 'wcpay_onboarding_flow_exited',
-	ONBOARDING_FLOW_REDIRECTED: 'wcpay_onboarding_flow_redirected',
-	ONBOARDING_FLOW_RESET: 'wcpay_onboarding_flow_reset',
-	ONBOARDING_FLOW_ELIGIBILITY_MODAL_CLOSED:
-		'wcpay_onboarding_flow_eligibility_modal_closed',
 };

--- a/client/tracks/events.ts
+++ b/client/tracks/events.ts
@@ -1,65 +1,4 @@
-/**
- * External dependencies
- */
-import domReady from '@wordpress/dom-ready';
-import { getConfig } from 'wcpay/utils/checkout';
-import { getPaymentRequestData } from 'wcpay/payment-request/utils';
-
-/**
- * Checks if site tracking is enabled.
- *
- * @return {boolean} True if site tracking is enabled.
- */
-function isEnabled() {
-	return window.wcTracks.isEnabled;
-}
-
-/**
- * Records site event.
- *
- * @param {string}  eventName        Name of the event.
- * @param {Object} [eventProperties] Event properties (optional).
- */
-function recordEvent( eventName, eventProperties = {} ) {
-	// Add `is_test_mode` property to every event.
-	eventProperties.is_test_mode = window.wcpaySettings?.testMode;
-
-	// Wc-admin track script is enqueued after ours, wrap in domReady
-	// to make sure we're not too early.
-	domReady( () => {
-		const recordFunction =
-			window.wc?.tracks?.recordEvent ?? window.wcTracks.recordEvent;
-		recordFunction( eventName, eventProperties );
-	} );
-}
-
-/**
- * Records events from buyers (aka shoppers).
- *
- * @param {string}  eventName         Name of the event.
- * @param {Object}  [eventProperties] Event properties (optional).
- * @param {boolean} isLegacy Event properties (optional).
- */
-function recordUserEvent( eventName, eventProperties, isLegacy = false ) {
-	const nonce =
-		getConfig( 'platformTrackerNonce' ) ??
-		getPaymentRequestData( 'nonce' )?.platform_tracker;
-	const ajaxUrl =
-		getConfig( 'ajaxUrl' ) ?? getPaymentRequestData( 'ajax_url' );
-	const body = new FormData();
-
-	body.append( 'tracksNonce', nonce );
-	body.append( 'action', 'platform_tracks' );
-	body.append( 'tracksEventName', eventName );
-	body.append( 'tracksEventProp', JSON.stringify( eventProperties ) );
-	body.append( 'isLegacy', isLegacy );
-	fetch( ajaxUrl, {
-		method: 'post',
-		body,
-	} );
-}
-
-const events = {
+export default {
 	APPLEPAY_BUTTON_CLICK: 'applepay_button_click',
 	APPLEPAY_BUTTON_LOAD: 'applepay_button_load',
 	CONNECT_ACCOUNT_CLICKED: 'wcpay_connect_account_clicked',
@@ -72,12 +11,48 @@ const events = {
 	DISPUTES_ROW_ACTION_CLICK: 'wcpay_disputes_row_action_click',
 	DISPUTE_CHALLENGE_CLICKED: 'wcpay_dispute_challenge_clicked',
 	DISPUTE_ACCEPT_CLICK: 'wcpay_dispute_accept_click',
+	DISPUTE_DOWNLOAD_CSV_CLICK: 'wcpay_disputes_download',
 	DISPUTE_ACCEPT_MODAL_VIEW: 'wcpay_dispute_accept_modal_view',
+	DISPUTE_PRODUCT_SELECTED: 'wcpay_dispute_product_selected',
 	DISPUTE_INQUIRY_REFUND_CLICK: 'wcpay_dispute_inquiry_refund_click',
+	DISPUTE_SUBMIT_EVIDENCE_CLICK: 'wcpay_dispute_submit_evidence_clicked',
+	DISPUTE_SAVE_EVIDENCE_CLICK: 'wcpay_dispute_save_evidence_clicked',
+	DISPUTE_SUBMIT_EVIDENCE_SUCCESS: 'wcpay_dispute_submit_evidence_success',
+	DISPUTE_SAVE_EVIDENCE_SUCCESS: 'wcpay_dispute_save_evidence_success',
+	DISPUTE_SUBMIT_EVIDENCE_FAILED: 'wcpay_dispute_submit_evidence_failed',
+	DISPUTE_SAVE_EVIDENCE_FAILED: 'wcpay_dispute_save_evidence_failed',
 	DISPUTE_INQUIRY_REFUND_MODAL_VIEW:
 		'wcpay_dispute_inquiry_refund_modal_view',
+	DISPUTE_NOTICE_VIEW: 'wcpay_order_dispute_notice_view',
+	DISPUTE_NOTICE_CLICK: 'wcpay_order_dispute_notice_action_click',
+	DISPUTE_FILE_UPLOAD_STARTED: 'wcpay_dispute_file_upload_started',
+	DISPUTE_FILE_UPLOAD_SUCCESS: 'wcpay_dispute_file_upload_success',
+	DISPUTE_FILE_UPLOAD_FAILED: 'wcpay_dispute_file_upload_failed',
+	FRAUD_PROTECTION_BANNER_RENDERED: 'wcpay_fraud_protection_banner_rendered',
+	FRAUD_PROTECTION_BANNER_LEARN_MORE_CLICKED:
+		'wcpay_fraud_protection_banner_learn_more_button_clicked',
+	FRAUD_PROTECTION_ORDER_DETAILS_LINK_CLICKED:
+		'wcpay_fraud_protection_order_details_link_clicked',
+	FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_APPROVED:
+		'wcpay_fraud_protection_transaction_reviewed_merchant_approved',
+	FRAUD_PROTECTION_TRANSACTION_REVIEWED_MERCHANT_BLOCKED:
+		'wcpay_fraud_protection_transaction_reviewed_merchant_blocked',
+	FRAUD_PROTECTION_ADVANCED_SETTINGS_SAVED:
+		'wcpay_fraud_protection_advanced_settings_saved',
+	FRAUD_PROTECTION_RISK_LEVEL_PRESET_ENABLED:
+		'wcpay_fraud_protection_risk_level_preset_enabled',
+	FRAUD_PROTECTION_BASIC_MODAL_VIEWED:
+		'wcpay_fraud_protection_basic_modal_viewed',
+	FRAUD_PROTECTION_TOUR_CLICKED_THROUGH:
+		'wcpay_fraud_protection_tour_clicked_through',
+	FRAUD_PROTECTION_TOUR_ABANDONED: 'wcpay_fraud_protection_tour_abandoned',
+	FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD:
+		'wcpay_fraud_outcome_transactions_download',
 	GOOGLEPAY_BUTTON_CLICK: 'gpay_button_click',
 	GOOGLEPAY_BUTTON_LOAD: 'gpay_button_load',
+	INBOX_ACTION_DISMISSED: 'wcpay_inbox_action_dismissed',
+	INBOX_ACTION_CLICK: 'wcpay_inbox_action_click',
+	INBOX_NOTE_VIEW: 'wcpay_inbox_note_view',
 	OVERVIEW_BALANCES_CURRENCY_CLICK:
 		'wcpay_overview_balances_currency_tab_click',
 	OVERVIEW_DEPOSITS_VIEW_HISTORY_CLICK:
@@ -89,8 +64,12 @@ const events = {
 		'wcpay_view_submitted_evidence_clicked',
 	SETTINGS_DEPOSITS_MANAGE_IN_STRIPE_CLICK:
 		'wcpay_settings_deposits_manage_in_stripe_click',
+	SETTINGS_FILE_UPLOAD_STARTED: 'wcpay_merchant_settings_file_upload_started',
+	SETTINGS_FILE_UPLOAD_SUCCESS: 'wcpay_merchant_settings_file_upload_success',
+	SETTINGS_FILE_UPLOAD_FAILED: 'wcpay_merchant_settings_upload_failed',
 	MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED:
 		'wcpay_multi_currency_enabled_currencies_updated',
+	PAGE_VIEW: 'page_view',
 	PAYMENT_REQUEST_SETTINGS_CHANGE: 'wcpay_payment_request_settings_change',
 	PLACE_ORDER_CLICK: 'checkout_place_order_button_click',
 	// WCPay Subscriptions empty state - prompts to connect to WCPay or create product.
@@ -107,6 +86,22 @@ const events = {
 	SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_DISMISS:
 		'wcpay_subscriptions_account_not_connected_product_modal_dismiss',
 	TRANSACTIONS_DOWNLOAD_CSV_CLICK: 'wcpay_transactions_download_csv_click',
+	TRANSACTIONS_DETAILS_REFUND_MODAL_CLOSE:
+		'payments_transactions_details_refund_modal_close',
+	TRANSACTIONS_DETAILS_REFUND_MODAL_OPEN:
+		'payments_transactions_details_refund_modal_open',
+	TRANSACTIONS_DETAILS_CAPTURE_CHARGE_BUTTON_CLICK:
+		'payments_transactions_details_capture_charge_button_click',
+	TRANSACTIONS_DETAILS_CANCEL_CHARGE_BUTTON_CLICK:
+		'payments_transactions_details_cancel_charge_button_click',
+	TRANSACTION_DETAILS_PARTIAL_REFUND:
+		'payments_transactions_details_partial_refund',
+	TRANSACTIONS_DETAILS_REFUND_FULL:
+		'payments_transactions_details_refund_full',
+	TRANSACTIONS_RISK_REVIEW_LIST_REVIEW_BUTTON_CLICK:
+		'payments_transactions_risk_review_list_review_button_click',
+	TRANSACTIONS_UNCAPTURED_LIST_CAPTURE_CHARGE_BUTTON_CLICK:
+		'payments_transactions_uncaptured_list_capture_charge_button_click',
 	WOOPAY_EMAIL_CHECK: 'checkout_email_address_woopay_check',
 	WOOPAY_OFFERED: 'checkout_woopay_save_my_info_offered',
 	WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
@@ -134,11 +129,4 @@ const events = {
 	ONBOARDING_FLOW_RESET: 'wcpay_onboarding_flow_reset',
 	ONBOARDING_FLOW_ELIGIBILITY_MODAL_CLOSED:
 		'wcpay_onboarding_flow_eligibility_modal_closed',
-};
-
-export default {
-	isEnabled,
-	recordEvent,
-	recordUserEvent,
-	events,
 };

--- a/client/tracks/index.ts
+++ b/client/tracks/index.ts
@@ -10,33 +10,12 @@ import { getPaymentRequestData } from 'wcpay/payment-request/utils';
  */
 import events from './events';
 
-declare const window: {
-	wc: {
-		tracks: {
-			recordEvent: (
-				eventName: string,
-				eventProperties: Record< string, unknown >
-			) => void;
-		};
-	};
-	wcTracks: {
-		isEnabled: boolean;
-		recordEvent: (
-			eventName: string,
-			eventProperties: Record< string, unknown >
-		) => void;
-	};
-	wcpaySettings: {
-		testMode: boolean;
-	};
-} & Window;
-
 /**
  * Checks if site tracking is enabled.
  *
  * @return {boolean} True if site tracking is enabled.
  */
-export const isEnabled = (): boolean => window.wcTracks.isEnabled;
+export const isEnabled = (): boolean => wcTracks.isEnabled;
 
 /**
  * Records site event.
@@ -49,13 +28,12 @@ export const recordEvent = (
 	eventProperties: Record< string, unknown > = {}
 ): void => {
 	// Add `is_test_mode` property to every event.
-	eventProperties.is_test_mode = window.wcpaySettings?.testMode;
+	eventProperties.is_test_mode = wcpaySettings?.testMode;
 
 	// Wc-admin track script is enqueued after ours, wrap in domReady
 	// to make sure we're not too early.
 	domReady( () => {
-		const recordFunction =
-			window.wc?.tracks?.recordEvent ?? window.wcTracks.recordEvent;
+		const recordFunction = wc?.tracks?.recordEvent ?? wcTracks.recordEvent;
 		recordFunction( eventName, eventProperties );
 	} );
 };

--- a/client/tracks/index.ts
+++ b/client/tracks/index.ts
@@ -36,7 +36,7 @@ declare const window: {
  *
  * @return {boolean} True if site tracking is enabled.
  */
-const isEnabled = (): boolean => window.wcTracks.isEnabled;
+export const isEnabled = (): boolean => window.wcTracks.isEnabled;
 
 /**
  * Records site event.
@@ -44,7 +44,7 @@ const isEnabled = (): boolean => window.wcTracks.isEnabled;
  * @param {string}  eventName        Name of the event.
  * @param {Object} [eventProperties] Event properties (optional).
  */
-const recordEvent = (
+export const recordEvent = (
 	eventName: string,
 	eventProperties: Record< string, unknown > = {}
 ): void => {
@@ -67,7 +67,7 @@ const recordEvent = (
  * @param {Object}  [eventProperties] Event properties (optional).
  * @param {boolean} isLegacy Event properties (optional).
  */
-const recordUserEvent = (
+export const recordUserEvent = (
 	eventName: string,
 	eventProperties: Record< string, unknown > = {},
 	isLegacy = false
@@ -90,9 +90,4 @@ const recordUserEvent = (
 	} );
 };
 
-export default {
-	isEnabled,
-	recordEvent,
-	recordUserEvent,
-	events,
-};
+export { events };

--- a/client/tracks/index.ts
+++ b/client/tracks/index.ts
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { getConfig } from 'wcpay/utils/checkout';
+import { getPaymentRequestData } from 'wcpay/payment-request/utils';
+
+/**
+ * Internal dependencies
+ */
+import events from './events';
+
+declare const window: {
+	wc: {
+		tracks: {
+			recordEvent: (
+				eventName: string,
+				eventProperties: Record< string, unknown >
+			) => void;
+		};
+	};
+	wcTracks: {
+		isEnabled: boolean;
+		recordEvent: (
+			eventName: string,
+			eventProperties: Record< string, unknown >
+		) => void;
+	};
+	wcpaySettings: {
+		testMode: boolean;
+	};
+} & Window;
+
+/**
+ * Checks if site tracking is enabled.
+ *
+ * @return {boolean} True if site tracking is enabled.
+ */
+const isEnabled = (): boolean => window.wcTracks.isEnabled;
+
+/**
+ * Records site event.
+ *
+ * @param {string}  eventName        Name of the event.
+ * @param {Object} [eventProperties] Event properties (optional).
+ */
+const recordEvent = (
+	eventName: string,
+	eventProperties: Record< string, unknown > = {}
+): void => {
+	// Add `is_test_mode` property to every event.
+	eventProperties.is_test_mode = window.wcpaySettings?.testMode;
+
+	// Wc-admin track script is enqueued after ours, wrap in domReady
+	// to make sure we're not too early.
+	domReady( () => {
+		const recordFunction =
+			window.wc?.tracks?.recordEvent ?? window.wcTracks.recordEvent;
+		recordFunction( eventName, eventProperties );
+	} );
+};
+
+/**
+ * Records events from buyers (aka shoppers).
+ *
+ * @param {string}  eventName         Name of the event.
+ * @param {Object}  [eventProperties] Event properties (optional).
+ * @param {boolean} isLegacy Event properties (optional).
+ */
+const recordUserEvent = (
+	eventName: string,
+	eventProperties: Record< string, unknown > = {},
+	isLegacy = false
+): void => {
+	const nonce =
+		getConfig( 'platformTrackerNonce' ) ??
+		getPaymentRequestData( 'nonce' )?.platform_tracker;
+	const ajaxUrl =
+		getConfig( 'ajaxUrl' ) ?? getPaymentRequestData( 'ajax_url' );
+	const body = new FormData();
+
+	body.append( 'tracksNonce', nonce );
+	body.append( 'action', 'platform_tracks' );
+	body.append( 'tracksEventName', eventName );
+	body.append( 'tracksEventProp', JSON.stringify( eventProperties ) );
+	body.append( 'isLegacy', JSON.stringify( isLegacy ) ); // formData does not allow appending booleans, so we stringify it - it is parsed back to a boolean on the PHP side.
+	fetch( ajaxUrl, {
+		method: 'post',
+		body,
+	} );
+};
+
+export default {
+	isEnabled,
+	recordEvent,
+	recordUserEvent,
+	events,
+};

--- a/client/transactions/blocked/index.tsx
+++ b/client/transactions/blocked/index.tsx
@@ -91,7 +91,7 @@ export const BlockedList = (): JSX.Element => {
 	}
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( 'page_view', {
+		wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
 			path: 'payments_transactions_blocked',
 		} );
 	}, [] );
@@ -146,7 +146,7 @@ export const BlockedList = (): JSX.Element => {
 			);
 
 			wcpayTracks.recordEvent(
-				'wcpay_fraud_outcome_transactions_download',
+				wcpayTracks.events.FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD,
 				{
 					exported_transactions: rows.length,
 					total_transactions: transactionsSummary.count,

--- a/client/transactions/blocked/index.tsx
+++ b/client/transactions/blocked/index.tsx
@@ -29,7 +29,7 @@ import {
 	useFraudOutcomeTransactionsSummary,
 } from 'data/index';
 import Page from '../../components/page';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import {
 	getBlockedListColumns,
 	getBlockedListColumnsStructure,
@@ -91,7 +91,7 @@ export const BlockedList = (): JSX.Element => {
 	}
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
+		recordEvent( events.PAGE_VIEW, {
 			path: 'payments_transactions_blocked',
 		} );
 	}, [] );
@@ -145,13 +145,10 @@ export const BlockedList = (): JSX.Element => {
 				generateCSVDataFromTable( columnsToDisplay, populatedRows )
 			);
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD,
-				{
-					exported_transactions: rows.length,
-					total_transactions: transactionsSummary.count,
-				}
-			);
+			recordEvent( events.FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD, {
+				exported_transactions: rows.length,
+				total_transactions: transactionsSummary.count,
+			} );
 		} catch ( e ) {
 			createNotice(
 				'error',

--- a/client/transactions/filters/index.tsx
+++ b/client/transactions/filters/index.tsx
@@ -11,7 +11,7 @@ import { getQuery } from '@woocommerce/navigation';
 import { getFilters, getAdvancedFilters } from './config';
 import { formatCurrencyName } from '../../utils/currency';
 import './style.scss';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 
 interface TransactionsFiltersProps {
 	storeCurrencies: string[];
@@ -56,7 +56,7 @@ export const TransactionsFilters = ( {
 				query={ getQuery() }
 				onAdvancedFilterAction={ ( event ) => {
 					if ( event === 'filter' ) {
-						wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
+						recordEvent( events.PAGE_VIEW, {
 							path: 'payments_transactions',
 							filter: 'advanced',
 						} );

--- a/client/transactions/filters/index.tsx
+++ b/client/transactions/filters/index.tsx
@@ -56,7 +56,7 @@ export const TransactionsFilters = ( {
 				query={ getQuery() }
 				onAdvancedFilterAction={ ( event ) => {
 					if ( event === 'filter' ) {
-						wcpayTracks.recordEvent( 'page_view', {
+						wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
 							path: 'payments_transactions',
 							filter: 'advanced',
 						} );

--- a/client/transactions/filters/test/index.tsx
+++ b/client/transactions/filters/test/index.tsx
@@ -19,6 +19,13 @@ jest.mock( '@woocommerce/settings', () => ( {
 	getSetting: jest.fn( ( key ) => ( key === 'wcVersion' ? 7.7 : '' ) ),
 } ) );
 
+jest.mock( 'tracks', () => ( {
+	recordEvent: jest.fn(),
+	events: {
+		PAGE_VIEW: 'page_view',
+	},
+} ) );
+
 function addAdvancedFilter( filter: string ) {
 	user.click( screen.getByRole( 'button', { name: /Add a Filter/i } ) );
 	user.click( screen.getByRole( 'button', { name: filter } ) );

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -52,7 +52,7 @@ import autocompleter from 'transactions/autocompleter';
 import './style.scss';
 import TransactionsFilters from '../filters';
 import Page from '../../components/page';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import DownloadButton from 'components/download-button';
 import { getTransactionsCSV } from '../../data/transactions/resolvers';
 import p24BankList from '../../payment-details/payment-method/p24/bank-list';
@@ -595,15 +595,12 @@ export const TransactionsList = (
 		const downloadType = totalRows > rows.length ? 'endpoint' : 'browser';
 		const userEmail = wcpaySettings.currentUserEmail;
 
-		wcpayTracks.recordEvent(
-			wcpayTracks.events.TRANSACTIONS_DOWNLOAD_CSV_CLICK,
-			{
-				location: props.depositId ? 'deposit_details' : 'transactions',
-				download_type: downloadType,
-				exported_transactions: rows.length,
-				total_transactions: transactionsSummary.count,
-			}
-		);
+		recordEvent( events.TRANSACTIONS_DOWNLOAD_CSV_CLICK, {
+			location: props.depositId ? 'deposit_details' : 'transactions',
+			download_type: downloadType,
+			exported_transactions: rows.length,
+			total_transactions: transactionsSummary.count,
+		} );
 
 		if ( 'endpoint' === downloadType ) {
 			const {

--- a/client/transactions/risk-review/columns.tsx
+++ b/client/transactions/risk-review/columns.tsx
@@ -87,7 +87,8 @@ export const getRiskReviewListRowContent = (
 
 	const handleActionButtonClick = () => {
 		wcpayTracks.recordEvent(
-			'payments_transactions_risk_review_list_review_button_click',
+			wcpayTracks.events
+				.TRANSACTIONS_RISK_REVIEW_LIST_REVIEW_BUTTON_CLICK,
 			{
 				payment_intent_id: data.payment_intent.id,
 			}

--- a/client/transactions/risk-review/columns.tsx
+++ b/client/transactions/risk-review/columns.tsx
@@ -14,7 +14,7 @@ import { Button } from '@wordpress/components';
 import { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 import { formatExplicitCurrency } from 'utils/currency';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import TransactionStatusChip from 'components/transaction-status-chip';
 import { FraudOutcomeTransaction } from '../../data';
 
@@ -86,13 +86,9 @@ export const getRiskReviewListRowContent = (
 	);
 
 	const handleActionButtonClick = () => {
-		wcpayTracks.recordEvent(
-			wcpayTracks.events
-				.TRANSACTIONS_RISK_REVIEW_LIST_REVIEW_BUTTON_CLICK,
-			{
-				payment_intent_id: data.payment_intent.id,
-			}
-		);
+		recordEvent( events.TRANSACTIONS_RISK_REVIEW_LIST_REVIEW_BUTTON_CLICK, {
+			payment_intent_id: data.payment_intent.id,
+		} );
 	};
 
 	return {

--- a/client/transactions/risk-review/index.tsx
+++ b/client/transactions/risk-review/index.tsx
@@ -140,7 +140,7 @@ export const RiskReviewList = (): JSX.Element => {
 			);
 
 			wcpayTracks.recordEvent(
-				'wcpay_fraud_outcome_transactions_download',
+				wcpayTracks.events.FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD,
 				{
 					exported_transactions: rows.length,
 					total_transactions: transactionsSummary.count,
@@ -160,7 +160,7 @@ export const RiskReviewList = (): JSX.Element => {
 	};
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( 'page_view', {
+		wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
 			path: 'payments_transactions_risk_review',
 		} );
 	}, [] );

--- a/client/transactions/risk-review/index.tsx
+++ b/client/transactions/risk-review/index.tsx
@@ -29,7 +29,7 @@ import {
 	useFraudOutcomeTransactionsSummary,
 } from 'data/index';
 import Page from '../../components/page';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import {
 	getRiskReviewListColumns,
 	getRiskReviewListColumnsStructure,
@@ -139,13 +139,10 @@ export const RiskReviewList = (): JSX.Element => {
 				generateCSVDataFromTable( columnsToDisplay, populatedRows )
 			);
 
-			wcpayTracks.recordEvent(
-				wcpayTracks.events.FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD,
-				{
-					exported_transactions: rows.length,
-					total_transactions: transactionsSummary.count,
-				}
-			);
+			recordEvent( events.FRAUD_OUTCOME_TRANSACTIONS_DOWNLOAD, {
+				exported_transactions: rows.length,
+				total_transactions: transactionsSummary.count,
+			} );
 		} catch ( e ) {
 			createNotice(
 				'error',
@@ -160,7 +157,7 @@ export const RiskReviewList = (): JSX.Element => {
 	};
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
+		recordEvent( events.PAGE_VIEW, {
 			path: 'payments_transactions_risk_review',
 		} );
 	}, [] );

--- a/client/transactions/uncaptured/index.tsx
+++ b/client/transactions/uncaptured/index.tsx
@@ -194,7 +194,8 @@ export const AuthorizationsList = (): JSX.Element => {
 						buttonIsSmall={ false }
 						onClick={ () => {
 							wcpayTracks.recordEvent(
-								'payments_transactions_uncaptured_list_capture_charge_button_click',
+								wcpayTracks.events
+									.TRANSACTIONS_UNCAPTURED_LIST_CAPTURE_CHARGE_BUTTON_CLICK,
 								{
 									payment_intent_id: auth.payment_intent_id,
 								}
@@ -249,7 +250,7 @@ export const AuthorizationsList = (): JSX.Element => {
 	}
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( 'page_view', {
+		wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
 			path: 'payments_transactions_uncaptured',
 		} );
 	}, [] );

--- a/client/transactions/uncaptured/index.tsx
+++ b/client/transactions/uncaptured/index.tsx
@@ -19,7 +19,7 @@ import { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 import { formatExplicitCurrency } from 'utils/currency';
 import RiskLevel, { calculateRiskMapping } from 'components/risk-level';
-import wcpayTracks from 'tracks';
+import { recordEvent, events } from 'tracks';
 import CaptureAuthorizationButton from 'wcpay/components/capture-authorization-button';
 
 interface Column extends TableCardColumn {
@@ -193,9 +193,8 @@ export const AuthorizationsList = (): JSX.Element => {
 						paymentIntentId={ auth.payment_intent_id }
 						buttonIsSmall={ false }
 						onClick={ () => {
-							wcpayTracks.recordEvent(
-								wcpayTracks.events
-									.TRANSACTIONS_UNCAPTURED_LIST_CAPTURE_CHARGE_BUTTON_CLICK,
+							recordEvent(
+								events.TRANSACTIONS_UNCAPTURED_LIST_CAPTURE_CHARGE_BUTTON_CLICK,
 								{
 									payment_intent_id: auth.payment_intent_id,
 								}
@@ -250,7 +249,7 @@ export const AuthorizationsList = (): JSX.Element => {
 	}
 
 	useEffect( () => {
-		wcpayTracks.recordEvent( wcpayTracks.events.PAGE_VIEW, {
+		recordEvent( events.PAGE_VIEW, {
 			path: 'payments_transactions_uncaptured',
 		} );
 	}, [] );


### PR DESCRIPTION
Fixes #8075 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This is mainly a tech debt PR, introducing `.ts` on the tracking files and setting up a file to store the event names.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm run watch`.

Instructions borrowed from #6128:

> To check that Tracks events are properly registered, you can use one of the following methods:
> - Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );` on your site browser console. And look for `verbose` logs.
> - Install [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) browser extension and use its log of events.
> - Go to [Tracks Live view](https://mc.a8c.com/tracks/live/), filter by any of the allowed methods, and wait patiently (~10min) for events to be registered there.
> 
> Go through the onboarding process ensuring every new track event gets registered accordingly. Apart from the description you can see [a table with screenshots here](https://docs.google.com/document/d/1XXPpXJtYPKkmOQxD43el8Mk6JTuw1IGG1SskKOvgYHE/edit).

For this PR, the desired effect is that nothing has changed - so a good way to test is to go through the onboarding flow and ensure the events are being recorded as expected - for example, we should see the following events when onboarding an account:

* `wcpay_onboarding_flow_started`
* `wcpay_onboarding_flow_mode_selected`
* `wcpay_onboarding_flow_step_completed` (for each step of the onboarding)
* `wcpay_onboarding_flow_redirected` (on Stripe redirect)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
