### PR TITLE
Add client error tracking when po eligibility can't be established

### DIFF
--- a/changelog/fix-5855-add-client-tracks-for-eligibility-errors
+++ b/changelog/fix-5855-add-client-tracks-for-eligibility-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add client error tracking when po eligibility can't be established

--- a/client/onboarding/steps/loading.tsx
+++ b/client/onboarding/steps/loading.tsx
@@ -11,7 +11,11 @@ import apiFetch from '@wordpress/api-fetch';
 import { useOnboardingContext } from '../context';
 import { POEligibleData, POEligibleResult } from '../types';
 import { fromDotNotation } from '../utils';
-import { trackRedirected, useTrackAbandoned } from '../tracking';
+import {
+	trackEligibilityError,
+	trackRedirected,
+	useTrackAbandoned,
+} from '../tracking';
 import LoadBar from 'components/load-bar';
 import strings from '../strings';
 
@@ -61,7 +65,7 @@ const LoadingStep: React.FC< Props > = () => {
 			isEligible = await isEligibleForPo();
 		} catch ( error ) {
 			// fall back to full KYC scenario.
-			// TODO maybe log these errors in future, e.g. with tracks.
+			trackEligibilityError( error );
 			isEligible = false;
 		}
 		const resultUrl = addQueryArgs( connectUrl, {

--- a/client/onboarding/tracking.ts
+++ b/client/onboarding/tracking.ts
@@ -66,6 +66,12 @@ export const trackEligibilityModalClosed = (
 		action,
 	} );
 
+export const trackEligibilityError = ( error: string ): void => {
+	recordEvent( 'wcpay_onboarding_flow_eligibility_error', {
+		error: JSON.stringify( error ),
+	} );
+};
+
 export const useTrackAbandoned = (): {
 	trackAbandoned: ( method: 'hide' | 'exit' ) => void;
 	removeTrackListener: () => void;


### PR DESCRIPTION
Fixes #5855 

#### Changes proposed in this Pull Request

This PR adds client error tracking when po eligibility can't be established.

Note: tests are not present since currently we don't unit test tracking.

#### Testing instructions

#### Tracks
To check that Tracks events are properly registered, you can use one of the following methods:
- Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );` on your site browser console. And look for verbose logs. Only works with JS events.
- Install [Tracks Vigilante 2](https://github.com/Automattic/tracks-vigilante-2-chrome-extension) browser extension and use its log of events.
- Go to [Tracks Live View](https://mc.a8c.com/tracks/live/), filter by any of the allowed methods, and wait patiently (~10min) for events to be registered there.

**Local server**
* Apply [this patch](https://gist.github.com/oaratovskyi/b2ee7f287347fabdc86e98a0e9638c1a) to your local server.
* Delete / mark as deleted your current account.
* Run `npm run listen`.

**Client**
* Refresh cache in dev tools.
* Checkout branch `fix/5855-add-client-tracks-for-eligibility-errors` on your client
* Build the branch or run `npm run start`.
* Start fresh onboarding, pick any params and proceed to the loading step.
* Observe that `wcadmin_wcpay_onboarding_flow_eligibility_error` event was tracked 
<img width="796" alt="Screenshot 2024-02-23 at 13 43 37" src="https://github.com/Automattic/woocommerce-payments/assets/79862886/8bd07d1d-34fa-44bb-867d-68de259d3a13">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
