### PR TITLE
Added notice to inform merchant that their bank account has an error

### DIFF
--- a/changelog/add-6294-deposit-account-error-notice
+++ b/changelog/add-6294-deposit-account-error-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added a notice to inform the merchant when the payout bank account is in errored state

--- a/client/components/account-balances/test/index.test.tsx
+++ b/client/components/account-balances/test/index.test.tsx
@@ -23,6 +23,7 @@ const mockAccount: AccountOverview.Account = {
 		weekly_anchor: 'Monday',
 		monthly_anchor: 1,
 	},
+	external_accounts: [],
 };
 
 // Mock the wcpaySettings localized variables needed by these tests.

--- a/client/components/account-balances/test/index.test.tsx
+++ b/client/components/account-balances/test/index.test.tsx
@@ -23,7 +23,7 @@ const mockAccount: AccountOverview.Account = {
 		weekly_anchor: 'Monday',
 		monthly_anchor: 1,
 	},
-	external_accounts: [],
+	default_external_accounts: [],
 };
 
 // Mock the wcpaySettings localized variables needed by these tests.

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -216,28 +216,28 @@ export const NoFundsAvailableForDepositNotice: React.FC = () => (
  * Renders a notice informing the user that deposits are paused due to a recent deposit failure.
  */
 export const DepositFailureNotice: React.FC = () => (
-    <InlineNotice
-        status="warning"
-        icon
-        className="deposit-failure-notice"
-        isDismissible={ false }
-    >
-        { interpolateComponents( {
-            mixedString: __(
-                'Deposits are currently paused because a recent deposit failed. Please {{updateLink}}update your bank account details{{/updateLink}}.',
-                'woocommerce-payments'
-            ),
-            components: {
-                updateLink: (
-                    // Link content is in the format string above.
-                    // eslint-disable-next-line jsx-a11y/anchor-has-content
-                    <a
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        href="https://woo.com/document/woopayments/deposits/change-deposit-account-info/"
-                    />
-                ),
-            },
-        } ) }
-    </InlineNotice>
+	<InlineNotice
+		status="warning"
+		icon
+		className="deposit-failure-notice"
+		isDismissible={ false }
+	>
+		{ interpolateComponents( {
+			mixedString: __(
+				'Deposits are currently paused because a recent deposit failed. Please {{updateLink}}update your bank account details{{/updateLink}}.',
+				'woocommerce-payments'
+			),
+			components: {
+				updateLink: (
+					// Link content is in the format string above.
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						target="_blank"
+						rel="noopener noreferrer"
+						href="https://woo.com/document/woopayments/deposits/change-deposit-account-info/"
+					/>
+				),
+			},
+		} ) }
+	</InlineNotice>
 );

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -211,3 +211,33 @@ export const NoFundsAvailableForDepositNotice: React.FC = () => (
 		} ) }
 	</InlineNotice>
 );
