### PR TITLE
Fix console error on customizer page

### DIFF
--- a/changelog/fix-4836-console-error-on-customize-page-fix
+++ b/changelog/fix-4836-console-error-on-customize-page-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed console error on customize page

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -11,7 +11,9 @@ import { getPaymentRequestData } from 'wcpay/payment-request/utils';
  * @return {boolean} True if site tracking is enabled.
  */
 function isEnabled() {
-	return window.wcTracks.isEnabled;
+	return window.wcTracks && window.wcTracks.isEnabled
+		? window.wcTracks.isEnabled
+		: false;
 }
 
 /**


### PR DESCRIPTION
Fixes #4836

#### Changes proposed in this Pull Request

This PR addresses and resolves a console error encountered upon opening the customize page. The solution involves verifying the existence of the `window.wcTracks `variable before proceeding with its use.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Open the browser dev tools.
- Go to WP Admin > Appearance > Customize.
- You should NOT see a JS exception: TypeError: Cannot read properties of undefined (reading 'isEnabled').

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
