### PR TITLE
Displaying the correct method name in Order Edit page for HPOS

### DIFF
--- a/changelog/fix-payment-method-name-hpos
+++ b/changelog/fix-payment-method-name-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Displaying the correct method name in Order Edit page for HPOS

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -409,13 +409,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @param string $id    Gateway ID.
 	 */
 	public function filter_gateway_title( $title, $id ) {
-		global $post;
-
-		if ( ! is_object( $post ) ) {
-			return $title;
-		}
-
-		$order        = wc_get_order( $post->ID );
+		$order        = $this->get_current_order();
 		$method_title = is_object( $order ) ? $order->get_payment_method_title() : '';
 
 		if ( 'woocommerce_payments' === $id && ! empty( $method_title ) ) {
@@ -429,6 +423,26 @@ class WC_Payments_Payment_Request_Button_Handler {
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Used to get the order in admin edit page.
+	 *
+	 * @return WC_Order|WC_Order_Refund|false
+	 */
+	private function get_current_order() {
+		global $theorder;
+		global $post;
+
+		if ( is_object( $theorder ) ) {
+			return $theorder;
+		}
+
+		if ( is_object( $post ) ) {
+			return wc_get_order( $post->ID );
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -428,7 +428,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	/**
 	 * Used to get the order in admin edit page.
 	 *
-	 * @return WC_Order|WC_Order_Refund|false
+	 * @return WC_Order|WC_Order_Refund|bool
 	 */
 	private function get_current_order() {
 		global $theorder;


### PR DESCRIPTION
Fixes #8095 
p1707328339815979-slack-C0E1AV8T0

#### Changes proposed in this Pull Request

This PR updates `filter_gateway_title` to support HPOS. It was using `global $post`, but in HPOS we need to use `global $theorder`.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make a payment using Apple Pay or Google Pay.
2. Enable HPOS in WooCommerce > Settings > Advanced > Features.
3. Check the order page and it should show the correct payment method name.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