+
+/**
+ * Renders a notice informing the user that deposits are paused due to a recent deposit failure.
+ */
+export const DepositFailureNotice: React.FC = () => (
+    <InlineNotice
+        status="warning"
+        icon
+        className="deposit-failure-notice"
+        isDismissible={ false }
+    >
+        { interpolateComponents( {
+            mixedString: __(
+                'Deposits are currently paused because a recent deposit failed. Please {{updateLink}}update your bank account details{{/updateLink}}.',
+                'woocommerce-payments'
+            ),
+            components: {
+                updateLink: (
+                    // Link content is in the format string above.
+                    // eslint-disable-next-line jsx-a11y/anchor-has-content
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://woo.com/document/woopayments/deposits/change-deposit-account-info/"
+                    />
+                ),
+            },
+        } ) }
+    </InlineNotice>
+);

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -6,6 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 import { tip } from '@wordpress/icons';
+import { ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -233,15 +234,7 @@ export const DepositFailureNotice: React.FC< {
 				'woocommerce-payments'
 			),
 			components: {
-				updateLink: (
-					// Link content is in the format string above.
-					// eslint-disable-next-line jsx-a11y/anchor-has-content
-					<a
-						target="_blank"
-						rel="noopener noreferrer"
-						href={ updateAccountLink }
-					/>
-				),
+				updateLink: <ExternalLink href={ updateAccountLink } />,
 			},
 		} ) }
 	</InlineNotice>

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -215,7 +215,12 @@ export const NoFundsAvailableForDepositNotice: React.FC = () => (
 /**
  * Renders a notice informing the user that deposits are paused due to a recent deposit failure.
  */
-export const DepositFailureNotice: React.FC = () => (
+export const DepositFailureNotice: React.FC< {
+	/**
+	 * The link to update the account details.
+	 */
+	updateAccountLink: string;
+} > = ( { updateAccountLink } ) => (
 	<InlineNotice
 		status="warning"
 		icon
@@ -234,7 +239,7 @@ export const DepositFailureNotice: React.FC = () => (
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woo.com/document/woopayments/deposits/change-deposit-account-info/"
+						href={ updateAccountLink }
 					/>
 				),
 			},

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -73,8 +73,11 @@ const DepositsOverview: React.FC = () => {
 	const hasScheduledDeposits = hasAutomaticScheduledDeposits(
 		account?.deposits_schedule?.interval
 	);
-	const hasErroredExternalAccount = account?.external_accounts?.some( 
-			external_account => external_account.currency === selectedCurrency && external_account.status === 'errored'
+	const hasErroredExternalAccount =
+		account?.external_accounts?.some(
+			( externalAccount ) =>
+				externalAccount.currency === selectedCurrency &&
+				externalAccount.status === 'errored'
 		) ?? false;
 
 	// Show a loading state if the page is still loading.

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -154,7 +154,11 @@ const DepositsOverview: React.FC = () => {
 							<NegativeBalanceDepositsPausedNotice />
 						) }
 						{ hasErroredExternalAccount && (
-							<DepositFailureNotice />
+							<DepositFailureNotice
+								updateAccountLink={
+									wcpaySettings.accountStatus.accountLink
+								}
+							/>
 						) }
 						{ availableFunds > 0 &&
 							! isAboveMinimumDepositAmount && (

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -28,6 +28,7 @@ import {
 	NewAccountWaitingPeriodNotice,
 	NoFundsAvailableForDepositNotice,
 	SuspendedDepositNotice,
+	DepositFailureNotice,
 } from './deposit-notices';
 import { hasAutomaticScheduledDeposits } from 'wcpay/deposits/utils';
 import useRecentDeposits from './hooks';
@@ -72,6 +73,9 @@ const DepositsOverview: React.FC = () => {
 	const hasScheduledDeposits = hasAutomaticScheduledDeposits(
 		account?.deposits_schedule?.interval
 	);
+	const hasErroredExternalAccount = account?.external_accounts?.some( 
+			external_account => external_account.currency === selectedCurrency && external_account.status === 'errored'
+		) ?? false;
 
 	// Show a loading state if the page is still loading.
 	if ( isLoading ) {
@@ -144,6 +148,9 @@ const DepositsOverview: React.FC = () => {
 							) }
 						{ isNegativeBalanceDepositsPaused && (
 							<NegativeBalanceDepositsPausedNotice />
+						) }
+						{ hasErroredExternalAccount && (
+							<DepositFailureNotice />
 						) }
 						{ availableFunds > 0 &&
 							! isAboveMinimumDepositAmount && (

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -139,7 +139,8 @@ const DepositsOverview: React.FC = () => {
 				) : (
 					<>
 						{ isDepositsUnrestricted &&
-							! isDepositAwaitingPendingFunds && (
+							! isDepositAwaitingPendingFunds &&
+							! hasErroredExternalAccount && (
 								<DepositTransitDaysNotice />
 							) }
 						{ ! hasCompletedWaitingPeriod && (

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -74,7 +74,7 @@ const DepositsOverview: React.FC = () => {
 		account?.deposits_schedule?.interval
 	);
 	const hasErroredExternalAccount =
-		account?.external_accounts?.some(
+		account?.default_external_accounts?.some(
 			( externalAccount ) =>
 				externalAccount.currency === selectedCurrency &&
 				externalAccount.status === 'errored'

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -39,7 +39,7 @@ exports[`DepositFailureNotice Renders Renders DepositFailureNotice component cor
         >
           Deposits are currently paused because a recent deposit failed. Please 
           <a
-            href="https://woo.com/document/woopayments/deposits/change-deposit-account-info/"
+            href="https://example.com"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -39,11 +39,33 @@ exports[`DepositFailureNotice Renders Renders DepositFailureNotice component cor
         >
           Deposits are currently paused because a recent deposit failed. Please 
           <a
+            class="components-external-link"
             href="https://example.com"
-            rel="noopener noreferrer"
+            rel="external noreferrer noopener"
             target="_blank"
           >
             update your bank account details
+            <span
+              class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="VisuallyHidden"
+              style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+            >
+              (opens in a new tab)
+            </span>
+            <svg
+              aria-hidden="true"
+              class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+              focusable="false"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+              />
+            </svg>
           </a>
           .
         </div>

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DepositFailureNotice Renders Renders DepositFailureNotice component correctly 1`] = `
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-warning-notice deposit-failure-notice components-notice is-warning"
+  >
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <svg
+            class="gridicon gridicons-notice-outline"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          Deposits are currently paused because a recent deposit failed. Please 
+          <a
+            href="https://woo.com/document/woopayments/deposits/change-deposit-account-info/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            update your bank account details
+          </a>
+          .
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Deposits Overview information Component Renders 1`] = `
 <div>
   <div

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -528,7 +528,9 @@ describe( 'Suspended Deposit Notice Renders', () => {
 
 describe( 'DepositFailureNotice Renders', () => {
 	test( 'Renders DepositFailureNotice component correctly', () => {
-		const { container } = render( <DepositFailureNotice /> );
+		const { container } = render(
+			<DepositFailureNotice updateAccountLink="https://example.com" />
+		);
 		expect( container ).toMatchSnapshot();
 	} );
 

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -10,7 +10,10 @@ import { render } from '@testing-library/react';
 import DepositsOverview from '..';
 import RecentDepositsList from '../recent-deposits-list';
 import DepositSchedule from '../deposit-schedule';
-import { SuspendedDepositNotice, DepositFailureNotice } from '../deposit-notices';
+import {
+	SuspendedDepositNotice,
+	DepositFailureNotice,
+} from '../deposit-notices';
 import {
 	useSelectedCurrencyOverview,
 	useSelectedCurrency,
@@ -538,7 +541,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			{
 				currency: 'chf',
 				status: 'errored',
-			}
+			},
 		];
 		const eurAccountOverview = createMockNewAccountOverview(
 			'eur',
@@ -557,7 +560,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			overview: chfAccountOverview,
 			isLoading: false,
 		} );
-		const { queryByText } = render( <DepositsOverview /> );	
+		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
 				/Deposits are currently paused because a recent deposit failed./,
@@ -577,7 +580,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			{
 				currency: 'chf',
 				status: 'new',
-			}
+			},
 		];
 		const eurAccountOverview = createMockNewAccountOverview(
 			'eur',
@@ -596,7 +599,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			overview: eurAccountOverview,
 			isLoading: false,
 		} );
-		const { queryByText } = render( <DepositsOverview /> );	
+		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
 				/Deposits are currently paused because a recent deposit failed./,
@@ -616,7 +619,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			{
 				currency: 'chf',
 				status: 'new',
-			}
+			},
 		];
 		const eurAccountOverview = createMockNewAccountOverview(
 			'eur',
@@ -635,7 +638,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			overview: chfAccountOverview,
 			isLoading: false,
 		} );
-		const { queryByText } = render( <DepositsOverview /> );	
+		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
 				/Deposits are currently paused because a recent deposit failed./,
@@ -645,8 +648,7 @@ describe( 'DepositFailureNotice Renders', () => {
 			)
 		).toBeFalsy();
 	} );
-	
-});
+} );
 
 describe( 'Paused Deposit notice Renders', () => {
 	test( 'When total balance is negative', () => {

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -45,6 +45,7 @@ const mockAccount: AccountOverview.Account = {
 		weekly_anchor: 'Monday',
 		monthly_anchor: 1,
 	},
+	external_accounts: [],
 };
 
 declare const global: {

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -48,7 +48,7 @@ const mockAccount: AccountOverview.Account = {
 		weekly_anchor: 'Monday',
 		monthly_anchor: 1,
 	},
-	external_accounts: [],
+	default_external_accounts: [],
 };
 
 declare const global: {
@@ -535,7 +535,7 @@ describe( 'DepositFailureNotice Renders', () => {
 	} );
 
 	test( 'Renders DepositFailureNotice when there is an errored external account', () => {
-		mockAccount.external_accounts = [
+		mockAccount.default_external_accounts = [
 			{
 				currency: 'eur',
 				status: 'new',
@@ -574,7 +574,7 @@ describe( 'DepositFailureNotice Renders', () => {
 	} );
 
 	test( 'Does not render DepositFailureNotice when there is no errored external account', () => {
-		mockAccount.external_accounts = [
+		mockAccount.default_external_accounts = [
 			{
 				currency: 'eur',
 				status: 'new',
@@ -613,7 +613,7 @@ describe( 'DepositFailureNotice Renders', () => {
 	} );
 
 	test( 'Does not render DepositFailureNotice if the selected currency does not have errored external account', () => {
-		mockAccount.external_accounts = [
+		mockAccount.default_external_accounts = [
 			{
 				currency: 'eur',
 				status: 'errored',

--- a/client/types/account-overview.d.ts
+++ b/client/types/account-overview.d.ts
@@ -25,7 +25,7 @@ export interface Account {
 		 */
 		monthly_anchor: number;
 	};
-	external_accounts: {
+	default_external_accounts: {
 		currency: string;
 		status: string;
 	}[];

--- a/client/types/account-overview.d.ts
+++ b/client/types/account-overview.d.ts
@@ -25,6 +25,10 @@ export interface Account {
 		 */
 		monthly_anchor: number;
 	};
+	external_accounts: {
+		currency: string;
+		status: string;
+	}[];
 }
 
 export interface Balance {


### PR DESCRIPTION
Fixes #6294 

#### Changes proposed in this Pull Request
- Added `DepositFailureNotice`
- Uses the `default_external_accounts` element from `overview-all` API

<img width="723" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/32092402/5fc188d5-3400-4138-81bd-56bfb2255dc5">

#### Testing instructions
- Test with woocommerce-payments-server#4862
- Visit the Stripe Express dashboard for your test WooPayments account (Payments → Overview → Account Details → Edit Details) and update the payout bank account to a [failing test account](https://href.li/?https://docs.stripe.com/connect/testing#payouts), e.g. 110000000/000111111116
- Use the [Stripe Shell](https://href.li/?https://docs.stripe.com/connect/manual-payouts?shell=true&api=true&resource=accounts&action=retrieve) to create a manual deposit.
`stripe payouts create --stripe-account="acct_123" --amount="123" --currency="USD" `
- Check that the notice is displayed informing the merchant that their bank account has an error and linking to information about how to update it.
- Test for an account with multiple settlement currencies and ensure that the notice is correctly displayed for only the currency which has an error.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
