### PR TITLE
Ensure Link disabling when WooPay is simultaneously enabled by default

### DIFF
--- a/changelog/migration-stripe-link-disablement-with-woopay-enabled
+++ b/changelog/migration-stripe-link-disablement-with-woopay-enabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add migration script to cover situations with Link and WooPay both enabled after plugin update.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -587,11 +587,13 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-sizes-update.php';
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-additional-payment-methods-admin-notes-removal.php';
+		require_once __DIR__ . '/migrations/class-stripe-link-woopay-mutual-exclusion-handler.php';
 		require_once __DIR__ . '/migrations/class-delete-active-woopay-webhook.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Allowed_Payment_Request_Button_Sizes_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Additional_Payment_Methods_Admin_Notes_Removal(), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Link_WooPay_Mutual_Exclusion_Handler( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_WooPay_Webhook', 'maybe_delete' ] );
 
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-explicit-price-formatter.php';
@@ -736,14 +738,6 @@ class WC_Payments {
 	 */
 	public static function register_gateway( $gateways ) {
 		$payment_methods = array_keys( self::get_payment_method_map() );
-
-		$key = array_search( 'link', $payment_methods, true );
-
-		if ( false !== $key && WC_Payments_Features::is_woopay_enabled() ) {
-			unset( $payment_methods[ $key ] );
-
-			self::get_gateway()->update_option( 'upe_enabled_payment_method_ids', $payment_methods );
-		}
 
 		$gateways[]       = self::$card_gateway;
 		$all_gateways     = [];

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -587,7 +587,7 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-sizes-update.php';
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-additional-payment-methods-admin-notes-removal.php';
-		require_once __DIR__ . '/migrations/class-stripe-link-woopay-mutual-exclusion-handler.php';
+		require_once __DIR__ . '/migrations/class-link-woopay-mutual-exclusion-handler.php';
 		require_once __DIR__ . '/migrations/class-delete-active-woopay-webhook.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Allowed_Payment_Request_Button_Sizes_Update( self::get_gateway() ), 'maybe_migrate' ] );

--- a/includes/migrations/class-link-woopay-mutual-exclusion-handler.php
+++ b/includes/migrations/class-link-woopay-mutual-exclusion-handler.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Class Link_WooPay_Mutual_Exclusion_Handler
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Migrations;
+
+use WC_Payment_Gateway_WCPay;
+use WC_Payments_Features;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Link_WooPay_Mutual_Exclusion_Handler
+ *
+ * In version 7.3.0, the logic responsible for disabling Stripe Link if WooPay is by default enabled, is moved from the gateways registration step to the migration.
+ *
+ * @since 7.3.0
+ */
+class Link_WooPay_Mutual_Exclusion_Handler {
+
+	/**
+	 * Version in which this migration was introduced.
+	 *
+	 * @var string
+	 */
+	const VERSION_SINCE = '7.3.0';
+
+	/**
+	 * WCPay gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $gateway;
+
+	/**
+	 * Link_WooPay_Mutual_Exclusion_Handler constructor.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway.
+	 */
+	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Only execute the migration if not applied yet.
+	 */
+	public function maybe_migrate() {
+		$previous_version = get_option( 'woocommerce_woocommerce_payments_version' );
+		if ( version_compare( self::VERSION_SINCE, $previous_version, '>' ) ) {
+			$this->migrate();
+		}
+	}
+
+	/**
+	 * Does the actual migration as described in the class docblock.
+	 */
+	private function migrate() {
+		// check if Stripe Link is enabled and also if WooPay should be enabled
+		// if both requirements met, disable Stripe Link.
+		$enabled_payment_methods   = $this->gateway->get_payment_method_ids_enabled_at_checkout();
+		$enabled_stripe_link_index = array_search( 'link', $enabled_payment_methods, true );
+
+		if ( false !== $enabled_stripe_link_index && WC_Payments_Features::is_woopay_enabled() ) {
+			unset( $enabled_payment_methods[ $enabled_stripe_link_index ] );
+
+			$this->gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+		}
+	}
+}

--- a/includes/migrations/class-link-woopay-mutual-exclusion-handler.php
+++ b/includes/migrations/class-link-woopay-mutual-exclusion-handler.php
@@ -58,8 +58,7 @@ class Link_WooPay_Mutual_Exclusion_Handler {
 	 * Does the actual migration as described in the class docblock.
 	 */
 	private function migrate() {
-		// check if Stripe Link is enabled and also if WooPay should be enabled
-		// if both requirements met, disable Stripe Link.
+		// check if both Stripe Link and WooPay are enabled and if so - disable Stripe Link.
 		$enabled_payment_methods   = $this->gateway->get_payment_method_ids_enabled_at_checkout();
 		$enabled_stripe_link_index = array_search( 'link', $enabled_payment_methods, true );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8325

More in p1709659019485299-slack-CGGCLBN58 

#### Changes proposed in this Pull Request
`register_gateway` is the callback that is run to register gateways in WooCommerce. Another logic updating enabled payment methods was part of this registration process as well. Once we changed the array of registered gateways, this side effect was activated, leading to the regression described in #8325. 

Since updating settings isn't part of gateway registration, it was moved to the migration script in order to accomplish our goals but also make sure https://github.com/Automattic/woocommerce-payments/pull/5650 is still working.

#### Testing instructions

* make sure `woocommerce_woocommerce_payments_version` option in the database is lower than `7.3.0`
* change [this line](https://github.com/Automattic/woocommerce-payments/blob/develop/client/settings/express-checkout/link-item.tsx#L28) to `const [ isWooPayEnabled ] = [ false ];` to show the Link checkbox when WooPay enabled
* change [this line](https://github.com/Automattic/woocommerce-payments/blob/develop/client/settings/express-checkout/woopay-item.tsx#L40) to `const isStripeLinkEnabled = false;`
* enable both Link & WooPay in settings, save and refresh, both should be enabled
* change version in `woocommerce-payments.php` to `7.3.0`
* refresh the page and confirm Link is disabled
* confirm #8325 isn't reproducible anymore

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
