### PR TITLE
refactor: handling from event listener

### DIFF
--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -29,6 +29,49 @@ import apiRequest from '../utils/request';
 import { handleWooPayEmailInput } from 'wcpay/checkout/woopay/email-input-iframe';
 import { isPreviewing } from 'wcpay/checkout/preview';
 import { recordUserEvent } from 'tracks';
+import { SHORTCODE_BILLING_ADDRESS_FIELDS } from 'wcpay/checkout/constants';
+
+const isBillingInformationMissing = () => {
+	const billingFieldsDisplayed = getUPEConfig( 'enabledBillingFields' );
+
+	// first name and last name are kinda special - we just need one of them to be at checkout
+	const name = `${
+		document.querySelector(
+			`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.first_name }`
+		)?.value || ''
+	} ${
+		document.querySelector(
+			`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.last_name }`
+		)?.value || ''
+	}`.trim();
+	if (
+		! name &&
+		( billingFieldsDisplayed.includes(
+			SHORTCODE_BILLING_ADDRESS_FIELDS.first_name
+		) ||
+			billingFieldsDisplayed.includes(
+				SHORTCODE_BILLING_ADDRESS_FIELDS.last_name
+			) )
+	) {
+		return true;
+	}
+
+	const billingFieldsToValidate = [
+		'billing_email',
+		SHORTCODE_BILLING_ADDRESS_FIELDS.country,
+		SHORTCODE_BILLING_ADDRESS_FIELDS.address_1,
+		SHORTCODE_BILLING_ADDRESS_FIELDS.city,
+		SHORTCODE_BILLING_ADDRESS_FIELDS.postcode,
+	].filter( ( field ) => billingFieldsDisplayed.includes( field ) );
+
+	// We need to just find one field with missing information. If even only one is missing, just return early.
+	return Boolean(
+		billingFieldsToValidate.find(
+			( fieldName ) =>
+				! document.querySelector( `#${ fieldName }` )?.value
+		)
+	);
+};
 
 jQuery( function ( $ ) {
 	enqueueFraudScripts( getUPEConfig( 'fraudServices' ) );
@@ -71,6 +114,10 @@ jQuery( function ( $ ) {
 	} );
 
 	$checkoutForm.on( generateCheckoutEventNames(), function () {
+		if ( isBillingInformationMissing() ) {
+			return;
+		}
+
 		return processPaymentIfNotUsingSavedMethod( $( this ) );
 	} );
 

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -94,36 +94,6 @@ export function validateElements( elements ) {
 }
 
 /**
- * Validates the checkout fields by checking if any fields required for payment method creation are misisng.
- * Throws an error if any required fields are missing. The error is caught by the processPayment function
- * and triggers WC Core's validation so that it can display its own error message.
- *
- * @param {Object} params The parameters to be validated.
- *
- */
-function validateCheckoutFields( params ) {
-	const requiredFields = [ 'name', 'email' ];
-	for ( const field of requiredFields ) {
-		if ( ! params.billing_details[ field ] ) {
-			throw new Error( 'Missing required field' );
-		}
-	}
-
-	const requiredAddressFields = [
-		'city',
-		'country',
-		'line1',
-		'postal_code',
-		'state',
-	];
-	for ( const field of requiredAddressFields ) {
-		if ( ! params.billing_details.address[ field ] ) {
-			throw new Error( 'Missing required field' );
-		}
-	}
-}
-
-/**
  * Submits the provided jQuery form and removes the 'processing' class from it.
  *
  * @param {Object} jQueryForm The jQuery object for the form being submitted.
@@ -201,8 +171,6 @@ function createStripePaymentMethod(
 				},
 			},
 		};
-
-		validateCheckoutFields( params );
 	}
 
 	return api


### PR DESCRIPTION
Fixes #8192 

#### Changes proposed in this Pull Request

Adding validation to the checkout inputs (only shortcode checkout) before a payment method is created.
When Stripe receives empty fields, a Stripe error is displayed at checkout (which doesn't have a great UI for customers). Instead, let's display the core WC errors.

This is happening because the core WC validation is performed after we submit the form.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure you're not logged in as a customer
- Add some products to the cart, go to shortcode checkout
- Fill in the CC details with valid values, and leave all other fields empty (alternative: use another payment method like giropay, that doesn't need other fields to be filled in before checking out)
- The WC error message should appear (instead of the "ugly" Stripe one)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
