### PR TITLE
Fix: Only Apply Woopay Direct Checkout Flow to the “Proceed to Checkout” Button, in Classic Cart

### DIFF
--- a/changelog/fix-classic-cart-direct-checkout-button-click
+++ b/changelog/fix-classic-cart-direct-checkout-button-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply the WooPay Direct Checkout flow only to the "Proceed to Checkout" button, in cthe classic cart.

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -16,7 +16,7 @@ class WooPayDirectCheckout {
 	static sessionConnect;
 	static encryptedSessionDataPromise;
 	static redirectElements = {
-		CLASSIC_CART_PROCEED_BUTTON: '.wc-proceed-to-checkout',
+		CLASSIC_CART_PROCEED_BUTTON: '.wc-proceed-to-checkout .checkout-button',
 		BLOCKS_CART_PROCEED_BUTTON:
 			'.wp-block-woocommerce-proceed-to-checkout-block',
 	};
@@ -189,8 +189,13 @@ class WooPayDirectCheckout {
 		elements.forEach( ( element ) => {
 			element.addEventListener( 'click', async ( event ) => {
 				// Store href before the async call to not lose the reference.
-				const currTargetHref = event.currentTarget.querySelector( 'a' )
-					?.href;
+				let currTargetHref;
+				const isAElement = element.tagName.toLowerCase() === 'a';
+				if ( isAElement ) {
+					currTargetHref = element.href;
+				} else {
+					currTargetHref = element.querySelector( 'a' )?.href;
+				}
 
 				// If there's no link where to redirect the user, do not break the expected behavior.
 				if ( ! currTargetHref ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request


This PR fixes a bug where the WooPay Direct Checkout flow was being applied on both the "Proceed to Checkout" and "Pay with WooPay" buttons. It does this by referencing a more specific CSS-class.

#### Testing instructions

**Test: Ensure the WooPay Direct Checkout click handler is only applied on the "Proceed to Checkout" button in the classic cart**
* Add a `console.log( "clicked" )` in the [click event handler](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js#L190-L219).
* As a shopper, navigate to the shop and add an item to your cart.
* Navigate to the classic cart page.
* Click on the "Proceed to Checkout" button and ensure "clicked" appears in the browser's console.
* Navigate back to the classic cart page.
* Click on the "Pay with WooPay" button and ensure "clicked" does not appear in the browser's console.

**Regression Test: Ensure First Party Auth flow works as intended**
* As a shopper, navigate to the shop and add an item to your cart.
* Navigate to the classic cart page.
* Click on the "Pay with WooPay" button and ensure you are navigated to the WooPay checkout.
* Click on the "Place order" button and ensure you are able to checkout successfully.

**Regression Test: Ensure Direct Checkout flow works as intended**
* Ensure third-party cookies are enabled.
* As a shopper, ensure you are authenticated on WooPay.
* Navigate to the shop and add an item to your cart.
* Navigate to the classic cart page.
* Click on the "Proceed to Checkout" button and ensure you are navigated to the WooPay checkout.
* Click on the "Place order" button and ensure you are able to checkout successfully.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
