### PR TITLE
Skip check-changelog worklfow if PR changes are only related to `.github` directory

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
       - 'release/**'
+    paths-ignore:
+      - '.github/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Fixes #5218 

#### Changes proposed in this Pull Request

Skips running check-changelog workflow if the PR contains changes only inside `.github` directory. Since this directory is used for storing GitHub Actions related stuff, and doesn't get added to release package, we can safely skip the changelog workflow.

#### Testing instructions

* Confirm that the changelog workflow is not triggered on this PR since the changes are only related to files under `.github` directory.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
