### PR TITLE
Add merchant MCCY order tests

### DIFF
--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+const { merchant, shopper } = require( '@woocommerce/e2e-utils' );
+
+/**
+ * Internal dependencies
+ */
+import { fillCardDetails, setupProductCheckout } from '../../../utils/payments';
+import { merchantWCP, shopperWCP, uiLoaded } from '../../../utils';
+
+const placeOrderWithCurrency = async ( currency ) => {
+	try {
+		await shopperWCP.goToShopWithCurrency( currency );
+		await setupProductCheckout(
+			config.get( 'addresses.customer.billing' ),
+			[ [ config.get( 'products.simple.name' ), 1 ] ],
+			currency
+		);
+		const card = config.get( 'cards.basic' );
+		await fillCardDetails( page, card );
+		await shopper.placeOrder();
+		await expect( page ).toMatch( 'Order received' );
+
+		const url = await page.url();
+		return url.match( /\/order-received\/(\d+)\// )[ 1 ];
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`Error placing order with currency ${ currency }: `,
+			error
+		);
+		throw error;
+	}
+};
+
+describe( 'Admin Multi-Currency Orders', () => {
+	let wasMulticurrencyEnabled;
+	const currenciesOrders = {
+		USD: null,
+		EUR: 115,
+	};
+
+	beforeAll( async () => {
+		await merchant.login();
+		wasMulticurrencyEnabled = await merchantWCP.activateMulticurrency();
+		for ( const currency in currenciesOrders ) {
+			await merchantWCP.addCurrency( currency );
+		}
+		await merchant.logout();
+
+		await shopper.login();
+		currenciesOrders.EUR = await placeOrderWithCurrency( 'EUR' );
+		await shopper.logout();
+		await merchant.login();
+	} );
+
+	afterAll( async () => {
+		if ( ! wasMulticurrencyEnabled ) {
+			await merchantWCP.deactivateMulticurrency();
+		}
+		await merchant.logout();
+	} );
+
+	it( 'order should display in shopper currency', async () => {
+		await merchant.goToOrder( currenciesOrders.EUR );
+
+		// Prices from order items table and confirm they are in the shopper currency
+		const orderItems = await page.$$eval(
+			'#woocommerce-order-items .woocommerce-Price-amount',
+			( elements ) => elements.map( ( element ) => element.textContent )
+		);
+
+		orderItems.forEach( ( item ) => {
+			expect( item ).toContain( '€' );
+		} );
+	} );
+
+	it( 'transaction page shows shopper currency', async () => {
+		// Pull out and follow the link to avoid working in multiple tabs
+		const paymentDetailsLink = await page.$eval(
+			'p.order_number > a',
+			( anchor ) => anchor.getAttribute( 'href' )
+		);
+		await Promise.all( [
+			page.goto( paymentDetailsLink, {
+				waitUntil: 'networkidle0',
+			} ),
+			uiLoaded(),
+		] );
+
+		await expect( page ).toMatchElement(
+			'.payment-details-summary__amount',
+			{
+				text: '€',
+			}
+		);
+	} );
+
+	it( 'transaction page shows converted merchant currency', async () => {
+		// Confirm that transaction page shows payment details in merchant currency
+		await expect( page ).toMatchElement(
+			'.payment-details-summary__breakdown',
+			{
+				text: '$',
+			}
+		);
+
+		// Confirm that transaction page shows fee in merchant currency
+		const feesTextElement = await page.$x(
+			"//div[@class='payment-details-summary__breakdown']/p[contains(text(), 'Fees')]"
+		);
+		const feesText = await page.evaluate(
+			( element ) => element.textContent,
+			feesTextElement[ 0 ]
+		);
+		expect( feesText ).toContain( '$' );
+	} );
+} );


### PR DESCRIPTION
Fixes #7383

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
