### PR TITLE
Add woopayMinimumSessionData in wcpayConfig when Express Checkout button is disabled on cart page

### DIFF
--- a/changelog/add-woopay-min-cart-data-when-express-button-disabled-on-cart
+++ b/changelog/add-woopay-min-cart-data-when-express-button-disabled-on-cart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woopayMinimumSessionData in wcpayConfig when Express Checkout button's disabled o on car page.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -269,7 +269,7 @@ class WC_Payments_Features {
 	/**
 	 * Checks whether WooPay Direct Checkout is enabled.
 	 *
-	 * @return bool
+	 * @return bool True if Direct Checkout is enabled, false otherwise.
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
 		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1539,6 +1539,7 @@ class WC_Payments {
 					'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
 					'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
 					'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
+					'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
 				]
 			);
 			wp_enqueue_script( 'WCPAY_WOOPAY_COMMON_CONFIG' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR ensures that `woopayMinimumSessionData` is included in the `wcpayConfig` global variable when the WooPay Express Checkout button is disabled on the cart page.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test: Ensure `wcpayConfig.woopayMinimumSessionData` exists when Express Checkout button's disabled on the cart page**

* Ensure the WooPay Direct Checkout flow is enabled on the merchant's site.
* As a merchant, navigate to `Payments > Settings`.
* Scroll down to the `Express checkouts` section and click on the `Customize` button for WooPay.
* Under the `Enable WooPay button on selected pages` section, make sure the `Cart Page` is disabled.
* As a shopper, ensure you are authenticated on WooPay.
* Navigate to the Merchant shop, add an item to your cart, and navigate to the Cart page.
* Open the console in the web browser's developer tools and type `wcpayConfig.woopayMinimumSessionData` and press enter.
* Ensure `wcpayConfig.woopayMinimumSessionData` returns data.
* Click the `Proceed to checkout` button.
* Ensure you are navigated to WooPay checkout.
* Click the `Place order` button and ensure you are able to checkout successfully.
* Repeat these steps once using the wcblocks-cart and once using the shortcode-cart.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
