### PR TITLE
E2E: skip failing test suite `shopper-bnpls-checkout` (#8355) 

### DIFF
--- a/changelog/e2e-skip-broken-test-shopper-bnpls-checkout-develop
+++ b/changelog/e2e-skip-broken-test-shopper-bnpls-checkout-develop
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not user-facing: skips the e2e test suite shopper-bnpls-checkout.spec.js due to test failure
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
@@ -22,7 +22,8 @@ const cardTestingPreventionStates = [
 	{ cardTestingPreventionEnabled: true },
 ];
 
-describe.each( cardTestingPreventionStates )(
+// Skipping due to test failure – missing selector when changing account currency #8354
+describe.skip.each( cardTestingPreventionStates )(
 	'BNPL checkout',
 	( { cardTestingPreventionEnabled } ) => {
 		beforeAll( async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR brings changes from PR #8355 from `trunk` → `develop`

It temporarily skips the e2e test suite `shopper-bnpls-checkout.spec.js` due to test failure for both client and server GH checks – missing selector when changing account currency reported in #8354.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure GH checks on this PR pass for `E2E Tests - Pull Request / WC - latest | wcpay - shopper` `shopper-bnpls-checkout.spec.js`


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
