### PR TITLE
Prevent sending shopper emails when disputes are closed

### DIFF
--- a/changelog/fix-7928-prevent-sending-order-complete-emails
+++ b/changelog/fix-7928-prevent-sending-order-complete-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Order completed and refunded emails are no longer sent when a dispute is closed.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -345,7 +345,6 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
-
 		// Order `completed` and `refunded` emails should both be blocked when disputes are closed.
 		add_filter( 'woocommerce_email_enabled_customer_completed_order', '__return_false' );
 		add_filter( 'woocommerce_email_enabled_customer_refunded_order', '__return_false' );

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -345,6 +345,11 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
+
+		// Order `completed` and `refunded` emails should both be blocked when disputes are closed.
+		add_filter( 'woocommerce_email_enabled_customer_completed_order', '__return_false' );
+		add_filter( 'woocommerce_email_enabled_customer_refunded_order', '__return_false' );
+
 		if ( 'lost' === $status ) {
 			wc_create_refund(
 				[
@@ -359,6 +364,10 @@ class WC_Payments_Order_Service {
 			$this->update_order_status( $order, Order_Status::COMPLETED );
 			$order->save();
 		}
+
+		// Restore completed and refunded order emails.
+		remove_filter( 'woocommerce_email_enabled_customer_completed_order', '__return_false' );
+		remove_filter( 'woocommerce_email_enabled_customer_refunded_order', '__return_false' );
 
 		$order->add_order_note( $note );
 	}

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -922,7 +922,6 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'Pending payment to Completed', $notes[1]->content );
 		$this->assertStringContainsString( 'Payment dispute has been closed with status won', $notes[0]->content );
 		$this->assertStringContainsString( '/payments/transactions/details&id=ch_123" target="_blank" rel="noopener noreferrer">dispute overview', $notes[0]->content );
-		$this->assert
 
 		// Assert: Applying the same data multiple times does not cause duplicate actions.
 		$this->order_service->mark_payment_dispute_closed( $this->order, $charge_id, $status );

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -922,6 +922,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'Pending payment to Completed', $notes[1]->content );
 		$this->assertStringContainsString( 'Payment dispute has been closed with status won', $notes[0]->content );
 		$this->assertStringContainsString( '/payments/transactions/details&id=ch_123" target="_blank" rel="noopener noreferrer">dispute overview', $notes[0]->content );
+		$this->assert
 
 		// Assert: Applying the same data multiple times does not cause duplicate actions.
 		$this->order_service->mark_payment_dispute_closed( $this->order, $charge_id, $status );


### PR DESCRIPTION
Fixes #7928 

#### Changes proposed in this Pull Request

When a dispute is created, WooPayments will mark the order as [`on-hold`](https://github.com/Automattic/woocommerce-payments/blob/ec9334e450440ae03c0afff251a090114d5d02e0/includes/class-wc-payments-order-service.php#L323). When the dispute is closed, the order is marked as `completed` or `refunded` depending on the dispute [`status`](https://github.com/Automattic/woocommerce-payments/blob/ec9334e450440ae03c0afff251a090114d5d02e0/includes/class-wc-payments-order-service.php#L353). 

The changing of the status to either `refunded` or `completed` triggers WooCommerce to send an email.

| `refunded` email | `completed` email |
|--------|--------|
| ![image](https://github.com/Automattic/woocommerce-payments/assets/57298/4edfb442-b7de-4cbb-9b9b-38a1e5f365a1) | ![image](https://github.com/Automattic/woocommerce-payments/assets/57298/353d8c02-cede-4cd5-abea-941b47d50a67) | 


In both cases, these emails should not be sent. In the case of `completed` the shopper will be confused as to why they are receiving the email. 

For `refunded` there are some benefits to still sending the email as it will let the shopper know that they are being refunded. However, as this refund is handled by Stripe and the shoppers' bank there may be a delay in receiving it. It is best to allow the shoppers' bank to communicate the dispute outcome.

This PR adds a filter to block these emails from being sent as the order status is being changed.  This will fix the immediate issue of emails being sent.

Long-term, disputes should have custom statuses. See #8306

#### Testing instructions

##### Setup
- Ensure you can see order emails (as shopper). e.g MailHog in local docker environment.
- Purchase something using a [dispute test card](https://stripe.com/docs/testing#disputes). I used `4000000000002685` (triggers `not received` dispute).

##### Order complete emails 
- Close the dispute. I closed by [submitting test `winning_evidence`](https://stripe.com/docs/testing#evidence).
- Email should not be sent to the shopper - `Your [STORE] order is now complete`

##### Order refunded emails 
- Close the dispute, by accepting the dispute or [submitting test `losing_evidence`](https://stripe.com/docs/testing#evidence).
- Email should not be sent to the shopper - `Your [STORE] order has been refunded `

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
