### PR TITLE
Allow Sandbox accounts to be deleted at any moment of the account lifecycle

### DIFF
--- a/changelog/add-account-reset-for-sandboxes
+++ b/changelog/add-account-reset-for-sandboxes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add account reset for sandboxes

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -9,7 +9,6 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import strings from './strings';
-import { isInDevMode } from 'utils';
 import './styles.scss';
 import ResetAccountModal from 'wcpay/overview/modal/reset-account';
 import { trackAccountReset } from 'wcpay/onboarding/tracking';
@@ -30,8 +29,6 @@ const handleReset = () => {
 export const AccountTools: React.FC< Props > = ( props: Props ) => {
 	const accountLink = props.accountLink;
 	const [ modalVisible, setModalVisible ] = useState( false );
-
-	if ( isInDevMode() ) return null;
 
 	return (
 		<>

--- a/client/components/account-status/account-tools/strings.tsx
+++ b/client/components/account-status/account-tools/strings.tsx
@@ -13,7 +13,7 @@ export default {
 	title: __( 'Account Tools', 'woocommerce-payments' ),
 	description: isInDevMode()
 		? __(
-				'You are in dev mode. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
+				'Your account is in sandbox mode. If you are experiencing problems completing account setup, or wish to test with a different email/country associated with your account, you can reset your account and start from the beginning.',
 				'woocommerce-payments'
 		  )
 		: __(

--- a/client/components/account-status/account-tools/strings.tsx
+++ b/client/components/account-status/account-tools/strings.tsx
@@ -4,12 +4,22 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { isInDevMode } from 'utils';
+
 export default {
 	title: __( 'Account Tools', 'woocommerce-payments' ),
-	description: __(
-		'Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
-		'woocommerce-payments'
-	),
+	description: isInDevMode()
+		? __(
+				'You are in dev mode. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
+				'woocommerce-payments'
+		  )
+		: __(
+				'Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
+				'woocommerce-payments'
+		  ),
 	finish: __( 'Finish setup', 'woocommerce-payments' ),
 	reset: __( 'Reset account', 'woocommerce-payments' ),
 };

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -24,6 +24,7 @@ import StatusChip from './status-chip';
 import './style.scss';
 import './shared.scss';
 import { AccountTools } from './account-tools';
+import { isInDevMode } from 'wcpay/utils';
 
 const AccountStatusCard = ( props ) => {
 	const { title, children, value } = props;
@@ -103,7 +104,7 @@ const AccountStatusDetails = ( props ) => {
 					}
 				/>
 			</AccountStatusItem>
-			{ ! accountStatus.detailsSubmitted && (
+			{ ( ! accountStatus.detailsSubmitted || isInDevMode() ) && (
 				<AccountTools accountLink={ accountStatus.accountLink } />
 			) }
 			{ accountFees.length > 0 && (

--- a/client/overview/modal/reset-account/strings.tsx
+++ b/client/overview/modal/reset-account/strings.tsx
@@ -4,12 +4,22 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { isInDevMode } from 'utils';
+
 export default {
 	title: __( 'Reset account', 'woocommerce-payments' ),
-	description: __(
-		'If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
-		'woocommerce-payments'
-	),
+	description: isInDevMode()
+		? __(
+				'If you want to start your testing over, you can reset your account and onboard again.',
+				'woocommerce-payments'
+		  )
+		: __(
+				'If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
+				'woocommerce-payments'
+		  ),
 	beforeContinue: __( 'Before you continue', 'woocommerce-payments' ),
 	step1: sprintf(
 		/* translators: %s: WooPayments. */

--- a/client/overview/modal/reset-account/strings.tsx
+++ b/client/overview/modal/reset-account/strings.tsx
@@ -13,7 +13,7 @@ export default {
 	title: __( 'Reset account', 'woocommerce-payments' ),
 	description: isInDevMode()
 		? __(
-				'If you want to start your testing over, you can reset your account and onboard again.',
+				'In sandbox mode, you can reset your account and onboard again at any time. Please note that all current WooPayments account details, test transactions, and deposits history will be lost.',
 				'woocommerce-payments'
 		  )
 		: __(

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1115,7 +1115,7 @@ class WC_Payments_Account {
 			}
 
 			if ( WC_Payments_Onboarding_Service::SOURCE_WCPAY_RESET_ACCOUNT === $source ) {
-				$test_mode = WC_Payments_Onboarding_Service::is_test_mode_enabled();
+				$test_mode = WC_Payments_Onboarding_Service::is_test_mode_enabled() || WC_Payments::mode()->is_dev();
 
 				// Delete the account.
 				$this->payments_api_client->delete_account( $test_mode );


### PR DESCRIPTION
Fixes #8132

#### Changes proposed in this Pull Request

Make sure not only live accounts can be deleted but sandbox accounts too.

#### Testing instructions

Scenario 1: A blocked/not-fully-onboarded account
* Get current PR
* Try to onboard a new WCPay account (Click **Continue** normally and fill in the data)
![Screenshot 2024-03-20 at 10 25 50](https://github.com/Automattic/woocommerce-payments/assets/12542046/29bb3363-2337-4f44-89d1-92a1a6c73b97)
* Once you're redirected to Stripe, leave the KYC flow and go back to the platform
* You should see that your account is restricted
![Screenshot 2024-03-20 at 10 19 05](https://github.com/Automattic/woocommerce-payments/assets/12542046/9aa46374-7285-4550-a48e-216ba0e8b5d5)
* Make sure the "Account Tools" section is present with a copy related to sandbox accounts (You are in dev mode. If you are experiencing problems completing...)
* Click the "Reset Account" button.
* You should see the following modal: (Make sure the copy talks about sandbox "If you want to start your testing over...")
![Screenshot 2024-03-20 at 10 25 16](https://github.com/Automattic/woocommerce-payments/assets/12542046/9ee15cca-0d89-4d07-bb1f-899e3f7bc4b1)
* Click the "Yes, reset account"
* You should be redirected to onboard a new account

Scenario 2: A fully onboarded sandbox account with some transactions
* Get current PR
* Try to onboard a new WCPay account (Click **Continue in sandbox mode**)
![Screenshot 2024-03-20 at 10 25 50](https://github.com/Automattic/woocommerce-payments/assets/12542046/29bb3363-2337-4f44-89d1-92a1a6c73b97)
* Once you're redirected to Stripe, complete the whole KYC
* You should see that your account is complete and no restrictions are in place (you may need to force-refresh the cache a few times for this)
![Screenshot 2024-03-20 at 10 23 59](https://github.com/Automattic/woocommerce-payments/assets/12542046/23d9a270-061d-4c10-bac1-3b8ba7249c16)
* Start your Stripe webhook listeners locally (from the server repo)
* Make at least one transaction

![Screenshot 2024-03-20 at 10 25 01](https://github.com/Automattic/woocommerce-payments/assets/12542046/05b9a506-f672-490d-ab7a-fa116627a423)
* Go back to the Payments > Overview page
* Make sure the "Account Tools" section is present with a copy related to sandbox accounts (You are in dev mode. If you are experiencing problems completing...)
* Click the "Reset Account" button.
* You should see the following modal: (Make sure the copy talks about sandbox "If you want to start your testing over...")
![Screenshot 2024-03-20 at 10 25 16](https://github.com/Automattic/woocommerce-payments/assets/12542046/9ee15cca-0d89-4d07-bb1f-899e3f7bc4b1)
* Click the "Yes, reset account"
* You should be redirected to onboard a new account **even if your account has some transactions** (this is not the case for live accounts)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
