### PR TITLE
Remove filtering of billing address details

### DIFF
--- a/changelog/fix-billing-address-update
+++ b/changelog/fix-billing-address-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed billing address line 2 not being updated for saved payment methods

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -358,7 +358,6 @@ class WC_Payments_Utils {
 			'phone'   => $order->get_billing_phone(),
 		];
 
-		$billing_details['address'] = array_filter( $billing_details['address'] );
 		return array_filter( $billing_details );
 	}
 

--- a/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
+++ b/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
@@ -343,6 +343,7 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 								'city'        => $order->get_billing_city(),
 								'country'     => $order->get_billing_country(),
 								'line1'       => $order->get_billing_address_1(),
+								'line2'       => $order->get_billing_address_2(),
 								'postal_code' => $order->get_billing_postcode(),
 								'state'       => $order->get_billing_state(),
 							],

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -488,6 +488,7 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 							'city'        => 'WooCity',
 							'country'     => Country_Code::UNITED_STATES,
 							'line1'       => 'WooAddress',
+							'line2'       => '',
 							'postal_code' => '12345',
 							'state'       => 'NY',
 						],


### PR DESCRIPTION
Fixes #8158

#### Changes proposed in this Pull Request

This PR removes the filtering of the address fields as it is not needed and was causing issues with optional fields not being updated.

#### Testing instructions

1. Make a purchase saving a card using a billing address with address line 2.
2. Make a new purchase using the saved card from before but with an empty line 2.
3. Check Stripe dashboard. The second address should not have line 2.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
