### PR TITLE
Skip the log file life extension unit test on WC after v8.6.0

### DIFF
--- a/changelog/fix-issue-8131
+++ b/changelog/fix-issue-8131
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixes a php unit test and so no customer facing
+
+

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-migration-log-handler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-migration-log-handler.php
@@ -72,6 +72,14 @@ class WC_Payments_Subscription_Migration_Log_Handler_Test extends WCPAY_UnitTest
 	 * Confirms that log files are not deleted by WC's log cleanup and that mock log files are deleted.
 	 */
 	public function test_extend_life_of_migration_file_logs() {
+
+		// WC 8.6 changed the way log files are cleaned up, this test which uses the `touch()` method is no longer valid.
+		if ( version_compare( WC_VERSION, '8.6.0', '>=' ) ) {
+			$this->markTestSkipped(
+				'This test only applies on WC versions prior to 8.6.0.'
+			);
+		}
+
 		$message = 'Test message 1234567890';
 
 		// Log messages - Log to the migration file and a dummy log.


### PR DESCRIPTION
Part of #8131 

#### Changes proposed in this Pull Request

This PR skips the test which is no longer valid on WC versions after 8.6.0. 

**Background**

Prior to version 8.6 of WooCommerce, log files were automatically deleted if they had be **modified** more than 30 days ago. In WooPayments, we used that behaviour to increase the life of files we wanted to live for longer than 30 days by calling `touch()` which updates a file's modified date. In WooCommerce 8.6, this is no longer the case as file are deleted based on the date in their name, not the modified date.

This change causes our unit test to fail and so in this PR I've made sure to skip that failing test on version of WC after 8.6. WooCommerce are working on an alternative approach that we can use (https://github.com/woocommerce/woocommerce/pull/44380). Once that PR has been approved, we can update our approach to use that new method.  

#### Testing instructions

* This PR just skips a test which is no longer applicable so no testing is required. The failing test should no longer fail.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
