### PR TITLE
Reduce multiple urgent dispute signals

### DIFF
--- a/client/payment-details/dispute-details/dispute-due-by-date.tsx
+++ b/client/payment-details/dispute-details/dispute-due-by-date.tsx
@@ -9,7 +9,8 @@ import moment from 'moment';
 
 const DisputeDueByDate: React.FC< {
 	dueBy: number;
-} > = ( { dueBy } ) => {
+	showRemainingDays?: boolean;
+} > = ( { dueBy, showRemainingDays = true } ) => {
 	const daysRemaining = Math.floor(
 		moment.unix( dueBy ).diff( moment(), 'days', true )
 	);
@@ -20,31 +21,33 @@ const DisputeDueByDate: React.FC< {
 	return (
 		<span className="dispute-steps__steps__response-date">
 			{ respondByDate }
-			<span
-				className={ classNames( {
-					'dispute-steps__steps__response-date--urgent':
-						daysRemaining < 3,
-					'dispute-steps__steps__response-date--warning':
-						daysRemaining < 7 && daysRemaining > 2,
-				} ) }
-			>
-				{ daysRemaining > 0 &&
-					sprintf(
-						// Translators: %d is the number of days left to respond to the dispute.
-						_n(
-							'(%d day left to respond)',
-							'(%d days left to respond)',
-							daysRemaining,
-							'woocommerce-payments'
-						),
-						daysRemaining
-					) }
+			{ showRemainingDays && (
+				<span
+					className={ classNames( {
+						'dispute-steps__steps__response-date--urgent':
+							daysRemaining < 3,
+						'dispute-steps__steps__response-date--warning':
+							daysRemaining < 7 && daysRemaining > 2,
+					} ) }
+				>
+					{ daysRemaining > 0 &&
+						sprintf(
+							// Translators: %d is the number of days left to respond to the dispute.
+							_n(
+								'(%d day left to respond)',
+								'(%d days left to respond)',
+								daysRemaining,
+								'woocommerce-payments'
+							),
+							daysRemaining
+						) }
 
-				{ daysRemaining === 0 &&
-					__( '(Last day today)', 'woocommerce-payments' ) }
-				{ daysRemaining < 0 &&
-					__( '(Past due)', 'woocommerce-payments' ) }
-			</span>
+					{ daysRemaining === 0 &&
+						__( '(Last day today)', 'woocommerce-payments' ) }
+					{ daysRemaining < 0 &&
+						__( '(Past due)', 'woocommerce-payments' ) }
+				</span>
+			) }
 		</span>
 	);
 };

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -115,7 +115,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 				<li>
 					{ createInterpolateElement(
 						__(
-							'Challenge <challengeIcon/> or accept <acceptIcon/> the dispute by <dueByDate/>.',
+							'Challenge <challengeIcon/> or accept <acceptIcon/> the dispute by <dueByDate/>',
 							'woocommerce-payments'
 						),
 						{
@@ -155,6 +155,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 							dueByDate: (
 								<DisputeDueByDate
 									dueBy={ dispute.evidence_details.due_by }
+									showRemainingDays={ false }
 								/>
 							),
 						}


### PR DESCRIPTION
Part 2 of #7504 

#### Changes proposed in this Pull Request
- Added `showRemainingDays` prop to due date for conditional rendering.
- This PR fixes removes the redundant due date in the dispute checklist. See issue.
- Removes "." from the end of the sentence
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Tests should pass.
- Make sure the behavior is as expected in the issue.
![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/003f6092-4751-4249-980b-7351626000ad)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
