### PR TITLE
Fix WordPress.Security phpcs report in Check model

### DIFF
--- a/changelog/fix-8470-phpcs-report
+++ b/changelog/fix-8470-phpcs-report
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Ignore a PHPCS rule in two lines.
+
+

--- a/includes/fraud-prevention/models/class-check.php
+++ b/includes/fraud-prevention/models/class-check.php
@@ -154,6 +154,8 @@ class Check {
 	 */
 	public static function list( string $operator, array $checks ) {
 		if ( ! in_array( $operator, self::$list_operators, true ) ) {
+			// $operator is a predefined constant, no need to escape.
+			// phpcs:ignore WordPress.Security.EscapeOutput
 			throw new Fraud_Ruleset_Exception( 'Operator for the check is invalid: ' . $operator );
 		}
 		if ( 0 < count(
@@ -183,6 +185,8 @@ class Check {
 	 */
 	public static function check( string $key, string $operator, $value ) {
 		if ( ! in_array( $operator, self::$check_operators, true ) ) {
+			// $operator is a predefined constant, no need to escape.
+			// phpcs:ignore WordPress.Security.EscapeOutput
 			throw new Fraud_Ruleset_Exception( 'Operator for the check is invalid: ' . $operator );
 		}
 


### PR DESCRIPTION
Fixes #8470

#### Changes proposed in this Pull Request
Ignore `WordPress.Security.EscapeOutput` in both cases.`$operator` is a predefined const so we don't need to escape it.

#### Testing instructions

Code changes make sense.

You can also double-check that there are no PHPCS errors by checking out https://github.com/Automattic/woocommerce-payments/commit/bc8ae14f29921f43f105a2240d21fe5c23ee932a, applying this PR changes, and running: `./vendor/bin/phpcs --standard=phpcs.xml.dist includes/fraud-prevention/models/class-check.php  --sniffs='WordPress.Security.EscapeOutput,WordPress.Security.ValidatedSanitizedInput'`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
