### PR TITLE
Allow WooPay button preview on settings page

### DIFF
--- a/changelog/fix-woopay-button-preview-style
+++ b/changelog/fix-woopay-button-preview-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow WooPay button preview on settings page

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -53,7 +53,7 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_script_handles() {
 
-		if ( ( is_cart() || is_checkout() || is_product() || has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) ) {
+		if ( ( is_cart() || is_checkout() || is_product() || has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) || is_admin() ) ) {
 			WC_Payments_Utils::enqueue_style(
 				'wc-blocks-checkout-style',
 				plugins_url( 'dist/blocks-checkout.css', WCPAY_PLUGIN_FILE ),


### PR DESCRIPTION
Fixes #8401 

#### Changes proposed in this Pull Request
Allow the WooPay button preview on the settings page. Introduce in #8259 when styles were loaded conditionally. This PR adds a check to allow loading on admin pages.
Open to better ways to narrow it down.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Go to Payments > Settings scroll to WooPay and select "Customize"
2. Scroll to bottom to see the WooPay button preview. In `develop` it is grey and the text is misaligned. On this branch it should be the normal purple and aligned.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before
<img width="689" alt="Screenshot 2024-03-15 at 8 05 39 AM" src="https://github.com/Automattic/woocommerce-payments/assets/7651258/4bcc122c-c3e8-42da-9edf-733565ca2624">

After 
<img width="678" alt="Screenshot 2024-03-19 at 2 11 23 PM" src="https://github.com/Automattic/woocommerce-payments/assets/7651258/c021b3b4-c7be-41cf-8c0f-1b3b0eec99e4">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
