### PR TITLE
Added a notice about custom checkout fields conflicting with express checkout

### DIFF
--- a/changelog/express-checkout-incompatibility-notice
+++ b/changelog/express-checkout-incompatibility-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added a notice about custom checkout fields conflicting with express checkouut

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -469,6 +469,11 @@ export const useWooPayShowIncompatibilityNotice = () =>
 		select( STORE_NAME ).getShowWooPayIncompatibilityNotice()
 	);
 
+export const useExpressCheckoutShowIncompatibilityNotice = () =>
+	useSelect( ( select ) =>
+		select( STORE_NAME ).getShowExpressCheckoutIncompatibilityNotice()
+	);
+
 export const useStripeBilling = () => {
 	const { updateIsStripeBillingEnabled } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -238,6 +238,13 @@ export const getShowWooPayIncompatibilityNotice = ( state ) => {
 	return getSettings( state ).show_woopay_incompatibility_notice || false;
 };
 
+export const getShowExpressCheckoutIncompatibilityNotice = ( state ) => {
+	return (
+		getSettings( state ).show_express_checkout_incompatibility_notice ||
+		false
+	);
+};
+
 export const getIsStripeBillingEnabled = ( state ) => {
 	return getSettings( state ).is_stripe_billing_enabled || false;
 };

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -14,7 +14,9 @@ import GeneralPaymentRequestButtonSettings from './general-payment-request-butto
 import {
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
+	useExpressCheckoutShowIncompatibilityNotice,
 } from 'wcpay/data';
+import { ExpressCheckoutIncompatibilityNotice } from 'wcpay/settings/settings-warnings/incompatibility-notice';
 
 const PaymentRequestSettings = ( { section } ) => {
 	const [
@@ -40,10 +42,15 @@ const PaymentRequestSettings = ( { section } ) => {
 		}
 	};
 
+	const showIncompatibilityNotice = useExpressCheckoutShowIncompatibilityNotice();
+
 	return (
 		<Card>
 			{ section === 'enable' && (
 				<CardBody>
+					{ showIncompatibilityNotice && (
+						<ExpressCheckoutIncompatibilityNotice />
+					) }
 					<CheckboxControl
 						checked={ isPaymentRequestEnabled }
 						onChange={ updateIsPaymentRequestEnabled }

--- a/client/settings/express-checkout-settings/test/index.js
+++ b/client/settings/express-checkout-settings/test/index.js
@@ -30,6 +30,9 @@ jest.mock( '../../../data', () => ( {
 		.fn()
 		.mockReturnValue( [ [ true, true, true ], jest.fn() ] ),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
+	useExpressCheckoutShowIncompatibilityNotice: jest
+		.fn()
+		.mockReturnValue( false ),
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -264,7 +264,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		expect(
 			screen.queryByText(
-				'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.'
+				'One or more of your extensions alters checkout fields. This might cause issues with this payment method.'
 			)
 		).toBeInTheDocument();
 	} );
@@ -276,7 +276,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		expect(
 			screen.queryByText(
-				'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.'
+				'One or more of your extensions alters checkout fields. This might cause issues with this payment method.'
 			)
 		).not.toBeInTheDocument();
 	} );

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -264,7 +264,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		expect(
 			screen.queryByText(
-				'One or more of your extensions are incompatible with Express Checkouts.'
+				'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.'
 			)
 		).toBeInTheDocument();
 	} );
@@ -276,7 +276,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		expect(
 			screen.queryByText(
-				'One or more of your extensions are incompatible with Express Checkouts.'
+				'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.'
 			)
 		).not.toBeInTheDocument();
 	} );

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -18,6 +18,7 @@ import {
 	usePaymentRequestButtonSize,
 	usePaymentRequestButtonTheme,
 	useWooPayEnabledSettings,
+	useExpressCheckoutShowIncompatibilityNotice,
 } from '../../../data';
 
 jest.mock( '../../../data', () => ( {
@@ -27,6 +28,7 @@ jest.mock( '../../../data', () => ( {
 	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'small' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
 	useWooPayEnabledSettings: jest.fn(),
+	useExpressCheckoutShowIncompatibilityNotice: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
 } ) );
 
@@ -253,5 +255,29 @@ describe( 'PaymentRequestSettings', () => {
 		expect(
 			updatePaymentRequestLocationsHandler
 		).toHaveBeenLastCalledWith( [ 'checkout', 'product' ] );
+	} );
+
+	it( 'triggers the hooks when the enable setting is being interacted with', () => {
+		useExpressCheckoutShowIncompatibilityNotice.mockReturnValue( true );
+
+		render( <PaymentRequestSettings section="enable" /> );
+
+		expect(
+			screen.queryByText(
+				'One or more of your extensions are incompatible with Express Checkouts.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'triggers the hooks when the enable setting is being interacted with', () => {
+		useExpressCheckoutShowIncompatibilityNotice.mockReturnValue( false );
+
+		render( <PaymentRequestSettings section="enable" /> );
+
+		expect(
+			screen.queryByText(
+				'One or more of your extensions are incompatible with Express Checkouts.'
+			)
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -28,7 +28,7 @@ import {
 	useWooPayShowIncompatibilityNotice,
 } from 'wcpay/data';
 import GeneralPaymentRequestButtonSettings from './general-payment-request-button-settings';
-import WooPayIncompatibilityNotice from '../settings-warnings/incompatibility-notice';
+import { WooPayIncompatibilityNotice } from '../settings-warnings/incompatibility-notice';
 
 const WooPaySettings = ( { section } ) => {
 	const [

--- a/client/settings/express-checkout/apple-google-pay-item.tsx
+++ b/client/settings/express-checkout/apple-google-pay-item.tsx
@@ -10,15 +10,21 @@ import React from 'react';
  * Internal dependencies
  */
 import { getPaymentMethodSettingsUrl } from '../../utils';
-import { usePaymentRequestEnabledSettings } from 'wcpay/data';
+import {
+	usePaymentRequestEnabledSettings,
+	useExpressCheckoutShowIncompatibilityNotice,
+} from 'wcpay/data';
 import { PaymentRequestEnabledSettingsHook } from './interfaces';
 import { ApplePayIcon, GooglePayIcon } from 'wcpay/payment-methods-icons';
+import { ExpressCheckoutIncompatibilityNotice } from 'wcpay/settings/settings-warnings/incompatibility-notice';
 
 const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
 	const [
 		isPaymentRequestEnabled,
 		updateIsPaymentRequestEnabled,
 	] = usePaymentRequestEnabledSettings() as PaymentRequestEnabledSettingsHook;
+
+	const showIncompatibilityNotice = useExpressCheckoutShowIncompatibilityNotice();
 
 	return (
 		<li
@@ -160,6 +166,9 @@ const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
 					</div>
 				</div>
 			</div>
+			{ showIncompatibilityNotice && (
+				<ExpressCheckoutIncompatibilityNotice />
+			) }
 		</li>
 	);
 };

--- a/client/settings/express-checkout/test/index.test.js
+++ b/client/settings/express-checkout/test/index.test.js
@@ -12,6 +12,7 @@ import userEvent from '@testing-library/user-event';
 import ExpressCheckout from '..';
 import {
 	useEnabledPaymentMethodIds,
+	useExpressCheckoutShowIncompatibilityNotice,
 	useGetAvailablePaymentMethodIds,
 	usePaymentRequestEnabledSettings,
 	useWooPayEnabledSettings,
@@ -25,6 +26,7 @@ jest.mock( 'wcpay/data', () => ( {
 	useEnabledPaymentMethodIds: jest.fn(),
 	useGetAvailablePaymentMethodIds: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn(),
+	useExpressCheckoutShowIncompatibilityNotice: jest.fn(),
 } ) );
 
 const getMockPaymentRequestEnabledSettings = (
@@ -191,7 +193,7 @@ describe( 'ExpressCheckout', () => {
 		expect( screen.getByLabelText( 'Link by Stripe' ) ).toBeChecked();
 	} );
 
-	it( 'should show incompatibility warning', async () => {
+	it( 'should show WooPay incompatibility warning', async () => {
 		const updateIsWooPayEnabledHandler = jest.fn();
 		useWooPayEnabledSettings.mockReturnValue(
 			getMockWooPayEnabledSettings( false, updateIsWooPayEnabledHandler )
@@ -211,6 +213,26 @@ describe( 'ExpressCheckout', () => {
 		expect(
 			screen.queryByText(
 				'One or more of your extensions are incompatible with WooPay.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should show Express Checkout incompatibility warning', async () => {
+		const context = { featureFlags: { woopay: true } };
+		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'link', 'card' ] );
+		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card', 'link' ] ] );
+
+		useExpressCheckoutShowIncompatibilityNotice.mockReturnValue( true );
+
+		render(
+			<WCPaySettingsContext.Provider value={ context }>
+				<ExpressCheckout />
+			</WCPaySettingsContext.Provider>
+		);
+
+		expect(
+			screen.queryByText(
+				'One or more of your extensions are incompatible with Express Checkouts.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/settings/express-checkout/test/index.test.js
+++ b/client/settings/express-checkout/test/index.test.js
@@ -232,7 +232,7 @@ describe( 'ExpressCheckout', () => {
 
 		expect(
 			screen.queryByText(
-				'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.'
+				'One or more of your extensions alters checkout fields. This might cause issues with this payment method.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/settings/express-checkout/test/index.test.js
+++ b/client/settings/express-checkout/test/index.test.js
@@ -232,7 +232,7 @@ describe( 'ExpressCheckout', () => {
 
 		expect(
 			screen.queryByText(
-				'One or more of your extensions are incompatible with Express Checkouts.'
+				'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/settings/express-checkout/woopay-item.tsx
+++ b/client/settings/express-checkout/woopay-item.tsx
@@ -20,7 +20,7 @@ import {
 } from 'wcpay/data';
 import WCPaySettingsContext from '../wcpay-settings-context';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
-import WooPayIncompatibilityNotice from '../settings-warnings/incompatibility-notice';
+import { WooPayIncompatibilityNotice } from '../settings-warnings/incompatibility-notice';
 
 import { WooPayEnabledSettingsHook } from './interfaces';
 import { WooIcon } from 'wcpay/payment-methods-icons';

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -67,6 +67,6 @@ export const ExpressCheckoutIncompatibilityNotice = () => (
 			'One or more of your extensions alters checkout fields. This might cause issues with this payment method.',
 			'woocommerce-payments'
 		) }
-		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/#express-checkout-methods"
+		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/apple-pay-and-google-pay-compatibility/"
 	/>
 );

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -64,7 +64,7 @@ export const WooPayIncompatibilityNotice = () => (
 export const ExpressCheckoutIncompatibilityNotice = () => (
 	<IncompatibilityNotice
 		message={ __(
-			'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.',
+			'One or more of your extensions alters checkout fields. This might cause issues with this payment method.',
 			'woocommerce-payments'
 		) }
 		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/#express-checkout-methods"

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -11,7 +11,7 @@ import { Notice } from '@wordpress/components';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import './style.scss';
 
-const WooPayIncompatibilityNotice = () => (
+const IncompatibilityNotice = ( { message, learnMoreLinkHref } ) => (
 	<Notice
 		status="warning"
 		isDismissible={ false }
@@ -29,10 +29,7 @@ const WooPayIncompatibilityNotice = () => (
 			/>
 		</span>
 		<span>
-			{ __(
-				'One or more of your extensions are incompatible with WooPay.',
-				'woocommerce-payments'
-			) }
+			{ message }
 			<br />
 			{ interpolateComponents( {
 				mixedString: __(
@@ -45,7 +42,7 @@ const WooPayIncompatibilityNotice = () => (
 						<a
 							target="_blank"
 							rel="noreferrer"
-							href="https://woo.com/document/woopay-merchant-documentation/#compatibility"
+							href={ learnMoreLinkHref }
 						/>
 					),
 				},
@@ -54,4 +51,22 @@ const WooPayIncompatibilityNotice = () => (
 	</Notice>
 );
 
-export default WooPayIncompatibilityNotice;
+export const WooPayIncompatibilityNotice = () => (
+	<IncompatibilityNotice
+		message={ __(
+			'One or more of your extensions are incompatible with WooPay.',
+			'woocommerce-payments'
+		) }
+		learnMoreLinkHref="https://woo.com/document/woopay-merchant-documentation/#compatibility"
+	/>
+);
+
+export const ExpressCheckoutIncompatibilityNotice = () => (
+	<IncompatibilityNotice
+		message={ __(
+			'One or more of your extensions are incompatible with Express Checkouts.',
+			'woocommerce-payments'
+		) }
+		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/#express-checkout-methods"
+	/>
+);

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -64,7 +64,7 @@ export const WooPayIncompatibilityNotice = () => (
 export const ExpressCheckoutIncompatibilityNotice = () => (
 	<IncompatibilityNotice
 		message={ __(
-			'One or more of your extensions are incompatible with Express Checkouts.',
+			'One or more of your extensions alters the checkout fields. This might cause issues with Express Checkout methods.',
 			'woocommerce-payments'
 		) }
 		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/#express-checkout-methods"

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -67,6 +67,7 @@ export const ExpressCheckoutIncompatibilityNotice = () => (
 			'One or more of your extensions alters checkout fields. This might cause issues with this payment method.',
 			'woocommerce-payments'
 		) }
+		// eslint-disable-next-line max-len
 		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/apple-pay-and-google-pay-compatibility/#faq-extra-fields-on-checkout"
 	/>
 );

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -67,6 +67,6 @@ export const ExpressCheckoutIncompatibilityNotice = () => (
 			'One or more of your extensions alters checkout fields. This might cause issues with this payment method.',
 			'woocommerce-payments'
 		) }
-		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/apple-pay-and-google-pay-compatibility/"
+		learnMoreLinkHref="https://woo.com/document/woopayments/payment-methods/apple-pay-and-google-pay-compatibility/#faq-extra-fields-on-checkout"
 	/>
 );

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -508,7 +508,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_card_present_eligible'            => $this->wcpay_gateway->is_card_present_eligible() && isset( WC()->payment_gateways()->get_available_payment_gateways()['cod'] ),
 				'is_woopay_enabled'                   => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
 				'show_woopay_incompatibility_notice'  => get_option( 'woopay_invalid_extension_found', false ),
-				'show_express_checkout_incompatibility_notice' => false, // TODO: implement this.
+				'show_express_checkout_incompatibility_notice' => $this->should_show_express_checkout_incompatibility_notice(),
 				'woopay_custom_message'               => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
 				'woopay_store_logo'                   => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),
 				'woopay_enabled_locations'            => $this->wcpay_gateway->get_option( 'platform_checkout_button_locations', array_keys( $wcpay_form_fields['payment_request_button_locations']['options'] ) ),
@@ -1080,5 +1080,39 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$reporting_export_language = $request->get_param( 'reporting_export_language' );
 
 		$this->wcpay_gateway->update_option( 'reporting_export_language', $reporting_export_language );
+	}
+
+	/**
+	 * Whether to show the express checkout incompatibility notice.
+	 *
+	 * @return bool
+	 */
+	private function should_show_express_checkout_incompatibility_notice() {
+		// Apply filters to empty arrays to check if any plugin is modifying the checkout fields.
+		$after_apply_billing  = apply_filters( 'woocommerce_billing_fields', [], '' );
+		$after_apply_shipping = apply_filters( 'woocommerce_shipping_fields', [], '' );
+		$after_apply_checkout = array_filter(
+			apply_filters(
+				'woocommerce_checkout_fields',
+				[
+					'billing'  => [],
+					'shipping' => [],
+					'account'  => [],
+					'order'    => [],
+				]
+			)
+		);
+		// All the input values are empty, so if any of them is not empty, it means that the checkout fields are being modified.
+		$is_modifying_checkout_fields = ! empty(
+			array_filter(
+				[
+					'after_apply_billing'  => $after_apply_billing,
+					'after_apply_shipping' => $after_apply_shipping,
+					'after_apply_checkout' => $after_apply_checkout,
+				]
+			)
+		);
+
+		return $is_modifying_checkout_fields;
 	}
 }

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -508,6 +508,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_card_present_eligible'            => $this->wcpay_gateway->is_card_present_eligible() && isset( WC()->payment_gateways()->get_available_payment_gateways()['cod'] ),
 				'is_woopay_enabled'                   => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
 				'show_woopay_incompatibility_notice'  => get_option( 'woopay_invalid_extension_found', false ),
+				'show_express_checkout_incompatibility_notice' => false, // TODO: implement this.
 				'woopay_custom_message'               => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
 				'woopay_store_logo'                   => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),
 				'woopay_enabled_locations'            => $this->wcpay_gateway->get_option( 'platform_checkout_button_locations', array_keys( $wcpay_form_fields['payment_request_button_locations']['options'] ) ),


### PR DESCRIPTION
Fixes #8299

#### Changes proposed in this Pull Request

Custom fields are currently incompatible with express checkout methods. This PR adds a notice next to the Apple Pay and Google Pay settings when a change in the checkout fields is detected.

![image](https://github.com/Automattic/woocommerce-payments/assets/12385501/02747aa2-32cc-43d8-9a8f-4eac18b592da)

![image](https://github.com/Automattic/woocommerce-payments/assets/12385501/c68a7486-1b10-4231-85f8-742a916988d4)


#### Testing instructions

1. Go to WooPayments settings and notice there is no warning next to Google Pay / Apple Pay toggle section.
2. Go to Google Pay / Apple Pay page settings and notice there is no warning.
3. Install an extension to change/add checkout fields, or do it manually by using the filters `woocommerce_billing_fields`, `woocommerce_shipping_fields`, and `woocommerce_checkout_fields`.
4. Go back to 1. and 2. and ensure there is a warning.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
