### PR TITLE
Revert removed REST controller class to prevent error on update

### DIFF
--- a/changelog/revert-return-rest-payments-survey-controller-to-avoid-update-error
+++ b/changelog/revert-return-rest-payments-survey-controller-to-avoid-update-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Reverts removed REST controller class to prevent error on update from older versions of the plugin.

--- a/includes/admin/class-wc-rest-payments-survey-controller.php
+++ b/includes/admin/class-wc-rest-payments-survey-controller.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Class WC_REST_Payments_Survey_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST dummy controller for settings. Needs to remain to prevent errors on update from v7.2 and earlier.
+ */
+class WC_REST_Payments_Survey_Controller extends WP_REST_Controller {
+	/**
+	 * Dummy register routes.
+	 */
+	public function register_routes() {}
+}


### PR DESCRIPTION
Fixes #8280 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Please read paJDYF-aZa-p2 for more context on the necessity of this change. `WC_REST_Payments_Survey_Controller` REST controller class was removed in #8215; however, this now causes a fatal on update from versions of the plugin v7.2 and under. This PR replaces the removed file with an inert dummy controller class to prevent any fatal errors while the plugin is being updated. 
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Essentially follow the steps described in #8280, but using this branch to build a new plugin to update the previously installed plugin.

1. Create any test site.
2. Install and activate all the required plugins.
3. Install the latest stable version of WooCommerce Payments via WP-ADMIN -> Plugins page.
4. Complete WooCommerce Payments KYC flow.
5. Create plugin build using this branch and upload to test site, replacing the existing plugin with the uploaded plugin. 
6. Hopefully see no evil.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.