### PR TITLE
Update Jetpack Sync options

### DIFF
--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -17,10 +17,6 @@
 #adminmenu
 	#toplevel_page_wc-admin-path--payments-connect
 	.menu-icon-generic
-	div.wp-menu-image::before,
-#adminmenu
-	#toplevel_page_wc-admin-path--payments-deposits
-	.menu-icon-generic
 	div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';

--- a/changelog/update-jetpack-sync-options
+++ b/changelog/update-jetpack-sync-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Activate the WooCommerce and WooCommerce HPOS Jetpack Sync modules when data tracking is enabled.
+
+

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -68,6 +68,11 @@ if ( ! $is_autoloading_ready ) {
 
 /**
  * Initialize the Jetpack functionalities: connection, identity crisis, etc.
+ *
+ * PSR-11 containers declares to throw an un-throwable interface
+ * (it does not extend Throwable), and Psalm does not accept it.
+ *
+ * @psalm-suppress MissingThrowsDocblock
  */
 function wcpay_jetpack_init() {
 	if ( ! wcpay_check_old_jetpack_version() ) {
@@ -101,7 +106,7 @@ function wcpay_jetpack_init() {
 		$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce';
 		if ( class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
 			try {
-				$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class ); // phpcs:ignore MissingThrowsDocblock
+				$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class );
 				if ( $cot_controller->custom_orders_table_usage_is_enabled() ) {
 					$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce_HPOS_Orders';
 				}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -101,7 +101,7 @@ function wcpay_jetpack_init() {
 		$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce';
 		if ( class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
 			try {
-				$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class );
+				$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class ); // phpcs:ignore MissingThrowsDocblock
 				if ( $cot_controller->custom_orders_table_usage_is_enabled() ) {
 					$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce_HPOS_Orders';
 				}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -102,7 +102,7 @@ function wcpay_jetpack_init() {
 		'Automattic\\Jetpack\\Sync\\Modules\\Options',
 		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
 	];
-	if ( WC_Site_Tracking::is_tracking_enabled() ) {
+	if ( class_exists( 'WC_Site_Tracking' ) && WC_Site_Tracking::is_tracking_enabled() ) {
 		$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce';
 		if ( class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
 			try {

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -100,9 +100,13 @@ function wcpay_jetpack_init() {
 	if ( WC_Site_Tracking::is_tracking_enabled() ) {
 		$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce';
 		if ( class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
-			$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class );
-			if ( $cot_controller->custom_orders_table_usage_is_enabled() ) {
-				$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce_HPOS_Orders';
+			try {
+				$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class );
+				if ( $cot_controller->custom_orders_table_usage_is_enabled() ) {
+					$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce_HPOS_Orders';
+				}
+			} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Do nothing.
 			}
 		}
 	}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -92,17 +92,27 @@ function wcpay_jetpack_init() {
 		]
 	);
 
-	// When only WooPayments is active, minimize the data to send back to WPcom for supporting Woo Mobile apps.
+	// When only WooPayments is active, minimize the data to send back to WPCOM, tied to merchant's privacy settings.
+	$sync_modules = [
+		'Automattic\\Jetpack\\Sync\\Modules\\Options',
+		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
+	];
+	if ( WC_Site_Tracking::is_tracking_enabled() ) {
+		$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce';
+		if ( class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
+			$cot_controller = wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class );
+			if ( $cot_controller->custom_orders_table_usage_is_enabled() ) {
+				$sync_modules[] = 'Automattic\\Jetpack\\Sync\\Modules\\WooCommerce_HPOS_Orders';
+			}
+		}
+	}
+
 	$jetpack_config->ensure(
 		'sync',
 		array_merge_recursive(
 			\Automattic\Jetpack\Sync\Data_Settings::MUST_SYNC_DATA_SETTINGS,
 			[
-				'jetpack_sync_modules'           =>
-					[
-						'Automattic\\Jetpack\\Sync\\Modules\\Options',
-						'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
-					],
+				'jetpack_sync_modules'           => $sync_modules,
 				'jetpack_sync_options_whitelist' =>
 					[
 						'active_plugins',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When WooCommerce tracking is enabled, we activate the Jetpack Sync WooCommerce modules (`WooCommerce` and, optionally, `WooCommerce_HPOS_Orders`).

For further context p7Ldg5-5VE-p2 (specifically p7Ldg5-5VE-p2#comment-12246)

#### Testing instructions

* Checkout the PR branch on your local client installation
* Check that WooPayments is loading and working without throwing any errors
* Make sure you have enabled WooCommerce tracking from WooCommerce > Settings > Advanced > Woo.com > Enable Tracking
* Install the Jetpack Debug Tools plugin: https://github.com/Automattic/jetpack-debug-helper/archive/refs/heads/trunk.zip
* In the Jetpack Debug settings, activate "Sync Data Settings Utility", reload the page and go to the "Sync Data Settings Tester" sub-page
* The `jetpack_sync_modules` section should show:

```
Automattic\Jetpack\Sync\Modules\Constants
Automattic\Jetpack\Sync\Modules\Full_Sync_Immediately
Automattic\Jetpack\Sync\Modules\Options
Automattic\Jetpack\Sync\Modules\Updates
Automattic\Jetpack\Sync\Modules\Full_Sync
Automattic\Jetpack\Sync\Modules\WooCommerce
Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders
``` 
* Disable WooCommerce tracking from WooCommerce > Settings > Advanced > Woo.com > Enable Tracking
* Check that WooPayments is loading and working without throwing any errors
* Go to the "Sync Data Settings Tester" Jetpack Debug sub-page. The `jetpack_sync_modules` section should show:

```
Automattic\Jetpack\Sync\Modules\Constants
Automattic\Jetpack\Sync\Modules\Full_Sync_Immediately
Automattic\Jetpack\Sync\Modules\Options
Automattic\Jetpack\Sync\Modules\Updates
Automattic\Jetpack\Sync\Modules\Full_Sync
``` 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.