### PR TITLE
Klarna E2E Tests - Fix failures + set browser language

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -112,10 +112,29 @@ function setTestTimeouts() {
 	jest.setTimeout( TIMEOUT );
 }
 
+async function setLanguage() {
+	// Override the navigator.language and navigator.languages properties
+	await page.evaluateOnNewDocument( () => {
+		Object.defineProperty( navigator, 'language', {
+			get: function () {
+				return 'en-US';
+			},
+		} );
+		Object.defineProperty( navigator, 'languages', {
+			get: function () {
+				return [ 'en-US', 'en' ];
+			},
+		} );
+	} );
+}
+
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll( async () => {
+	// Set language
+	await setLanguage();
+
 	if ( process.env.E2E_MORE_DEBUG ) {
 		addPageDebugEvents();
 	}

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -25,11 +25,8 @@ describe( 'Klarna checkout', () => {
 		await shopperWCP.changeAccountCurrencyTo( 'USD' );
 	} );
 
-	afterEach( async () => {
-		await shopperWCP.emptyCart();
-	} );
-
 	afterAll( async () => {
+		await shopperWCP.emptyCart();
 		await shopperWCP.logout();
 		await merchant.login();
 		await merchantWCP.disablePaymentMethod( UPE_METHOD_CHECKBOXES );

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -64,6 +64,7 @@ describe( 'Klarna checkout', () => {
 				text: 'Buy Now. Pay Later.',
 			}
 		);
+
 		await expect( paymentMethodMessageModalIframe ).toMatchElement(
 			'[data-testid="ModalDescription"] > p',
 			{
@@ -74,12 +75,7 @@ describe( 'Klarna checkout', () => {
 	} );
 
 	it( `should successfully place an order with Klarna`, async () => {
-		const getNewKlarnaIframe = async () => {
-			const klarnaFrameHandle = await page.waitForSelector(
-				'#klarna-apf-iframe'
-			);
-			return await klarnaFrameHandle.contentFrame();
-		};
+		await shopperWCP.emptyCart();
 
 		await setupProductCheckout(
 			{
@@ -101,50 +97,60 @@ describe( 'Klarna checkout', () => {
 		await paymentMethodLabel.click();
 		await shopper.placeOrder();
 
+		// Get Klarna Iframe.
+		const klarnaFrameHandle = await page.waitForSelector(
+			'#klarna-apf-iframe'
+		);
+		const klarnaIframe = await klarnaFrameHandle.contentFrame();
+
 		// waiting for the redirect & the Klarna iframe to load within the Stripe test page.
 		// this is the "confirm phone number" page - we just click "continue".
-		await ( await getNewKlarnaIframe() ).waitForSelector(
-			'#collectPhonePurchaseFlow'
-		);
+		await klarnaIframe.waitForSelector( '#collectPhonePurchaseFlow' );
 		(
-			await ( await getNewKlarnaIframe() ).waitForSelector(
+			await klarnaIframe.waitForSelector(
 				'#onContinue[data-testid="kaf-button"]'
 			)
 		 ).click();
 		// this is where the OTP code is entered.
-		await ( await getNewKlarnaIframe() ).waitForSelector( '#phoneOtp' );
-		await expect( await getNewKlarnaIframe() ).toFill(
+		await klarnaIframe.waitForSelector( '#phoneOtp' );
+		await expect( klarnaIframe ).toFill(
 			'[data-testid="kaf-field"]',
 			'000000'
 		);
 
-		// selecting the installment plan.
-		(
-			await ( await getNewKlarnaIframe() ).waitForSelector(
-				'button[data-testid="select-payment-category"]'
+		await klarnaIframe.waitForSelector(
+			'button[data-testid="select-payment-category"'
+		);
+
+		await klarnaIframe.waitForSelector( '.skeleton-wrapper' );
+		await klarnaIframe.waitForSelector( '.skeleton-wrapper', {
+			hidden: true,
+		} );
+
+		// Select Payment Plan - 4 weeks & click continue.
+		await klarnaIframe
+			.waitForSelector( 'input[type="radio"][id*="pay_in_n"]' )
+			.then( ( input ) => input.click() );
+		await klarnaIframe
+			.waitForSelector( 'button[data-testid="select-payment-category"' )
+			.then( ( button ) => button.click() );
+
+		// Payment summary page. Click continue.
+		await klarnaIframe
+			.waitForSelector( 'button[data-testid="pick-plan"' )
+			.then( ( button ) => button.click() );
+
+		// Confirm payment.
+		await klarnaIframe
+			.waitForSelector(
+				'button[data-testid="confirm-and-pay"]:not(:disabled)'
 			)
-		 ).click();
-		// the buttons might be present, but in a "disabled" state.
-		// We need to ensure they can be clickable, before performing the "click" action.
-		(
-			await ( await getNewKlarnaIframe() ).waitForSelector(
-				'button[data-testid="pick-plan"]'
-			)
-		 ).click();
-		(
-			await (
-				await getNewKlarnaIframe()
-			 ).waitForSelector(
-				'button[data-testid="confirm-and-pay"]:not(:disabled)',
-				{ timeout: 15000 }
-			)
-		 ).click();
+			.then( ( button ) => button.click() );
 
 		// Wait for the order confirmation page to load.
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );
-		await page.reload( { waitUntil: 'networkidle0' } );
 		await expect( page ).toMatch( 'Order received' );
 	} );
 } );

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -41,16 +41,16 @@ describe( 'Klarna checkout', () => {
 			'#payment-method-message iframe'
 		);
 		const paymentMethodMessageIframe = await paymentMethodMessageFrameHandle.contentFrame();
-		const productMessaging = await paymentMethodMessageIframe.waitForSelector(
-			'button[aria-label="Open Learn More Modal"]'
-		);
-		// scrolling vertically to get the "product messaging" into view, since it seems that otherwise clicking on it fails.
-		await page.evaluate( () => {
-			window.scrollBy( 0, 100 );
-		} );
-		await productMessaging.click();
 
-		// we need to wait for the iframe to be added by Stripe JS after clicking on the element.
+		// Click on Klarna link to open the modal.
+		await paymentMethodMessageIframe.evaluate( ( selector ) => {
+			const element = document.querySelector( selector );
+			if ( element ) {
+				element.click();
+			}
+		}, 'button[aria-label="Open Learn More Modal"]' );
+
+		// Wait for the iframe to be added by Stripe JS after clicking on the element.
 		await page.waitFor( 1000 );
 
 		const paymentMethodMessageModalIframeHandle = await page.waitForSelector(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a method to force set browser language to `en-US`. While testing locally, noticed that Chromium uses English (UK) by default, causing problems with string comparisons. e.g `$55` vs `US$55`, `installments` vs `instalments`. Puppeteer allows setting language via the `--lang` flag, but it doesn't work on MacOS. Hence I added a new method to work across all operating systems.
* Fixes the failing Klarna tests


E2E tests won't run if base branch is not develop or trunk. So triggered manually here - https://github.com/Automattic/woocommerce-payments/actions/runs/7957537188

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
