### PR TITLE
fix: help text alignemnt with Gutenberg plugin

### DIFF
--- a/changelog/fix-radio-button-help-text
+++ b/changelog/fix-radio-button-help-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: help text alignment with Gutenberg plugin enabled

--- a/client/settings/card-body/styles.scss
+++ b/client/settings/card-body/styles.scss
@@ -40,6 +40,8 @@
 	// spacing in the "Express checkouts" settings page
 	.components-radio-control__option {
 		margin-bottom: 18px;
+		align-items: center;
+		display: flex;
 	}
 
 	.components-base-control__help {

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -336,14 +336,6 @@
 	}
 }
 
-.components-radio-control {
-	.payment-method-settings {
-		&__option-help-text {
-			margin-left: 26px;
-		}
-	}
-}
-
 .components-notice {
 	&__content {
 		display: flex;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8087

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The Gutenberg plugin can inject some CSS onto the page.
I ensured that the UI of the help text on radio buttons behaves consistently with or without the Gutenberg plugin.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=payment_request & http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=woopay
* The help text below the "Theme" options should be correctly aligned under the option's label
* Enable the Gutenberg plugin
* Go to http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=payment_request & http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=woopay
* The help text should remain aligned

Before - with Gutenberg enabled:
![Screenshot 2024-02-07 at 11 25 10 AM](https://github.com/Automattic/woocommerce-payments/assets/273592/834cdd66-5cc8-4a3d-bde2-768a5e690069)


After - with/without Gutenberg enabled:
![Screenshot 2024-02-07 at 11 23 59 AM](https://github.com/Automattic/woocommerce-payments/assets/273592/7f6cdf08-82b0-4d6d-a745-b23a4f3d1c72)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
