### PR TITLE
Add Loading Spinner to “Proceed to Checkout” Button, in Shortcode Cart

### DIFF
--- a/changelog/add-2561-woopay-load-spinner-to-button-in-shortcode-cart
+++ b/changelog/add-2561-woopay-load-spinner-to-button-in-shortcode-cart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a loading spinner to the "Proceed to Checkout" button in shortcode cart.

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -186,8 +186,59 @@ class WooPayDirectCheckout {
 	 * @param {boolean} useCheckoutRedirect Whether to use the `checkout_redirect` flag to let WooPay handle the checkout flow.
 	 */
 	static redirectToWooPay( elements, useCheckoutRedirect = false ) {
+		/**
+		 * Adds a loading spinner to the given element.
+		 *
+		 * @param {Element} element The element to add the loading spinner to.
+		 */
+		const addLoadingSpinner = ( element ) => {
+			// Create a spinner to show when the user clicks the button.
+			const spinner = document.createElement( 'span' );
+			spinner.classList.add( 'wc-block-components-spinner' );
+			spinner.style.position = 'relative';
+			spinner.style.fontSize = 'unset';
+			// Remove the existing content of the button.
+			// Set innerHTML to '&nbsp;' to keep the button's height.
+			element.innerHTML = '&nbsp;';
+			element.classList.remove( 'wc-forward' );
+			// Add the spinner to the button.
+			element.appendChild( spinner );
+		};
+
+		/**
+		 * Checks if the given element is the checkout button in the cart shortcode.
+		 *
+		 * @param {Element} element The element to check.
+		 *
+		 * @return {boolean} True if the element is a checkout button in the cart shortcode.
+		 */
+		const isCheckoutButtonInCartShortCode = ( element ) => {
+			const isCheckoutButton = element.classList.contains(
+				'checkout-button'
+			);
+			const isParentProceedToCheckout = element.parentElement?.classList?.contains(
+				'wc-proceed-to-checkout'
+			);
+
+			return isCheckoutButton && isParentProceedToCheckout;
+		};
+
 		elements.forEach( ( element ) => {
+			const elementState = {
+				is_loading: false,
+			};
+
 			element.addEventListener( 'click', async ( event ) => {
+				if ( elementState.is_loading ) {
+					event.preventDefault();
+					return;
+				}
+
+				elementState.is_loading = true;
+				if ( isCheckoutButtonInCartShortCode( element ) ) {
+					addLoadingSpinner( element );
+				}
+
 				// Store href before the async call to not lose the reference.
 				let currTargetHref;
 				const isAElement = element.tagName.toLowerCase() === 'a';

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -235,6 +235,7 @@ class WooPayDirectCheckout {
 				}
 
 				elementState.is_loading = true;
+
 				if ( isCheckoutButtonInCartShortCode( element ) ) {
 					addLoadingSpinner( element );
 				}


### PR DESCRIPTION
Fixes 2561-gh-Automattic/woopay.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR ensures the "Proceed to Checkout" button in the shortcode cart has a loading state. Additionally, it ensures the button (in both the shortcode and the wc-blocks cart) cannot be spam-clicked to unintentionally enque a series of HTTP requests.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Regression Test: Ensure the Woopay Direct Checkout Flow Continues to Work as Intended**
* Ensure the WooPay Direct Checkout flow is enabled by running `npm run wp option update _wcpay_feature_woopay_direct_checkout 1`.
* Ensure a valid WooPay user is authenticated on WooPay.
* As a shopper, navigate to the Merchant store, add an item to your cart, and navigate to the cart.
* Click the `Proceed to checkout` button.
* Ensure you are navigated to the WooPay checkout.
* Click the `Place Order` button.
* Ensure you have checked out successfully.

**Regression Test: Ensure the Loading Spinner Continues to Appear on the Checkout Button in the wc-blocks Cart**
* As a merchant, navigate to `Pages > Cart` and ensure the Cart page contains the `Cart` wc-block.
* As a shopper, navigate to the Merchant store, add an item to your cart, and navigate to the cart.
* Click the `Proceed to checkout` button.
* Ensure a loading spinner appears on the button.

**Test: Ensure the Loading Spinner Appears in the Checkout Button in the shortcode Cart**
* As a merchant, navigate to `Pages > Cart` and ensure the Cart page contains the `Classic Cart` shortcode.
* As a shopper, navigate to the Merchant store, add an item to your cart, and navigate to the cart.
* Click the `Proceed to checkout` button.
* Ensure a loading spinner appears on the button.

**Test: Ensure Spam Clicking the Checkout Button Does Not Result in Multiple HTTP Requests**
* As a shopper, navigate to the Merchant store, add an item to your cart, and navigate to the cart.
* Open the `Network` tab in the browser's developer tools.
* Spam click the `Proceed to checkout` button multiple times.
* Ensure only one `POST https://woopay.com/wp-json/platform-checkout/v1/sessions` request is created.
* Repeat these steps in the wc-blocks cart or shortcode cart, as needed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
When adding testing instructions, you edit the page for the current release.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
