### PR TITLE
Fix - Enable code freeze slack notification even if release PR is not created

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -80,13 +80,22 @@ jobs:
   slack-notification:
     name: "Send notification to Slack"
     needs: [check-code-freeze, create-release-pr]
-    if: ${{ ! ( inputs.skipSlackPing && needs.create-release-pr.outputs.release-pr-id ) }}
+    if: ${{ ! ( inputs.skipSlackPing && cancelled() ) }}
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.check-code-freeze.outputs.nextReleaseVersion }}
       RELEASE_DATE: ${{ needs.check-code-freeze.outputs.nextReleaseDate }}
       RELEASE_PR_ID: ${{ needs.create-release-pr.outputs.release-pr-id }}
     steps:
+      - name: Check whether PR is created
+        id: check-pr-status
+        run: |
+          if [[ -z "$RELEASE_PR_ID" ]]; then
+            echo "RELEASE_PR_STATUS=:warning-8c: Failed to create Release PR. <https://github.com/Automattic/woocommerce-payments/compare/release/${{ env.RELEASE_VERSION }}|Click here to create the PR manually.>" >> $GITHUB_OUTPUT
+          else
+            echo "RELEASE_PR_STATUS=• Raised a <https://github.com/Automattic/woocommerce-payments/pull/${{ env.RELEASE_PR_ID }}|Pull Request> to `trunk`" >> $GITHUB_OUTPUT
+          fi
+
       - name: "Slack ping"
         uses: slackapi/slack-github-action@v1.25.0
         env:
@@ -116,7 +125,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "• Created a release branch `release/${{ env.RELEASE_VERSION }}` \n • Raised a <https://github.com/Automattic/woocommerce-payments/pull/${{ env.RELEASE_PR_ID }}|Pull Request> to `trunk`\n • Built a <https://github.com/Automattic/woocommerce-payments/actions/runs/${{ github.run_id }}|zip file and ran smoke tests> against it"
+                    "text": "• Created a release branch `release/${{ env.RELEASE_VERSION }}` \n ${{ steps.check-pr-status.outputs.RELEASE_PR_STATUS }} \n • Built a <https://github.com/Automattic/woocommerce-payments/actions/runs/${{ github.run_id }}|zip file and ran smoke tests> against it"
                   }
                 },
                 {


### PR DESCRIPTION
Fixes #6296 

#### Changes proposed in this Pull Request


#### Testing instructions


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
