### PR TITLE
Rename log title to woopayments

### DIFF
--- a/changelog/fix-7927-rename-log-title-to-woopayments
+++ b/changelog/fix-7927-rename-log-title-to-woopayments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rename log file to woopayments

--- a/src/Internal/Logger.php
+++ b/src/Internal/Logger.php
@@ -18,7 +18,7 @@ use WCPay\Core\Mode;
  */
 class Logger {
 
-	const LOG_FILENAME = 'woocommerce-payments';
+	const LOG_FILENAME = 'woopayments';
 
 	/**
 	 * The holding property for our WC_Logger_Interface instance.


### PR DESCRIPTION
Fixes #7927 

#### Changes proposed in this Pull Request

Update the log title to match the product name to ensure consistency.

#### Testing instructions

* Checkout the branch `fix/7927-rename-log-title-to-woopayments`
* Perform some actions on your store (onboarding / buy and order / etc)
* Visit http://localhost:8082/wp-admin/admin.php?page=wc-status&tab=logs
* Observer there's new `woopayments` log file alongside with `woocommerce-payments`
* Open it and check that logs are being written to the new file
* Search by `woopayments` and see that results are in both old and new log

![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/e5bcc515-35bf-432e-a33e-ef57291c846b)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
