### PR TITLE
Bump WC tested up to 8.7.0 and set Requires Plugins header.

### DIFF
--- a/changelog/2024-03-22-10-13-01-959432
+++ b/changelog/2024-03-22-10-13-01-959432
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 8.7.0 and set Requires Plugins header.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,10 +8,11 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 8.6.0
+ * WC tested up to: 8.7.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 7.3.0
+ * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Bumped `WC tested up to` header to 8.7.0. Why only `WC tested up to`? Because there will be problem if we bump `WC requires at least`. Context: PaJDYF-6n7-p2
- Set `Requires Plugins` header. Context: pcShBQ-1yd-p2

#### Testing instructions

* With WordPress 6.5, the effect of `Requires Plugins` header is that the required plugins, in this case, WooCommerce, won't be able to be deactivated.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.