### PR TITLE
Checking if wc.wcSettings is correctly set in checkout.js

### DIFF
--- a/changelog/fix-check-wc
+++ b/changelog/fix-check-wc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Checking if wc.wcSettings is correctly set in checkou.js. This will not change anything as other extensions and even WC itself depends on it being correctly set, so it's just a minor enhancement.
+
+

--- a/client/utils/checkout.js
+++ b/client/utils/checkout.js
@@ -8,18 +8,12 @@
  */
 export const getConfig = ( name ) => {
 	// Classic checkout or blocks-based one.
-	let config = null;
 	if ( typeof wcpayConfig !== 'undefined' ) {
-		config = wcpayConfig;
-	} else if ( typeof wcpay_upe_config !== 'undefined' ) {
-		config = wcpay_upe_config;
-	} else if ( typeof wc !== 'undefined' ) {
-		config = wc.wcSettings.getSetting( 'woocommerce_payments_data' );
-	} else {
-		return null;
+		return wcpayConfig[ name ];
 	}
 
-	return config[ name ] || null;
+	// eslint-disable-next-line no-use-before-define
+	return getUPEConfig( name );
 };
 
 /**
@@ -30,10 +24,18 @@ export const getConfig = ( name ) => {
  */
 export const getUPEConfig = ( name ) => {
 	// Classic checkout or blocks-based one.
-	const config =
-		typeof wcpay_upe_config !== 'undefined'
-			? wcpay_upe_config
-			: wc.wcSettings.getSetting( 'woocommerce_payments_data' );
+	let config = null;
+	if ( typeof wcpay_upe_config !== 'undefined' ) {
+		config = wcpay_upe_config;
+	} else if (
+		typeof wc === 'object' &&
+		typeof wc.wcSettings !== 'undefined'
+	) {
+		// If getSettings or woocommerce_payments_data is not available, default to an empty object so we return null bellow.
+		config = wc.wcSettings?.getSetting( 'woocommerce_payments_data' ) || {};
+	} else {
+		return null;
+	}
 
 	return config[ name ] || null;
 };

--- a/client/utils/checkout.js
+++ b/client/utils/checkout.js
@@ -32,7 +32,7 @@ export const getUPEConfig = ( name ) => {
 		typeof wc.wcSettings !== 'undefined'
 	) {
 		// If getSettings or woocommerce_payments_data is not available, default to an empty object so we return null bellow.
-		config = wc.wcSettings?.getSetting( 'woocommerce_payments_data' ) || {};
+		config = wc.wcSettings.getSetting( 'woocommerce_payments_data' ) || {};
 	} else {
 		return null;
 	}


### PR DESCRIPTION
Fixes #7855

#### Changes proposed in this Pull Request

This PR adds a check for `wc` and `wc.wcSettings` to `client/utils/checkout.js`. While updateding that file I also refactored the methods that had duplicate logic.
This will not change anything as other extensions and even WC itself depends on it being correctly set, so it's just a minor enhancement.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Because WooCommerce and other Extensions also rely on `wc` I couldn't simulate any scenario where the store is broken and this check fixes it, so smoke testing should be enough.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
