### PR TITLE
Create e2e test report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/e2e_test_report.md
+++ b/.github/ISSUE_TEMPLATE/e2e_test_report.md
@@ -24,9 +24,15 @@ assignees: ''
 <!-- Any additional context or details you think might be helpful. -->
 <!-- Ticket numbers/links, plugin versions, system statuses etc. -->
 
----
+### Priority
+<!-- Add a priority label based on your best judgement (quick is fine). -->
+<!-- Optional: add comments here to explain your decision or highlight any questions/potential risks. -->
 
-- [ ] Added priority label.
-<!-- For the priority label, use your best judgement. -->
-- [ ] Added e2e label.
-<!-- Add one of the "e2e: broken flow/test/environment" labels. See their description and try to match it with the actual issue. -->
+### Reason why this e2e test is broken
+<!-- Add one of the "e2e: broken flow/test/environment" labels based on your best judgement (quick is fine). -->
+<!-- Optional: add comments here to explain your decision. -->
+
+> [!Important]
+> As assignee, you're also responsible for reviewing this label and change it, if needed.
+> - [ ] I have reviewed this label and it's matching the actual reason why this e2e test was broken.
+<!-- Leave the above for who picks up this issue. -->

--- a/.github/ISSUE_TEMPLATE/e2e_test_report.md
+++ b/.github/ISSUE_TEMPLATE/e2e_test_report.md
@@ -33,6 +33,6 @@ assignees: ''
 <!-- Optional: add comments here to explain your decision. -->
 
 > [!Important]
-> As assignee, you're also responsible for reviewing this label and change it, if needed.
-> - [ ] I have reviewed this label and it's matching the actual reason why this e2e test was broken.
-<!-- Leave the above for who picks up this issue. -->
+> Please, ensure when closing this issue (PR fix) that only one `e2e: broken` label is added and it is accurate.
+> - [ ] I confirmed there's only one `e2e: broken` label in this issue and it is accurate.
+<!-- Leave the above for who's fixing this issue. -->

--- a/.github/ISSUE_TEMPLATE/e2e_test_report.md
+++ b/.github/ISSUE_TEMPLATE/e2e_test_report.md
@@ -1,0 +1,36 @@
+---
+name: e2e test report
+about: Report an e2e test failure.
+title: ''
+labels: ['category: e2e', 'needs triage']
+assignees: ''
+
+---
+
+### Description
+<!-- Before reporting an issue, are you sure this e2e test is failing consistently? -->
+<!-- Add a clear and concise description of what the issue is. Please, be as descriptive as possible. -->
+
+**Error**:
+<!-- The error that the e2e test indicates. -->
+
+**Spec**:
+<!-- The test file that's triggering this error. -->
+
+**Relevant line(s) of code**:
+<!-- Line of code that is triggering this error. -->
+
+**GitHub jobs where this spec is failing**:
+<!-- Can you list all the jobs where the test failing? e.g. "WC - latest | wcpay - shopper", "WC - beta | wcpay - shopper" etc. -->
+- 
+
+### Additional context
+<!-- Any additional context or details you think might be helpful. -->
+<!-- Ticket numbers/links, plugin versions, system statuses etc. -->
+
+---
+
+- [ ] Added priority label.
+<!-- For the priority label, use your best judgement. -->
+- [ ] Added e2e label.
+<!-- Add one of the "e2e: broken flow/test/environment" labels. See their description and try to match it with the actual issue. -->

--- a/.github/ISSUE_TEMPLATE/e2e_test_report.md
+++ b/.github/ISSUE_TEMPLATE/e2e_test_report.md
@@ -11,14 +11,14 @@ assignees: ''
 <!-- Before reporting an issue, are you sure this e2e test is failing consistently? -->
 <!-- Add a clear and concise description of what the issue is. Please, be as descriptive as possible. -->
 
-**Error**:
-<!-- The error that the e2e test indicates. -->
-
-**Spec**:
-<!-- The test file that's triggering this error. -->
-
-**Relevant line(s) of code**:
-<!-- Line of code that is triggering this error. -->
+**Output from the test failure**:
+<!-- Chunk of the output from the test failure. It doesn't need to be the entire output, just the relevant part. e.g.
+    TimeoutError: waiting for selector "..." failed: timeout 100000ms exceeded
+      336 | 	);
+    > 337 | 	const selector = await page.waitForSelector(
+          | 	                              ^
+      339 | 			selector
+ -->
 
 **GitHub jobs where this spec is failing**:
 <!-- Can you list all the jobs where the test failing? e.g. "WC - latest | wcpay - shopper", "WC - beta | wcpay - shopper" etc. -->

--- a/.github/ISSUE_TEMPLATE/e2e_test_report.md
+++ b/.github/ISSUE_TEMPLATE/e2e_test_report.md
@@ -10,6 +10,7 @@ assignees: ''
 ### Description
 <!-- Before reporting an issue, are you sure this e2e test is failing consistently? -->
 <!-- Add a clear and concise description of what the issue is. Please, be as descriptive as possible. -->
+<!-- Make sure you include relevant details such as what test/spec is failing and the link of the job where it started failing. -->
 
 **Output from the test failure**:
 <!-- Chunk of the output from the test failure. It doesn't need to be the entire output, just the relevant part. e.g.
@@ -17,7 +18,7 @@ assignees: ''
       336 | 	);
     > 337 | 	const selector = await page.waitForSelector(
           | 	                              ^
-      339 | 			selector
+      339 | 			'selector'
  -->
 
 ### Additional context

--- a/.github/ISSUE_TEMPLATE/e2e_test_report.md
+++ b/.github/ISSUE_TEMPLATE/e2e_test_report.md
@@ -20,10 +20,6 @@ assignees: ''
       339 | 			selector
  -->
 
-**GitHub jobs where this spec is failing**:
-<!-- Can you list all the jobs where the test failing? e.g. "WC - latest | wcpay - shopper", "WC - beta | wcpay - shopper" etc. -->
-- 
-
 ### Additional context
 <!-- Any additional context or details you think might be helpful. -->
 <!-- Ticket numbers/links, plugin versions, system statuses etc. -->

--- a/changelog/chore-e2e-test-report-template
+++ b/changelog/chore-e2e-test-report-template
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Create e2e test report issue template.
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new issue template to be used when logging broken e2e tests. This is part of a new process to log issues in e2e tests to reduce disruption from flaky or tricky tests, and over time better understand how our e2e tests are failing.

The process consists in:

1. Logging of persistent failures (this issue template is going to facilitate this step).
2. Assignment of ownership: issue will be triaged and assigned to the relevant team.
3. Resolution.

More context in paJDYF-cCK-p2.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Not applicable.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
