### PR TITLE
Fix PHPCS reports in account files

### DIFF
--- a/changelog/dev-8469-fix-phpcs-report
+++ b/changelog/dev-8469-fix-phpcs-report
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fixes to comply with updates to PHPCS linter.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -184,7 +184,7 @@ class WC_Payments_Account {
 	public function try_is_stripe_connected(): bool {
 		$account = $this->get_cached_account_data();
 		if ( false === $account ) {
-			throw new Exception( __( 'Failed to detect connection status', 'woocommerce-payments' ) );
+			throw new Exception( esc_html__( 'Failed to detect connection status', 'woocommerce-payments' ) );
 		}
 
 		// The empty array indicates that account is not connected yet.

--- a/includes/core/server/request/class-update-account.php
+++ b/includes/core/server/request/class-update-account.php
@@ -58,7 +58,7 @@ class Update_Account extends Request {
 	public static function from_account_settings( array $account_settings ) {
 		if ( 0 === count( $account_settings ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				__( 'No account settings provided', 'woocommerce-payments' ),
+				esc_html__( 'No account settings provided', 'woocommerce-payments' ),
 				'wcpay_core_invalid_request_parameter_account_settings_empty'
 			);
 		}


### PR DESCRIPTION
Fixes #8469

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch `tweak/revert-phpcs-update-revert-pr`
* Open the `phpcs.xml.dist` file and temporarily remove the lines excluding any `WordPress.Security` sniffs.
* Run the following commands and observe the output:

```
./vendor/bin/phpcs --standard=phpcs.xml.dist --sniffs='WordPress.Security.EscapeOutput,WordPress.Security.ValidatedSanitizedInput' includes/core/server/request/class-update-account.php
```

```
./vendor/bin/phpcs --standard=phpcs.xml.dist --sniffs='WordPress.Security.EscapeOutput,WordPress.Security.ValidatedSanitizedInput' includes/class-wc-payments-account.php
```

For reference, here are the messages I observed running the command:


```

FILE: /Users/danielmallory/projects/wcpay/includes/core/server/request/class-update-account.php
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 61 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'. (WordPress.Security.EscapeOutput.ExceptionNotEscaped)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: /Users/danielmallory/projects/wcpay/includes/class-wc-payments-account.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 187 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'. (WordPress.Security.EscapeOutput.ExceptionNotEscaped)
-------------------------------------------------------------------------------------------------------------------------------------
```


* Confirm that this change makes sense and will fix the errors.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
