### PR TITLE
Client side routing to improve the navigation times for "View Deposit History"

### DIFF
--- a/changelog/fix-6527-improved-navigation-time
+++ b/changelog/fix-6527-improved-navigation-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Used client side navigation to improve the UX for "View Deposit History"

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -10,6 +10,7 @@ import {
 	CardHeader,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies.
@@ -72,6 +73,18 @@ const DepositsOverview: React.FC = () => {
 	const hasScheduledDeposits = hasAutomaticScheduledDeposits(
 		account?.deposits_schedule?.interval
 	);
+
+	const navigateToDepositsHistory = () => {
+		recordEvent( 'wcpay_overview_deposits_view_history_click' );
+
+		const history = getHistory();
+		history.push(
+			getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/deposits',
+			} )
+		);
+	};
 
 	// Show a loading state if the page is still loading.
 	if ( isLoading ) {
@@ -174,15 +187,7 @@ const DepositsOverview: React.FC = () => {
 					{ hasRecentDeposits && (
 						<Button
 							variant="secondary"
-							href={ getAdminUrl( {
-								page: 'wc-admin',
-								path: '/payments/deposits',
-							} ) }
-							onClick={ () =>
-								recordEvent(
-									'wcpay_overview_deposits_view_history_click'
-								)
-							}
+							onClick={ navigateToDepositsHistory }
 						>
 							{ __(
 								'View full deposits history',

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -262,12 +262,12 @@ exports[`Deposits Overview information Component Renders 1`] = `
         data-wp-c16t="true"
         data-wp-component="CardFooter"
       >
-        <a
+        <button
           class="components-button is-secondary"
-          href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits"
+          type="button"
         >
           View full deposits history
-        </a>
+        </button>
         <a
           class="components-button is-tertiary"
           href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#deposit-schedule"


### PR DESCRIPTION
Fixes #6527 

#### Changes proposed in this Pull Request

- Used the`getHistory` hook to leverage the client-side navigation. 
- Create a common function that tracks the events and navigate to the `/payments/deposits` page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Verify that on clicking the "View deposits history" button, it navigates via the client side and doesn't reload the whole page while navigating.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
