### PR TITLE
fix: e2e merchant tests for manual capture wording

### DIFF
--- a/changelog/fix-e2e-merchant-manual-capture-test
+++ b/changelog/fix-e2e-merchant-manual-capture-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: e2e merchant tests for manual capture wording
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-payment-settings-manual-capture.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-payment-settings-manual-capture.spec.js
@@ -30,7 +30,7 @@ describe( 'As a merchant, I should be prompted a confirmation modal when I try t
 			confirmationModalClass
 		);
 		await expect( confirmationModal ).toMatch(
-			'Are you sure you want to enable manual capture of payments?'
+			'Payments must be captured within 7 days or the authorization will expire and money will be returned to the shopper'
 		);
 	} );
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed the e2e test failing due to wording changes in https://github.com/Automattic/woocommerce-payments/pull/8244.

Fixing.

New wording:
![Screenshot 2024-02-29 at 12 07 33 PM](https://github.com/Automattic/woocommerce-payments/assets/273592/ee213dac-d415-45ce-8775-bba0d8279489)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
