### PR TITLE
Ensure every gateway has individual settings object

### DIFF
--- a/changelog/fix-gateway-individual-settings
+++ b/changelog/fix-gateway-individual-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure every gateway has individual settings object.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2400,7 +2400,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function get_option_key() {
 		// Intentionally using self instead of static so options are loaded from main gateway settings.
-		return $this->plugin_id . self::GATEWAY_ID . '_settings';
+		return $this->plugin_id . $this->id . '_settings';
 	}
 
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2399,7 +2399,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Overrides parent method so the option key is the same as the parent class.
 	 */
 	public function get_option_key() {
-		// Intentionally using self instead of static so options are loaded from main gateway settings.
 		return $this->plugin_id . $this->id . '_settings';
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/8349

#### Changes proposed in this Pull Request
A few weeks ago, we started to register all known payment methods in WooCommerce during plugin initialization. This was done for our system to work correctly as WooCommerce expects all gateways (even enabled ones) to be registered. 

After that change, multiple third-party actors (WooCommerce and WooCommerce Blocks) started to behave differently, by introducing two new symptoms: spamming with emails after WooPayments plugin gets enabled, and spamming with incompatible payment methods in Blocks editor. 

All this happens because we are now treating gateways separately, while still keeping settings for them in [the centralized settings option.](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payment-gateway-wcpay.php#L2401-L2404)

This PR ensures that every gateway has its own settings object, which eventually resolves all the problems mentioned in https://github.com/Automattic/woocommerce-payments/issues/8349.

While this solution is the fix, the design of settings options still requires improvements, by e.g. ensuring the `enabled` property is in line with gateway's status and by e.g. removing the array with enabled UPE methods since we now have separate settings with `enabled` flag. Those are improvements unrelated to https://github.com/Automattic/woocommerce-payments/issues/8349 and I'll make sure we act there as well, but separately.

#### Testing instructions
Create a new JN site. As WooPayments plugin, use [this version.](https://github.com/Automattic/woocommerce-payments/actions/runs/8201421972)

* Complete the WooPayments onboarding and confirm that only one email is sent to your inbox
* Navigate to Blocks checkout editor under `Pages` in the admin panel and make sure the warning about incompatible gateways ([screenshot here](https://github.com/Automattic/woocommerce-payments/issues/8349#issue-2174408143)) is not present
* Perform a few tests on settings update
    * enable all payment methods, save settings, refresh the page, confirm the settings are accurate
    * disable one specific PM and after save & refresh confirm the settings are accurate
    * disable all PMs and after save & refresh confirm the settings are accurate
    * disable WooPayments on the WooCommerce level (under `WooCommerce -> Settings -> Payments`), refresh the page and confirm the disablement status is still in place
    * enable WooPayments back again, refresh the page and confirm the plugin is still enabled

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
