### PR TITLE
E2E: Try fix `shopper-bnpls-checkout` missing selector `#wcpay_selected_currency`

### DIFF
--- a/changelog/e2e-skip-broken-test-shopper-bnpls-checkout-develop
+++ b/changelog/e2e-skip-broken-test-shopper-bnpls-checkout-develop
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not user-facing: skips the e2e test suite shopper-bnpls-checkout.spec.js due to test failure
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
@@ -22,7 +22,8 @@ const cardTestingPreventionStates = [
 	{ cardTestingPreventionEnabled: true },
 ];
 
-describe.each( cardTestingPreventionStates )(
+// Skipping due to test failure – missing selector when changing account currency #8354
+describe.skip.each( cardTestingPreventionStates )(
 	'BNPL checkout',
 	( { cardTestingPreventionEnabled } ) => {
 		beforeAll( async () => {

--- a/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
@@ -23,7 +23,7 @@ const cardTestingPreventionStates = [
 ];
 
 // Skipping due to test failure – missing selector when changing account currency #8354
-describe.skip.each( cardTestingPreventionStates )(
+describe.each( cardTestingPreventionStates )(
 	'BNPL checkout',
 	( { cardTestingPreventionEnabled } ) => {
 		beforeAll( async () => {

--- a/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.js
@@ -32,6 +32,7 @@ describe.each( cardTestingPreventionStates )(
 			if ( cardTestingPreventionEnabled ) {
 				await merchantWCP.enableCardTestingProtection();
 			}
+			await merchantWCP.activateMulticurrency();
 			await merchant.logout();
 			await shopper.login();
 			await shopperWCP.changeAccountCurrencyTo(
@@ -48,6 +49,7 @@ describe.each( cardTestingPreventionStates )(
 			if ( cardTestingPreventionEnabled ) {
 				await merchantWCP.disableCardTestingProtection();
 			}
+			await merchantWCP.deactivateMulticurrency();
 			await merchant.logout();
 		} );
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -164,6 +164,8 @@ export const shopperWCP = {
 			customerDetails.lastname
 		);
 
+		await page.waitForSelector( '#wcpay_selected_currency' );
+
 		await page.select( '#wcpay_selected_currency', currencyToSet );
 		await expect( page ).toClick( 'button', {
 			text: 'Save changes',

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -164,8 +164,6 @@ export const shopperWCP = {
 			customerDetails.lastname
 		);
 
-		await page.waitForSelector( '#wcpay_selected_currency' );
-
 		await page.select( '#wcpay_selected_currency', currencyToSet );
 		await expect( page ).toClick( 'button', {
 			text: 'Save changes',


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

It seems that multicurrency activation is required by this test and is not, for whatever reason.

#### Testing instructions

This PR seems to fix #8354 locally, running on GH actions to check if it resolves:
https://github.com/Automattic/woocommerce-payments/actions/runs/8199215530/job/22424058859

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.