### PR TITLE
Filtering billing details from order based on checkout fields

### DIFF
--- a/changelog/fix-subscription-billing-fields
+++ b/changelog/fix-subscription-billing-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed billing address error for subscription without some billing details

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -346,7 +346,7 @@ class WC_Payments_Utils {
 	 * @return array
 	 */
 	public static function get_billing_details_from_order( $order ) {
-		$billing_fields       = array_keys( wc()->checkout()->get_checkout_fields( 'billing' ) );
+		$billing_fields       = array_keys( WC()->checkout()->get_checkout_fields( 'billing' ) );
 		$address_field_to_key = [
 			'billing_city'      => 'city',
 			'billing_country'   => 'country',
@@ -372,7 +372,7 @@ class WC_Payments_Utils {
 			$billing_details['name'] = trim( $order->get_formatted_billing_full_name() );
 		}
 
-		return array_filter( $billing_details );
+		return $billing_details;
 	}
 
 	/**

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -338,26 +338,39 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Extract the billing details from the WC order
+	 * Extract the billing details from the WC order.
+	 * It only returns the fields that are present in the billing section of the checkout.
 	 *
 	 * @param WC_Order $order Order to extract the billing details from.
 	 *
 	 * @return array
 	 */
 	public static function get_billing_details_from_order( $order ) {
-		$billing_details = [
-			'address' => [
-				'city'        => $order->get_billing_city(),
-				'country'     => $order->get_billing_country(),
-				'line1'       => $order->get_billing_address_1(),
-				'line2'       => $order->get_billing_address_2(),
-				'postal_code' => $order->get_billing_postcode(),
-				'state'       => $order->get_billing_state(),
-			],
-			'email'   => $order->get_billing_email(),
-			'name'    => trim( $order->get_formatted_billing_full_name() ),
-			'phone'   => $order->get_billing_phone(),
+		$billing_fields       = array_keys( wc()->checkout()->get_checkout_fields( 'billing' ) );
+		$address_field_to_key = [
+			'billing_city'      => 'city',
+			'billing_country'   => 'country',
+			'billing_address_1' => 'line1',
+			'billing_address_2' => 'line2',
+			'billing_postcode'  => 'postal_code',
+			'billing_state'     => 'state',
 		];
+		$field_to_key         = [
+			'billing_email' => 'email',
+			'billing_phone' => 'phone',
+		];
+		$billing_details      = [ 'address' => [] ];
+		foreach ( $billing_fields as $field ) {
+			if ( isset( $address_field_to_key[ $field ] ) ) {
+				$billing_details['address'][ $address_field_to_key[ $field ] ] = $order->{"get_{$field}"}();
+			} elseif ( isset( $field_to_key[ $field ] ) ) {
+				$billing_details[ $field_to_key[ $field ] ] = $order->{"get_{$field}"}();
+			}
+		}
+
+		if ( in_array( 'billing_first_name', $billing_fields, true ) && in_array( 'billing_last_name', $billing_fields, true ) ) {
+			$billing_details['name'] = trim( $order->get_formatted_billing_full_name() );
+		}
 
 		return array_filter( $billing_details );
 	}

--- a/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
+++ b/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
@@ -340,16 +340,16 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 						'test_mode'       => false,
 						'billing_details' => [
 							'address' => [
-								'city'        => $order->get_billing_city(),
 								'country'     => $order->get_billing_country(),
 								'line1'       => $order->get_billing_address_1(),
 								'line2'       => $order->get_billing_address_2(),
-								'postal_code' => $order->get_billing_postcode(),
+								'city'        => $order->get_billing_city(),
 								'state'       => $order->get_billing_state(),
+								'postal_code' => $order->get_billing_postcode(),
 							],
+							'phone'   => $order->get_billing_phone(),
 							'email'   => $order->get_billing_email(),
 							'name'    => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
-							'phone'   => $order->get_billing_phone(),
 						],
 					]
 				),

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -504,6 +504,37 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 		$this->customer_service->update_payment_method_with_billing_details_from_order( 'pm_mock', $order );
 	}
 
+	public function test_update_payment_method_with_billing_details_from_checkout_fields() {
+		$fields = wc()->checkout()->checkout_fields;
+		unset( $fields['billing']['billing_company'] );
+		unset( $fields['billing']['billing_country'] );
+		unset( $fields['billing']['billing_address_1'] );
+		unset( $fields['billing']['billing_address_2'] );
+		unset( $fields['billing']['billing_city'] );
+		unset( $fields['billing']['billing_state'] );
+		unset( $fields['billing']['billing_phone'] );
+		wc()->checkout()->checkout_fields = $fields;
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_payment_method' )
+			->with(
+				'pm_mock',
+				[
+					'billing_details' => [
+						'address' => [
+							'postal_code' => '12345',
+						],
+						'email'   => 'admin@example.org',
+						'name'    => 'Jeroen Sormani',
+					],
+				]
+			);
+
+		$order = WC_Helper_Order::create_order();
+
+		$this->customer_service->update_payment_method_with_billing_details_from_order( 'pm_mock', $order );
+	}
+
 	public function test_get_payment_methods_for_customer_not_throw_resource_missing_code_exception() {
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'get_payment_methods' )

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -485,16 +485,16 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 				[
 					'billing_details' => [
 						'address' => [
-							'city'        => 'WooCity',
 							'country'     => Country_Code::UNITED_STATES,
 							'line1'       => 'WooAddress',
 							'line2'       => '',
-							'postal_code' => '12345',
+							'city'        => 'WooCity',
 							'state'       => 'NY',
+							'postal_code' => '12345',
 						],
 						'email'   => 'admin@example.org',
-						'name'    => 'Jeroen Sormani',
 						'phone'   => '555-32123',
+						'name'    => 'Jeroen Sormani',
 					],
 				]
 			);

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -485,16 +485,16 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 				[
 					'billing_details' => [
 						'address' => [
+							'city'        => 'WooCity',
 							'country'     => Country_Code::UNITED_STATES,
 							'line1'       => 'WooAddress',
 							'line2'       => '',
-							'city'        => 'WooCity',
-							'state'       => 'NY',
 							'postal_code' => '12345',
+							'state'       => 'NY',
 						],
 						'email'   => 'admin@example.org',
-						'phone'   => '555-32123',
 						'name'    => 'Jeroen Sormani',
+						'phone'   => '555-32123',
 					],
 				]
 			);

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use PHPUnit\Framework\Constraint\IsEqualCanonicalizing;
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Country_Code;
 use WCPay\Database_Cache;
