### PR TITLE
E2E: apply fix  for`merchant-orders-status-change` in `trunk`

### DIFF
--- a/changelog/fix-e2e-merchant-orders-status-change-test
+++ b/changelog/fix-e2e-merchant-orders-status-change-test
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Fix e2e test for order status change to Cancelled
-
-

--- a/changelog/fix-e2e-merchant-orders-status-change-test
+++ b/changelog/fix-e2e-merchant-orders-status-change-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix e2e test for order status change to Cancelled
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js
@@ -11,7 +11,7 @@ const { merchant, shopper, uiUnblocked } = require( '@woocommerce/e2e-utils' );
 
 const orderIdSelector = '.woocommerce-order-overview__order.order > strong';
 const orderStatusDropdownSelector = 'select[name="order_status"]';
-const cancelModalSelector = 'div.cancel-confirmation-modal';
+const cancelModalSelector = 'div.wcpay-confirmation-modal';
 const refundModalSelector = 'div.refund-confirmation-modal';
 const refundCancelSelector =
 	'.refund-confirmation-modal .wcpay-confirmation-modal__footer .is-secondary';
@@ -98,6 +98,8 @@ describe( 'Order > Status Change', () => {
 
 			// Click on Cancel order.
 			await expect( page ).toClick( 'button', { text: 'Cancel order' } );
+
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 
 			// Verify the order status is set to cancel.
 			const selectedOrderStatus = await page.$(


### PR DESCRIPTION
Fixes: #8344 

> [!CAUTION]  
> This PR targets `trunk` which is required to fix e2e tests for server and client repos.



#### Changes proposed in this Pull Request

This PR cherry-picks this fix https://github.com/Automattic/woocommerce-payments/pull/8333 so we can apply it into `trunk` without waiting for the next release.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The tests in the `tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.js` spec should pass the CI checks: `E2E Tests - Pull Request / WC - latest | wcpay - merchant (pull_request)`

-------------------

- [x] ~Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.~ NOT applies when targeting `trunk`
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.