### PR TITLE
Fix WooPay direct checkout eligibility check

### DIFF
--- a/changelog/fix-woopay-direct-checkout-feature-flag
+++ b/changelog/fix-woopay-direct-checkout-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay direct checkout eligibility checks.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -276,7 +276,7 @@ class WC_Payments_Features {
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '0' );
 
-		return ( $is_direct_checkout_eligible || $is_direct_checkout_flag_enabled ) && self::is_woopay_first_party_auth_enabled();
+		return $is_direct_checkout_eligible && $is_direct_checkout_flag_enabled && self::is_woopay_first_party_auth_enabled();
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -274,7 +274,7 @@ class WC_Payments_Features {
 	public static function is_woopay_direct_checkout_enabled() {
 		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
-		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '0' );
+		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
 
 		return $is_direct_checkout_eligible && $is_direct_checkout_flag_enabled && self::is_woopay_first_party_auth_enabled();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a simple fix for the `WC_Payments_Features::is_woopay_direct_checkout_enabled()` function which ensures the direct checkout feature is only available if both the option flag and the server-side feature flag are enabled.

This is to only enable the feature when we explicitly set the option to `1` by default, and not have the feature enabled by the server-side flag in an earlier WooPayments version.

#### Testing instructions

1. Switch to this branch.
2. In your local server, add an early `return false;` to the `calculate_woopay_direct_checkout_eligibility` method.
3. From your local merchant store, navigate to the dev tools plugin and clear the account cache.
4. Ensure the `platform_direct_checkout_eligible` prop is `false`.
5. Ensure the direct checkout flow is disabled.
   - From the cart page, click the "Proceed to checkout" button while logged in to WooPay and ensure you're redirected to the merchant checkout.
6. Remove the early `return false;` and clear the account cache.
7. Ensure both the `platform_direct_checkout_eligible` account prop and the `_wcpay_feature_woopay_direct_checkout` option are `true`.
8. Ensure the direct checkout flow is enabled.
   - From the cart page, click the "Proceed to checkout" button while logged in to WooPay and ensure you're redirected to the merchant checkout.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
