### PR TITLE
Format fee descriptions for iDeal payment method without percentage rate

### DIFF
--- a/changelog/fix-6531-display-zero-percentage-rate-in-fee-pill
+++ b/changelog/fix-6531-display-zero-percentage-rate-in-fee-pill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Format fee descriptions for iDeal payment method without percentage rate
+
+

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -258,14 +258,7 @@ export const formatAccountFeesDescription = (
 	accountFees: FeeStructure,
 	customFormats = {}
 ): string | JSX.Element => {
-	const defaultFee = {
-		fixed_rate: 0,
-		percentage_rate: 0,
-		currency: 'USD',
-	};
 	const baseFee = accountFees.base;
-	const additionalFee = accountFees.additional ?? defaultFee;
-	const fxFee = accountFees.fx ?? defaultFee;
 	const currentBaseFee = getCurrentBaseFee( accountFees );
 
 	// Default formats will be used if no matching field was passed in the `formats` parameter.
@@ -282,17 +275,9 @@ export const formatAccountFeesDescription = (
 		...customFormats,
 	};
 
-	// Some payment methods doesn't have base percentage rate. In this case, the lowest rate will be shown as a start value
-	let displayFeePercentageRate = baseFee.percentage_rate;
-	if ( displayFeePercentageRate <= 0 ) {
-		displayFeePercentageRate =
-			additionalFee.percentage_rate < fxFee.percentage_rate
-				? additionalFee.percentage_rate
-				: fxFee.percentage_rate;
-	}
 	const feeDescription = sprintf(
 		formats.fee,
-		formatFee( displayFeePercentageRate ),
+		formatFee( baseFee.percentage_rate ),
 		formatCurrency( baseFee.fixed_rate, baseFee.currency )
 	);
 	const isFormattingWithDiscount =


### PR DESCRIPTION
Fixes #6531 

#### Changes proposed in this Pull Request

Format fee descriptions for payment methods without percentage rate (right now, iDeal)

Related discussion https://github.com/Automattic/woocommerce-payments/pull/8044

#### Testing instructions

- Go to `payments` -> `settings`
- observe that pill for iDeal is `From 0% + $0.8`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
