### PR TITLE
Fix WCPay Tracks events recorded from Admin area

### DIFF
--- a/changelog/fix-wcpay-admin-tracks
+++ b/changelog/fix-wcpay-admin-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix a bug in Tracks where admin events were not recorded properly

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -348,10 +348,6 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 */
 	public function tracks_get_identity() {
 		$user_id  = get_current_user_id();
-		// If the user is not trackable, return an empty array.
-		if ( ! $this->should_enable_tracking() ) {
-			return [];
-		}
 
 		// Meta is set, and user is still connected.  Use WPCOM ID.
 		$wpcom_id = get_user_meta( $user_id, 'jetpack_tracks_wpcom_id', true );

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -12,7 +12,7 @@ use WC_Payments_Http;
 /**
  * WooPay_Tracker unit tests.
  */
-class WooPay_Tracker_Test extends WCPay_UnitTestCase {
+class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	/**
 	 * @var WooPay_Tracker
 	 */

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -38,7 +38,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	 */
 	private $cache;
 
-	public function set_up(): void {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->http_client_stub = $this->createMock( WC_Payments_Http::class );
@@ -55,7 +55,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->mock_account = $this->createMock( WC_Payments_Account::class );
 	}
 
-	public function tear_down(): void {
+	public function tearDown(): void {
 		WC_Payments::set_database_cache( $this->cache );
 		parent::tearDown();
 	}

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -5,138 +5,129 @@
  * @package WooCommerce\Payments\Tests
  */
 
-use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\WooPay_Tracker;
+use PHPUnit\Framework\TestCase;
+use WC_Payments_Account;
+use WC_Payments_Http;
 
 /**
  * WooPay_Tracker unit tests.
  */
-class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
-
+class WooPay_Tracker_Test extends TestCase {
 	/**
 	 * @var WooPay_Tracker
 	 */
 	private $tracker;
 
 	/**
-	 * The HTTP client.
-	 *
 	 * @var WC_Payments_Http
 	 */
 	private $http_client_stub;
 
 	/**
-	 * @var WC_Payments_Account|MockObject
+	 * @var WC_Payments_Account
 	 */
 	private $mock_account;
 
 	/**
-	 * Pre-test setup
+	 * @var WCPay\Database_Cache
 	 */
-	public function set_up() {
-		parent::set_up();
+	private $mock_cache;
 
-		$this->http_client_stub = $this->getMockBuilder( WC_Payments_Http::class )->disableOriginalConstructor()->setMethods( [ 'wpcom_json_api_request_as_user', 'is_user_connected', 'get_connected_user_data' ] )->getMock();
-		$this->tracker          = new WCPay\WooPay_Tracker( $this->http_client_stub );
+	/**
+	 * @var WCPay\Database_Cache
+	 */
+	private $cache;
 
-		// Mock the main class's cache service.
-		$this->_cache     = WC_Payments::get_database_cache();
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->http_client_stub = $this->createMock( WC_Payments_Http::class );
+		$this->http_client_stub->method( 'is_user_connected' )->willReturn( true );
+		$this->http_client_stub->method( 'get_connected_user_data' )->willReturn( [ 'ID' => 1234 ] );
+
+		$this->tracker = new WooPay_Tracker( $this->http_client_stub );
+
+		$this->cache      = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
 		WC_Payments::set_database_cache( $this->mock_cache );
 		WC_Payments::get_gateway()->enable();
 
-		$this->mock_account = $this->getMockBuilder( WC_Payments_Account::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->http_client_stub->method( 'is_user_connected' )
-			->willReturn( true );
-
-		$this->http_client_stub->method( 'get_connected_user_data' )
-			->willReturn( [ 'ID' => 1234 ] );
+		$this->mock_account = $this->createMock( WC_Payments_Account::class );
 	}
 
-	public function tear_down() {
-		// Restore the cache service in the main class.
-		WC_Payments::set_database_cache( $this->_cache );
-
-		parent::tear_down();
+	protected function tearDown(): void {
+		WC_Payments::set_database_cache( $this->cache );
+		parent::tearDown();
 	}
 
-	public function test_tracks_obeys_woopay_flag() {
-		$this->set_account_connected( true );
-		WC_Payments::set_account_service( $this->mock_account );
-		$this->set_is_woopay_eligible( false );
-		$this->assertFalse( $this->tracker->should_enable_tracking( null ) );
+	public function test_tracks_obeys_woopay_flag(): void {
+		$is_woopay_eligible   = false;
+		$is_account_connected = true;
+
+		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
-	public function test_does_not_track_admin_pages() {
-		wp_set_current_user( 1 );
-		$this->set_is_woopay_eligible( true );
-		$this->set_account_connected( true );
-		WC_Payments::set_account_service( $this->mock_account );
-		$this->set_is_admin( true );
-		$this->assertFalse( $this->tracker->should_enable_tracking( null ) );
+	public function test_does_not_track_admin_pages(): void {
+		$is_woopay_eligible   = true;
+		$is_account_connected = true;
+		$is_admin_page        = true;
+		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected, $is_admin_page );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
-	public function test_does_track_non_admins() {
+	public function test_does_track_non_admins(): void {
+		$is_woopay_eligible   = true;
+		$is_account_connected = true;
+		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
+
 		global $wp_roles;
-		$this->set_is_woopay_eligible( true );
-		$this->set_account_connected( true );
-		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
-		WC_Payments::set_account_service( $this->mock_account );
-		wp_set_current_user( 1 );
-		$this->set_is_admin( false );
-
-		$all_roles = $wp_roles->get_names();
-		$all_roles = array_diff( $all_roles, [ 'administrator' ] );
+		$all_roles = array_diff( $wp_roles->get_names(), [ 'administrator' ] );
 
 		foreach ( $all_roles as $role ) {
 			wp_get_current_user()->set_role( $role );
-			$this->assertTrue( $this->tracker->should_enable_tracking( null ) );
+			$this->assertTrue( $this->tracker->should_enable_tracking() );
 		}
 	}
 
-	public function test_does_not_track_when_account_not_connected() {
-		wp_set_current_user( 1 );
-		$this->set_is_woopay_eligible( true );
-		$this->set_account_connected( false );
-		WC_Payments::set_account_service( $this->mock_account );
-		$is_admin_event = false;
-		$this->assertFalse( $this->tracker->should_enable_tracking( $is_admin_event ) );
+	public function test_does_not_track_when_account_not_connected(): void {
+		$is_woopay_eligible   = true;
+		$is_account_connected = false;
+		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
-	public function test_tracks_build_event_obj_for_admin_events() {
-		wp_set_current_user( 1 );
-		$this->set_is_admin( true );
+	public function test_tracks_build_event_obj_for_admin_events(): void {
 		$this->set_account_connected( true );
 		$event_name = 'wcadmin_test_event';
 		$properties = [ 'test_property' => 'value' ];
 
 		$event_obj = $this->invoke_method( $this->tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
-
-		// Ensure the event object is correctly built.
-		$this->assertInstanceOf( Jetpack_Tracks_Event::class, $event_obj );
 		$this->assertEquals( 'value', $event_obj->test_property );
 		$this->assertEquals( 1234, $event_obj->_ui );
 		$this->assertEquals( $event_name, $event_obj->_en );
 	}
 
 	public function test_tracks_build_event_obj_for_shopper_events() {
-		wp_set_current_user( 1 );
 		$this->set_account_connected( true );
 		$event_name = 'wcpay_test_event';
 		$properties = [ 'test_property' => 'value' ];
 
 		$event_obj = $this->invoke_method( $this->tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
 
-		// Ensure the event object is correctly built.
 		$this->assertInstanceOf( Jetpack_Tracks_Event::class, $event_obj );
 		$this->assertEquals( 'value', $event_obj->test_property );
 		$this->assertEquals( 1234, $event_obj->_ui );
 		$this->assertEquals( $event_name, $event_obj->_en );
 	}
 
+	private function setup_woopay_environment( bool $is_woopay_eligible, bool $is_stripe_connected, bool $is_admin = false ): void {
+		$this->set_is_woopay_eligible( $is_woopay_eligible );
+		$this->set_account_connected( $is_stripe_connected );
+		$this->set_is_admin( $is_admin );
+		WC_Payments::set_account_service( $this->mock_account );
+	}
 
 	/**
 	 * Utility method to access protected methods for testing.
@@ -149,6 +140,8 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Mock is_admin() function.
+	 *
 	 * @param bool $is_admin
 	 */
 	private function set_is_admin( bool $is_admin ) {

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -6,14 +6,13 @@
  */
 
 use WCPay\WooPay_Tracker;
-use PHPUnit\Framework\TestCase;
 use WC_Payments_Account;
 use WC_Payments_Http;
 
 /**
  * WooPay_Tracker unit tests.
  */
-class WooPay_Tracker_Test extends TestCase {
+class WooPay_Tracker_Test extends WCPay_UnitTestCase {
 	/**
 	 * @var WooPay_Tracker
 	 */

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -38,7 +38,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	 */
 	private $cache;
 
-	protected function setUp(): void {
+	public function set_up(): void {
 		parent::setUp();
 
 		$this->http_client_stub = $this->createMock( WC_Payments_Http::class );
@@ -55,7 +55,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->mock_account = $this->createMock( WC_Payments_Account::class );
 	}
 
-	protected function tearDown(): void {
+	public function tear_down(): void {
 		WC_Payments::set_database_cache( $this->cache );
 		parent::tearDown();
 	}


### PR DESCRIPTION
Tracks events recorded from the Admin area are missing the identity string. This is a side effect of a recent additional check, introduced in https://github.com/Automattic/woocommerce-payments/pull/8161 which is being removed with this commit.
This check is redundant as we check the Tracking conditions before calling the `tracks_get_identity` function, where we can pass the additional parameters to flag events from the admin area.

#### Changes proposed in this Pull Request
- Remove a redundant check which affects attaching user identity string to Tracks events recorded in the admin area.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
*Replicate the issue*

- On `develop` as a merchant, disable or enable WooPay from Payments -> Settings.
- In ~5 minutes, go to MC' Tracks Live view.
- Check the "Filter for only rejected events" checkbox and search for the `wcadmin_woopay_enabled` or `wcadmin_woopay_disabled` 
- Events from your test blog will appear here.

*Test the fix*
- On this branch, repeat the above steps.
- Your events should not appear when filtering for rejected events. Instead it should appear when the checkbox is not checked.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
