### PR TITLE
Fix/8465 fix phpcs reports

### DIFF
--- a/changelog/fix-8465-fix-phpcs-reports
+++ b/changelog/fix-8465-fix-phpcs-reports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixed phpcs errors

--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -134,7 +134,7 @@ class Payment_Information {
 		if ( empty( $payment_method ) && empty( $token ) && ! \WC_Payments::is_network_saved_cards_enabled() ) {
 			// If network-wide cards are enabled, a payment method or token may not be specified and the platform default one will be used.
 			throw new Invalid_Payment_Method_Exception(
-				__( 'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.', 'woocommerce-payments' ),
+				esc_html__( 'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.', 'woocommerce-payments' ),
 				'payment_method_not_provided'
 			);
 		}

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1265,7 +1265,7 @@ class WC_Payments_Order_Service {
 		);
 
 		if ( is_wp_error( $refund ) ) {
-			throw new Exception( $refund->get_error_message() );
+			throw new Exception( esc_html( $refund->get_error_message() ) );
 		}
 
 		return $refund;
@@ -1915,7 +1915,7 @@ class WC_Payments_Order_Service {
 		$order = $this->is_order_type_object( $order ) ? $order : wc_get_order( $order );
 		if ( ! $this->is_order_type_object( $order ) ) {
 			throw new Order_Not_Found_Exception(
-				__( 'The requested order was not found.', 'woocommerce-payments' ),
+				esc_html__( 'The requested order was not found.', 'woocommerce-payments' ),
 				'order_not_found'
 			);
 		}

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -99,7 +99,7 @@ class WC_Payments_Status {
 				<td class="help">
 					<?php
 					/* translators: %s: WooPayments */
-					echo wc_help_tip( sprintf( esc_html__( 'The current version of the %s extension.', 'woocommerce-payments' ), 'WooPayments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */
+					echo wc_help_tip( sprintf( esc_html__( 'The current version of the %s extension.', 'woocommerce-payments' ), 'WooPayments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */
 					?>
 				</td>
 				<td><?php echo esc_html( WCPAY_VERSION_NUMBER ); ?></td>
@@ -109,7 +109,7 @@ class WC_Payments_Status {
 				<td class="help">
 					<?php
 					/* translators: %s: WooPayments */
-					echo wc_help_tip( sprintf( esc_html__( 'Can your store connect securely to wordpress.com? Without a proper WPCOM connection %s can\'t function!', 'woocommerce-payments' ), 'WooPayments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */
+					echo wc_help_tip( sprintf( esc_html__( 'Can your store connect securely to wordpress.com? Without a proper WPCOM connection %s can\'t function!', 'woocommerce-payments' ), 'WooPayments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */
 					?>
 				</td>
 				<td><?php echo $this->http->is_connected() ? esc_html__( 'Yes', 'woocommerce-payments' ) : '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'No', 'woocommerce-payments' ) . '</mark>'; ?></td>
@@ -117,12 +117,12 @@ class WC_Payments_Status {
 			<?php if ( $this->http->is_connected() ) : ?>
 				<tr>
 					<td data-export-label="WPCOM Blog ID"><?php esc_html_e( 'WPCOM Blog ID', 'woocommerce-payments' ); ?>:</td>
-					<td class="help"><?php echo wc_help_tip( esc_html__( 'The corresponding wordpress.com blog ID for this store.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+					<td class="help"><?php echo wc_help_tip( esc_html__( 'The corresponding wordpress.com blog ID for this store.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 					<td><?php echo esc_html( $this->http->is_connected() ? $this->http->get_blog_id() : '-' ); ?></td>
 				</tr>
 				<tr>
 					<td data-export-label="Account ID"><?php esc_html_e( 'Account ID', 'woocommerce-payments' ); ?>:</td>
-					<td class="help"><?php echo wc_help_tip( esc_html__( 'The merchant account ID you are currently using to process payments with.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+					<td class="help"><?php echo wc_help_tip( esc_html__( 'The merchant account ID you are currently using to process payments with.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 					<td><?php echo $this->gateway->is_connected() ? esc_html( $this->account->get_stripe_account_id() ?? '-' ) : '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Not connected', 'woocommerce-payments' ) . '</mark>'; ?></td>
 				</tr>
 				<?php
@@ -131,17 +131,17 @@ class WC_Payments_Status {
 					?>
 					<tr>
 						<td data-export-label="Payment Gateway"><?php esc_html_e( 'Payment Gateway', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Is the payment gateway ready and enabled for use on your store?', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Is the payment gateway ready and enabled for use on your store?', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php echo $this->gateway->needs_setup() ? '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Needs setup', 'woocommerce-payments' ) . '</mark>' : ( $this->gateway->is_enabled() ? esc_html__( 'Enabled', 'woocommerce-payments' ) : esc_html__( 'Disabled', 'woocommerce-payments' ) ); ?></td>
 					</tr>
 					<tr>
 						<td data-export-label="Test Mode"><?php esc_html_e( 'Test Mode', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the payment gateway has test payments enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the payment gateway has test payments enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments::mode()->is_test() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
 					</tr>
 					<tr>
 						<td data-export-label="Enabled APMs"><?php esc_html_e( 'Enabled APMs', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'What payment methods are enabled for the store.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'What payment methods are enabled for the store.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php echo esc_html( implode( ',', $this->gateway->get_upe_enabled_payment_method_ids() ) ); ?></td>
 					</tr>
 
@@ -151,7 +151,7 @@ class WC_Payments_Status {
 						<td class="help">
 							<?php
 							/* translators: %s: WooPayments */
-							echo wc_help_tip( sprintf( esc_html__( 'WooPay is not available, as a %s feature, or the store is not yet eligible.', 'woocommerce-payments' ), 'WooPayments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */
+							echo wc_help_tip( sprintf( esc_html__( 'WooPay is not available, as a %s feature, or the store is not yet eligible.', 'woocommerce-payments' ), 'WooPayments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */
 							?>
 						</td>
 						<td><?php echo ! WC_Payments_Features::is_woopay_eligible() ? esc_html__( 'Not eligible', 'woocommerce-payments' ) : esc_html__( 'Not active', 'woocommerce-payments' ); ?></td>
@@ -159,7 +159,7 @@ class WC_Payments_Status {
 <?php else : ?>
 					<tr>
 						<td data-export-label="WooPay"><?php esc_html_e( 'WooPay Express Checkout', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the new WooPay Express Checkout is enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the new WooPay Express Checkout is enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td>
 						<?php
 						$woopay_enabled_locations = $this->gateway->get_option( 'platform_checkout_button_locations', [] );
@@ -170,14 +170,14 @@ class WC_Payments_Status {
 					</tr>
 					<tr>
 						<td data-export-label="WooPay Incompatible Extensions"><?php esc_html_e( 'WooPay Incompatible Extensions', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether there are extensions active that are have known incompatibilities with the functioning of the new WooPay Express Checkout.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether there are extensions active that are have known incompatibilities with the functioning of the new WooPay Express Checkout.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php get_option( \WCPay\WooPay\WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, false ) ? esc_html_e( 'Yes', 'woocommerce-payments' ) : esc_html_e( 'No', 'woocommerce-payments' ); ?></td>
 					</tr>
 <?php endif; ?>
 
 					<tr>
 						<td data-export-label="Apple Pay / Google Pay"><?php esc_html_e( 'Apple Pay / Google Pay Express Checkout', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has Payment Request enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has Payment Request enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td>
 						<?php
 						$payment_request_enabled           = 'yes' === $this->gateway->get_option( 'payment_request' );
@@ -189,13 +189,13 @@ class WC_Payments_Status {
 					</tr>
 					<tr>
 						<td data-export-label="Fraud Protection Level"><?php esc_html_e( 'Fraud Protection Level', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'The current fraud protection level the payment gateway is using.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'The current fraud protection level the payment gateway is using.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php echo esc_html( $this->gateway->get_option( 'current_protection_level' ) ); ?></td>
 					</tr>
 					<?php if ( $this->gateway->get_option( 'current_protection_level' ) === 'advanced' ) : ?>
 					<tr>
 						<td data-export-label="Enabled Fraud Filters"><?php esc_html_e( 'Enabled Fraud Filters', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'The advanced fraud protection filters currently enabled.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'The advanced fraud protection filters currently enabled.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td>
 							<?php
 							// Process the list.
@@ -237,29 +237,29 @@ class WC_Payments_Status {
 
 					<tr>
 						<td data-export-label="Multi-currency"><?php esc_html_e( 'Multi-currency', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has the Multi-currency feature enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has the Multi-currency feature enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments_Features::is_customer_multi_currency_enabled() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
 					</tr>
 					<tr>
 						<td data-export-label="Public Key Encryption"><?php esc_html_e( 'Public Key Encryption', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has the Public Key Encryption feature enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has the Public Key Encryption feature enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments_Features::is_client_secret_encryption_enabled() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
 					</tr>
 					<tr>
 						<td data-export-label="Auth and Capture"><?php esc_html_e( 'Auth and Capture', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has the Auth & Capture feature enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the store has the Auth & Capture feature enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments_Features::is_auth_and_capture_enabled() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
 					</tr>
 					<tr>
 						<td data-export-label="Documents"><?php esc_html_e( 'Documents', 'woocommerce-payments' ); ?>:</td>
-						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the tax documents section is enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the tax documents section is enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments_Features::is_documents_section_enabled() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
 					</tr>
 <?php endif; // Gateway connected. ?>
 <?php endif; // Connected to WPCOM. ?>
 			<tr>
 				<td data-export-label="Logging"><?php esc_html_e( 'Logging', 'woocommerce-payments' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether debug logging is enabled and working or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether debug logging is enabled and working or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php \WCPay\Logger::can_log() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
 			</tr>
 		</tbody>

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -273,10 +273,12 @@ abstract class Request {
 
 		if ( ! empty( $missing_params ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				sprintf(
-					'Trying to access the parameters of a request which is not (fully) initialized yet. Missing parameter(s) for %s: %s',
-					get_class( $this ),
-					implode( ', ', $missing_params )
+				esc_html(
+					sprintf(
+						'Trying to access the parameters of a request which is not (fully) initialized yet. Missing parameter(s) for %s: %s',
+						get_class( $this ),
+						implode( ', ', $missing_params )
+					)
 				),
 				'wcpay_core_invalid_request_parameter_missing_parameters'
 			);
@@ -305,9 +307,11 @@ abstract class Request {
 			return $this->params[ $key ];
 		}
 		throw new Invalid_Request_Parameter_Exception(
-			sprintf(
-				'The passed key %s does not exist in Request class',
-				$key
+			esc_html(
+				sprintf(
+					'The passed key %s does not exist in Request class',
+					$key
+				)
 			),
 			'wcpay_core_invalid_request_parameter_uninitialized_param'
 		);
@@ -457,7 +461,7 @@ abstract class Request {
 
 		if ( ! $base_request->protected_mode ) {
 			throw new Extend_Request_Exception(
-				get_class( $base_request ) . ' can only be extended within its ->apply_filters() method.',
+				esc_html( get_class( $base_request ) . ' can only be extended within its ->apply_filters() method.' ),
 				'wcpay_core_extend_class_incorrectly'
 			);
 		}
@@ -538,10 +542,12 @@ abstract class Request {
 	 */
 	private function throw_immutable_exception( string $param ) {
 		throw new Immutable_Parameter_Exception(
-			sprintf(
-				'The value of %s::%s is immutable and cannot be changed.',
-				get_class( $this ),
-				$param
+			esc_html(
+				sprintf(
+					'The value of %s::%s is immutable and cannot be changed.',
+					get_class( $this ),
+					$param
+				)
 			),
 			'wcpay_core_immutable_parameter_changed'
 		);
@@ -629,7 +635,7 @@ abstract class Request {
 	protected function validate_stripe_id( $id, $prefixes = null ) {
 		if ( empty( $id ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				__( 'Empty parameter is not allowed', 'woocommerce-payments' ),
+				esc_html__( 'Empty parameter is not allowed', 'woocommerce-payments' ),
 				'wcpay_core_invalid_request_parameter_stripe_id'
 			);
 		}
@@ -657,10 +663,12 @@ abstract class Request {
 		}
 
 		throw new Invalid_Request_Parameter_Exception(
-			sprintf(
+			esc_html(
+				sprintf(
 				// Translators: %s is a Stripe ID.
-				__( '%s is not a valid Stripe identifier', 'woocommerce-payments' ),
-				$id
+					__( '%s is not a valid Stripe identifier', 'woocommerce-payments' ),
+					$id
+				)
 			),
 			'wcpay_core_invalid_request_parameter_stripe_id'
 		);
@@ -680,11 +688,13 @@ abstract class Request {
 		}
 
 		throw new Invalid_Request_Parameter_Exception(
-			sprintf(
+			esc_html(
+				sprintf(
 				/* translators: %1$s and %2$s are both numbers */
-				__( 'Invalid number passed. Number %1$s needs to be larger than %2$s', 'woocommerce-payments' ),
-				$value_to_validate,
-				$value_to_compare
+					__( 'Invalid number passed. Number %1$s needs to be larger than %2$s', 'woocommerce-payments' ),
+					$value_to_validate,
+					$value_to_compare
+				)
 			),
 			'wcpay_core_invalid_request_parameter_order'
 		);
@@ -702,10 +712,12 @@ abstract class Request {
 		$account_data = WC_Payments::get_account_service()->get_cached_account_data();
 		if ( isset( $account_data['customer_currencies']['supported'] ) && ! in_array( $currency_code, $account_data['customer_currencies']['supported'], true ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				sprintf(
-				// Translators: %s is a currency code.
-					__( '%s is not a supported currency for payments.', 'woocommerce-payments' ),
-					$currency_code
+				esc_html(
+					sprintf(
+					// Translators: %s is a currency code.
+						__( '%s is not a supported currency for payments.', 'woocommerce-payments' ),
+						$currency_code
+					)
 				),
 				'wcpay_core_invalid_request_parameter_currency_not_available'
 			);
@@ -725,10 +737,12 @@ abstract class Request {
 
 		if ( ! is_subclass_of( $child_class, $parent_class ) ) {
 			throw new Extend_Request_Exception(
-				sprintf(
-					'Failed to extend request. %s is not a subclass of %s',
-					is_string( $child_class ) ? $child_class : get_class( $child_class ),
-					$parent_class
+				esc_html(
+					sprintf(
+						'Failed to extend request. %s is not a subclass of %s',
+						is_string( $child_class ) ? $child_class : get_class( $child_class ),
+						$parent_class
+					)
 				),
 				'wcpay_core_extend_class_not_subclass'
 			);
@@ -748,11 +762,13 @@ abstract class Request {
 		$d = DateTime::createFromFormat( $format, $date );
 		if ( ! ( $d && $d->format( $format ) === $date ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				sprintf(
+				esc_html(
+					sprintf(
 					// Translators: %1$s is a provided date string, %2$s is a date format.
-					__( '%1$s is not a valid date for format %2$s.', 'woocommerce-payments' ),
-					$date,
-					$format
+						__( '%1$s is not a valid date for format %2$s.', 'woocommerce-payments' ),
+						$date,
+						$format
+					)
 				),
 				'wcpay_core_invalid_request_parameter_invalid_date'
 			);
@@ -771,10 +787,12 @@ abstract class Request {
 		$check_fallback_url = wp_generate_password( 12, false );
 		if ( hash_equals( $check_fallback_url, wp_validate_redirect( $redirect_url, $check_fallback_url ) ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				sprintf(
-				// Translators: %s is a currency code.
-					__( '%1$s is not a valid redirect URL. Use a URL in the allowed_redirect_hosts filter.', 'woocommerce-payments' ),
-					$redirect_url
+				esc_html(
+					sprintf(
+					// Translators: %s is a currency code.
+						__( '%1$s is not a valid redirect URL. Use a URL in the allowed_redirect_hosts filter.', 'woocommerce-payments' ),
+						$redirect_url
+					)
 				),
 				'wcpay_core_invalid_request_parameter_invalid_redirect_url'
 			);
@@ -793,10 +811,12 @@ abstract class Request {
 		$user = get_user_by( 'login', $user_name );
 		if ( false === $user ) {
 			throw new Invalid_Request_Parameter_Exception(
-				sprintf(
+				esc_html(
+					sprintf(
 					// Translators: %s is a provided username.
-					__( '%s is not a valid username.', 'woocommerce-payments' ),
-					$user_name
+						__( '%s is not a valid username.', 'woocommerce-payments' ),
+						$user_name
+					)
 				),
 				'wcpay_core_invalid_request_parameter_invalid_username'
 			);

--- a/includes/core/server/request/class-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-setup-intention.php
@@ -102,7 +102,7 @@ class Create_And_Confirm_Setup_Intention extends Request {
 		// Hard to validate without hardcoding a list here.
 		if ( empty( $payment_methods ) ) {
 			throw new Invalid_Request_Parameter_Exception(
-				__( 'Intentions require at least one payment method', 'woocommerce-payments' ),
+				esc_html__( 'Intentions require at least one payment method', 'woocommerce-payments' ),
 				'wcpay_core_invalid_request_parameter_missing_payment_method_types'
 			);
 		}

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -166,7 +166,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	private function validate_required_fields( array $required_fields, array $data, string $message ) {
 		foreach ( $required_fields as $required_key ) {
 			if ( ! array_key_exists( $required_key, $data ) ) {
-				throw new \RuntimeException( sprintf( '%s. Missing key: %s', $message, $required_key ) );
+				throw new \RuntimeException( esc_html( sprintf( '%s. Missing key: %s', $message, $required_key ) ) );
 			}
 		}
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,9 @@
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8434 is closed. -->
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped" />
+		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
+		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated" />
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8435 is closed. -->
 		<exclude name="WordPress.WP.AlternativeFunctions.unlink_unlink" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,9 +30,6 @@
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8434 is closed. -->
-		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped" />
-		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
-		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated" />
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8435 is closed. -->
 		<exclude name="WordPress.WP.AlternativeFunctions.unlink_unlink" />

--- a/src/Container.php
+++ b/src/Container.php
@@ -107,7 +107,7 @@ class Container implements ContainerInterface {
 		try {
 			return $this->container->get( $id );
 		} catch ( \Throwable $e ) {
-			throw new ContainerException( $e->getMessage(), $e->getCode(), $e );
+			throw new ContainerException( $e->getMessage(), $e->getCode(), $e ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 	}
 

--- a/src/Internal/DependencyManagement/DelegateContainer/LegacyContainer.php
+++ b/src/Internal/DependencyManagement/DelegateContainer/LegacyContainer.php
@@ -33,7 +33,7 @@ class LegacyContainer implements ContainerInterface {
 		$method = $this->transform_class_to_method( $id );
 
 		if ( ! $this->has( $id ) ) {
-			throw new ContainerException( sprintf( 'Class (%s) is not being managed by the legacy container', $id ) );
+			throw new ContainerException( esc_html( sprintf( 'Class (%s) is not being managed by the legacy container', $id ) ) );
 		}
 
 		return $this->$method();

--- a/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -41,9 +41,11 @@ class ExtendedContainer extends Container {
 		 */
 		if ( ! $this->has( $id ) ) {
 			throw new ContainerException(
-				sprintf(
-					'The ID you provided (%s) for replacement is not associated with anything inside the container or its delegates. Maybe try adding it instead?',
-					$id
+				esc_html(
+					sprintf(
+						'The ID you provided (%s) for replacement is not associated with anything inside the container or its delegates. Maybe try adding it instead?',
+						$id
+					)
 				)
 			);
 		}

--- a/src/Internal/Payment/PaymentRequest.php
+++ b/src/Internal/Payment/PaymentRequest.php
@@ -117,7 +117,7 @@ class PaymentRequest {
 
 		$is_woopayment_selected = isset( $request['payment_method'] ) && WC_Payment_Gateway_WCPay::GATEWAY_ID === $request['payment_method'];
 		if ( ! $is_woopayment_selected ) {
-			throw new PaymentRequestException( __( 'WooPayments is not used during checkout.', 'woocommerce-payments' ) );
+			throw new PaymentRequestException( esc_html__( 'WooPayments is not used during checkout.', 'woocommerce-payments' ) );
 		}
 
 		$token_request_key = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
@@ -132,7 +132,7 @@ class PaymentRequest {
 			$token = $this->legacy_proxy->call_static( WC_Payment_Tokens::class, 'get', $token_id );
 
 			if ( is_null( $token ) ) {
-				throw new PaymentRequestException( __( 'Invalid saved payment method (token) ID.', 'woocommerce-payments' ) );
+				throw new PaymentRequestException( esc_html__( 'Invalid saved payment method (token) ID.', 'woocommerce-payments' ) );
 			}
 			return new SavedPaymentMethod( $token->get_token(), $token->get_id() );
 		}
@@ -142,7 +142,7 @@ class PaymentRequest {
 			return new NewPaymentMethod( $payment_method );
 		}
 
-		throw new PaymentRequestException( __( 'No valid payment method was selected.', 'woocommerce-payments' ) );
+		throw new PaymentRequestException( esc_html__( 'No valid payment method was selected.', 'woocommerce-payments' ) );
 	}
 
 	/**

--- a/src/Internal/Payment/State/AbstractPaymentState.php
+++ b/src/Internal/Payment/State/AbstractPaymentState.php
@@ -127,11 +127,13 @@ abstract class AbstractPaymentState {
 	 */
 	private function throw_unavailable_method_exception( string $method_name ) {
 		throw new StateTransitionException(
-			sprintf(
+			esc_html(
+				sprintf(
 				// translators: %1$s is the name of a method of the payment object, %2$s is its current state.
-				__( 'The %1$s method is not available in the current payment state (%2$s).', 'woocommerce-payments' ),
-				$method_name,
-				get_class( $this )
+					__( 'The %1$s method is not available in the current payment state (%2$s).', 'woocommerce-payments' ),
+					$method_name,
+					get_class( $this )
+				)
 			)
 		);
 	}

--- a/src/Internal/Payment/State/InitialState.php
+++ b/src/Internal/Payment/State/InitialState.php
@@ -150,14 +150,14 @@ class InitialState extends AbstractPaymentState {
 
 		if ( ! $this->fraud_prevention_service->verify_token( $context->get_fraud_prevention_token() ) ) {
 			throw new StateTransitionException(
-				__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' )
+				esc_html__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' )
 			);
 		}
 
 		if ( $this->failed_transaction_rate_limiter->is_limited() ) {
 			$this->order_service->add_rate_limiter_note( $context->get_order_id() );
 			throw new StateTransitionException(
-				__( 'Your payment was not processed.', 'woocommerce-payments' ),
+				esc_html__( 'Your payment was not processed.', 'woocommerce-payments' ),
 				400
 			);
 		}
@@ -287,7 +287,7 @@ class InitialState extends AbstractPaymentState {
 
 		if ( ! $this->order_service->is_valid_phone_number( $order_id ) ) {
 			throw new StateTransitionException(
-				__(
+				esc_html__(
 					'Please enter a valid phone number, whose length is less than 20.',
 					'woocommerce-payments'
 				)

--- a/src/Internal/Payment/State/StateFactory.php
+++ b/src/Internal/Payment/State/StateFactory.php
@@ -49,11 +49,13 @@ class StateFactory {
 	public function create_state( string $state_class, PaymentContext $context ): AbstractPaymentState {
 		if ( ! is_subclass_of( $state_class, AbstractPaymentState::class ) ) {
 			throw new StateTransitionException(
-				sprintf(
+				esc_html(
+					sprintf(
 					// Translators: %1$s is the PHP class for a new payment state, %1$s is the state base class.
-					__( 'The class %1$s is not a subclass of %2$s', 'woocommerce-payments' ),
-					$state_class,
-					AbstractPaymentState::class
+						__( 'The class %1$s is not a subclass of %2$s', 'woocommerce-payments' ),
+						$state_class,
+						AbstractPaymentState::class
+					)
 				)
 			);
 		}

--- a/src/Internal/Proxy/LegacyProxy.php
+++ b/src/Internal/Proxy/LegacyProxy.php
@@ -63,7 +63,7 @@ class LegacyProxy {
 	 */
 	public function get_global( string $name ) {
 		if ( ! $this->has_global( $name ) ) {
-			throw new ProxyException( sprintf( 'The global "%s" is not set.', $name ) );
+			throw new ProxyException( esc_html( sprintf( 'The global "%s" is not set.', $name ) ) );
 		}
 
 		return $GLOBALS[ $name ];

--- a/src/Internal/Service/MinimumAmountService.php
+++ b/src/Internal/Service/MinimumAmountService.php
@@ -59,7 +59,7 @@ class MinimumAmountService {
 		$minimum_amount = $this->get_cached_amount( $currency );
 
 		if ( $minimum_amount > $amount ) {
-			throw new Amount_Too_Small_Exception( __( 'Order amount too small', 'woocommerce-payments' ), $minimum_amount, $currency, 400 );
+			throw new Amount_Too_Small_Exception( esc_html__( 'Order amount too small', 'woocommerce-payments' ), $minimum_amount, $currency, 400 ); //phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 	}
 

--- a/src/Internal/Service/OrderService.php
+++ b/src/Internal/Service/OrderService.php
@@ -478,10 +478,12 @@ class OrderService {
 		$order = $this->legacy_proxy->call_function( 'wc_get_order', $order_id );
 		if ( ! $order instanceof WC_Order ) {
 			throw new Order_Not_Found_Exception(
-				sprintf(
+				esc_html(
+					sprintf(
 					// Translators: %d is the ID of an order.
-					__( 'The requested order (ID %d) was not found.', 'woocommerce-payments' ),
-					$order_id
+						__( 'The requested order (ID %d) was not found.', 'woocommerce-payments' ),
+						$order_id
+					)
 				),
 				'order_not_found'
 			);


### PR DESCRIPTION
Fixes #8465 

#### Changes proposed in this Pull Request

This PR fixes all errors founded by the phpcs. Make sure to check the linked issue for more details.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Comment or remove from line 38 to line 40 inside the phpcs.xml.dist file
* Run this command: 
```shell
./vendor/bin/phpcs --standard=phpcs.xml.dist --no-cache --sniffs='WordPress.Security.EscapeOutput,WordPress.Security.ValidatedSanitizedInput' src/Container.php src/Internal/Payment/State/InitialState.php src/Internal/DependencyManagement/DelegateContainer/LegacyContainer.php includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php src/Internal/Payment/State/StateFactory.php src/Internal/DependencyManagement/ExtendedContainer.php src/Internal/Proxy/LegacyProxy.php src/Internal/Service/MinimumAmountService.php src/Internal/Service/OrderService.php src/Internal/Payment/PaymentRequest.php src/Internal/Payment/State/AbstractPaymentState.php includes/core/server/class-request.php includes/class-payment-information.php includes/core/server/request/class-create-and-confirm-setup-intention.php includes/class-wc-payments-order-service.php includes/class-wc-payments-status.php
```

* Make sure that no errors are displayed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
