### PR TITLE
Fix typo "Loan Dispersement" to "Loan disbursement"

### DIFF
--- a/changelog/fix-5979-loan-typo
+++ b/changelog/fix-5979-loan-typo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix typo of transaction type "Loan dispersement" to "Loan disbursement" on transactions list page.

--- a/client/transactions/filters/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/filters/test/__snapshots__/index.tsx.snap
@@ -135,7 +135,7 @@ HTMLOptionsCollection [
   <option
     value="financing_payout"
   >
-    Loan dispersement
+    Loan disbursement
   </option>,
   <option
     value="financing_paydown"

--- a/client/transactions/strings.ts
+++ b/client/transactions/strings.ts
@@ -19,7 +19,7 @@ export const displayType = {
 	dispute: __( 'Dispute', 'woocommerce-payments' ),
 	dispute_reversal: __( 'Dispute reversal', 'woocommerce-payments' ),
 	card_reader_fee: __( 'Reader fee', 'woocommerce-payments' ),
-	financing_payout: __( 'Loan dispersement', 'woocommerce-payments' ),
+	financing_payout: __( 'Loan disbursement', 'woocommerce-payments' ),
 	financing_paydown: __( 'Loan repayment', 'woocommerce-payments' ),
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5979

#### Changes proposed in this Pull Request

Fix a typo on the transactions list page for transaction with type `financing_payout` that was displayed as 'Loan Dispersement' to 'Loan disbursement'.

#### Testing instructions

As mentioned in the issue https://github.com/Automattic/woocommerce-payments/issues/5979, to get a `financing_payout` transaction, we need to create a loan offer from Stripe's dashboard, which then needs to be accepted from an email.

However, newly onboarded test account somehow does not have email.

<img width="283" alt="Screenshot 2024-02-13 at 14 29 25" src="https://github.com/Automattic/woocommerce-payments/assets/73803630/c675acc4-fa7b-4362-9a1c-219e9db8b912">

So I can't really test this end-to-end.

The way I tested it is to have at least one transaction (buy purchasing something) and then hard-code that transaction's type by changing this [line](https://github.com/Automattic/woocommerce-payments/blob/9fa7c02fa977ab424174aa5b25f864cc697aa3c2/includes/admin/class-wc-rest-payments-transactions-controller.php#L121) to:

```php
$response = $wcpay_request->handle_rest_request();
$response['data'][0]['type'] = 'financing_payout';
return $response;
```

Make sure the first transaction's type says 'Loan disbursement'.
<img width="1491" alt="Screenshot 2024-02-13 at 14 33 33" src="https://github.com/Automattic/woocommerce-payments/assets/73803630/e32f337f-9e3e-40a4-aa33-b1e8bd059b9a">

The correctness of some of the values from the other columns can safely be ignored as we are hard-coding the type and it's not a real `financing_payout` transaction.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
