### PR TITLE
Handle undefined booking_id in express checkout

### DIFF
--- a/changelog/fix-bookings-id-undefined-variable
+++ b/changelog/fix-bookings-id-undefined-variable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Small defensive check for booking_id variable.
+
+

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -109,7 +109,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		$data          += $this->build_display_items();
 		$data['result'] = 'success';
 
-		if ( $booking_id ) {
+		if ( ! empty( $booking_id ) ) {
 			$data['bookingId'] = $booking_id;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a check to the express checkout `ajax_add_to_cart` function for `$booking_id`, in case the product is not a bookable product. p1708111315723409-slack-CU6SYV31A

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a shopper, navigate to the shop.
- Click on a non-bookable product.
- Click on Buy with WooPay button or Payment Request button.
- Check that no notices appear in the console and that no errors occur on the `wc-ajax=wcpay_add_to_cart` request.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.