### PR TITLE
Hide Refund in Full option when a partial refund has already happened

### DIFF
--- a/changelog/fix-8210-error-when-attempting-to-fully-refund-remaining-amount-after-partial-refund
+++ b/changelog/fix-8210-error-when-attempting-to-fully-refund-remaining-amount-after-partial-refund
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide the option to refund in full from the transaction details menu when a transaction is partially refunded.

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -210,6 +210,8 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 	// present, partial refund is not possible.
 	const isPartiallyRefundable = charge.order && charge.order.number;
 
+	const hasRefundedAmount = charge.amount_refunded > 0;
+
 	// Control menu only shows refund actions for now. In the future, it may show other actions.
 	const showControlMenu =
 		charge.captured && ! charge.refunded && isDisputeRefundable;
@@ -554,26 +556,28 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 								>
 									{ ( { onClose } ) => (
 										<MenuGroup>
-											<MenuItem
-												onClick={ () => {
-													setIsRefundModalOpen(
-														true
-													);
-													recordEvent(
-														'payments_transactions_details_refund_modal_open',
-														{
-															payment_intent_id:
-																charge.payment_intent,
-														}
-													);
-													onClose();
-												} }
-											>
-												{ __(
-													'Refund in full',
-													'woocommerce-payments'
-												) }
-											</MenuItem>
+											{ ! hasRefundedAmount && (
+												<MenuItem
+													onClick={ () => {
+														setIsRefundModalOpen(
+															true
+														);
+														recordEvent(
+															'payments_transactions_details_refund_modal_open',
+															{
+																payment_intent_id:
+																	charge.payment_intent,
+															}
+														);
+														onClose();
+													} }
+												>
+													{ __(
+														'Refund in full',
+														'woocommerce-payments'
+													) }
+												</MenuItem>
+											) }
 											{ isPartiallyRefundable && (
 												<MenuItem
 													onClick={ () => {

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -210,7 +210,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 	// present, partial refund is not possible.
 	const isPartiallyRefundable = charge.order && charge.order.number;
 
-	const hasRefundedAmount = charge.amount_refunded > 0;
+	const isPartiallyRefunded = charge.amount_refunded > 0;
 
 	// Control menu only shows refund actions for now. In the future, it may show other actions.
 	const showControlMenu =
@@ -556,7 +556,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 								>
 									{ ( { onClose } ) => (
 										<MenuGroup>
-											{ ! hasRefundedAmount && (
+											{ ! isPartiallyRefunded && (
 												<MenuItem
 													onClick={ () => {
 														setIsRefundModalOpen(

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import moment from 'moment';
@@ -959,6 +959,42 @@ describe( 'PaymentDetailsSummary', () => {
 			).not.toBeInTheDocument();
 
 			expect( container ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'Refund actions menu', () => {
+		test( 'Refund control menu is visible when conditions are met', () => {
+			renderCharge( getBaseCharge() );
+			expect(
+				screen.getByLabelText( 'Transaction actions' )
+			).toBeInTheDocument();
+		} );
+
+		test( 'Refund in full option is available when no amount has been refunded', () => {
+			renderCharge( getBaseCharge() );
+			fireEvent.click( screen.getByLabelText( 'Transaction actions' ) );
+			expect( screen.getByText( 'Refund in full' ) ).toBeInTheDocument();
+		} );
+
+		test( 'Refund in full option is not available when an amount has been refunded', () => {
+			renderCharge( { ...getBaseCharge(), amount_refunded: 42 } );
+			fireEvent.click( screen.getByLabelText( 'Transaction actions' ) );
+			expect(
+				screen.queryByText( 'Refund in full' )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'Partial refund option is available when charge is associated with an order', () => {
+			renderCharge( getBaseCharge() );
+			fireEvent.click( screen.getByLabelText( 'Transaction actions' ) );
+			expect( screen.getByText( 'Partial refund' ) ).toBeInTheDocument();
+		} );
+
+		test( 'Refund control menu is not visible when charge is not captured', () => {
+			renderCharge( { ...getBaseCharge(), captured: false } );
+			expect(
+				screen.queryByLabelText( 'Transaction actions' )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #8210 

#### Changes proposed in this Pull Request

- Hide the `Refund in Full` option from the dropdown menu in the transactions details page when the transactions is partially refunded.

**Screenshots**
Before

<img width="1033" alt="Screenshot 2024-03-05 at 11 05 52" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/1799ba56-8bef-4350-b151-7bd9517a0392">


After

<img width="1040" alt="Screenshot 2024-03-05 at 11 04 31" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/d21fa268-6e52-467c-9fe9-856f7cd8f3a0">


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a shopper, purchase an order
* As a merchant, perform a partial refund
* Navigate to the transaction details of the order
* Click on the three-dot menu on the upper right corner of the payment details
* Check that the "Refund in Full" option is not present

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
