### PR TITLE
Add settings object for every gateway

### DIFF
--- a/changelog/fix-payment-methods-rendering
+++ b/changelog/fix-payment-methods-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add settings object for every gateway

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -630,7 +630,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 			}
 		}
 
-		$this->wcpay_gateway->update_option( 'upe_enabled_payment_method_ids', $payment_method_ids_to_enable );
+		foreach ( $payment_method_ids_to_enable as $payment_method_id ) {
+			$gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
+			$gateway->update_option( 'upe_enabled_payment_method_ids', $payment_method_ids_to_enable );
+		}
+
 		if ( $payment_method_ids_to_enable ) {
 			$this->request_unrequested_payment_methods( $payment_method_ids_to_enable );
 		}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -588,12 +588,14 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-additional-payment-methods-admin-notes-removal.php';
 		require_once __DIR__ . '/migrations/class-link-woopay-mutual-exclusion-handler.php';
+		require_once __DIR__ . '/migrations/class-gateway-settings-sync.php';
 		require_once __DIR__ . '/migrations/class-delete-active-woopay-webhook.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Allowed_Payment_Request_Button_Sizes_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Additional_Payment_Methods_Admin_Notes_Removal(), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Link_WooPay_Mutual_Exclusion_Handler( self::get_gateway() ), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Gateway_Settings_Sync( self::get_gateway(), self::get_payment_gateway_map() ), 'maybe_sync' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_WooPay_Webhook', 'maybe_delete' ] );
 
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-explicit-price-formatter.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1136,6 +1136,15 @@ class WC_Payments {
 	}
 
 	/**
+	 * Returns Payment Gateway map.
+	 *
+	 * @return array
+	 */
+	public static function get_payment_gateway_map() {
+		return self::$payment_gateway_map;
+	}
+
+	/**
 	 * Returns the WC_Payment_Gateway_WCPay instance
 	 *
 	 * @return WC_Payment_Gateway_WCPay gateway instance

--- a/includes/migrations/class-gateway-settings-sync.php
+++ b/includes/migrations/class-gateway-settings-sync.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Class Gateway_Settings_Sync
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Migrations;
+
+use WC_Payment_Gateway_WCPay;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Delete_Active_WooPay_Webhook
+ *
+ * Aligns settings object for every gateway to support new approach of settings handling without the need of using the settings controller.
+ */
+class Gateway_Settings_Sync {
+
+
+	/**
+	 * Version in which this migration was introduced.
+	 *
+	 * @var string
+	 */
+	const VERSION_SINCE = '7.4.0';
+
+	/**
+	 * WCPay gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $main_gateway;
+
+	/**
+	 * All registered gateways.
+	 *
+	 * @var array
+	 */
+	private $all_registered_gateways;
+
+	/**
+	 * Gateway_Settings_Sync constructor.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $main_gateway WCPay gateway.
+	 * @param array                    $all_registered_gateways All registered gateways.
+	 */
+	public function __construct( WC_Payment_Gateway_WCPay $main_gateway, $all_registered_gateways ) {
+		$this->main_gateway            = $main_gateway;
+		$this->all_registered_gateways = $all_registered_gateways;
+	}
+
+	/**
+	 * Checks whether we should trigger the event.
+	 */
+	public function maybe_sync() {
+		$previous_version = get_option( 'woocommerce_woocommerce_payments_version' );
+		if ( version_compare( self::VERSION_SINCE, $previous_version, '>' ) ) {
+			$this->sync();
+		}
+	}
+
+	/**
+	 * Deletes the active webhook.
+	 */
+	private function sync() {
+		$enabled_payment_methods = $this->main_gateway->get_option( 'upe_enabled_payment_method_ids', [] );
+
+		foreach ( $this->all_registered_gateways as $gateway ) {
+			if ( in_array( $gateway->get_stripe_id(), $enabled_payment_methods, true ) ) {
+				$gateway->enable();
+				$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+			} else {
+				$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+			}
+		}
+	}
+}

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -350,15 +350,15 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
-	public function test_update_settings_saves_enabled_payment_methods() {
-			$this->gateway->update_option( 'upe_enabled_payment_method_ids', [ Payment_Method::CARD ] );
+	public function test_timur_testing() {
+		WC_Payments::get_gateway()->update_option( 'upe_enabled_payment_method_ids', [ Payment_Method::CARD ] );
 
-			$request = new WP_REST_Request();
-			$request->set_param( 'enabled_payment_method_ids', [ Payment_Method::CARD, Payment_Method::GIROPAY ] );
+		$request = new WP_REST_Request();
+		$request->set_param( 'enabled_payment_method_ids', [ Payment_Method::CARD, Payment_Method::GIROPAY ] );
 
-			$this->controller->update_settings( $request );
+		$this->controller->update_settings( $request );
 
-			$this->assertEquals( [ Payment_Method::CARD, Payment_Method::GIROPAY ], $this->gateway->get_option( 'upe_enabled_payment_method_ids' ) );
+		$this->assertEquals( [ Payment_Method::CARD, Payment_Method::GIROPAY ], WC_Payments::get_gateway()->get_option( 'upe_enabled_payment_method_ids' ) );
 	}
 
 	public function test_update_settings_fails_if_user_cannot_manage_woocommerce() {

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 8.6.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 7.4.0
+ * Version: 7.3.0
  *
  * @package WooCommerce\Payments
  */

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 8.6.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 7.3.0
+ * Version: 7.4.0
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8370

#### Changes proposed in this Pull Request
This PR adds setting objects for every gateway, because after https://github.com/Automattic/woocommerce-payments/pull/8361 those are expected to exist. This PR makes sure that main gateway settings (`upe_enabled_payment_method_ids`) are synchronized with the rest. Also, the `enable` flag for every gateway should now reflect the real status of the gateway.

#### Testing instructions

> While going through the steps below, while on the checkout page, please switch the billing country to check that payment methods are filtered out as expected (e.g. Giropay only for `EUR & Germany`, P24 for Poland with EUR etc.)

##### Settings screen
* perform the following actions and for every action check if the shortcode and blocks checkout pages are rendering the payment methods as expected. While checking the page, place an order with any of the methods (preferably switching methods between attempts) and verify the payment went successful
    * enable all / disable all / enable subset / disable subset
* enable Stripe Link / Apple Pay / Google Pay / WooPay and confirm that those checkout options are rendered as expected
    * perform a purchase with the ones that don't require any set up from your side. I think Stripe Link and Google Pay should be pretty easy to work with
* disable WooPayments from `WooCommerce -> Settings -> Payments` and then enable back again: confirm that the enabled payment method list didn't change 

##### Migration script testing with WooPayments `7.3.0` on the JN site
* create a JN site with WooPayments `7.3.0`
* enable some randomly picked payment methods, keep the rest disabled, confirm that checkout displays correctly
* update the plugin with [this version](https://github.com/Automattic/woocommerce-payments/actions/runs/8330923470), open the settings page, confirm that same payment methods are enabled & disabled, don't `Save` settings
* open the checkout again and check if the correct payment methods list is shown on the page

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
