### PR TITLE
Fix admin multi currency e2e tests

### DIFF
--- a/changelog/fix-8357-admin-multi-currency-e2e-tests
+++ b/changelog/fix-8357-admin-multi-currency-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix admin multi-currency e2e tests.
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-admin-multi-currency.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-admin-multi-currency.spec.js
@@ -6,7 +6,7 @@ const { merchant, WP_ADMIN_DASHBOARD } = require( '@woocommerce/e2e-utils' );
 /**
  * Internal dependencies
  */
-import { merchantWCP, takeScreenshot, uiLoaded } from '../../../utils';
+import { merchantWCP, takeScreenshot } from '../../../utils';
 
 describe( 'Admin Multi-Currency', () => {
 	let wasMulticurrencyEnabled;
@@ -36,8 +36,9 @@ describe( 'Admin Multi-Currency', () => {
 	} );
 
 	it( 'should be possible to add the currency switcher to a post/page', async () => {
-		await page.goto( `${ WP_ADMIN_DASHBOARD }post-new.php` );
-		await uiLoaded();
+		await page.goto( `${ WP_ADMIN_DASHBOARD }post-new.php`, {
+			waitUntil: 'load',
+		} );
 
 		const closeWelcomeModal = await page.$( 'button[aria-label="Close"]' );
 		if ( closeWelcomeModal ) {

--- a/tests/e2e/specs/wcpay/merchant/merchant-admin-multi-currency.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-admin-multi-currency.spec.js
@@ -48,7 +48,7 @@ describe( 'Admin Multi-Currency', () => {
 		await page.click( 'button[aria-label="Add block"]' );
 
 		const searchInput = await page.waitForSelector(
-			'input.components-search-control__input'
+			'input[placeholder="Search"]'
 		);
 		searchInput.type( 'switcher', { delay: 20 } );
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -887,9 +887,8 @@ export const merchantWCP = {
 
 	addMulticurrencyWidget: async () => {
 		await page.goto( `${ WP_ADMIN_DASHBOARD }widgets.php`, {
-			waitUntil: 'networkidle0',
+			waitUntil: 'load',
 		} );
-		await uiLoaded();
 
 		const closeWelcomeModal = await page.$( 'button[aria-label="Close"]' );
 		if ( closeWelcomeModal ) {

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -902,7 +902,7 @@ export const merchantWCP = {
 			await page.click( 'button[aria-label="Add block"]' );
 
 			const searchInput = await page.waitForSelector(
-				'input.components-search-control__input'
+				'input[placeholder="Search"]'
 			);
 			searchInput.type( 'switcher', { delay: 20 } );
 


### PR DESCRIPTION
Fixes #8357 

#### Changes proposed in this Pull Request

This updates two small details in the admin multi-currency e2e tests:

- First is how to wait for the page navigation. Looks like `networkidle0` was making this fail in WP beta, and replacing it with `load` worked. I removed the `uiLoaded` call as well because that helper is a WooPayments thing and doesn't make sense to call it in native WordPress pages.
- Second was updating the search input to a more generic selector. Looks like the selector changed in WP beta.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Previously this test was failing only in the `WP - nightly | WC - latest | wcpay - merchant` check. Confirm this test doesn't fail in any e2e tests check in this PR.

**Test: running the test locally**

1. Switch to this branch.
2. Run `npm run test:e2e-reset && npm run test:e2e-setup` to reset and setup your local e2e environment.
3. Run `npm run test:e2e -- merchant-admin-multi-currency.spec.js`.
4. All tests in that spec should pass.
5. Update WordPress to the [Nightly version](https://wordpress.org/download/beta-nightly/) in the e2e environment.
5.1. You can do that by replacing the WordPress files in `tests/e2e/docker/wordpress`. Be careful to not overwrite plugins and themes in the `wp-content` folder.
5.2. Go to http://localhost:8084/wp-admin/ and update the database.
6. Run `npm run test:e2e -- merchant-admin-multi-currency.spec.js`.
7. All tests in that spec should pass.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
