### PR TITLE
E2E: Update expiry year for test cards to a future date (#8318)

### DIFF
--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -137,7 +137,7 @@
       "number": "4242424242424242",
       "expires": {
         "month": "02",
-        "year": "24"
+        "year": "45"
       },
       "cvc": "424",
       "label": "Visa ending in 4242"
@@ -146,7 +146,7 @@
       "number": "4111111111111111",
       "expires": {
         "month": "11",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "123",
       "label": "Visa ending in 1111"
@@ -155,7 +155,7 @@
       "number": "378282246310005",
       "expires": {
         "month": "11",
-        "year": "30"
+        "year": "45"
       },
       "cvc": "1234",
       "label": "Amex ending in 0005"
@@ -164,7 +164,7 @@
       "number": "4000002760003184",
       "expires": {
         "month": "03",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "525",
       "label": "Visa ending in 3184"
@@ -173,7 +173,7 @@
       "number": "4000002500003155",
       "expires": {
         "month": "04",
-        "year": "36"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 3155"
@@ -182,7 +182,7 @@
       "number": "4000000000003220",
       "expires": {
         "month": "04",
-        "year": "36"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 3220"
@@ -191,7 +191,7 @@
       "number": "4000000000000259",
       "expires": {
         "month": "05",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "525",
       "label": "Visa ending in 0259"
@@ -200,7 +200,7 @@
       "number": "4000000000002685",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 2685"
@@ -209,7 +209,7 @@
       "number": "4000000000000002",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 0002"
@@ -218,7 +218,7 @@
       "number": "4000000000009995",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 9995"
@@ -227,7 +227,7 @@
       "number": "4242424242424241",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 4241"
@@ -245,7 +245,7 @@
       "number": "4000000000000127",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 0127"
@@ -254,7 +254,7 @@
       "number": "4000000000000119",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 0119"
@@ -263,7 +263,7 @@
       "number": "4000008400001629",
       "expires": {
         "month": "06",
-        "year": "25"
+        "year": "45"
       },
       "cvc": "626",
       "label": "Visa ending in 1629"
@@ -281,7 +281,7 @@
       "number": "4242424242424242",
       "expires": {
         "month": "06",
-        "year": "24"
+        "year": "45"
       },
       "cvc": "11",
       "label": "Visa ending in 4242"


### PR DESCRIPTION
Fixes #8317

#### Changes proposed in this Pull Request


> [!WARNING]  
> Don't press `Update branch` since we don't want `develop` commits pushed to `trunk`

This PR carries over changes introduced to `trunk` via PR #8318 to `develop`.

It updates the expiry date for E2E test cards to `2045` to allow test purchases to occur.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe the E2E GH checks for this PR
* Ensure that expected GH checks `E2E Tests - Pull Request` pass
	* Ensure that expected GH checks `E2E Tests - Pull Request` pass
	* E2E Tests - Pull Request / WC - latest | wcpay - merchant ❌
		* fails due to unrelated issue with `merchant-orders-full-refund.spec.js` which was [previously failing on `trunk`](https://github.com/Automattic/woocommerce-payments/actions/runs/8090804627/job/22108877821#step:4:108). See #8319.
	* E2E Tests - Pull Request / WC - latest | wcpay - shopper ❌
		* Passes on `trunk` but fails here due to unrelated issue with `shopper-bnpls-checkout.spec.js`
	* E2E Tests - Pull Request / WC - latest | subscriptions - merchant ✅
	* E2E Tests - Pull Request / WC - latest | subscriptions - shopper ✅
-------------------

- [ ] Run `npm run changelog` to add a changelog file
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **N/A**


**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
