### PR TITLE
Update Tracks conditions

### DIFF
--- a/changelog/fix-update-shopper-track-conditions
+++ b/changelog/fix-update-shopper-track-conditions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update Tracks conditions

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -200,7 +200,6 @@ class WC_Payments_Checkout {
 			'woopaySessionNonce'             => wp_create_nonce( 'woopay_session_nonce' ),
 			'woopayMerchantId'               => Jetpack_Options::get_option( 'id' ),
 			'icon'                           => $this->gateway->get_icon_url(),
-			'tracksUserIdentity'             => WC_Payments::woopay_tracker()->tracks_get_identity( get_current_user_id() ),
 		];
 
 		/**
@@ -230,6 +229,10 @@ class WC_Payments_Checkout {
 			}
 		}
 		$payment_fields['enabledBillingFields'] = $enabled_billing_fields;
+
+		if ( WC_Payments::woopay_tracker()->should_enable_tracking() ) {
+			$payment_fields['tracksUserIdentity'] = WC_Payments::woopay_tracker()->tracks_get_identity( get_current_user_id() );
+		}
 
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
 			if ( $this->gateway->is_subscriptions_enabled() && $this->gateway->is_changing_payment_method_for_subscription() ) {

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -61,7 +61,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->set_account_connected( true );
 		WC_Payments::set_account_service( $this->mock_account );
 		$this->set_is_woopay_eligible( false );
-		$this->assertFalse( $this->tracker->should_enable_tracking( null, null ) );
+		$this->assertFalse( $this->tracker->should_enable_tracking( null ) );
 	}
 
 	public function test_does_not_track_admin_pages() {
@@ -70,7 +70,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->set_account_connected( true );
 		WC_Payments::set_account_service( $this->mock_account );
 		$this->set_is_admin( true );
-		$this->assertFalse( $this->tracker->should_enable_tracking( null, null ) );
+		$this->assertFalse( $this->tracker->should_enable_tracking( null ) );
 	}
 
 	public function test_does_track_non_admins() {
@@ -87,7 +87,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 
 		foreach ( $all_roles as $role ) {
 			wp_get_current_user()->set_role( $role );
-			$this->assertTrue( $this->tracker->should_enable_tracking( null, null ) );
+			$this->assertTrue( $this->tracker->should_enable_tracking( null ) );
 		}
 	}
 
@@ -96,9 +96,8 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->set_is_woopay_eligible( true );
 		$this->set_account_connected( false );
 		WC_Payments::set_account_service( $this->mock_account );
-		$is_admin_event      = false;
-		$track_on_all_stores = true;
-		$this->assertFalse( $this->tracker->should_enable_tracking( $is_admin_event, $track_on_all_stores ) );
+		$is_admin_event = false;
+		$this->assertFalse( $this->tracker->should_enable_tracking( $is_admin_event ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR updates Tracks conditions so that Shopper-originated Tracks events are only tracked on US stores. 
Further, the `tracksUserIdentity` is only sent to the frontend when Tracks is enabled.

p2: p4H3ND-1EM-p2#comment-3548
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a breakpoint to [this line](https://github.com/Automattic/woocommerce-payments/blob/2432a795d25a00a39a7e3acf718784037a3e678c/includes/class-woopay-tracker.php#L275)
2. As an admin, go to WooCommerce -> Settings -> General, and update store country to US.
3. As an unauthenticated shopper, add a product to the cart and visit the checkout page.
4. Make sure the breakpoint is reached.
5. Open browser dev tools and make sure a `tk_ai` cookie is set.
6. As an admin, update the store country to a non US country
7. Open a new browser window and add a product to the cart and visit the checkout page.
8. This time the breakpoint should not be reached and a `tk_ai` cookie should not be set.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.