### PR TITLE
Include payment title in order_placed Tracks event

### DIFF
--- a/changelog/add-track-gateway-name
+++ b/changelog/add-track-gateway-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Include gateway name in order-placed Tracks event

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -70,8 +70,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'woocommerce_after_single_product', [ $this, 'classic_product_page_view' ] );
 		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', [ $this, 'blocks_checkout_start' ] );
 		add_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after', [ $this, 'blocks_cart_page_view' ] );
-		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
-		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
+		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
+		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
 		add_action( 'woocommerce_payments_save_user_in_woopay', [ $this, 'must_save_payment_method_to_platform' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'pay_for_order_page_view' ] );
 		add_action( 'woocommerce_thankyou', [ $this, 'thank_you_page_view' ] );
@@ -463,11 +463,20 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	/**
 	 * Record a Tracks event that the order has been processed.
 	 */
-	public function checkout_order_processed() {
+	public function checkout_order_processed( $order_id ) {
 		$is_woopay_order = ( isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'] );
+
+		$payment_gateway = wc_get_payment_gateway_by_order( $order_id );
+		$gateway_name  = false !== $payment_gateway ? ( ! empty( $payment_gateway->method_title ) ? $payment_gateway->method_title : $payment_gateway->get_title() ) : '';
+
+		$properties = [ 'gateway_name' => 'other' ];
+		if (strpos( $payment_gateway->id, 'woocommerce_payments') === 0 ) {
+			$properties = [ 'gateway_name' => $gateway_name ];
+		}
+
 		// Don't track WooPay orders. They will be tracked on WooPay side with more flow specific details.
 		if ( ! $is_woopay_order ) {
-			$this->maybe_record_wcpay_shopper_event( 'checkout_order_placed' );
+			$this->maybe_record_wcpay_shopper_event( 'checkout_order_placed', $properties );
 		}
 	}
 

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -467,11 +467,12 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		$is_woopay_order = ( isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'] );
 
 		$payment_gateway = wc_get_payment_gateway_by_order( $order_id );
-		$gateway_name  = false !== $payment_gateway ? ( ! empty( $payment_gateway->method_title ) ? $payment_gateway->method_title : $payment_gateway->get_title() ) : '';
+		$properties = [ 'payment_title' => 'other' ];
 
-		$properties = [ 'gateway_name' => 'other' ];
 		if (strpos( $payment_gateway->id, 'woocommerce_payments') === 0 ) {
-			$properties = [ 'gateway_name' => $gateway_name ];
+			$order = wc_get_order( $order_id );
+			$payment_title = $order->get_payment_method_title();
+			$properties = [ 'payment_title' => $payment_title ];
 		}
 
 		// Don't track WooPay orders. They will be tracked on WooPay side with more flow specific details.


### PR DESCRIPTION
Fixes #8233

#### Changes proposed in this Pull Request
This introduces the `payment_title` property to the `wcpay_checkout_order_placed` event. This will record the payment method title for the orders placed via WooPayments and for other gateways it will record the `payment_title` as `other`

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. As a shopper, place an order using Klarna
2. Open browser dev tools and copy the value of your `tk_ai` cookie. URL decode the value and note it down.
3. In ~5 minutes, go to Tracks Live view in MC and search for the `wcpay_checkout_order_placed` and your Tracks identity noted in Step 2.
4. Make sure the `wcpay_checkout_order_placed` event shows up in Tracks Live view and it contains the `payment_title: Klarna` property
<img width="490" alt="SCR-20240222-jvgc" src="https://github.com/Automattic/woocommerce-payments/assets/6216000/26818b33-5f4b-402b-a0d0-0d9990638f7a">

5. Repeat the above steps with a Credit/Debit card, Affirm, any other payment methods offered via WooPayments, and make sure the correct payment title shows up.
6. Finally, use a non-WooPayments gateway (eg: PayPal, Stripe, Cash on Delivery) and make sure payment_title is recorded as `other`.



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
