### PR TITLE
Re-enable Direct-to-Checkout Feature Flag in WooPay OTP Iframe

### DIFF
--- a/changelog/fix-re-add-direct-checkout-feature-flag-to-otp-iframe
+++ b/changelog/fix-re-add-direct-checkout-feature-flag-to-otp-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Re-enable Direct-to-Checkout Feature Flag in WooPay OTP Iframe.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -626,7 +626,11 @@ export const handleWooPayEmailInput = async (
 		);
 
 		// Check if user already has a WooPay login session and only open the iframe if there is WCPay.
-		if ( ! hasCheckedLoginSession && hasWCPayPaymentMethod ) {
+		if (
+			! hasCheckedLoginSession &&
+			hasWCPayPaymentMethod &&
+			! getConfig( 'isWooPayDirectCheckoutEnabled' )
+		) {
 			openLoginSessionIframe( woopayEmailInput.value );
 		}
 	} else {


### PR DESCRIPTION
Re-enable Direct-to-Checkout Feature Flag in WooPay OTP Iframe that was removed in #8116.

#### Testing instructions

Follow the testing instructions from https://github.com/Automattic/woocommerce-payments/pull/8133.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
