### PR TITLE
refactor: shortcode checkout wp-data dependency

### DIFF
--- a/changelog/refactor-shortcode-checkout-wp-data-dependency
+++ b/changelog/refactor-shortcode-checkout-wp-data-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+refactor: reduce wp-data dependency on shortcode checkout

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -19,11 +19,11 @@ import { useEffect, useRef } from 'react';
 import { usePaymentCompleteHandler } from './hooks';
 import {
 	getStripeElementOptions,
-	useCustomerData,
 	blocksShowLinkButtonHandler,
 	getBlocksEmailValue,
 	isLinkEnabled,
 } from 'wcpay/checkout/utils/upe';
+import { useCustomerData } from './utils';
 import enableStripeLinkPaymentMethod from 'wcpay/checkout/stripe-link';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import { validateElements } from 'wcpay/checkout/classic/payment-processing';

--- a/client/checkout/blocks/test/payment-processor.test.js
+++ b/client/checkout/blocks/test/payment-processor.test.js
@@ -12,7 +12,7 @@ import { PaymentElement } from '@stripe/react-stripe-js';
 jest.mock( 'wcpay/checkout/classic/payment-processing', () => ( {
 	validateElements: jest.fn().mockResolvedValue(),
 } ) );
-jest.mock( '../../utils', () => ( {
+jest.mock( 'wcpay/checkout/blocks/utils', () => ( {
 	useCustomerData: jest.fn().mockReturnValue( { billingAddress: {} } ),
 } ) );
 jest.mock( '../hooks', () => ( {

--- a/client/checkout/blocks/test/payment-processor.test.js
+++ b/client/checkout/blocks/test/payment-processor.test.js
@@ -12,8 +12,7 @@ import { PaymentElement } from '@stripe/react-stripe-js';
 jest.mock( 'wcpay/checkout/classic/payment-processing', () => ( {
 	validateElements: jest.fn().mockResolvedValue(),
 } ) );
-jest.mock( 'wcpay/checkout/utils/upe', () => ( {
-	...jest.requireActual( 'wcpay/checkout/utils/upe' ),
+jest.mock( '../../utils', () => ( {
 	useCustomerData: jest.fn().mockReturnValue( { billingAddress: {} } ),
 } ) );
 jest.mock( '../hooks', () => ( {

--- a/client/checkout/blocks/utils.js
+++ b/client/checkout/blocks/utils.js
@@ -1,0 +1,28 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { WC_STORE_CART } from 'wcpay/checkout/constants';
+
+/**
+ *
+ * Custom React hook that provides customer data and related functions for managing customer information.
+ * The hook retrieves customer data from the WC_STORE_CART selector and dispatches actions to modify billing and shipping addresses.
+ *
+ * @return {Object} An object containing customer data and functions for managing customer information.
+ */
+export const useCustomerData = () => {
+	const customerData = useSelect( ( select ) =>
+		select( WC_STORE_CART ).getCustomerData()
+	);
+	const {
+		setShippingAddress,
+		setBillingData,
+		setBillingAddress,
+	} = useDispatch( WC_STORE_CART );
+
+	return {
+		// Backward compatibility billingData/billingAddress
+		billingAddress: customerData.billingAddress || customerData.billingData,
+		// Backward compatibility setBillingData/setBillingAddress
+		setBillingAddress: setBillingAddress || setBillingData,
+		setShippingAddress,
+	};
+};

--- a/client/checkout/blocks/utils.js
+++ b/client/checkout/blocks/utils.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { WC_STORE_CART } from 'wcpay/checkout/constants';
 
 /**

--- a/client/checkout/constants.js
+++ b/client/checkout/constants.js
@@ -11,7 +11,6 @@ export const PAYMENT_METHOD_NAME_AFFIRM = 'woocommerce_payments_affirm';
 export const PAYMENT_METHOD_NAME_AFTERPAY =
 	'woocommerce_payments_afterpay_clearpay';
 export const PAYMENT_METHOD_NAME_KLARNA = 'woocommerce_payments_klarna';
-export const PAYMENT_METHOD_NAME_UPE = 'woocommerce_payments_upe';
 export const PAYMENT_METHOD_NAME_PAYMENT_REQUEST =
 	'woocommerce_payments_payment_request';
 export const PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT =

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -2,8 +2,7 @@
  * Internal dependencies
  */
 import { getUPEConfig } from 'wcpay/utils/checkout';
-import { WC_STORE_CART, getPaymentMethodsConstants } from '../constants';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { getPaymentMethodsConstants } from '../constants';
 
 /**
  * Generates terms parameter for UPE, with value set for reusable payment methods
@@ -182,32 +181,6 @@ export function dispatchChangeEventFor( element ) {
 	const event = new Event( 'change', { bubbles: true } );
 	element.dispatchEvent( event );
 }
-
-/**
- *
- * Custom React hook that provides customer data and related functions for managing customer information.
- * The hook retrieves customer data from the WC_STORE_CART selector and dispatches actions to modify billing and shipping addresses.
- *
- * @return {Object} An object containing customer data and functions for managing customer information.
- */
-export const useCustomerData = () => {
-	const customerData = useSelect( ( select ) =>
-		select( WC_STORE_CART ).getCustomerData()
-	);
-	const {
-		setShippingAddress,
-		setBillingData,
-		setBillingAddress,
-	} = useDispatch( WC_STORE_CART );
-
-	return {
-		// Backward compatibility billingData/billingAddress
-		billingAddress: customerData.billingAddress || customerData.billingData,
-		// Backward compatibility setBillingData/setBillingAddress
-		setBillingAddress: setBillingAddress || setBillingData,
-		setShippingAddress,
-	};
-};
 
 /**
  * Returns the prepared set of options needed to initialize the Stripe elements for UPE in Block Checkout.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Moving `useCustomerData` (which has a dependency on `@wordpress/data`) from `wcpay/checkout/utils/upe` (which has utilities for both shortcode & blocks checkout) to `client/checkout/blocks/utils.js` (so that it includes only utilities for blocks checkout).

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
