### PR TITLE
fix: error handling when saved card and amount too large

### DIFF
--- a/changelog/payment-utils-when-amount-too-large
+++ b/changelog/payment-utils-when-amount-too-large
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: better error message when saved card and amount too large

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -572,8 +572,8 @@ class WC_Payments_Utils {
 				),
 				wp_strip_all_tags( html_entity_decode( $price ) )
 			);
-		} elseif ( $e instanceof API_Exception && "amount_too_large" === $e->get_error_code() ) {
-			$error_message=$e->getMessage();
+		} elseif ( $e instanceof API_Exception && 'amount_too_large' === $e->get_error_code() ) {
+			$error_message = $e->getMessage();
 		} elseif ( $e instanceof API_Exception && 'wcpay_bad_request' === $e->get_error_code() ) {
 			$error_message = __( 'We\'re not able to process this request. Please refresh the page and try again.', 'woocommerce-payments' );
 		} elseif ( $e instanceof API_Exception && ! empty( $e->get_error_type() ) && 'card_error' !== $e->get_error_type() ) {

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -572,6 +572,8 @@ class WC_Payments_Utils {
 				),
 				wp_strip_all_tags( html_entity_decode( $price ) )
 			);
+		} elseif ( $e instanceof API_Exception && "amount_too_large" === $e->get_error_code() ) {
+			$error_message=$e->getMessage();
 		} elseif ( $e instanceof API_Exception && 'wcpay_bad_request' === $e->get_error_code() ) {
 			$error_message = __( 'We\'re not able to process this request. Please refresh the page and try again.', 'woocommerce-payments' );
 		} elseif ( $e instanceof API_Exception && ! empty( $e->get_error_type() ) && 'card_error' !== $e->get_error_type() ) {


### PR DESCRIPTION
Helps with https://github.com/Automattic/woocommerce-payments/issues/7485

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

A customer could attempt to pay with a saved card for a cart amount of >$1M.
If that happens, we show a generic error message "We're not able to process this request. Please refresh the page and try again.":
<img width="1324" alt="Screenshot 2024-03-18 at 10 36 56 AM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/9531d8eb-c3eb-46dc-8f8b-08a26f65da15">

Making the error message less generic by elevating the Stripe error:
<img width="1362" alt="Screenshot 2024-03-18 at 10 31 09 AM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/9ef689f5-03df-4292-9d1f-4bb90d74813b">


PLEASE NOTE: this doesn't fix the Stripe elements failing to load when the amount is >$1M. This just changes the error message when using a saved card.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a customer, add some saved cards in My Account > Payment Methods (if you don't have a saved card already)
- As a customer, go to checkout and add one (or multiple) product(s) to go over $1M
- Attempt to pay with one of the saved cards
- The error message displayed should state that the amount is too large

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
