### PR TITLE
Updates GitHub actions to support NodeJS 20

### DIFF
--- a/.github/actions/e2e/atomic-prepare-and-run/action.yml
+++ b/.github/actions/e2e/atomic-prepare-and-run/action.yml
@@ -10,7 +10,7 @@ runs:
     # Cache node dependencies
     - name: "Cache node modules"
       id: node-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -20,14 +20,14 @@ runs:
 
     # Use node version from .nvmrc
     - name: Setup NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
 
     # Cache composer dependencies
     - name: Cache composer dependencies
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./vendor
         key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -35,7 +35,7 @@ runs:
     # Cache node dependencies
     - name: Cache node dependencies
       id: node-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./node_modules
         key:  ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/actions/e2e/run-log-tests/action.yml
+++ b/.github/actions/e2e/run-log-tests/action.yml
@@ -35,7 +35,7 @@ runs:
     # Archive screenshots if any
     - name: Archive e2e test screenshots & logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: wp(${{ env.E2E_WP_VERSION }})-wc(${{ env.E2E_WC_VERSION }})-${{ env.E2E_GROUP }}-${{ env.E2E_BRANCH }}
           path: |

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -5,13 +5,13 @@ runs:
   using: composite
   steps:
     - name: "Setup Node"
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: ".nvmrc"
         cache: "npm"
 
     - name: "Enable composer dependencies caching"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/composer/
         key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/build-zip-and-run-smoke-tests.yml
+++ b/.github/workflows/build-zip-and-run-smoke-tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
 
@@ -43,7 +43,7 @@ jobs:
           echo ":information_source: Ignore the artifact size mentioned since GitHub calculates the size of the source folder instead of the zip file created." >> $GITHUB_STEP_SUMMARY
 
       - name: "Upload the zip file as an artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,9 +14,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version-file: '.nvmrc'
                   cache: npm

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # enable dependencies caching
       - name: Add composer to cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -40,9 +40,9 @@ jobs:
       matrix: ${{ fromJSON(needs.generate-wc-compat-matrix.outputs.matrix) }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -81,9 +81,9 @@ jobs:
       GUTENBERG_VERSION: ${{ matrix.gutenberg }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,9 +25,9 @@ jobs:
       COVERAGE_DIR: ${{ matrix.directory }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -13,12 +13,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Build
               run: cd docs/rest-api && ./build.sh
             - name: Deploy to GitHub Pages
               if: success()
-              uses: crazy-max/ghaction-github-pages@v3
+              uses: crazy-max/ghaction-github-pages@v4
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -60,13 +60,13 @@ jobs:
 
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
 
       - name: "Download WooCommerce Payments build file"
         if: ${{ inputs.wcpay-use-build-artifact }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: woocommerce-payments
           path: ${{ env.WCPAY_ARTIFACT_DIRECTORY }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup E2E environment
         uses: ./.github/actions/e2e/env-setup
@@ -83,7 +83,7 @@ jobs:
 
   #   steps:
   #     - name: Checkout WCPay repository
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v4
 
   #     - name: Setup E2E environment
   #       uses: ./.github/actions/e2e/env-setup
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup E2E environment
         uses: ./.github/actions/e2e/env-setup

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -39,7 +39,7 @@ jobs:
     
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Run the tests"
         uses: ./.github/actions/e2e/atomic-prepare-and-run

--- a/.github/workflows/i18n-weekly-release.yml
+++ b/.github/workflows/i18n-weekly-release.yml
@@ -10,19 +10,19 @@ jobs:
 
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Use project specific node version
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
       # enable dependencies caching (vendor and node_modules are wiped during build so they are ignored here)
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm/
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
@@ -35,16 +35,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -13,7 +13,7 @@ jobs:
     name: PHP Compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Set up PHP"
         uses: ./.github/actions/setup-php
       - run: bash bin/phpcs-compat.sh

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -54,9 +54,9 @@ jobs:
       matrix: ${{ fromJSON(needs.generate-test-matrix.outputs.matrix) }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # enable dependencies caching
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'trunk'
 
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'trunk'
 
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'trunk'
           fetch-depth: 0
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'trunk'
 
@@ -120,7 +120,7 @@ jobs:
     
     steps:
       - name: "Checkout repository (develop)"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'develop'
   
@@ -129,7 +129,7 @@ jobs:
         run: php .github/workflows/scripts/get-next-version.php
   
       - name: "Checkout repository's wiki"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "${{ github.repository }}.wiki"
           path: "wiki"

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Get current version"
         id: current-version
@@ -73,7 +73,7 @@ jobs:
           echo ":information_source: Ignore the artifact size mentioned since GitHub calculates the size of the source folder instead of the zip file created." >> $GITHUB_STEP_SUMMARY
 
       - name: "Upload the zip file as an artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -36,7 +36,7 @@ jobs:
       RELEASE_DATE: ${{ inputs.release-date }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ SECRETS.BOTWOO_TOKEN }}
       

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -26,7 +26,7 @@ jobs:
       nextReleaseDate: ${{ steps.define_var.outputs.RELEASE_PLANNED_DATE }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'develop'
 
@@ -88,7 +88,7 @@ jobs:
       RELEASE_PR_ID: ${{ needs.create-release-pr.outputs.release-pr-id }}
     steps:
       - name: "Slack ping"
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo

--- a/changelog/github-actions-update-to-node20
+++ b/changelog/github-actions-update-to-node20
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Updates GH actions NodeJS version to 20
+
+


### PR DESCRIPTION
Fixes #8176 

#### Changes proposed

* Updates the action versions for `checkout`, `cache`, `setup-node`, `upload-artifact`, `download-artifact` from v3 to v4, which supports NodeJS 20 for the following workflows
* Updates `slackapi/slack-github-action` to v1.25.0
* Updates `crazy-max/ghaction-github-pages` to v4

#### Unsupported actions

* `preactjs/compressed-size-action` doesn't support NodeJS 20 and will continue to display the deprecation notice. Unless the developer, adds a new version, we'll have to go with the current version.

#### Testing instructions

* Check and confirm the tests ran against this branch doesn't show any NodeJS deprecation notices.
* Since some workflows are used for release & post release processes, it can be tested directly without modifying the workflow files. The changes made to the workflows are straightforward and it is expected that the changes doesn't cause any problems. Most of the actions updated are from GitHub, which doesn't cause issues.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
