### PR TITLE
Disputes: Update a more clear order note for dispute fund withdrawn event

### DIFF
--- a/changelog/fix-6380-edit-dispute-order-note
+++ b/changelog/fix-6380-edit-dispute-order-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the order note for `dispute funds withdrawn` event clearly mention that the dispute amount and fee would be deducted from the next deposit

--- a/changelog/fix-6380-edit-dispute-order-note
+++ b/changelog/fix-6380-edit-dispute-order-note
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: update
 
-Make the order note for `dispute funds withdrawn` event clearly mention that the dispute amount and fee would be deducted from the next deposit
+Make the order note for `dispute funds withdrawn` event clearly mention that the dispute amount and fee would be deducted from the next deposit.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -618,7 +618,7 @@ class WC_Payments_Webhook_Processing_Service {
 
 		switch ( $event_type ) {
 			case 'charge.dispute.funds_withdrawn':
-				$message = __( 'Payment dispute funds have been withdrawn', 'woocommerce-payments' );
+				$message = __( 'Payment dispute and fees have been deducted from your next deposit', 'woocommerce-payments' );
 				break;
 			case 'charge.dispute.funds_reinstated':
 				$message = __( 'Payment dispute funds have been reinstated', 'woocommerce-payments' );

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1359,7 +1359,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'add_order_note' )
 			->with(
 				$this->matchesRegularExpression(
-					'/Payment dispute funds have been withdrawn/'
+					'/Payment dispute and fees have been deducted from your next deposit/'
 				)
 			);
 


### PR DESCRIPTION
Fixes #6380 

#### Changes proposed in this Pull Request

The PR updates the order note text, when a dispute fund withdrawal event occurs. It clearly mentions that the Dispute amount and fees will be both deducted from the next deposit. 

#### Before

Text:
```
Payment dispute funds have been withdrawn. See [dispute overview](#) for more details.
```

![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/9f521b17-1e6f-4910-aa14-496d07b1a023)

#### After
```
Payment dispute and fees have been deducted from your next deposit. See [dispute overview](#) for more details.
```
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/f719463e-f6c0-4c3b-869c-9a5ecea48eec)


#### Testing instructions

* Set up store – onboarded, products for sale, connected to WCPay etc in test mode.
* Also ensure your store can receive webhooks (on publicly-accessible hostname e.g. ngrok/jurassic tube).

Test these steps before and after checking out this branch. 

1. On front end, add a product to cart and proceed to checkout.
2. Complete checkout and [use a disputed card number](https://stripe.com/docs/testing#disputes), e.g. 4000 0000 0000 2685.
3. Go to WP admin > Payments > Disputes.
4. Click the most recent disputed order (the thing you just bought & disputed).
5. Review the order notes and compare with the `before` and `after` screenshots / texts shared above. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - N. A.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
