### PR TITLE
Fix merchant onboarding e2e tests after recent changes

### DIFF
--- a/changelog/fix-merchant-onboarding-e2e-tests
+++ b/changelog/fix-merchant-onboarding-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixing the merchant e2e tests.
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js
@@ -20,7 +20,7 @@ describe( 'Admin merchant progressive onboarding', () => {
 	} );
 
 	it( 'should pass merchant flow without any errors', async () => {
-		// Open connect account page and click Finish Setup
+		// Open connect account page and click the primary CTA to start onboarding.
 		await merchantWCP.openConnectPage();
 		await Promise.all( [
 			evalAndClick(
@@ -30,41 +30,9 @@ describe( 'Admin merchant progressive onboarding', () => {
 			uiLoaded(),
 		] );
 
-		// Merchant vs builder flow step
+		// Business details step
 		await expect( page ).toMatchElement( 'h1.stepper__heading', {
 			text: 'Let’s get your store ready to accept payments',
-		} );
-		await expect( page ).toClick(
-			'div.stepper__content button.components-button.is-primary',
-			{
-				text: 'Continue',
-			}
-		);
-
-		// User details step
-		await expect( page ).toMatchElement( 'h1.stepper__heading', {
-			text: 'First, you’ll need to create an account',
-		} );
-		await expect( page ).toFill( '[name="individual.first_name"]', 'Test' );
-		await expect( page ).toFill( '[name="individual.last_name"]', 'Test' );
-		await expect( page ).toFill( '[name="email"]', 'test@gmail.com' );
-		await page.waitForSelector(
-			'div.wcpay-component-phone-number-control input[type="text"]'
-		);
-		await expect( page ).toFill(
-			'div.wcpay-component-phone-number-control input[type="text"]',
-			'0000000000'
-		);
-		await expect( page ).toClick(
-			'div.stepper__content button.components-button.is-primary',
-			{
-				text: 'Continue',
-			}
-		);
-
-		// Tell us about your business step
-		await expect( page ).toMatchElement( 'h1.stepper__heading', {
-			text: 'Tell us about your business',
 		} );
 		// pick Individual business entity
 		await expect( page ).toClick( '[name="business_type"]' );
@@ -74,7 +42,7 @@ describe( 'Admin merchant progressive onboarding', () => {
 		await expect( page ).toClick(
 			'[name="business_type"] ~ ul li.components-custom-select-control__item'
 		);
-		// pick Software type of goods
+		// pick Software type of goods (MCC)
 		await expect( page ).toClick( '[name="mcc"]' );
 		await page.waitForSelector(
 			'[name="mcc"] ~ ul li.wcpay-component-grouped-select-control__item:not(.is-group)'
@@ -82,6 +50,8 @@ describe( 'Admin merchant progressive onboarding', () => {
 		await expect( page ).toClick(
 			'[name="mcc"] ~ ul li.wcpay-component-grouped-select-control__item:not(.is-group)'
 		);
+		// The ToS copy should be shown.
+		await page.waitForSelector( 'span.wcpay-onboarding__tos' );
 		await expect( page ).toClick(
 			'div.stepper__content button.components-button.is-primary',
 			{
@@ -89,7 +59,7 @@ describe( 'Admin merchant progressive onboarding', () => {
 			}
 		);
 
-		// Store details step: pick annual revenue and go live timeframe
+		// Store self-assessment step: pick annual revenue and go live timeframe
 		await expect( page ).toMatchElement( 'h1.stepper__heading', {
 			text: 'Please share a few more details',
 		} );
@@ -114,9 +84,9 @@ describe( 'Admin merchant progressive onboarding', () => {
 			}
 		);
 
-		// Loading screen
+		// Loading screen before redirect to Stripe.
 		await expect( page ).toMatchElement( 'h1.stepper__heading', {
-			text: 'Let’s get you set up for payments',
+			text: 'One last step! Verify your identity with our partner',
 		} );
 
 		// Merchant is redirected away to payments/connect again (because of force fisconnected option)


### PR DESCRIPTION
Fixes #8496  

#### Changes proposed in this Pull Request

After our recent changes to the MOX (https://github.com/Automattic/woocommerce-payments/pull/8426), we needed to update the merchant (progressive) onboarding e2e tests because they were failing.

#### Testing instructions

* Merchant e2e tests should pass without errors (`npm run test:e2e` or more specifically `npm run test:e2e tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js`)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
