### PR TITLE
Update WPORG plugin title

### DIFF
--- a/changelog/update-8099-change-plugin-title-for-wporg-seo
+++ b/changelog/update-8099-change-plugin-title-for-wporg-seo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: We just changed the plugin title as displayed on WPORG.
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WooPayments - Fully Integrated Solution Built and Supported by Woo ===
+=== WooPayments: Integrated WooCommerce Payments ===
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0


### PR DESCRIPTION
Fixes #8099 

#### Changes proposed in this Pull Request

We change the WPORG plugin title from "WooPayments – Fully Integrated Solution Built and Supported by Woo" to "WooPayments: Integrated WooCommerce Payments".

#### Testing instructions

* Changes make sense

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
