### PR TITLE
Do not open the email input iframe when there is no wcpay as payment method

### DIFF
--- a/changelog/fix-encode-order-endpoint-params
+++ b/changelog/fix-encode-order-endpoint-params
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Encode the order endpoint params

--- a/changelog/fix-open-email-input-iframe-when-no-wcpay
+++ b/changelog/fix-open-email-input-iframe-when-no-wcpay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not open the email input iframe without wcpay payment method

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -11,6 +11,7 @@ import {
 	validateEmail,
 	appendRedirectionParams,
 } from './utils';
+import { select } from '@wordpress/data';
 
 export const handleWooPayEmailInput = async (
 	field,
@@ -608,11 +609,16 @@ export const handleWooPayEmailInput = async (
 	} );
 
 	if ( ! customerClickedBackButton ) {
-		// Check if user already has a WooPay login session.
-		if (
-			! hasCheckedLoginSession &&
-			! getConfig( 'isWooPayDirectCheckoutEnabled' )
-		) {
+		const paymentMethods = await select(
+			'wc/store/payment'
+		).getAvailablePaymentMethods();
+
+		const hasWCPayPaymentMethod = paymentMethods.hasOwnProperty(
+			'woocommerce_payments'
+		);
+
+		// Check if user already has a WooPay login session and only open the iframe if there is WCPay.
+		if ( ! hasCheckedLoginSession && hasWCPayPaymentMethod ) {
 			openLoginSessionIframe( woopayEmailInput.value );
 		}
 	} else {

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -408,7 +408,7 @@ class WooPay_Session {
 		// This uses the same logic as the Checkout block in hydrate_from_api to get the cart and checkout data.
 		$cart_data = ! $is_pay_for_order
 			? rest_preload_api_request( [], '/wc/store/v1/cart' )['/wc/store/v1/cart']['body']
-			: rest_preload_api_request( [], "/wc/store/v1/order/" . urlencode( $order_id ) . "?key=" . urlencode( $key ) . "&billing_email=" . urlencode( $billing_email ) )[ "/wc/store/v1/order/" . urlencode( $order_id ) . "?key=" . urlencode( $key ) . "&billing_email=" . urlencode( $billing_email ) ]['body'];
+			: rest_preload_api_request( [], "/wc/store/v1/order/{$order_id}?key={$key}&billing_email={$billing_email}" )[ "/wc/store/v1/order/{$order_id}?key={$key}&billing_email={$billing_email}" ]['body'];
 		add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 		$preloaded_checkout_data = rest_preload_api_request( [], '/wc/store/v1/checkout' );
 		remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );


### PR DESCRIPTION
Fixes #7684 
Fixes #8053 

#### Changes proposed in this Pull Request
In this PR, we check the available payment methods on the checkout page.  If there's no `woocommerce-payments`, we don't open the login session iframe.

#### Videos
https://github.com/Automattic/woocommerce-payments/assets/56378160/2bbdee20-6060-4341-88a4-b8bc60f73505

https://github.com/Automattic/woocommerce-payments/assets/56378160/712f0ff0-57ef-49ff-bf1d-994eed288358

https://github.com/Automattic/woocommerce-payments/assets/56378160/78e99e5d-1dc3-4195-89c7-6669da36b97f

https://github.com/Automattic/woocommerce-payments/assets/56378160/2eebfad0-0a90-49e2-b131-5b308685146b

#### Testing instructions
*Test with WooCommerce Bookings*
1. Install and activate the WC Bookings plugin
2. Check the "Requires confirmation?" box
3. Use an existing WooPay shopper email on the checkout page
4. The login session iframe should not be opened

*Test with WooCommerce Pre-Orders*
1. Install and activate the WC Pre-Orders plugin
2. Under the product data meta -> Pre-orders, select when to charge to `Upon release`
3. Use an existing WooPay shopper email on the checkout page
4. The login session iframe should not be opened


*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
