### PR TITLE
Revert removing depositsStatus key from account request.

### DIFF
--- a/changelog/dev-4710-remove-deposit-status
+++ b/changelog/dev-4710-remove-deposit-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Removed deprecated deposit_status key from account status

--- a/changelog/revert-8376-removed-depositsstatus
+++ b/changelog/revert-8376-removed-depositsstatus
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Reverting https://github.com/Automattic/woocommerce-payments/pull/8376 that removes depositsStatus key from account response.
+
+

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -45,6 +45,7 @@ declare global {
 				minimum_manual_deposit_amounts: Record< string, number >;
 				minimum_scheduled_deposit_amounts: Record< string, number >;
 			};
+			depositsStatus?: string;
 			currentDeadline?: bigint;
 			detailsSubmitted?: boolean;
 			pastDue?: boolean;

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -289,6 +289,7 @@ class WC_Payments_Account {
 			'paymentsEnabled'       => $account['payments_enabled'],
 			'detailsSubmitted'      => $account['details_submitted'] ?? true,
 			'deposits'              => $account['deposits'] ?? [],
+			'depositsStatus'        => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
 			'currentDeadline'       => $account['current_deadline'] ?? false,
 			'pastDue'               => $account['has_overdue_requirements'] ?? false,
 			'accountLink'           => $this->get_login_url(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts https://github.com/Automattic/woocommerce-payments/pull/8376 because it causes an integration test to fail.

Failing changelog GitHub check can be ignored since this is a revert.

Reopened the original issue https://github.com/Automattic/woocommerce-payments/issues/4710 so we can re-apply the removal of `depositsStatus` key once the test is fixed.

Context: p1710976497541019-slack-C02BW3Z8SHK

#### Testing instructions

* Make sure all tests pass and no breakage in functionality of the plugin.
* Make sure the change in this PR is the opposite of https://github.com/Automattic/woocommerce-payments/pull/8376/files.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.