### PR TITLE
Added empty check on meta key and meta value getting order id from meta values

### DIFF
--- a/changelog/fix-4393-fix-quering-order-by-empty-metakey
+++ b/changelog/fix-4393-fix-quering-order-by-empty-metakey
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add empty validation when quering order by meta key and meta value

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -86,6 +86,11 @@ class WC_Payments_DB {
 	 * @return null|string
 	 */
 	private function order_id_from_meta_key_value( $meta_key, $meta_value ) {
+
+		// Don't proceed if the meta key or value is empty.
+		if ( ! $meta_key || ! $meta_value ) {
+			return null;
+		}
 		$orders = wc_get_orders(
 			[
 				'limit'      => 1,

--- a/tests/unit/test-class-wc-payments-db.php
+++ b/tests/unit/test-class-wc-payments-db.php
@@ -59,4 +59,26 @@ class WC_Payments_DB_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( in_array( $orders_with_charge_ids[1]['charge_id'], $existing_charge_ids, true ) );
 	}
 
+	public function test_order_from_charge_id() {
+		$charge_id = 'ch_123';
+		$order     = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->save();
+
+		$result = $this->wcpay_db->order_from_charge_id( $charge_id );
+		$this->assertSame( $order->get_id(), $result->get_id() );
+	}
+	public function test_order_from_charge_id_will_return_false_if_value_is_empty() {
+		$charge_id = 'ch_123';
+		$order     = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->save();
+
+		$result = $this->wcpay_db->order_from_charge_id( '' );
+		$this->assertFalse( $result );
+
+		$result = $this->wcpay_db->order_from_charge_id( null );
+		$this->assertFalse( $result );
+	}
+
 }


### PR DESCRIPTION

Fixes #4393

#### Changes proposed in this Pull Request

This small PR addresses the edge case when we want to get [order_id](https://github.com/Automattic/woocommerce-payments/blob/9a5b11226b48858d25c407f0c955e2dfc3d02371/includes/class-wc-payments-db.php#L88) from the order's meta key and value.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that all tests are passing
* For detailed testing instructions, please check linked issue and how to reproduce the issue.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
