### PR TITLE
E2E setup – don't install deprecated WooCommerce Blocks plugin

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -55,7 +55,7 @@ jobs:
       E2E_WC_VERSION: ${{ matrix.woocommerce }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
-      SKIP_WC_BLOCKS_TESTS: 1 #skip installing & running blocks tests
+      SKIP_WC_BLOCKS_TESTS: 1 # skip running blocks tests
 
     steps:
       - name: Checkout WCPay repository

--- a/changelog/fix-failing-e2e-setup-woo-gutenberg-products-block
+++ b/changelog/fix-failing-e2e-setup-woo-gutenberg-products-block
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: E2E setup: don't attempt to install archived plugin woo-gutenberg-products-block
-
-

--- a/changelog/fix-failing-e2e-setup-woo-gutenberg-products-block
+++ b/changelog/fix-failing-e2e-setup-woo-gutenberg-products-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E setup: don't attempt to install archived plugin woo-gutenberg-products-block
+
+

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -323,12 +323,6 @@ else
 	echo "Skipping install of Action Scheduler"
 fi
 
-if [[ ! ${SKIP_WC_BLOCKS_TESTS} ]]; then
-	echo "Install and activate the latest release of WooCommerce Blocks"
-	cli wp plugin install woo-gutenberg-products-block --activate
-else
-	echo "Skipping install of WooCommerce Blocks"
-fi
 
 echo "Creating screenshots directory"
 mkdir -p $WCP_ROOT/screenshots


### PR DESCRIPTION
Fixes #8291 

#### Changes proposed in this Pull Request

The [WooCommerce Blocks plugin has now been archived](https://developer.woo.com/2024/02/22/woocommerce-blocks-is-being-archived-on-github-and-wordpress-org/) and all functionality rolled into WooCommerce Core, causing the e2e setup script to fail.

Therefore, this PR removes this plugin installation from the E2E env setup script.

> [!CAUTION]
> This PR will merge to `trunk`, which is required to ensure this fix applies to `woocommerce-payments-server` GH checks.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure E2E GH checks pass the `Setup E2E environment` step. (Merchant E2E tests were failing prior to this for an unrelated reason – [see previous run](https://github.com/Automattic/woocommerce-payments/actions/runs/8046038729/job/21972483308?pr=8216))

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

### Post-merge
- [ ] Cherry-pick the merge commit to `develop`