@@ -482,21 +483,23 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'update_payment_method' )
 			->with(
 				'pm_mock',
-				[
-					'billing_details' => [
-						'address' => [
-							'country'     => Country_Code::UNITED_STATES,
-							'line1'       => 'WooAddress',
-							'line2'       => '',
-							'city'        => 'WooCity',
-							'state'       => 'NY',
-							'postal_code' => '12345',
+				new IsEqualCanonicalizing(
+					[
+						'billing_details' => [
+							'address' => [
+								'country'     => Country_Code::UNITED_STATES,
+								'line1'       => 'WooAddress',
+								'line2'       => '',
+								'city'        => 'WooCity',
+								'state'       => 'NY',
+								'postal_code' => '12345',
+							],
+							'email'   => 'admin@example.org',
+							'phone'   => '555-32123',
+							'name'    => 'Jeroen Sormani',
 						],
-						'email'   => 'admin@example.org',
-						'phone'   => '555-32123',
-						'name'    => 'Jeroen Sormani',
-					],
-				]
+					]
+				)
 			);
 
 		$order = WC_Helper_Order::create_order();
@@ -519,15 +522,17 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'update_payment_method' )
 			->with(
 				'pm_mock',
-				[
-					'billing_details' => [
-						'address' => [
-							'postal_code' => '12345',
+				new IsEqualCanonicalizing(
+					[
+						'billing_details' => [
+							'address' => [
+								'postal_code' => '12345',
+							],
+							'email'   => 'admin@example.org',
+							'name'    => 'Jeroen Sormani',
 						],
-						'email'   => 'admin@example.org',
-						'name'    => 'Jeroen Sormani',
-					],
-				]
+					]
+				)
 			);
 
 		$order = WC_Helper_Order::create_order();

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Payments\Tests
  */
 
-use PHPUnit\Framework\Constraint\IsEqualCanonicalizing;
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Country_Code;
 use WCPay\Database_Cache;
@@ -483,23 +482,21 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'update_payment_method' )
 			->with(
 				'pm_mock',
-				new IsEqualCanonicalizing(
-					[
-						'billing_details' => [
-							'address' => [
-								'country'     => Country_Code::UNITED_STATES,
-								'line1'       => 'WooAddress',
-								'line2'       => '',
-								'city'        => 'WooCity',
-								'state'       => 'NY',
-								'postal_code' => '12345',
-							],
-							'email'   => 'admin@example.org',
-							'phone'   => '555-32123',
-							'name'    => 'Jeroen Sormani',
+				[
+					'billing_details' => [
+						'address' => [
+							'country'     => Country_Code::UNITED_STATES,
+							'line1'       => 'WooAddress',
+							'line2'       => '',
+							'city'        => 'WooCity',
+							'state'       => 'NY',
+							'postal_code' => '12345',
 						],
-					]
-				)
+						'email'   => 'admin@example.org',
+						'phone'   => '555-32123',
+						'name'    => 'Jeroen Sormani',
+					],
+				]
 			);
 
 		$order = WC_Helper_Order::create_order();
@@ -522,17 +519,15 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'update_payment_method' )
 			->with(
 				'pm_mock',
-				new IsEqualCanonicalizing(
-					[
-						'billing_details' => [
-							'address' => [
-								'postal_code' => '12345',
-							],
-							'email'   => 'admin@example.org',
-							'name'    => 'Jeroen Sormani',
+				[
+					'billing_details' => [
+						'address' => [
+							'postal_code' => '12345',
 						],
-					]
-				)
+						'email'   => 'admin@example.org',
+						'name'    => 'Jeroen Sormani',
+					],
+				]
 			);
 
 		$order = WC_Helper_Order::create_order();


### PR DESCRIPTION
Fixes #8352

#### Changes proposed in this Pull Request

In #8226 we started updating the billing address every time a saved payment method was used.
Later, in #8257, we stopped filtering the billing fields we send to prevent an issue where fields that were previously set would not update to empty.
This PR updates `get_billing_details_from_order` to return only the fields present in checkout to prevent sending required fields, such as Country, as empty.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a simple subscription product
3. Install [Checkout Field Editor](https://woo.com/products/woocommerce-checkout-field-editor/?aff=10486&cid=1131038)
4. Remove all billing fields except ZIP code, email, and first/last name
5. Purchase a subscription via shortcode checkout (CFE is not compatible with the checkout block)
7. Process a renewal by running the woocommerce_scheduled_subscription_payment hook in the action scheduler.
8. The renewal should work

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
