### PR TITLE
skip main gateway from updates on migration script

### DIFF
--- a/changelog/fix-migration-script-for-newly-onboarded-stores
+++ b/changelog/fix-migration-script-for-newly-onboarded-stores
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure card gateway is not running through the settings migration.

--- a/includes/migrations/class-gateway-settings-sync.php
+++ b/includes/migrations/class-gateway-settings-sync.php
@@ -62,17 +62,20 @@ class Gateway_Settings_Sync {
 	}
 
 	/**
-	 * Deletes the active webhook.
+	 * Syncs gateway setting objects.
 	 */
 	private function sync() {
 		$enabled_payment_methods = $this->main_gateway->get_option( 'upe_enabled_payment_method_ids', [] );
 
 		foreach ( $this->all_registered_gateways as $gateway ) {
-			if ( in_array( $gateway->get_stripe_id(), $enabled_payment_methods, true ) ) {
-				$gateway->enable();
-				$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
-			} else {
-				$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+			// Skip the main gateway as it's settings are already in sync.
+			if ( 'card' !== $gateway->get_stripe_id() ) {
+				if ( in_array( $gateway->get_stripe_id(), $enabled_payment_methods, true ) ) {
+					$gateway->enable();
+					$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+				} else {
+					$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently, the migration script for gateway settings will be applied to the main card gateway as well [in this place](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/migrations/class-gateway-settings-sync.php#L71-L76). First, it's not needed because `card` gateway settings weren't changed and thus don't need a migration. Secondly, this has a side effect on the gateway enablement email notification which doesn't enter [this branch](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-payment-gateways.php#L272) because the card gateway was enabled on the migration and thus isn't new anymore.

#### Testing instructions

* create a new JN site and install [this version](https://github.com/Automattic/woocommerce-payments/actions/runs/8345133830) of WooPayments
* after onboarding, confirm that you received the email with the title **_Payment gateway "WooPayments" enabled_**

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
