### PR TITLE
fix: add payment method page initialization on missing UPE styles

### DIFF
--- a/changelog/fix-add-payment-method-page-initialization
+++ b/changelog/fix-add-payment-method-page-initialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: "Add payment method" page initialization on missing UPE styles

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -129,9 +129,13 @@ export const getBackgroundColor = ( selectors ) => {
 	let color = null;
 	let i = 0;
 	while ( ! color && i < selectors.length ) {
-		const bgColor = window.getComputedStyle(
-			document.querySelector( selectors[ i ] )
-		).backgroundColor;
+		const element = document.querySelector( selectors[ i ] );
+		if ( ! element ) {
+			i++;
+			continue;
+		}
+
+		const bgColor = window.getComputedStyle( element ).backgroundColor;
 		// If backgroundColor property present and alpha > 0.
 		if ( bgColor && tinycolor( bgColor ).getAlpha() > 0 ) {
 			color = bgColor;


### PR DESCRIPTION
Fixes #8383

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The "Add payment method" page fails to initialize when the `wcpay_upe_appearance` or the `wcpay_wc_blocks_upe_appearance` transients are expired.

It looks like styles are being attempted to be computed on the "Add payment method" page, but the JS isn't able to get the input to derive the styles from.

I added some checks to ensure the elements are present in the DOM, before passing them to `window.getComputedStyle()`.
This is meant to be a patch, I will be looking into additional solutions to ensure the styles can also be calculated on the "Add payment method" page.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Delete the `wcpay_wc_blocks_upe_appearance` and the `wcpay_upe_appearance` transients from your DB (or comment out [these two lines](https://github.com/Automattic/woocommerce-payments/blob/beff10e730e31ea6c50f2e59eb9072ea82718d30/includes/class-wc-payments-checkout.php#L220-L221))
- As a customer, go to the "Add payment method" page
- The elements should now load

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
