### PR TITLE
E2E setup – don't install deprecated WooCommerce Blocks plugin (#8290)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -55,7 +55,7 @@ jobs:
       E2E_WC_VERSION: ${{ matrix.woocommerce }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
-      SKIP_WC_BLOCKS_TESTS: 1 #skip installing & running blocks tests
+      SKIP_WC_BLOCKS_TESTS: 1 # skip running blocks tests
 
     steps:
       - name: Checkout WCPay repository

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -323,12 +323,6 @@ else
 	echo "Skipping install of Action Scheduler"
 fi
 
-if [[ ! ${SKIP_WC_BLOCKS_TESTS} ]]; then
-	echo "Install and activate the latest release of WooCommerce Blocks"
-	cli wp plugin install woo-gutenberg-products-block --activate
-else
-	echo "Skipping install of WooCommerce Blocks"
-fi
 
 echo "Creating screenshots directory"
 mkdir -p $WCP_ROOT/screenshots


### PR DESCRIPTION
Fixes #8291

#### Changes proposed in this Pull Request

This PR brings the commit merged to `trunk` in #8290 over to `develop`.

> The [WooCommerce Blocks plugin has now been archived](https://developer.woo.com/2024/02/22/woocommerce-blocks-is-being-archived-on-github-and-wordpress-org/) and all functionality rolled into WooCommerce Core, causing the e2e setup script to fail.

> Therefore, this PR removes this plugin installation from the E2E env setup script.

> [!CAUTION]
> Dont press `Update branch`, since this could bring `develop` commits over to `trunk` if branch protection rules allow it 🫣