### PR TITLE
Conditionally enqueue the wc-blocks-checkout-style CSS

### DIFF
--- a/changelog/4861-only-load-block-checkout-css-on-cart-checkout
+++ b/changelog/4861-only-load-block-checkout-css-on-cart-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only load `blocks-checkout.css` on single product, cart, and checkout pages.

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -52,13 +52,17 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * @return string[] A list of script handles.
 	 */
 	public function get_payment_method_script_handles() {
-		WC_Payments_Utils::enqueue_style(
-			'wc-blocks-checkout-style',
-			plugins_url( 'dist/blocks-checkout.css', WCPAY_PLUGIN_FILE ),
-			[],
-			'1.0',
-			'all'
-		);
+
+		if ( ( is_cart() || is_checkout() || is_product() ) ) {
+			WC_Payments_Utils::enqueue_style(
+				'wc-blocks-checkout-style',
+				plugins_url( 'dist/blocks-checkout.css', WCPAY_PLUGIN_FILE ),
+				[],
+				'1.0',
+				'all'
+			);
+		}
+
 		wp_register_script(
 			'stripe',
 			'https://js.stripe.com/v3/',


### PR DESCRIPTION
Fixes #4861 

#### Changes proposed in this Pull Request

This PR adds a condition to enqueue the `wc-blocks-checkout-style` stylesheet only on the cart, checkout, or single product pages. There was a comment on the issue around utilizing the `IntegrationInterface` class, but after researching it a bit, our `WC_Payments_Blocks_Payments_Method` is already doing that. It's also not possible to pass a stylesheet handle back in the `get_payment_method_script_handles()` method as setting a stylesheet as a dependency for a script causes the script to not be enqueued.

It also appears that there are styles in this stylesheet that could apply to elements on all 3 of those pages - blocks or not. This is out of scope for this issue, however, and I'll start some discussion internally on how to approach refactoring those styles into their own stylesheets.

#### Testing instructions

* Load a page that is not the cart, checkout, or single product and see that `blocks-checkout.css` is loaded on the page.
* Apply this PR, reload the page, and that CSS file should no longer be loaded.
* Visit a single product page, the cart, or the checkout pages and verify that `blocks-checkout.css` is loaded on the page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
