### PR TITLE
Fix WooPayments overriding a WooCommerce analytics style

### DIFF
--- a/changelog/fix-5622-wcpay-overriding-analytics-style
+++ b/changelog/fix-5622-wcpay-overriding-analytics-style
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent WooPayments overriding a WooCommerce analytics style
+
+

--- a/client/deposits/details/style.scss
+++ b/client/deposits/details/style.scss
@@ -69,4 +69,40 @@
 			padding: 24px;
 		}
 	}
+
+	/* WC SummaryNumber modifications: some margins, colors and hide of unused fields */
+	.woocommerce-summary {
+		.woocommerce-summary__item-label {
+			margin-bottom: 12px;
+		}
+		.woocommerce-summary__item-data {
+			margin-top: 0;
+			margin-bottom: 8px;
+		}
+		.wcpay-summary__item-detail {
+			color: $dark-gray-500;
+		}
+		/* Hide unused SummaryNumber fields */
+		.woocommerce-summary__item-prev-value,
+		.woocommerce-summary__item-delta {
+			display: none;
+		}
+		.woocommerce-summary__item {
+			background: $studio-white;
+			&:hover .woocommerce-summary__item-label {
+				color: $gray-700;
+			}
+		}
+		a.woocommerce-summary__item {
+			&:hover {
+				background-color: $studio-gray-0;
+				&:hover .woocommerce-summary__item-label {
+					color: var( --wp-admin-theme-color );
+				}
+			}
+			&:active {
+				background-color: $studio-gray-5;
+			}
+		}
+	}
 }

--- a/client/style.scss
+++ b/client/style.scss
@@ -58,42 +58,6 @@
 	}
 }
 
-/* SummaryNumber modifications: some margins, colors and hide of unused fields */
-.woocommerce-summary {
-	.woocommerce-summary__item-label {
-		margin-bottom: 12px;
-	}
-	.woocommerce-summary__item-data {
-		margin-top: 0;
-		margin-bottom: 8px;
-	}
-	.wcpay-summary__item-detail {
-		color: $dark-gray-500;
-	}
-	/* Hide unused SummaryNumber fields */
-	.woocommerce-summary__item-prev-value,
-	.woocommerce-summary__item-delta {
-		display: none;
-	}
-	.woocommerce-summary__item {
-		background: $studio-white;
-		&:hover .woocommerce-summary__item-label {
-			color: $gray-700;
-		}
-	}
-	a.woocommerce-summary__item {
-		&:hover {
-			background-color: $studio-gray-0;
-			&:hover .woocommerce-summary__item-label {
-				color: var( --wp-admin-theme-color );
-			}
-		}
-		&:active {
-			background-color: $studio-gray-5;
-		}
-	}
-}
-
 /**
  * This styling changes the appearance of warning notices to match our designs.
  * In particular it removes margins that aren't supposed to be present, and


### PR DESCRIPTION
Fixes #5622

#### Changes proposed in this Pull Request
Move `.woocommerce-summary` style overrides under `.wcpay-deposit-overview`, where it is used, to avoid modifying the component style globally.

#### Testing instructions
- Go to **Payments -> Deposits** and pick a deposit.
- Should match the attached screenshot.
- Go to **Analytics -> Orders**
- Should match the attached screenshot.

#### Screenshots
| Deposits | Analytics |
| - | - |
|<img width="1230" alt="Screenshot 2024-02-08 at 10 26 22" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/100f48e6-5730-49fb-a5ea-056b823a6f64">|<img width="1225" alt="Screenshot 2024-02-08 at 10 26 31" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/ac284a2f-0254-44ec-b119-69ba3f1eaa5d">|

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
