### PR TITLE
Prevent double payment request init on checkout page

### DIFF
--- a/changelog/fix-double-init-payment-request
+++ b/changelog/fix-double-init-payment-request
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor improvement, nothing changed
+
+

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -653,7 +653,10 @@ jQuery( ( $ ) => {
 		},
 	};
 
-	wcpayPaymentRequest.init();
+	// We don't need to initialize payment request on the checkout page now because it will be initialized by updated_checkout event.
+	if ( ! wcpayPaymentRequestParams.is_checkout_page ) {
+		wcpayPaymentRequest.init();
+	}
 
 	// We need to refresh payment request data when total is updated.
 	$( document.body ).on( 'updated_cart_totals', () => {

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -654,7 +654,10 @@ jQuery( ( $ ) => {
 	};
 
 	// We don't need to initialize payment request on the checkout page now because it will be initialized by updated_checkout event.
-	if ( ! wcpayPaymentRequestParams.is_checkout_page ) {
+	if (
+		! wcpayPaymentRequestParams.is_checkout_page ||
+		wcpayPaymentRequestParams.is_pay_for_order
+	) {
 		wcpayPaymentRequest.init();
 	}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -744,6 +744,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			'has_block'          => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
 			'product'            => $this->get_product_data(),
 			'total_label'        => $this->express_checkout_helper->get_total_label(),
+			'is_checkout_page'   => $this->express_checkout_helper->is_checkout(),
 		];
 
 		WC_Payments::register_script_with_dependencies( 'WCPAY_PAYMENT_REQUEST', 'dist/payment-request', [ 'jquery', 'stripe' ] );


### PR DESCRIPTION
Fixes #8266

#### Changes proposed in this Pull Request

The checkout page always triggers the `updated_checkout` event, which initializes the payment request here https://github.com/Automattic/woocommerce-payments/pull/8282/files#diff-3b09c95dc3e8c6f0dd75f523bc8fccba95d8308a909d8641c5248c92134b2cacL664-L666. Because of this we were always initializing the payment request twice in the checkout page. With these changes we are removing the first initialization and letting `updated_checkout` trigger it.

#### Testing instructions

Smoke test Payment Request button in checkout, product page, and cart page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.