### PR TITLE
Remove extra WooPay icon on connect page

### DIFF
--- a/changelog/fix-connect-page-double-woopay-logo
+++ b/changelog/fix-connect-page-double-woopay-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove extra WooPay icon on connect page

--- a/client/connect-account-page/payment-methods.tsx
+++ b/client/connect-account-page/payment-methods.tsx
@@ -36,7 +36,6 @@ const PaymentMethods: React.FC = () => {
 				<IdealIcon />
 				<ApplePayIcon />
 				<GooglePayIcon />
-				{ wcpaySettings.isWooPayStoreCountryAvailable && <WooIcon /> }
 				<WooIcon />
 				<KlarnaIcon />
 				<AffirmIcon />

--- a/client/connect-account-page/test/__snapshots__/index.test.tsx.snap
+++ b/client/connect-account-page/test/__snapshots__/index.test.tsx.snap
@@ -369,11 +369,6 @@ exports[`ConnectAccountPage should render correctly with WooPay eligible 1`] = `
               src="assets/images/payment-methods/woo.svg"
             />
             <img
-              alt="WooPay"
-              class="payment-method__icon"
-              src="assets/images/payment-methods/woo.svg"
-            />
-            <img
               alt="Klarna"
               class="payment-method__icon"
               src="assets/images/payment-methods/klarna.svg"


### PR DESCRIPTION
Fixes #8505 

#### Changes proposed in this Pull Request
Remove extra instance of WooPay icon on the connect page.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Set up a new site with WooCommerce and WooPayments. Make sure the store location is a WooPay eligible country, i.e. US.
2. Go to **Payments**
3. See two WooPay icons.
4. Switch branch and re-build and see one icon.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before
<img width="697" alt="Screenshot 2024-03-28 at 3 41 00 PM" src="https://github.com/Automattic/woocommerce-payments/assets/7651258/db7c312c-c26d-4a53-9da1-e1c2740f12f3">


After
<img width="699" alt="Screenshot 2024-03-28 at 3 32 56 PM" src="https://github.com/Automattic/woocommerce-payments/assets/7651258/d026aa0d-03ea-4f83-82d5-1f1ee4e302de">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
