### PR TITLE
Move test notice for transactions to the top

### DIFF
--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -17,10 +17,6 @@
 #adminmenu
 	#toplevel_page_wc-admin-path--payments-connect
 	.menu-icon-generic
-	div.wp-menu-image::before,
-#adminmenu
-	#toplevel_page_wc-admin-path--payments-deposits
-	.menu-icon-generic
 	div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';

--- a/changelog/fix-7733-minor-test-mode-notice-adjustments-for-transactions
+++ b/changelog/fix-7733-minor-test-mode-notice-adjustments-for-transactions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move test mode transactions notice to the top of the page.

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -50,25 +50,21 @@ export const TransactionsPage: React.FC = () => {
 	const tabsComponentMap = {
 		'transactions-page': (
 			<>
-				<TestModeNotice currentPage="transactions" />
 				<TransactionsList />
 			</>
 		),
 		'uncaptured-page': (
 			<>
-				<TestModeNotice currentPage="transactions" />
 				<Authorizations />
 			</>
 		),
 		'review-page': (
 			<>
-				<TestModeNotice currentPage="transactions" />
 				<RiskReviewList />
 			</>
 		),
 		'blocked-page': (
 			<>
-				<TestModeNotice currentPage="transactions" />
 				<BlockedList />
 			</>
 		),
@@ -138,9 +134,9 @@ export const TransactionsPage: React.FC = () => {
 	} );
 
 	return (
-		<Page>
+		<Page className="wcpay-transactions-page">
+			<TestModeNotice currentPage="transactions" />
 			<TabPanel
-				className="wcpay-transactions-page"
 				activeClass="active-tab"
 				onSelect={ onTabSelected }
 				initialTabName={ initialTab || 'transactions-page' }
@@ -160,10 +156,8 @@ export const TransactionsPage: React.FC = () => {
 
 export default (): JSX.Element => {
 	return (
-		<Page>
-			<WCPaySettingsContext.Provider value={ window.wcpaySettings }>
-				<TransactionsPage />
-			</WCPaySettingsContext.Provider>
-		</Page>
+		<WCPaySettingsContext.Provider value={ window.wcpaySettings }>
+			<TransactionsPage />
+		</WCPaySettingsContext.Provider>
 	);
 };

--- a/client/transactions/style.scss
+++ b/client/transactions/style.scss
@@ -1,6 +1,10 @@
 .wcpay-transactions-page {
+	.wcpay-banner-notice.is-warning {
+		margin-bottom: $gap-smallest;
+	}
 	.components-tab-panel__tabs {
 		box-shadow: inset 0 -1px 0 #ccc;
+		margin-bottom: $gap-large;
 
 		.components-tab-panel__tabs-item {
 			&.active-tab,


### PR DESCRIPTION
Fixes #7733

#### Changes proposed in this Pull Request

- Moved the test mode notice out of the transactions tab to the top
- Removed the duplicate page wrapper.
- Minor styling fixes around spacing

| Before | After |
|--------|--------|
|![Screenshot 2024-03-21 at 11 30 07](https://github.com/Automattic/woocommerce-payments/assets/8830539/83e346ec-2bca-4721-97ec-f8ea301e6198)|![Screenshot 2024-03-21 at 11 27 42](https://github.com/Automattic/woocommerce-payments/assets/8830539/b8b2f597-93e8-4065-a653-45cd0d0815f8)|

#### Testing instructions

* Checkout the PR branch on your local client installation
* Build the client assets by running `npm run build:client`
* Make sure that dev mode is activated
* Go to [the transactions page](http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions) and the notice should appear at the top
* Disable dev mode and the notice should not show

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
