### PR TITLE
Inform hard blocked merchants they're under review

### DIFF
--- a/changelog/fix-server-4691-inform-merchants-about-under-review
+++ b/changelog/fix-server-4691-inform-merchants-about-under-review
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Inform hard blocked merchants they're under review

--- a/client/components/account-status/status-chip.js
+++ b/client/components/account-status/status-chip.js
@@ -12,6 +12,7 @@ import Chip from 'components/chip';
 import './style.scss';
 
 const StatusChip = ( props ) => {
+	// TODO add status under review.
 	const { accountStatus, poEnabled, poComplete } = props;
 
 	let description = __( 'Unknown', 'woocommerce-payments' );

--- a/client/components/account-status/status-chip.js
+++ b/client/components/account-status/status-chip.js
@@ -12,7 +12,6 @@ import Chip from 'components/chip';
 import './style.scss';
 
 const StatusChip = ( props ) => {
-	// TODO add status under review.
 	const { accountStatus, poEnabled, poComplete } = props;
 
 	let description = __( 'Unknown', 'woocommerce-payments' );
@@ -46,6 +45,9 @@ const StatusChip = ( props ) => {
 		type = 'alert';
 	} else if ( accountStatus.startsWith( 'rejected' ) ) {
 		description = __( 'Rejected', 'woocommerce-payments' );
+		type = 'light';
+	} else if ( accountStatus === 'under_review' ) {
+		description = __( 'Under review', 'woocommerce-payments' );
 		type = 'light';
 	}
 

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -339,6 +339,16 @@ exports[`StatusChip renders restricted status 1`] = `
 </div>
 `;
 
+exports[`StatusChip renders under review status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Under review
+  </span>
+</div>
+`;
+
 exports[`StatusChip renders unknown status 1`] = `
 <div>
   <span

--- a/client/components/account-status/test/index.js
+++ b/client/components/account-status/test/index.js
@@ -121,6 +121,11 @@ describe( 'StatusChip', () => {
 		expect( statusChip ).toMatchSnapshot();
 	} );
 
+	test( 'renders under review status', () => {
+		const { container: statusChip } = renderStatusChip( 'under_review' );
+		expect( statusChip ).toMatchSnapshot();
+	} );
+
 	test( 'renders pending verification status', () => {
 		const { container: statusChip } = renderStatusChip(
 			'pending_verification'

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -121,7 +121,7 @@ const DepositsStatus: React.FC< Props > = ( {
 } ) => {
 	const isPoInProgress = poEnabled && ! poComplete;
 
-	if ( status === 'blocked' ) {
+	if ( status === 'blocked' || accountStatus === 'under_review' ) {
 		return (
 			<DepositsStatusSuspended
 				iconSize={ iconSize }

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -85,6 +85,7 @@ const OverviewPage = () => {
 	const queryParams = getQuery();
 	const accountRejected =
 		accountStatus.status && accountStatus.status.startsWith( 'rejected' );
+	const accountUnderReview = accountStatus.status === 'under_review';
 
 	const showConnectionSuccess =
 		queryParams[ 'wcpay-connection-success' ] === '1';
@@ -96,7 +97,8 @@ const OverviewPage = () => {
 		showConnectionSuccess &&
 		accountStatus.progressiveOnboarding.isEnabled &&
 		! accountStatus.progressiveOnboarding.isComplete;
-	const showTaskList = ! accountRejected && tasks.length > 0;
+	const showTaskList =
+		! accountRejected && ! accountUnderReview && tasks.length > 0;
 
 	const activeAccountFees = Object.entries( wcpaySettings.accountFees )
 		.map( ( [ key, value ] ) => {
@@ -163,7 +165,7 @@ const OverviewPage = () => {
 				<FRTDiscoverabilityBanner />
 			</ErrorBoundary>
 			{ showConnectionSuccess && <ConnectionSuccessNotice /> }
-			{ ! accountRejected && (
+			{ ! accountRejected && ! accountUnderReview && (
 				<ErrorBoundary>
 					<>
 						{ showTaskList ? (
@@ -205,7 +207,7 @@ const OverviewPage = () => {
 					<ActiveLoanSummary />
 				</ErrorBoundary>
 			) }
-			{ ! accountRejected && (
+			{ ! accountRejected && ! accountUnderReview && (
 				<ErrorBoundary>
 					<InboxNotifications />
 				</ErrorBoundary>

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -375,7 +375,7 @@ class WC_Payments_Admin {
 			]
 		);
 
-		if ( $this->account->is_account_rejected() ) {
+		if ( $this->account->is_account_rejected() || $this->account->is_account_under_review() ) {
 			// If the account is rejected, only show the overview page.
 			wc_admin_register_page( $this->admin_child_pages['wc-payments-overview'] );
 			return;

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -375,6 +375,9 @@ class WC_Payments_Admin {
 			]
 		);
 
+		// Merchants are unable to see their deposits, transactions, disputes and settings if their account is rejected or under review.
+		// That's expected, because account under review is hard-blocked account that spends in a review pretty short time-frame.
+		// Either merchant gets approved and continues to use payments or they remain suspended and can't use payments.
 		if ( $this->account->is_account_rejected() || $this->account->is_account_under_review() ) {
 			// If the account is rejected, only show the overview page.
 			wc_admin_register_page( $this->admin_child_pages['wc-payments-overview'] );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -230,6 +230,21 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Checks if the account is under review, assumes the value of false on any account retrieval error.
+	 * Returns false if the account is not connected.
+	 *
+	 * @return bool
+	 */
+	public function is_account_under_review(): bool {
+		if ( ! $this->is_stripe_connected() ) {
+			return false;
+		}
+
+		$account = $this->get_cached_account_data();
+		return 'under_review' === $account['status'];
+	}
+
+	/**
 	 * Checks if the account "details_submitted" flag is true.
 	 * This is a proxy for telling if an account has completed onboarding.
 	 * If the "details_submitted" flag is false, it means that the account has not


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments-server/issues/4691

#### Changes proposed in this Pull Request

* Support Under Review status chip if merchant account is hard blocked.

#### Testing instructions

* Checkout to `fix/server-4691-inform-merchants-about-under-review`
* Build the branch locally using `npm run build:client`
* Follow the instructions in the https://github.com/Automattic/woocommerce-payments-server/pull/4868
* Onboard a new account, pass regular KYC, wait a bit until account is complete 
* Hard Block your local account, clear the cache
* Check that account is under review rather than rejected (Complete, not under review)

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/ead098f3-a987-43dc-ab0b-a8968980c297) | ![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/c9a7a5c1-c2c2-4059-8d59-faa044cf6919)|
* Approve the account (revert hard block)
* Check that account is now complete
![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/1d08c552-3c87-462f-9439-0c95bce8a0b6)
**Test soft-block account**
* Add the account meta with a `meta_key` = `last_fraud_action` and `meta_value` = `soft_block`.
* Clear the cache
* Check that account works as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.