### PR TITLE
Update MOX cancellation to consistently redirect back to the payment connect page

### DIFF
--- a/changelog/update-8447-always-redirect-to-payment-connect
+++ b/changelog/update-8447-always-redirect-to-payment-connect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update MOX cancellation to consistently redirect back to the payment connect page.

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -15,16 +15,15 @@ import BusinessDetails from './steps/business-details';
 import StoreDetails from './steps/store-details';
 import LoadingStep from './steps/loading';
 import { trackStarted } from './tracking';
+import { getAdminUrl } from 'wcpay/utils';
 import './style.scss';
 
 const OnboardingStepper = () => {
 	const handleExit = () => {
-		if (
-			window.history.length > 1 &&
-			document.referrer.includes( wcSettings.adminUrl )
-		)
-			return window.history.back();
-		window.location.href = wcSettings.adminUrl;
+		window.location.href = getAdminUrl( {
+			page: 'wc-admin',
+			path: '/payments/connect',
+		} );
 	};
 
 	const handleStepChange = () => window.scroll( 0, 0 );


### PR DESCRIPTION
Fixes #8447

#### Changes proposed in this Pull Request
When users click the MOX `Back` or `X` buttons, they will be redirected to the last admin page visited. This PR updates the approach to consistently redirect back to the Payments Connect page.

#### Testing instructions
- Start a fresh account onboarding.
- Press `Back` button on the top left corner.
- Verify you are redirected to `/payments/connect` page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
