### PR TITLE
Showing "started" event in transaction timeline

### DIFF
--- a/changelog/timeline-started-event
+++ b/changelog/timeline-started-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Showing "started" event in transaction timeline

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -605,6 +605,13 @@ const mapEventToTimelineItems = ( event ) => {
 		);
 
 	switch ( type ) {
+		case 'started':
+			return [
+				getStatusChangeTimelineItem(
+					event,
+					__( 'Started', 'woocommerce-payments' )
+				),
+			];
 		case 'authorized':
 			return [
 				getStatusChangeTimelineItem(


### PR DESCRIPTION
Related to Automattic/woocommerce-payments#7618

#### Changes proposed in this Pull Request

Currently, the server has been using the `authorized` event as initial state even if the payment has not been authorized. The `timeline-started-event` branch on server's repository creates a `started` event and fixes the authorized event to only be included when the payment is authorized.

This PR adds support to the `started` event.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/woocommerce-payments/assets/12385501/1e6ac767-76b2-4e49-9a73-143940fb5b07) | ![image](https://github.com/Automattic/woocommerce-payments/assets/12385501/958eb790-55c4-4db7-bf97-d492103b4324) |

#### Testing instructions

* When using the `timeline-started-event` branch on the server these changes should display the started state in the transactions page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
