### PR TITLE
Deposits: Clean up remnant code from past A/B Experiment on Deposit List

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -17,10 +17,6 @@
 #adminmenu
 	#toplevel_page_wc-admin-path--payments-connect
 	.menu-icon-generic
-	div.wp-menu-image::before,
-#adminmenu
-	#toplevel_page_wc-admin-path--payments-deposits
-	.menu-icon-generic
 	div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';

--- a/changelog/update-6224-clean-up-old-experiment-code
+++ b/changelog/update-6224-clean-up-old-experiment-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Clean up remaining unused code from a past experiment - `wcpay_empty_state_preview_mode`, done on Deposits list.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -285,53 +285,6 @@ class WC_Payments_Admin {
 	}
 
 	/**
-	 * Add deposits and transactions menus for wcpay_empty_state_preview_mode_v1 experiment's treatment group.
-	 * This code can be removed once we're done with the experiment.
-	 */
-	public function add_payments_menu_for_treatment() {
-		wc_admin_register_page(
-			[
-				'id'         => 'wc-payments',
-				'title'      => __( 'Payments', 'woocommerce-payments' ),
-				'capability' => 'manage_woocommerce',
-				'path'       => '/payments/deposits',
-				'position'   => '55.7', // After WooCommerce & Product menu items.
-				'nav_args'   => [
-					'title'        => 'WooPayments',
-					'is_category'  => true,
-					'menuId'       => 'plugins',
-					'is_top_level' => true,
-				],
-			]
-		);
-
-		wc_admin_register_page( $this->admin_child_pages['wc-payments-deposits'] );
-		wc_admin_register_page( $this->admin_child_pages['wc-payments-transactions'] );
-		wc_admin_register_page(
-			[
-				'id'       => 'wc-payments-connect',
-				'title'    => __( 'Connect', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/connect',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 10,
-				],
-			]
-		);
-
-		WC_Payments_Utils::enqueue_style(
-			'wcpay-admin-css',
-			plugins_url( 'assets/css/admin.css', WCPAY_PLUGIN_FILE ),
-			[],
-			WC_Payments::get_file_version( 'assets/css/admin.css' ),
-			'all',
-		);
-
-		$this->add_menu_notification_badge();
-	}
-
-	/**
 	 * Add payments menu items.
 	 */
 	public function add_payments_menu() {


### PR DESCRIPTION
Fixes #6224 

#### Changes proposed in this Pull Request

The PR cleans up some unwanted code from a past A/B Experiment on the Deposit list. More details:

* The test was done in 2021 with changes pushed through this PR 
https://github.com/Automattic/woocommerce-payments/pull/1963
and
https://github.com/Automattic/woocommerce-payments/pull/2557/files

* Clean up was pushed via 
https://github.com/Automattic/woocommerce-payments/pull/7045

However, there was a function left to be cleaned - `add_payments_menu_for_treatment` within `WC_Payments_Admin` , and that is being removed by this PR. 

#### Testing instructions

Since this is a clean-up of unused code, all existing tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - N. A.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
