### PR TITLE
fire dispute row click from click on any cell, not just button

### DIFF
--- a/changelog/fix-8204-consistently-track-dispute-table-clicks
+++ b/changelog/fix-8204-consistently-track-dispute-table-clicks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fire `wcpay_disputes_row_action_click` for any click to dispute details (not just `Respond` button).

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -226,9 +226,19 @@ export const DisputesList = (): JSX.Element => {
 	const totalRows = disputesSummary.count || 0;
 
 	const rows = disputes.map( ( dispute ) => {
+		const onClickDisputeRow = (
+			e: React.MouseEvent< HTMLAnchorElement >
+		) => {
+			// Use client-side routing to avoid page refresh.
+			e.preventDefault();
+			recordEvent( 'wcpay_disputes_row_action_click' );
+			const history = getHistory();
+			history.push( getDetailsURL( dispute.charge_id, 'transactions' ) );
+		};
 		const clickable = ( children: React.ReactNode ): JSX.Element => (
 			<ClickableCell
 				href={ getDetailsURL( dispute.charge_id, 'transactions' ) }
+				onClick={ onClickDisputeRow }
 			>
 				{ children }
 			</ClickableCell>
@@ -331,20 +341,7 @@ export const DisputesList = (): JSX.Element => {
 							dispute.charge_id,
 							'transactions'
 						) }
-						onClick={ (
-							e: React.MouseEvent< HTMLAnchorElement >
-						) => {
-							// Use client-side routing to avoid page refresh.
-							e.preventDefault();
-							recordEvent( 'wcpay_disputes_row_action_click' );
-							const history = getHistory();
-							history.push(
-								getDetailsURL(
-									dispute.charge_id,
-									'transactions'
-								)
-							);
-						} }
+						onClick={ onClickDisputeRow }
 					>
 						{ needsResponse
 							? __( 'Respond', 'woocommerce-payments' )


### PR DESCRIPTION
Fixes #8204

#### Changes proposed in this Pull Request
Ensures the tracks event `wcpay_disputes_row_action_click` is fired consistently when merchant clicks to view details. We have an action button in the row, but clicking in any row cell performs the same action. So we need to make sure all ways of navigating to dispute details are tracked.

I suspect the row-click was added later (after the button and event) to make it easier to view dispute, but the existing tracks event was missed.

Note that the event name is not ideal - `wcpay_disputes_row_action_click`. Really the event is `wcpay_disputes_list_view_detail_click` or similar. However it's a good match – this event fires when merchant clicks the row or a specific call to action button in the row. Keeping the existing name so we have consistent data – no major issue with current event name IMO.

<img width="1297" alt="Screenshot 2024-02-15 at 12 19 50 PM" src="https://github.com/Automattic/woocommerce-payments/assets/4167300/c6f3a0e8-22e3-458d-95a6-f37782235844">


#### Testing instructions
- Get your store in a state where it has some disputes, in progress/needs response.
- Ensure your store is opted in to tracking and you can see events (browser dev tools `t.gif` or in tracks live view, etc).
- View `Payments > Disputes`.
- Click a dispute to see details.
  - Try clicking various places in the row - button and random cells/row background.
- Should always see `wcpay_disputes_row_action_click` when navigating to dispute detail.

Also test taking other actions on that page, e.g. view order or view customer. The correct events should fire, i.e. should not see `wcpay_disputes_row_action_click` when navigating to something other than dispute detail.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) n/a - no functonality change
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

Post-merge tasks all n/a:

- No specific manual one-off testing required
- No changes to critical flows / common flows tested every release
- No merchant-facing changes to add to What's New

<details>
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
</details>