### PR TITLE
E2E: fix `merchant-orders-full-refund` missing order amount (#8319)

### DIFF
--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
@@ -34,10 +34,16 @@ describe( 'Order > Full refund', () => {
 		await expect( page ).toMatch( 'Order received' );
 
 		// Get the order ID so we can open it in the merchant view
-		const orderIdField = await page.$(
-			'.woocommerce-order-overview__order.order > strong'
-		);
+		const ORDER_RECEIVED_ID_SELECTOR =
+			'.woocommerce-order-overview__order.order > strong';
+		const orderIdField = await page.$( ORDER_RECEIVED_ID_SELECTOR );
 		orderId = await orderIdField.evaluate( ( el ) => el.innerText );
+
+		// Get the order total so we can verify the refund amount
+		const ORDER_RECEIVED_AMOUNT_SELECTOR =
+			'.woocommerce-order-overview__total .woocommerce-Price-amount';
+		const orderTotalField = await page.$( ORDER_RECEIVED_AMOUNT_SELECTOR );
+		orderAmount = await orderTotalField.evaluate( ( el ) => el.innerText );
 
 		// Login and open the order
 		await merchant.login();
@@ -45,13 +51,6 @@ describe( 'Order > Full refund', () => {
 
 		// We need to remove any listeners on the `dialog` event otherwise we can't catch the dialog below
 		await page.removeAllListeners( 'dialog' );
-
-		// Get the order price
-		const priceElement = await page.$( '.woocommerce-Price-amount' );
-		orderAmount = await page.evaluate(
-			( el ) => el.textContent,
-			priceElement
-		);
 	} );
 
 	afterAll( async () => {

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js
@@ -11,7 +11,7 @@ const { merchant, shopper, uiUnblocked } = require( '@woocommerce/e2e-utils' );
 
 const orderIdSelector = '.woocommerce-order-overview__order.order > strong';
 const orderStatusDropdownSelector = 'select[name="order_status"]';
-const cancelModalSelector = 'div.cancel-confirmation-modal';
+const cancelModalSelector = 'div.wcpay-confirmation-modal';
 const refundModalSelector = 'div.refund-confirmation-modal';
 const refundCancelSelector =
 	'.refund-confirmation-modal .wcpay-confirmation-modal__footer .is-secondary';
@@ -98,6 +98,8 @@ describe( 'Order > Status Change', () => {
 
 			// Click on Cancel order.
 			await expect( page ).toClick( 'button', { text: 'Cancel order' } );
+
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 
 			// Verify the order status is set to cancel.
 			const selectedOrderStatus = await page.$(


### PR DESCRIPTION
Fixes #8330

#### Changes proposed in this Pull Request

> [!WARNING]  
> Don't press `Update branch` since we don't want `develop` commits pushed to `trunk`

This PR carries over changes introduced to `trunk` via PR #8319 to `develop`.

It fixes the `merchant-orders-full-refund` e2e test suite by changing the target element used to get the order amount.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Inspect the results of this PR's GH check `E2E Tests - Pull Request / WC - latest | wcpay - merchant (pull_request)`
* Ensure the test suite `merchant-orders-full-refund` passes (see [passing test](https://github.com/Automattic/woocommerce-payments/actions/runs/8182157985/job/22373071597?pr=8342#step:4:108)) ✅

-------------------

- [x] Run `npm run changelog` to add a changelog file, **changelog N/A, pulling over a single commit**
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
