### PR TITLE
fix: multi-currency confirmation modal ui

### DIFF
--- a/changelog/fix-multi-currency-confirmation-modal-ui
+++ b/changelog/fix-multi-currency-confirmation-modal-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: multi-currency confirmation modal ui

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/delete-button.js
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/delete-button.js
@@ -4,15 +4,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
-import InfoOutlineIcon from 'gridicons/dist/info-outline';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useCallback, useState } from '@wordpress/element';
 import ConfirmationModal from 'wcpay/components/confirmation-modal';
 import CurrencyDeleteIllustration from 'wcpay/components/currency-delete-illustration';
 import PaymentMethodIcon from 'wcpay/settings/payment-method-icon';
+import React from 'react';
 
-// TODO: Delete button and modal should be separated.
-// TODO: This removes the item, but the list does not refresh.
 const DeleteButton = ( { code, label, symbol, onClick, className } ) => {
 	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(
 		false
@@ -51,21 +49,14 @@ const DeleteButton = ( { code, label, symbol, onClick, className } ) => {
 		<>
 			{ isConfirmationModalOpen && (
 				<ConfirmationModal
-					title={ interpolateComponents( {
-						mixedString: sprintf(
-							__(
-								/* translators: %1: Name of the currency being removed */
-								'{{infoIcon /}} Remove %1$s',
-								'woocommerce-payments'
-							),
-							label
+					title={ sprintf(
+						__(
+							/* translators: %1: Name of the currency being removed */
+							'Remove %1$s',
+							'woocommerce-payments'
 						),
-						components: {
-							infoIcon: (
-								<InfoOutlineIcon className="currency-delete-illustration__currency-info-icon" />
-							),
-						},
-					} ) }
+						label
+					) }
 					onRequestClose={ handleDeleteCancelClick }
 					className="enabled-currency-delete-modal"
 					actions={
@@ -108,11 +99,10 @@ const DeleteButton = ( { code, label, symbol, onClick, className } ) => {
 					</p>
 					<ul>
 						{ dependentPaymentMethods.map( ( paymentMethod ) => (
-							<li key={ 'pm-icon-wrapper-' + paymentMethod }>
+							<li key={ paymentMethod }>
 								<PaymentMethodIcon
-									key={ 'pm-icon-' + paymentMethod }
 									name={ paymentMethod }
-									showName={ true }
+									showName
 								/>
 							</li>
 						) ) }

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/delete-button.js
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/delete-button.js
@@ -9,7 +9,6 @@ import { useCallback, useState } from '@wordpress/element';
 import ConfirmationModal from 'wcpay/components/confirmation-modal';
 import CurrencyDeleteIllustration from 'wcpay/components/currency-delete-illustration';
 import PaymentMethodIcon from 'wcpay/settings/payment-method-icon';
-import React from 'react';
 
 const DeleteButton = ( { code, label, symbol, onClick, className } ) => {
 	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
@@ -196,21 +196,6 @@
 
 .wcpay-confirmation-modal.wcpay-confirmation-modal.enabled-currency-delete-modal {
 	max-width: 495px;
-	.components-modal__header {
-		padding: 0 16px;
-		margin: 0 -16px 16px;
-		.components-modal__header-heading {
-			font-size: 16px;
-			font-weight: 500;
-			line-height: 24px;
-		}
-		.components-modal__header-heading-container svg {
-			height: 22px;
-			transform: translate( 0, 4px ) rotate( 180deg );
-			margin-right: 6px;
-			fill: #d94f4f;
-		}
-	}
 	.components-modal__content {
 		padding: 0 16px 16px;
 		p {

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -306,20 +306,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
           class="components-modal__header-heading"
           id="components-modal-header-1"
         >
-          <svg
-            class="gridicon gridicons-info-outline currency-delete-illustration__currency-info-icon"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g>
-              <path
-                d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-              />
-            </g>
-          </svg>
-           Remove Euro
+          Remove Euro
         </h1>
       </div>
       <button

--- a/client/settings/payment-method-icon/style.scss
+++ b/client/settings/payment-method-icon/style.scss
@@ -16,4 +16,9 @@
 		width: 38px;
 		height: auto;
 	}
+
+	.payment-method__icon {
+		order: initial;
+		margin-right: 3px;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8206

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fixing the UI/alignment of some of the elements for the confirmation modal displayed in the multi-currency settings.
Aligning with

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the multi-currency settings at http://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency
- Add a currency, e.g.: Euro (if you don't have existing ones)
- Remove the currency via the trash icon
- The modal should appear
- The UI of the modal should be more in line with the one of existing modals

Before:
![Screenshot 2024-02-16 at 4 24 19 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/0d27ebea-5aa6-4615-a4ec-268d7020a51e)

After:
![Screenshot 2024-02-16 at 4 19 25 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/f54d6f30-5aa4-433e-9d86-5bf8d8555c7d)

Other examples:
![Screenshot 2024-02-16 at 4 19 35 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/402f592d-c858-4228-90b3-22e80b2d296f)
![Screenshot 2024-02-16 at 4 19 44 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/c460e62b-1e97-4c9b-8406-b317f058390a)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
