### PR TITLE
Prevent double stock quantity reduction

### DIFF
--- a/changelog/fix-8292-reducing-stock
+++ b/changelog/fix-8292-reducing-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preventing stock quantity from being reduced twice.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1726,7 +1726,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return $response;
 		}
 
-		wc_reduce_stock_levels( $order_id );
+		wc_maybe_reduce_stock_levels( $order_id );
 		if ( isset( $cart ) ) {
 			$cart->empty_cart();
 		}


### PR DESCRIPTION
Fixes #8292 

#### Changes proposed in this Pull Request

Instead of calling `wc_reduce_stock_levels` from the gateway, call `wc_maybe_reduce_stock_levels` (notice the `maybe_` part).

Based on the description of the issue in https://github.com/Automattic/woocommerce-payments/issues/8292, it seems like we could remove the function call altogether, and I tend to agree. However, few of us are testing locally with stock management enabled, and that might introduce other issues that would go unnoticed.

The line (`wc_reduce_stock_levels`) has been in the gateway since its inception, without any reasoning provided behind it: https://github.com/Automattic/woocommerce-payments/pull/21/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124R90. To avoid guessing, I'm choosing to keep the line, as the `maybe_` fixes the duplication that we were experiencing.

#### Testing instructions

1. Confirm the issue.
    1. Start by testing `develop` to confirm that there's an issue in the first place. The setup (local or remote) should have working webhooks (`npm start` the server when working locally).
    2. Add a `sleep( 20 )` after `$intent = $request->send();` within the `process_payment_for_order` method. That's around line 1476 for me. This will allow the webhook to complete the order before this method gets to call `wc_reduce_stock_levels`.
    3. Check out an item that has stock management enabled, and a positive stock quantity.
    4. After checkout is complete, navigate to the order details page in the dashboard. You will see two stock reductions. See original issue for screenshots.
2. Confirm the fix.
    1. Switch to this branch.
    2. Add the same sleep as point 2 above.
    3. Check out a product with stock management enabled, and a positive stock quantity.
    4. Check the order details, and confirm that the quantity was only reduced once.

Reasoning: Calling `wc_reduce_stock_levels` without `maybe` immediately reduces stock. The `maybe` method checks if the stock has been reduced already, and bails if so.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply)