### PR TITLE
refactor: validator package bundle size improvements

### DIFF
--- a/changelog/refactor-validator-bundle-size
+++ b/changelog/refactor-validator-bundle-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+refactor: validator package bundle size improvements

--- a/client/checkout/woopay/express-button/use-express-checkout-product-handler.js
+++ b/client/checkout/woopay/express-button/use-express-checkout-product-handler.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import validator from 'validator';
+import isEmail from 'validator/lib/isEmail';
 import { __ } from '@wordpress/i18n';
 
 const useExpressCheckoutProductHandler = ( api ) => {
@@ -49,7 +49,7 @@ const useExpressCheckoutProductHandler = ( api ) => {
 			if (
 				! data.wc_gc_giftcard_to_multiple
 					.split( ',' )
-					.every( ( email ) => validator.isEmail( email.trim() ) )
+					.every( ( email ) => isEmail( email.trim() ) )
 			) {
 				alert(
 					__(
@@ -62,7 +62,7 @@ const useExpressCheckoutProductHandler = ( api ) => {
 		}
 
 		if ( data.hasOwnProperty( 'wc_gc_giftcard_to' ) ) {
-			if ( ! validator.isEmail( data.wc_gc_giftcard_to ) ) {
+			if ( ! isEmail( data.wc_gc_giftcard_to ) ) {
 				alert(
 					__(
 						'Please type only valid emails',


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Improving the tree-shaking by importing only the necessary functions (in this case, `isEmail`) from the `validator` library we're consuming.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a merchant, enable WooPay on your settings, and ensure it is visible on product pages
- As a customer, go to a product page
- Click on the WooPay button
- The WooPay modal should still appear (same as `develop`)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
