### PR TITLE
Checking if field is required in isBillingInformationMissing

### DIFF
--- a/changelog/fix-optional-zip
+++ b/changelog/fix-optional-zip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed optional billing field validation

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -216,10 +216,16 @@ jQuery( function ( $ ) {
 
 		// We need to just find one field with missing information. If even only one is missing, just return early.
 		return Boolean(
-			billingFieldsToValidate.find(
-				( fieldName ) =>
-					! document.querySelector( `#${ fieldName }` )?.value
-			)
+			billingFieldsToValidate.find( ( fieldName ) => {
+				const $field = document.querySelector( `#${ fieldName }` );
+				const $formRow = $field.closest( '.form-row' );
+				const isRequired = $formRow.classList.contains(
+					'validate-required'
+				);
+				const hasValue = $field?.value;
+
+				return isRequired && ! hasValue;
+			} )
 		);
 	}
 } );


### PR DESCRIPTION
Fixes #8368

#### Changes proposed in this Pull Request

In #8258 we started checking if the required billing fields were filled before proceeding with the request to Stripe. This introduced a problem with countries were the postal code is optional. This PR updates the logic to check if a field is required.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a product to your cart.
2. Proceed to the shortcode checkout.
3. Ship to any address in HK.
4. Leave the postcode empty (as it is optional).
5. Attempt to pay for the order with a new card.
6. Before this change it would fail.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
