### PR TITLE
Set background-size: cover to fix PM icon styling issue

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -36,7 +36,8 @@
 	height: 1.25rem;
 	width: 32px;
 	width: 2rem;
-	background-size: contain;
+	background-size: cover;
+	background-position: center;
 	background-repeat: no-repeat;
 	border-radius: 2px;
 	outline: 1px solid rgba( 0, 0, 0, 0.25 );

--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -36,7 +36,8 @@
 	height: 1.25rem;
 	width: 32px;
 	width: 2rem;
-	background-size: contain;
+	background-size: cover;
+	background-position: center;
 	background-repeat: no-repeat;
 	border-radius: 2px;
 	outline: 1px solid rgba( 0, 0, 0, 0.25 );

--- a/changelog/fix-7183-pm-icon-styling-issue-in-transaction-details-page
+++ b/changelog/fix-7183-pm-icon-styling-issue-in-transaction-details-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a 1px gap on the right side of some payment method icons in transaction details.


### PR DESCRIPTION
Fixes #7183 

#### Changes proposed in this Pull Request

Change the `background-size` from `contain` to `cover` to avoid styling issues caused by unexpected aspect ratios of PM assets

**Before**

![bnpl-4](https://github.com/Automattic/woocommerce-payments/assets/1553182/362a92cb-6660-4ded-aa13-aea2b1f8cb1d)


**After**

<img width="253" alt="Screenshot 2024-03-12 at 13 21 52" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/aaa36526-2452-4ab6-8e67-a7220fe885aa">

<img width="242" alt="Screenshot 2024-03-12 at 13 32 14" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/ed6e447d-cedf-4a21-ae46-d9fcf6ad3cc7">


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* We need to check that PM icons are displayed correctly in onboarding, payment settings, transactions list and payment details.
* Hint: using developer tools you can edit the CSS class to check the payment method you'd like. (i.e: 
<img width="2010" alt="Screenshot 2024-03-12 at 13 46 06" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/a5be64a4-0947-427c-9de3-161bd4040619">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
