### PR TITLE
Minor copy improvements on the Settings page

### DIFF
--- a/changelog/update-7299-general-settings-desc
+++ b/changelog/update-7299-general-settings-desc
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Minor copy improvements on the Settings page.
+Remove mention of test mode from general settings help text.

--- a/changelog/update-7299-general-settings-desc
+++ b/changelog/update-7299-general-settings-desc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Minor copy improvements on the Settings page.

--- a/client/components/payment-methods-list/payment-method.tsx
+++ b/client/components/payment-methods-list/payment-method.tsx
@@ -350,7 +350,7 @@ const PaymentMethod = ( {
 						) }
 						<a
 							// eslint-disable-next-line max-len
-							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation"
+							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-migration"
 							target="_blank"
 							rel="external noreferrer noopener"
 						>

--- a/client/payment-methods/delete-modal.tsx
+++ b/client/payment-methods/delete-modal.tsx
@@ -94,7 +94,7 @@ const ConfirmPaymentMethodDeleteModal: React.FunctionComponent< {
 						) }
 						<a
 							// eslint-disable-next-line max-len
-							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation"
+							href="https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-migration"
 							target="_blank"
 							rel="external noreferrer noopener"
 						>

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -65,7 +65,7 @@ const GeneralSettingsDescription = () => (
 			{ sprintf(
 				/* translators: %s: WooPayments */
 				__(
-					'Enable or disable %s on your store and turn on test mode to simulate transactions.',
+					'Enable or disable %s on your store.',
 					'woocommerce-payments'
 				),
 				'WooPayments'


### PR DESCRIPTION
Fixes #7299

#### Changes proposed in this Pull Request

* De-emphasize test mode in the description for General settings section - screenshot below.
* Fix sofort migration links - replaced the docs link from `#sofort-deprecation` to `#sofort-migration`.


A note about the second change: The old link https://woo.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-deprecation doesn't work anymore. The section in the docs it refers to seems to have been renamed recently, causing the link to break.

![image](https://github.com/Automattic/woocommerce-payments/assets/1288616/db461fc0-b44c-473a-b315-7a2d4d91f0ae)


#### Testing instructions

This pull request contains very minor text refinements. Reviewing them should be enough.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
