### PR TITLE
Disputes: Address new PHPCS error

### DIFF
--- a/changelog/fix-8465-fix-phpcs-new-disputes-errors
+++ b/changelog/fix-8465-fix-phpcs-new-disputes-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Address update PHPCS error - a single one recommending escaping an exception message

--- a/includes/core/server/request/class-list-disputes.php
+++ b/includes/core/server/request/class-list-disputes.php
@@ -134,7 +134,7 @@ class List_Disputes extends Paginated {
 	public function set_search( $search ) {
 		if ( ! is_string( $search ) && ! is_array( $search ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				__( 'The search parameter must be a string, or an array of strings.', 'woocommerce-payments' ),
+				esc_html__( 'The search parameter must be a string, or an array of strings.', 'woocommerce-payments' ),
 				'wcpay_core_invalid_request_parameter_invalid_search'
 			);
 		}


### PR DESCRIPTION
Fixes #8471 

#### Changes proposed in this Pull Request

Address PHPCS error in updated version asking to escape an exception output. This appears when we use the updated PHPCS as per steps  here : 

```
FILE: /<path>/woocommerce-payments/includes/core/server/request/class-list-disputes.php
--------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------
 137 | ERROR | All output should be run through an escaping function (see the Security sections in the
     |       | WordPress Developer Handbooks), found '__'.
     |       | (WordPress.Security.EscapeOutput.ExceptionNotEscaped)
--------------------------------------------------------------------------------------------------------
```

#### Testing instructions

* update PHPCS and Slevomat coding standards, with changes similar to https://github.com/Automattic/woocommerce-payments/pull/8415/commits/b764b8c7cc0879d213491572e5aa348155c2b00d in composer.json. 
* run `composer update`
* run `./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep '.php$') --sniffs='WordPress.Security.EscapeOutput,WordPress.Security.ValidatedSanitizedInput'`  
* The logs should not show any errors for `/woocommerce-payments/includes/core/server/request/class-list-disputes.php`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.