### PR TITLE
Add server-side WooPay direct checkout eligibility flag

### DIFF
--- a/changelog/add-woopay-direct-checkout-eligibility-flag
+++ b/changelog/add-woopay-direct-checkout-eligibility-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WooPay direct checkout flow behind a server-side feature flag.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -262,7 +262,11 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
-		return '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '0' ) && self::is_woopay_first_party_auth_enabled();
+		$account_cache               = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
+		$is_direct_checkout_eligible = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
+		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '0' );
+
+		return ( $is_direct_checkout_eligible || $is_direct_checkout_flag_enabled ) && self::is_woopay_first_party_auth_enabled();
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -262,8 +262,8 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
-		$account_cache               = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
-		$is_direct_checkout_eligible = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
+		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
+		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '0' );
 
 		return ( $is_direct_checkout_eligible || $is_direct_checkout_flag_enabled ) && self::is_woopay_first_party_auth_enabled();


### PR DESCRIPTION
Fixes 2455-gh-Automattic/woopay

#### Changes proposed in this Pull Request

* Adds a server-side feature flag for enabling the WooPay direct checkout eligibility.

#### Testing instructions

* Please refer to 4833-gh-Automattic/woocommerce-payments-server for the testing instructions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.