### PR TITLE
Revert "Include payment title in order_placed Tracks event (#8252)"

### DIFF
--- a/changelog/add-track-gateway-name
+++ b/changelog/add-track-gateway-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Include gateway name in order-placed Tracks event

--- a/changelog/revert-8252-add-track-gateway-name
+++ b/changelog/revert-8252-add-track-gateway-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Reverts an unreleased change
+
+

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -70,8 +70,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'woocommerce_after_single_product', [ $this, 'classic_product_page_view' ] );
 		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', [ $this, 'blocks_checkout_start' ] );
 		add_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after', [ $this, 'blocks_cart_page_view' ] );
-		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
-		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
+		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
+		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_payments_save_user_in_woopay', [ $this, 'must_save_payment_method_to_platform' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'pay_for_order_page_view' ] );
 		add_action( 'woocommerce_thankyou', [ $this, 'thank_you_page_view' ] );
@@ -463,21 +463,11 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	/**
 	 * Record a Tracks event that the order has been processed.
 	 */
-	public function checkout_order_processed( $order_id ) {
+	public function checkout_order_processed() {
 		$is_woopay_order = ( isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'] );
-
-		$payment_gateway = wc_get_payment_gateway_by_order( $order_id );
-		$properties = [ 'payment_title' => 'other' ];
-
-		if (strpos( $payment_gateway->id, 'woocommerce_payments') === 0 ) {
-			$order = wc_get_order( $order_id );
-			$payment_title = $order->get_payment_method_title();
-			$properties = [ 'payment_title' => $payment_title ];
-		}
-
 		// Don't track WooPay orders. They will be tracked on WooPay side with more flow specific details.
 		if ( ! $is_woopay_order ) {
-			$this->maybe_record_wcpay_shopper_event( 'checkout_order_placed', $properties );
+			$this->maybe_record_wcpay_shopper_event( 'checkout_order_placed' );
 		}
 	}
 


### PR DESCRIPTION
This reverts commit #8252 until the question in the following p2 is answered p2y3YZ-87v-p2

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

### Testing instructions

Follow the instructions in https://github.com/Automattic/woocommerce-payments/pull/8252 make sure `payment_title` field is not present.
<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.