### PR TITLE
fix: translatable comma-separated list

### DIFF
--- a/changelog/fix-translatable-comma-separated-list
+++ b/changelog/fix-translatable-comma-separated-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: ensure comma-separated list is translatable.

--- a/client/components/currency-information-for-methods/index.js
+++ b/client/components/currency-information-for-methods/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import _ from 'lodash';
+import { uniq } from 'lodash';
 import { sprintf, __, _n } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 
@@ -14,17 +14,19 @@ import WCPaySettingsContext from '../../settings/wcpay-settings-context';
 import InlineNotice from 'components/inline-notice';
 import PaymentMethodsMap from '../../payment-methods-map';
 
-const ListToCommaSeparatedSentencePartConverter = ( items ) => {
+const formatListOfItems = ( items ) => {
 	if ( items.length === 1 ) {
 		return items[ 0 ];
-	} else if ( items.length === 2 ) {
+	}
+
+	if ( items.length === 2 ) {
 		return items.join( ' ' + __( 'and', 'woocommerce-payments' ) + ' ' );
 	}
+
 	const lastItem = items.pop();
-	return (
-		items.join( ', ' ) +
-		__( ', and', 'woocommerce-payments' ) +
-		' ' +
+	return sprintf(
+		__( '%s, and %s', 'woocommerce-payments' ),
+		items.join( ', ' ),
 		lastItem
 	);
 };
@@ -40,7 +42,7 @@ export const BuildMissingCurrenciesTooltipMessage = (
 			'woocommerce-payments'
 		),
 		paymentMethodLabel,
-		ListToCommaSeparatedSentencePartConverter( missingCurrencies ),
+		formatListOfItems( missingCurrencies ),
 		_n(
 			'currency',
 			'currencies',
@@ -110,8 +112,8 @@ const CurrencyInformationForMethods = ( { selectedMethods } ) => {
 		return paymentMethod;
 	} );
 
-	missingCurrencyLabels = _.uniq( missingCurrencyLabels );
-	paymentMethodsWithMissingCurrencies = _.uniq(
+	missingCurrencyLabels = uniq( missingCurrencyLabels );
+	paymentMethodsWithMissingCurrencies = uniq(
 		paymentMethodsWithMissingCurrencies
 	);
 
@@ -125,7 +127,7 @@ const CurrencyInformationForMethods = ( { selectedMethods } ) => {
 								'You can view & manage currencies later in settings.',
 							'woocommerce-payments'
 						),
-						ListToCommaSeparatedSentencePartConverter(
+						formatListOfItems(
 							paymentMethodsWithMissingCurrencies
 						),
 						_n(
@@ -141,9 +143,7 @@ const CurrencyInformationForMethods = ( { selectedMethods } ) => {
 							missingCurrencyLabels.length,
 							'woocommerce-payments'
 						),
-						ListToCommaSeparatedSentencePartConverter(
-							missingCurrencyLabels
-						)
+						formatListOfItems( missingCurrencyLabels )
 					),
 					components: {
 						strong: <strong />,

--- a/client/multi-currency-setup/tasks/add-currencies-task/index.js
+++ b/client/multi-currency-setup/tasks/add-currencies-task/index.js
@@ -5,7 +5,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { sprintf, __, _n } from '@wordpress/i18n';
 import { Button, Card, CardBody } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
-import _ from 'lodash';
+import { without, isString, capitalize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -150,7 +150,7 @@ const AddCurrenciesTask = () => {
 			] );
 		} else {
 			setSelectedCurrencyCodes(
-				_.without( selectedCurrencyCodes, currencyCode )
+				without( selectedCurrencyCodes, currencyCode )
 			);
 		}
 	};
@@ -180,7 +180,7 @@ const AddCurrenciesTask = () => {
 				checked={ selectedCurrencyCodes.includes( code ) }
 				onChange={ handleChange }
 				currency={ availableCurrencies[ code ] }
-				testId={ _.isString( testId ) ? testId : null }
+				testId={ isString( testId ) ? testId : null }
 			/>
 		);
 
@@ -196,7 +196,7 @@ const AddCurrenciesTask = () => {
 					'woocommerce-payments'
 				),
 				selectedCurrencyCodesLength < 10
-					? _.capitalize( numberWords[ selectedCurrencyCodesLength ] )
+					? capitalize( numberWords[ selectedCurrencyCodesLength ] )
 					: selectedCurrencyCodesLength
 			) }
 			index={ 1 }

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -19,7 +19,7 @@ import moment from 'moment';
 import React, { useContext, useState } from 'react';
 import { createInterpolateElement } from '@wordpress/element';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies.
@@ -623,7 +623,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 					} }
 				/>
 			) }
-			{ ! _.isEmpty( charge ) && ! charge.order && ! isLoading && (
+			{ ! isEmpty( charge ) && ! charge.order && ! isLoading && (
 				<MissingOrderNotice
 					charge={ charge }
 					isLoading={ isLoading }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The output of the `ListToCommaSeparatedSentencePartConverter` function is not translatable.
Also, I'm not sure why the function starts with a capital `L`, since it's not a ReactJS component.

Renaming the function similarly to [`wc_format_list_of_items`](https://wp-kama.com/plugin/woocommerce/function/wc_format_list_of_items).
And ensuring that its output can be translatable via `i18n` functions.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
