### PR TITLE
Fix UPE fields erroneously showing black background in some themes.

### DIFF
--- a/changelog/8381-fix-upe-input-background-color
+++ b/changelog/8381-fix-upe-input-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes some instances where Stripe UPE styles add a black background to input fields.

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -44,7 +44,7 @@ describe( 'Getting styles for automated theming', () => {
 			'.Input'
 		);
 		expect( fieldStyles ).toEqual( {
-			backgroundColor: 'rgb(0, 0, 0)',
+			backgroundColor: 'rgb(255, 255, 255)',
 			color: 'rgb(109, 109, 109)',
 			fontFamily:
 				'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -131,7 +131,7 @@ describe( 'Getting styles for automated theming', () => {
 			theme: 'stripe',
 			rules: {
 				'.Input': {
-					backgroundColor: 'rgb(0, 0, 0)',
+					backgroundColor: 'rgb(255, 255, 255)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -140,7 +140,7 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 				'.Input--invalid': {
-					backgroundColor: 'rgb(0, 0, 0)',
+					backgroundColor: 'rgb(255, 255, 255)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -156,24 +156,24 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 				'.Tab': {
-					backgroundColor: 'rgb(0, 0, 0)',
+					backgroundColor: 'rgb(255, 255, 255)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 				},
 				'.Tab:hover': {
-					backgroundColor: 'rgb(18, 18, 18)',
-					color: 'rgb(255, 255, 255)',
+					backgroundColor: 'rgb(237, 237, 237)',
+					color: 'rgb(0, 0, 0)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 				},
 				'.Tab--selected': {
-					backgroundColor: 'rgb(0, 0, 0)',
+					backgroundColor: 'rgb(255, 255, 255)',
 					color: 'rgb(109, 109, 109)',
 					outline: '1px solid rgb(150, 88, 138)',
 				},
 				'.TabIcon:hover': {
-					color: 'rgb(255, 255, 255)',
+					color: 'rgb(0, 0, 0)',
 				},
 				'.TabIcon--selected': {
 					color: 'rgb(109, 109, 109)',

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -110,10 +110,14 @@ export const dashedToCamelCase = ( string ) => {
  */
 export const maybeConvertRGBAtoRGB = ( color ) => {
 	const colorParts = color.match(
-		/^rgba\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/
+		/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0?(\.\d+)?|1?(\.0+)?)\s*\)$/
 	);
 	if ( colorParts ) {
-		color = `rgb(${ colorParts[ 1 ] }, ${ colorParts[ 2 ] }, ${ colorParts[ 3 ] })`;
+		const alpha = colorParts[ 4 ] || 1;
+		const newColorParts = colorParts.slice( 1, 4 ).map( ( part ) => {
+			return Math.round( part * alpha + 255 * ( 1 - alpha ) );
+		} );
+		color = `rgb(${ newColorParts.join( ', ' ) })`;
 	}
 	return color;
 };


### PR DESCRIPTION
Fixes #8381 

#### Changes proposed in this Pull Request
On some themes, the credit card fields from UPE were displaying a black background when they shouldn't have. The UPE appearance is generated on the checkout page and we're trying to make an educated guess as to what the styles of the input fields should be. The reported issue occurred when `rgba(0,0,0,0)` (transparent) was being detected and we turned that into `rgb(0,0,0)` (black). We now return `rgb(255,255,255)` in this scenario.

I've also made the regex detecting `rgba` a bit more robust.

#### Testing instructions

1. Activate the Blockbase theme on a site where WooPayments 7.3.0 is active and configured to accept card payments.
2. Create a new page.
3. Use the `[woocommerce_checkout]` shortcode and publish the page.
4. Add a product to your cart.
5. Navigate to the page created in steps 2–3.
6. Locate the card fields.
7. Note that the background color of the .input fields related to WooPayments are white.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
