### PR TITLE
Make cursor disabled when hovering over disabled checkboxes

### DIFF
--- a/changelog/fix-cursor-pointer-for-disabled-logging
+++ b/changelog/fix-cursor-pointer-for-disabled-logging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix the cursor pointer when hovering over disabled checkboxes in Advanced Settings

--- a/client/settings/advanced-settings/style.scss
+++ b/client/settings/advanced-settings/style.scss
@@ -9,3 +9,11 @@
 		margin-bottom: 1em;
 	}
 }
+
+.settings-section__controls {
+	input[type='checkbox'] {
+		&:disabled {
+			cursor: not-allowed;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #8138

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This fixes the pointer when you hover over a disabled checkbox in Advanced Settings.
 
#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

https://github.com/Automattic/woocommerce-payments/assets/12542046/9c3bdc4a-9e1f-41d4-9b05-f0ba9a4b4950

* Get the PR locally and build it using `npm run dev`
* Go to Payments > Settings and scroll down to Advanced Settings

If you're on sandbox mode:
* Hover on the checkbox next to "Sandbox mode is active so logging is on by default."
* The cursor should show a disabled/not-allowed pointer (like in the video)

Get out of sandbox mode, or force it to [false here](https://github.com/Automattic/woocommerce-payments/blob/develop/client/settings/advanced-settings/debug-mode.js#L34):
* Hover on the checkbox next to "Sandbox mode is active so logging is on by default."
* Make sure you can check and uncheck the checkbox without any change to the pointer

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
