### PR TITLE
fix: checkout error message on empty field

### DIFF
--- a/changelog/fix-8270-field-validation
+++ b/changelog/fix-8270-field-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: checkout error message on empty field

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -108,16 +108,11 @@ function submitForm( jQueryForm ) {
  *
  * @param {Object} api The API object used to call the Stripe API's createPaymentMethod method.
  * @param {Object} elements The Stripe elements object used to create a Stripe payment method.
- * @param {Object} jQueryForm The jQuery object for the form being submitted.
+ * @param {Object} $form The jQuery object for the form being submitted.
  * @param {string} paymentMethodType The type of Stripe payment method to create.
  * @return {Promise<Object>} A promise that resolves with the created Stripe payment method.
  */
-function createStripePaymentMethod(
-	api,
-	elements,
-	jQueryForm,
-	paymentMethodType
-) {
+function createStripePaymentMethod( api, elements, $form, paymentMethodType ) {
 	/* global wcpayCustomerData */
 	let params = {};
 	if ( window.wcpayCustomerData ) {
@@ -132,20 +127,27 @@ function createStripePaymentMethod(
 		};
 	}
 
-	if ( jQueryForm.attr( 'name' ) === 'checkout' ) {
+	if ( $form.attr( 'name' ) === 'checkout' ) {
 		params = {
 			billing_details: {
 				...params.billing_details,
 				name:
-					`${
-						document.querySelector(
-							`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.first_name }`
-						)?.value || ''
-					} ${
-						document.querySelector(
-							`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.last_name }`
-						)?.value || ''
-					}`.trim() || undefined,
+					document.querySelector(
+						`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.first_name }`
+					) ||
+					document.querySelector(
+						`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.last_name }`
+					)
+						? `${
+								document.querySelector(
+									`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.first_name }`
+								)?.value || ''
+						  } ${
+								document.querySelector(
+									`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.last_name }`
+								)?.value || ''
+						  }`.trim()
+						: undefined,
 				email: document.querySelector( '#billing_email' )?.value,
 				phone: document.querySelector( '#billing_phone' )?.value,
 				address: {

--- a/client/checkout/classic/test/payment-processing.test.js
+++ b/client/checkout/classic/test/payment-processing.test.js
@@ -347,7 +347,25 @@ describe( 'Payment processing', () => {
 			}
 		} );
 	} );
+
 	afterEach( () => {
+		[
+			'billing_first_name',
+			'billing_last_name',
+			'billing_email',
+			'billing_phone',
+			'billing_city',
+			'billing_country',
+			'billing_address_1',
+			'billing_address_2',
+			'billing_postcode',
+			'billing_state',
+		].forEach( ( id ) => {
+			const element = document.getElementById( id );
+			if ( ! element ) return;
+
+			document.body.removeChild( element );
+		} );
 		jest.clearAllMocks();
 	} );
 
@@ -452,6 +470,91 @@ describe( 'Payment processing', () => {
 			elements: expect.any( Object ),
 			params: {
 				billing_details: expect.any( Object ),
+			},
+		} );
+	} );
+
+	test( 'Payment processing creates the correct `name` attribute when both last/first name fields are removed', async () => {
+		setupBillingDetailsFields();
+		// pretending that the customizer removed the billing name field
+		document.body.removeChild(
+			document.getElementById( 'billing_first_name' )
+		);
+		document.body.removeChild(
+			document.getElementById( 'billing_last_name' )
+		);
+		getFingerprint.mockImplementation( () => {
+			return 'fingerprint';
+		} );
+
+		const mockDomElement = document.createElement( 'div' );
+		mockDomElement.dataset.paymentMethodType = 'card';
+
+		await mountStripePaymentElement( apiMock, mockDomElement );
+
+		const checkoutForm = {
+			submit: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+			} ) ),
+			attr: jest.fn().mockReturnValue( 'checkout' ),
+		};
+
+		await processPayment( apiMock, checkoutForm, 'card' );
+
+		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
+			elements: expect.any( Object ),
+			params: {
+				billing_details: expect.objectContaining( {
+					name: undefined,
+					email: 'john.doe@example.com',
+					phone: '555-1234',
+					address: expect.any( Object ),
+				} ),
+			},
+		} );
+	} );
+
+	test( 'Payment processing creates the correct `name` attribute when last name field is removed via customizer', async () => {
+		setupBillingDetailsFields();
+		// pretending that the customizer removed the billing name field
+		document.body.removeChild(
+			document.getElementById( 'billing_first_name' )
+		);
+		getFingerprint.mockImplementation( () => {
+			return 'fingerprint';
+		} );
+
+		const mockDomElement = document.createElement( 'div' );
+		mockDomElement.dataset.paymentMethodType = 'card';
+
+		await mountStripePaymentElement( apiMock, mockDomElement );
+
+		const checkoutForm = {
+			submit: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+			} ) ),
+			attr: jest.fn().mockReturnValue( 'checkout' ),
+		};
+
+		await processPayment( apiMock, checkoutForm, 'card' );
+
+		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
+			elements: expect.any( Object ),
+			params: {
+				billing_details: expect.objectContaining( {
+					name: 'Doe',
+					email: 'john.doe@example.com',
+					phone: '555-1234',
+					address: expect.any( Object ),
+				} ),
 			},
 		} );
 	} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8270

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The Stripe payment creation error message is displayed to the customer, when the customer doesn't enter any values for the fields.

Right now we're passing `undefined` if the fields is present but not filled, it seems that we need to pass an empty string to Stripe if the field is present instead.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure you're not logged into as a customer
- Add some products to the cart, go to checkout
- Fill in the CC details with valid values, leave all other fields empty
- The WC error message should appear (instead of the "ugly" Stripe one

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
