### PR TITLE
Initialises BNPL payment messaging element with Stripe account ID

### DIFF
--- a/changelog/fix-adds-correct-options-to-bnpl-messaging-element
+++ b/changelog/fix-adds-correct-options-to-bnpl-messaging-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Uses WCPayAPI to initialise Stripe for BNPL payment element, includes necessary required parameters.

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -3,24 +3,35 @@
  * Internal dependencies
  */
 import './style.scss';
+import WCPayAPI from 'wcpay/checkout/api';
 
 export const initializeBnplSiteMessaging = () => {
 	const {
 		productVariations,
 		country,
+		locale,
+		accountId,
 		publishableKey,
 		paymentMethods,
 	} = window.wcpayStripeSiteMessaging;
 
 	// eslint-disable-next-line no-undef
-	const stripe = Stripe( publishableKey );
+	const api = new WCPayAPI(
+		{
+			publishableKey: publishableKey,
+			accountId: accountId,
+			locale: locale,
+		},
+		null
+	);
 	const options = {
 		amount: parseInt( productVariations.base_product.amount, 10 ) || 0,
 		currency: productVariations.base_product.currency || 'USD',
 		paymentMethodTypes: paymentMethods || [],
 		countryCode: country, // Customer's country or base country of the store.
 	};
-	const paymentMessageElement = stripe
+	const paymentMessageElement = api
+		.getStripe()
 		.elements()
 		.create( 'paymentMethodMessaging', options );
 	paymentMessageElement.mount( '#payment-method-message' );

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -15,7 +15,6 @@ export const initializeBnplSiteMessaging = () => {
 		paymentMethods,
 	} = window.wcpayStripeSiteMessaging;
 
-	// eslint-disable-next-line no-undef
 	const api = new WCPayAPI(
 		{
 			publishableKey: publishableKey,

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -90,6 +90,8 @@ class WC_Payments_Payment_Method_Messaging_Element {
 				'productId'         => 'base_product',
 				'productVariations' => $product_variations,
 				'country'           => empty( $billing_country ) ? $store_country : $billing_country,
+				'locale'            => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
+				'accountId'         => $this->account->get_stripe_account_id(),
 				'publishableKey'    => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
 				'paymentMethods'    => array_values( $bnpl_payment_methods ),
 			]


### PR DESCRIPTION
#### Changes proposed in this Pull Request
<!--
Title: A descriptive, yet concise, title.
-->
# Adds missing parameters to Stripe initialisation when mounting BNPL payment messaging element
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
> For context, when WooPayments platform tries to mount the payment method messaging element on the merchant's product pages, for example, Stripe internally makes a GET call to Affirm to fetch merchant's summary. We believe Woo might not be leveraging stripeAccount [option](https://docs.stripe.com/js/initializing#init_stripe_js-options-stripeAccount), when trying to create an instance of Stripe. When stripeAccount option is not specified, stripe is initialized & PMME is mounted on behalf of Woo platform account...not the connected account (MoR). Since Affirm as a capability, is applied to the connected account...these GET calls are returning 404.

This PR uses the `WCPayAPI` object to instantiate the `Stripe` instance used to create and mount the payment messaging element. We add the missing `accountId` parameter, as well as the `locale` parameter, to the initialisation, as well as ensuring we have a consistent implementation to summon Stripe that includes any other auxiliary parameters used at checkout, such as including optional `betas`, for example. 

This should resolve the pertinent misplaced parameter problem, while hopefully using a more robust, shared utility.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Pull the changes in this PR and ensure you have at least one BNPL payment method (i.e. Affirm, Afterpay, Klarna) enabled at checkout.
2. Visit a product page that will be compatibile with BNPL checkout (check respective payment method class files inside `/includes/payment-methods/...` to confirm amount, currency, and country restrictions).
3. Observe that BNPL payment messaging element object is present and that suggested payment installments correspond correctly to product total amount.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
