### PR TITLE
misc: remove redundant wrapper for getting account default currency

### DIFF
--- a/changelog/misc-remove-unnecessary-wrapper
+++ b/changelog/misc-remove-unnecessary-wrapper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove redundant wrapper around method invocation.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2593,15 +2593,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Gets account default currency.
-	 *
-	 * @return string Currency code.
-	 */
-	public function get_account_default_currency(): string {
-		return $this->account->get_account_default_currency();
-	}
-
-	/**
 	 * Gets connected account business name.
 	 *
 	 * @param string $default_value Value to return when not connected or failed to fetch business name.
@@ -2790,7 +2781,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$merchant_country
 				)
 			);
-			return $this->get_account_default_currency();
+			return $this->account->get_account_default_currency();
 		}
 
 		return $country_locale_data['currency_code'];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some time ago, we discussed [the improvements for `get_account_domestic_currency()`](https://github.com/Automattic/woocommerce-payments/pull/8212#discussion_r1492405595). Not everything was eventually worth it to refactor, but I've noticed one small redundant wrapper in the gateway, which probably was needed when separate gateways were in place and isn't required anymore. This PR simply removes it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.