### PR TITLE
Implement a feature flag for the Payment Overview widget

### DIFF
--- a/changelog/add-8242-payment-overview-widget-feature-flag
+++ b/changelog/add-8242-payment-overview-widget-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Implement a feature flag for the Payment Overview widget.

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -17,6 +17,7 @@ declare global {
 			isAuthAndCaptureEnabled: boolean;
 			paymentTimeline: boolean;
 			isDisputeIssuerEvidenceEnabled: boolean;
+			isPaymentOverviewWidgetEnabled?: boolean;
 		};
 		fraudServices: unknown[];
 		testMode: boolean;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -24,6 +24,7 @@ class WC_Payments_Features {
 	const PAY_FOR_ORDER_FLOW                = '_wcpay_feature_pay_for_order_flow';
 	const DISPUTE_ISSUER_EVIDENCE           = '_wcpay_feature_dispute_issuer_evidence';
 	const STREAMLINE_REFUNDS_FLAG_NAME      = '_wcpay_feature_streamline_refunds';
+	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME = '_wcpay_feature_payment_overview_widget';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -257,6 +258,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Payment Overview Widget is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_payment_overview_widget_ui_enabled(): bool {
+		return '1' === get_option( self::PAYMENT_OVERVIEW_WIDGET_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Checks whether WooPay Direct Checkout is enabled.
 	 *
 	 * @return bool
@@ -385,6 +395,7 @@ class WC_Payments_Features {
 				'isPayForOrderFlowEnabled'       => self::is_pay_for_order_flow_enabled(),
 				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 				'isRefundControlsEnabled'        => self::is_streamline_refunds_enabled(),
+				'isPaymentOverviewWidgetEnabled' => self::is_payment_overview_widget_ui_enabled(),
 			]
 		);
 	}


### PR DESCRIPTION
Fixes #8242

#### Changes proposed in this Pull Request
Add a feature flag for Payment Overview Widget project.

> [!NOTE]
>PS: Omitting unit tests is intentional as this feature flag is somewhat temporary.

#### Testing instructions
- To verify the flag in PHP use `WC_Payments_Features::is_payment_overview_widget_ui_enabled()`.
- To verify in JavaScript, navigate to `Payments` > `Overview` page and enter window.wcpaySettings.featureFlags.isPaymentOverviewWidgetEnabled in the developer console. If the feature flag is disabled, it will return a non-true or undefined value.
- To enable the feature flag use `wp option update _wcpay_feature_payment_overview_widget 1` in CLI.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.