### PR TITLE
Fixed Clearpay aria-label for UK sites

### DIFF
--- a/changelog/fix-clearpay-aria-label
+++ b/changelog/fix-clearpay-aria-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed Clearpay aria-label for UK sites

--- a/client/payment-methods/constants.ts
+++ b/client/payment-methods/constants.ts
@@ -20,6 +20,7 @@ enum PAYMENT_METHOD_IDS {
 	SOFORT = 'sofort',
 }
 
+const accountCountry = window.wcpaySettings?.accountStatus?.country || 'US';
 // This constant is used for rendering tooltip titles for payment methods in transaction list and details pages.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const PAYMENT_METHOD_TITLES = {
@@ -27,7 +28,10 @@ export const PAYMENT_METHOD_TITLES = {
 	ach_debit: __( 'ACH Debit', 'woocommerce-payments' ),
 	acss_debit: __( 'ACSS Debit', 'woocommerce-payments' ),
 	affirm: __( 'Affirm', 'woocommerce-payments' ),
-	afterpay_clearpay: __( 'Afterpay', 'woocommerce-payments' ),
+	afterpay_clearpay:
+		'GB' === accountCountry
+			? __( 'Clearpay', 'woocommerce-payments' )
+			: __( 'Afterpay', 'woocommerce-payments' ),
 	alipay: __( 'Alipay', 'woocommerce-payments' ),
 	amex: __( 'American Express', 'woocommerce-payments' ),
 	au_becs_debit: __( 'AU BECS Debit', 'woocommerce-payments' ),


### PR DESCRIPTION
Fixes #8137

#### Changes proposed in this Pull Request

This PR fixes the aria-label and the tooltip for UK stores in the Transactions page.

**US:**
![image](https://github.com/Automattic/woocommerce-payments/assets/12385501/31e9b8e1-682f-4016-a1a7-fd1625007876)

**UK:**
![image](https://github.com/Automattic/woocommerce-payments/assets/12385501/414de0c3-498c-4754-99de-705cac7f9a4d)


#### Testing instructions

1. Make a payment using Afterpay/Clearpay
2. Check the transaction details page for this payment and notice the the tooltip is correct for you country
3. You can change the country by using different Stripe accounts or updating this line:
	https://github.com/Automattic/woocommerce-payments/blob/bb876e12d97b1bc07fa10f1e51b1ffd42f5f5c09/includes/class-wc-payments-account.php#L286

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
