### PR TITLE
fix: payment method checkbox loadable state

### DIFF
--- a/changelog/fix-payment-method-checkboxes-styles
+++ b/changelog/fix-payment-method-checkboxes-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: payment method checkbox loadable state

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -53,13 +53,12 @@ const LoadableCheckboxControl = ( {
 
 	return (
 		<div
-			className={ classNames(
-				'loadable-checkbox',
-				hideLabel ? 'label-hidden' : ''
-			) }
+			className={ classNames( 'loadable-checkbox', {
+				'label-hidden': hideLabel,
+			} ) }
 		>
 			{ isLoading && (
-				<div className={ 'loadable-checkbox__spinner' }>
+				<div className="loadable-checkbox__spinner">
 					<svg
 						width="131px"
 						height="131px"

--- a/client/components/loadable-checkbox/style.scss
+++ b/client/components/loadable-checkbox/style.scss
@@ -1,14 +1,20 @@
 .loadable-checkbox {
 	position: relative;
+
 	&__spinner {
 		background: var( --wp-admin-theme-color );
-		width: 20px;
-		height: 20px;
+		width: 24px;
+		height: 24px;
 		position: absolute;
 		z-index: 1;
 		border-radius: 2px;
-		margin-top: 1px;
 		cursor: pointer;
+
+		@include breakpoint( '>660px' ) {
+			width: 20px;
+			height: 20px;
+		}
+
 		svg {
 			background: none;
 			display: block;
@@ -17,6 +23,7 @@
 			height: 100%;
 		}
 	}
+
 	&.label-hidden label {
 		display: none;
 	}

--- a/client/components/loadable-checkbox/style.scss
+++ b/client/components/loadable-checkbox/style.scss
@@ -10,7 +10,8 @@
 		border-radius: 2px;
 		cursor: pointer;
 
-		@include breakpoint( '>660px' ) {
+		// this breakpoint is defined within the Gutenberg styles.
+		@media ( min-width: 600px ) {
 			width: 20px;
 			height: 20px;
 		}

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -32,10 +32,6 @@
 		}
 	}
 
-	.loadable-checkbox__spinner {
-		margin-top: 2px;
-	}
-
 	.components-base-control__field,
 	.loadable-checkbox__spinner {
 		margin-bottom: 0;

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -81,11 +81,7 @@ const placeholderValues = {
 };
 
 const isTapToPay = ( model: string ) => {
-	if ( model === 'COTS_DEVICE' ) {
-		return true;
-	}
-
-	return false;
+	return model === 'COTS_DEVICE';
 };
 
 const getTapToPayChannel = ( platform: string ) => {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the loading state of the payment method checkbox can appear off-kilter.
![Screenshot 2024-02-14 at 5 55 55 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/4099b9a2-401a-4764-ac7b-9b52c3b1e47b)

Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On your local setup, go to http://wcpay.test/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fadditional-payment-methods
- Checking an unchecked checkbox should show the correct layout for the loadable state
![2024-02-14 18 12 58](https://github.com/Automattic/woocommerce-payments/assets/273592/c19b2d22-13a4-4abc-9659-4d28ac189cba)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
