### PR TITLE
Refactor - `isInquiry` utility function to accept only dispute status as param

### DIFF
--- a/changelog/refactor-7085-pass-only-dispute-status-as-param
+++ b/changelog/refactor-7085-pass-only-dispute-status-as-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Minor refactor to disputes utility function inInquiry to make it accept only dispute status as a param, instead of whole dispute object.

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -43,7 +43,7 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 
 	// Special case the dispute "under review" notice which is much simpler.
 	// (And return early.)
-	if ( isUnderReview( dispute.status ) && ! isInquiry( dispute ) ) {
+	if ( isUnderReview( dispute.status ) && ! isInquiry( dispute.status ) ) {
 		return (
 			<DisputeOrderLockedNotice
 				message={ __(
@@ -100,7 +100,7 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 				dispute.amount,
 				dispute.currency
 			) }
-			isPreDisputeInquiry={ isInquiry( dispute ) }
+			isPreDisputeInquiry={ isInquiry( dispute.status ) }
 			dueBy={ dueBy }
 			countdownDays={ Math.floor( dueBy.diff( now, 'days', true ) ) }
 			disputeDetailsUrl={ disputeDetailsUrl }

--- a/client/disputes/test/utils.test.ts
+++ b/client/disputes/test/utils.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isDueWithin } from '../utils';
+import { isDueWithin, isInquiry } from '../utils';
 
 describe( 'isDueWithin', () => {
 	// 2021-01-01T00:00:00.000Z
@@ -92,5 +92,21 @@ describe( 'isDueWithin', () => {
 		expect(
 			isDueWithin( { dueBy: '2020-12-31T23:59:00.000Z', days: 10 } )
 		).toBe( false );
+	} );
+} );
+
+describe( 'isInquiry', () => {
+	test( 'returns true if status is inquiry', () => {
+		expect( isInquiry( 'warning_needs_response' ) ).toBe( true );
+		expect( isInquiry( 'warning_under_review' ) ).toBe( true );
+		expect( isInquiry( 'warning_closed' ) ).toBe( true );
+	} );
+
+	test( 'returns false if status is not inquiry', () => {
+		expect( isInquiry( 'needs_response' ) ).toBe( false );
+		expect( isInquiry( 'under_review' ) ).toBe( false );
+		expect( isInquiry( 'charge_refunded' ) ).toBe( false );
+		expect( isInquiry( 'won' ) ).toBe( false );
+		expect( isInquiry( 'lost' ) ).toBe( false );
 	} );
 } );

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -67,14 +67,14 @@ export const isUnderReview = ( status: DisputeStatus | string ): boolean => {
 	return disputeUnderReviewStatuses.includes( status );
 };
 
-export const isInquiry = ( dispute: Pick< Dispute, 'status' > ): boolean => {
+export const isInquiry = ( status: DisputeStatus ): boolean => {
 	// Inquiry dispute statuses are one of `warning_needs_response`, `warning_under_review` or `warning_closed`.
-	return dispute.status.startsWith( 'warning' );
+	return status.startsWith( 'warning' );
 };
 
 export const isRefundable = ( status: DisputeStatus ): boolean => {
 	// Refundable dispute statuses are one of `warning_needs_response`, `warning_under_review`, `warning_closed` or `won`.
-	return isInquiry( { status } ) || 'won' === status;
+	return isInquiry( status ) || 'won' === status;
 };
 
 /**

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -90,7 +90,7 @@ function getAcceptDisputeProps( {
 	dispute: Dispute;
 	isDisputeAcceptRequestPending: boolean;
 } ): AcceptDisputeProps {
-	if ( isInquiry( dispute ) ) {
+	if ( isInquiry( dispute.status ) ) {
 		return {
 			acceptButtonLabel: __( 'Issue refund', 'woocommerce-payments' ),
 			acceptButtonTracksEvent: 'wcpay_dispute_inquiry_refund_modal_view',
@@ -204,7 +204,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		isDisputeAcceptRequestPending,
 	} );
 
-	const challengeButtonDefaultText = isInquiry( dispute )
+	const challengeButtonDefaultText = isInquiry( dispute.status )
 		? __( 'Submit evidence', 'woocommerce-payments' )
 		: __( 'Challenge dispute', 'woocommerce-payments' );
 
@@ -227,7 +227,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 
 					<DisputeSummaryRow dispute={ dispute } />
 
-					{ isInquiry( dispute ) ? (
+					{ isInquiry( dispute.status ) ? (
 						<InquirySteps
 							dispute={ dispute }
 							customer={ customer }
@@ -373,7 +373,9 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 												 * Handle the primary modal action.
 												 * If it's an inquiry, redirect to the order page; otherwise, continue with the default dispute acceptance.
 												 */
-												if ( isInquiry( dispute ) ) {
+												if (
+													isInquiry( dispute.status )
+												) {
 													viewOrder();
 												} else {
 													doAccept();

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -43,7 +43,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 	let learnMoreDocsUrl =
 		'https://woo.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding';
 
-	if ( isInquiry( dispute ) ) {
+	if ( isInquiry( dispute.status ) ) {
 		/* translators: <a> link to dispute inquiry documentation. %s is the clients claim for the dispute, eg "The cardholder claims this is an unrecognized charge." */
 		noticeText = __(
 			'<strong>%s</strong> You can challenge their claim if you believe it’s invalid. ' +


### PR DESCRIPTION
Fixes #7085 

#### Changes proposed in this Pull Request

The PR does a minor refactor to make `isInquiry` function take only the dispute status, and not the complete dispute object ( unnecessary ). 

Functions that call `inInquiry` have also been amended to send only `dispute.status`. 

Props to @shendy-a8c for identifying the improvement.

#### Testing instructions
* All existing unit tests should pass

-------------------

- [*] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [*] Covered with tests
- [*] Tested on mobile - N.A.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
