### PR TITLE
Reset onboarding stored test mode when reonboarding without URL param

### DIFF
--- a/changelog/fix-8334-leftover-onboarding-sandbox-mode
+++ b/changelog/fix-8334-leftover-onboarding-sandbox-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevent leftover sandbox mode onboarding and allow for live onboarding on subsequent retries.
+
+

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1070,6 +1070,14 @@ class WC_Payments_Account {
 			) ) {
 				// Redirect non-onboarded account to the onboarding flow, otherwise to payments overview page.
 				if ( ! $this->is_stripe_connected() ) {
+					$should_onboard_in_test_mode = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
+					if ( ! $should_onboard_in_test_mode && WC_Payments_Onboarding_Service::is_test_mode_enabled() ) {
+						// If there is no test mode in the URL informing us to onboard in test mode,
+						// but the onboarding test mode is enabled in our DB, we should disable it.
+						// This is most likely a leftover from a previous onboarding attempt.
+						WC_Payments_Onboarding_Service::set_test_mode( false );
+					}
+
 					$this->redirect_to_onboarding_flow_page( $source );
 				} else {
 					// Accounts with Stripe account connected will be redirected to the overview page.


### PR DESCRIPTION
Fixes #8334 

#### Changes proposed in this Pull Request

* In the local install, have the dev mode active
* Go to our MOX and continue with the sandbox step, sandbox mode should be active on the mode selection step
* Finish Stripe KYC onboarding
* Check that `wcpay_onboarding_test_mode` is set to `1`.
* Delete the account, clear the cache, disable dev mode
* Go to our MOX and check that sandbox mode should not remain active at the mode selection step
* Check that `wcpay_onboarding_test_mode` is set to `0`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
