### PR TITLE
Adjustments to the wording of confirmation modals on the order and transaction details pages

### DIFF
--- a/changelog/update-8243-multiple-modals-alignment-on-used-wording
+++ b/changelog/update-8243-multiple-modals-alignment-on-used-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjustments to the wording of confirmation modals on the order and transaction details pages.

--- a/client/order/order-status-change-strategies/index.tsx
+++ b/client/order/order-status-change-strategies/index.tsx
@@ -87,7 +87,7 @@ function triggerCancelAuthorizationModal(
 					href="https://woo.com/document/woopayments/settings-guide/authorize-and-capture/#cancelling-authorizations"
 					rel="noopener noreferrer"
 				>
-					{ __( 'cancel the authorization', 'woocommerce-payments' ) }
+					{ __( 'cancel the payment', 'woocommerce-payments' ) }
 				</a>
 			),
 			newOrderStatus: <b>{ OrderStatusLookup[ newOrderStatus ] }</b>,
@@ -96,12 +96,12 @@ function triggerCancelAuthorizationModal(
 
 	renderModal(
 		<OrderStatusConfirmationModal
-			title={ __( 'Cancel authorization', 'woocommerce-payments' ) }
+			title={ __( 'Cancel payment', 'woocommerce-payments' ) }
 			confirmButtonText={ __(
-				'Cancel order and authorization',
+				'Cancel order and payment',
 				'woocommerce-payments'
 			) }
-			cancelButtonText={ __( 'Do Nothing', 'woocommerce-payments' ) }
+			cancelButtonText={ __( 'Cancel', 'woocommerce-payments' ) }
 			confirmationMessage={ interpolatedMessage }
 			onConfirm={ () => {
 				const orderEditForm: HTMLFormElement | null =
@@ -167,12 +167,12 @@ function triggerCaptureAuthorizationModal(
 
 	renderModal(
 		<OrderStatusConfirmationModal
-			title={ __( 'Capture Authorization', 'woocommerce-payments' ) }
+			title={ __( 'Capture payment', 'woocommerce-payments' ) }
 			confirmButtonText={ __(
-				'Complete order and capture authorization',
+				'Complete order and capture payment',
 				'woocommerce-payments'
 			) }
-			cancelButtonText={ __( 'Do Nothing', 'woocommerce-payments' ) }
+			cancelButtonText={ __( 'Cancel', 'woocommerce-payments' ) }
 			confirmationMessage={ interpolatedMessage }
 			onConfirm={ () => {
 				const orderEditForm: HTMLFormElement | null =

--- a/client/order/order-status-change-strategies/index.tsx
+++ b/client/order/order-status-change-strategies/index.tsx
@@ -76,7 +76,7 @@ function triggerCancelAuthorizationModal(
 					rel="noopener noreferrer"
 				>
 					{ __(
-						'authorized but not captured',
+						'authorized but payment has not been captured',
 						'woocommerce-payments'
 					) }
 				</a>
@@ -145,7 +145,7 @@ function triggerCaptureAuthorizationModal(
 					rel="noopener noreferrer"
 				>
 					{ __(
-						'authorized but not captured',
+						'authorized but payment has not been captured',
 						'woocommerce-payments'
 					) }
 				</a>

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -58,7 +58,7 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 	return (
 		<ConfirmationModal
 			className="missing-order-notice-modal"
-			title={ __( 'Refund Transaction', 'woocommerce-payments' ) }
+			title={ __( 'Refund transaction', 'woocommerce-payments' ) }
 			actions={
 				<>
 					<Button onClick={ handleModalCancel } variant="secondary">

--- a/client/settings/transactions/manual-capture-control.tsx
+++ b/client/settings/transactions/manual-capture-control.tsx
@@ -93,7 +93,10 @@ const ManualCaptureControl = (): JSX.Element => {
 								onClick={ handleModalConfirmation }
 								isPrimary
 							>
-								{ __( 'Enable', 'woocommerce-payments' ) }
+								{ __(
+									'Enable manual capture',
+									'woocommerce-payments'
+								) }
 							</Button>
 						</>
 					}
@@ -101,20 +104,19 @@ const ManualCaptureControl = (): JSX.Element => {
 				>
 					<strong>
 						{ __(
-							'Are you sure you want to enable manual capture of payments?',
+							'Payments must be captured within 7 days or the authorization will expire and money will be returned to the shopper.',
 							'woocommerce-payments'
 						) }
 					</strong>
 					<p>
 						{ __(
-							'Only cards support manual capture. When enabled, all other payment methods will be hidden from checkout.',
+							'Additionally, only card payments support manual capture. Non-card payments will be hidden from checkout.',
 							'woocommerce-payments'
 						) }
 					</p>
 					<p>
 						{ __(
-							'You must capture the payment on the order details screen within 7 days of authorization,' +
-								' otherwise the money will return to the shopper.',
+							'Do you want to continue?',
 							'woocommerce-payments'
 						) }
 					</p>


### PR DESCRIPTION
Fixes #8243 

#### Changes proposed in this Pull Request

Adjustments to the wording of the following confirmation modals:

**Enable manual capture**
| Before | After |
|--------|--------|
| <img width="675" alt="Screenshot 2024-02-22 at 13 22 44" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/ad16dda1-2236-40a8-b954-fbf093fa5fd4"> | <img width="675" alt="Screenshot 2024-02-22 at 13 20 50" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/c4146736-6336-406a-83dc-1301288fe3da"> | 

**Capture payment**

| Before | After |
|--------|--------|
|<img width="675" alt="Screenshot 2024-02-22 at 13 29 13" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/1e0661b6-8ff9-497f-9172-ab80a0ba144a"> |<img width="675" alt="Screenshot 2024-02-22 at 13 27 40" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/f1477028-cdf5-42af-8b98-8b81f66d97f3">| 

**Cancel payment**

| Before | After |
|--------|--------|
| <img width="675" alt="Screenshot 2024-02-22 at 13 29 02" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/f3e1fba3-a25a-4e9f-98f5-34415c7d1d19"> | <img width="675" alt="Screenshot 2024-02-22 at 13 27 26" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/42efc7b2-4fd7-452d-a944-9519e978cae2"> | 

**Refund transaction**

| Before | After |
|--------|--------|
| <img width="675" alt="Screenshot 2024-02-22 at 13 29 48" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/89e6d8af-8627-4ddf-bd1e-a08443c7a0b9"> | <img width="675" alt="Screenshot 2024-02-22 at 13 31 05" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/ce1e8c4d-bbd9-4d4b-acbf-cfa7e7f5ea00"> | 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
I'm adding the before/after screenshots above to facilitate the review. Changes are restricted to strings so no functionality is changed. In case you want to manually test:

* In WP Admin, enable the capture later option. The modal should be the same as **Enable manual capture** above
* As a shopper, place an order.
* As a merchant go to the order details page.
* Change the status of the order to Cancelled and check the **Cancel payment** modal.
* Change the status of the order to Completed and check the **Capture payment** modal.
* Capture the payment and go to the transaction details page. Check the **Refund transaction** modal.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
