### PR TITLE
Remove UTC label from transaction listing

### DIFF
--- a/changelog/fix-8386-remove-utc-label
+++ b/changelog/fix-8386-remove-utc-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Transaction listing incorrectly labeled times as UTC
+Remove incorrect "UTC" label from the time column of Transactions page

--- a/changelog/fix-8386-remove-utc-label
+++ b/changelog/fix-8386-remove-utc-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Transaction listing incorrectly labeled times as UTC

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -156,10 +156,7 @@ const getColumns = (
 		{
 			key: 'date',
 			label: __( 'Date / Time', 'woocommerce-payments' ),
-			screenReaderLabel: __(
-				'Date and time in UTC',
-				'woocommerce-payments'
-			),
+			screenReaderLabel: __( 'Date and time', 'woocommerce-payments' ),
 			required: true,
 			isLeftAligned: true,
 			defaultOrder: 'desc',

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -155,7 +155,7 @@ const getColumns = (
 		},
 		{
 			key: 'date',
-			label: __( 'Date / Time (UTC)', 'woocommerce-payments' ),
+			label: __( 'Date / Time', 'woocommerce-payments' ),
 			screenReaderLabel: __(
 				'Date and time in UTC',
 				'woocommerce-payments'

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -253,14 +253,14 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       <span
                         class="screen-reader-text"
                       >
-                        Date and time in UTC
+                        Date and time
                       </span>
                     </button>
                     <span
                       class="screen-reader-text"
                       id="header-15-0"
                     >
-                      Sort by Date and time in UTC in ascending order
+                      Sort by Date and time in ascending order
                     </span>
                   </th>
                   <th
@@ -1242,14 +1242,14 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       <span
                         class="screen-reader-text"
                       >
-                        Date and time in UTC
+                        Date and time
                       </span>
                     </button>
                     <span
                       class="screen-reader-text"
                       id="header-16-0"
                     >
-                      Sort by Date and time in UTC in ascending order
+                      Sort by Date and time in ascending order
                     </span>
                   </th>
                   <th
@@ -2228,14 +2228,14 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                       <span
                         class="screen-reader-text"
                       >
-                        Date and time in UTC
+                        Date and time
                       </span>
                     </button>
                     <span
                       class="screen-reader-text"
                       id="header-0-0"
                     >
-                      Sort by Date and time in UTC in ascending order
+                      Sort by Date and time in ascending order
                     </span>
                   </th>
                   <th
@@ -2905,14 +2905,14 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       <span
                         class="screen-reader-text"
                       >
-                        Date and time in UTC
+                        Date and time
                       </span>
                     </button>
                     <span
                       class="screen-reader-text"
                       id="header-14-0"
                     >
-                      Sort by Date and time in UTC in ascending order
+                      Sort by Date and time in ascending order
                     </span>
                   </th>
                   <th
@@ -3968,14 +3968,14 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       <span
                         class="screen-reader-text"
                       >
-                        Date and time in UTC
+                        Date and time
                       </span>
                     </button>
                     <span
                       class="screen-reader-text"
                       id="header-1-0"
                     >
-                      Sort by Date and time in UTC in ascending order
+                      Sort by Date and time in ascending order
                     </span>
                   </th>
                   <th
@@ -4999,14 +4999,14 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       <span
                         class="screen-reader-text"
                       >
-                        Date and time in UTC
+                        Date and time
                       </span>
                     </button>
                     <span
                       class="screen-reader-text"
                       id="header-11-0"
                     >
-                      Sort by Date and time in UTC in ascending order
+                      Sort by Date and time in ascending order
                     </span>
                   </th>
                   <th

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -248,7 +248,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       <span
                         aria-hidden="true"
                       >
-                        Date / Time (UTC)
+                        Date / Time
                       </span>
                       <span
                         class="screen-reader-text"
@@ -1237,7 +1237,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       <span
                         aria-hidden="true"
                       >
-                        Date / Time (UTC)
+                        Date / Time
                       </span>
                       <span
                         class="screen-reader-text"
@@ -2223,7 +2223,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                       <span
                         aria-hidden="true"
                       >
-                        Date / Time (UTC)
+                        Date / Time
                       </span>
                       <span
                         class="screen-reader-text"
@@ -2900,7 +2900,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       <span
                         aria-hidden="true"
                       >
-                        Date / Time (UTC)
+                        Date / Time
                       </span>
                       <span
                         class="screen-reader-text"
@@ -3963,7 +3963,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       <span
                         aria-hidden="true"
                       >
-                        Date / Time (UTC)
+                        Date / Time
                       </span>
                       <span
                         class="screen-reader-text"
@@ -4994,7 +4994,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       <span
                         aria-hidden="true"
                       >
-                        Date / Time (UTC)
+                        Date / Time
                       </span>
                       <span
                         class="screen-reader-text"

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -319,10 +319,10 @@ describe( 'Transactions list', () => {
 		} );
 
 		test( 'sorts by default field date', () => {
-			sortBy( 'Date and time in UTC' );
+			sortBy( 'Date and time' );
 			expectSortingToBe( 'date', 'asc' );
 
-			sortBy( 'Date and time in UTC' );
+			sortBy( 'Date and time' );
 			expectSortingToBe( 'date', 'desc' );
 		} );
 

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -620,7 +620,7 @@ describe( 'Transactions list', () => {
 
 			const expected = [
 				'"Transaction Id"',
-				'"Date / Time (UTC)"',
+				'"Date / Time"',
 				'Type',
 				'Channel',
 				'"Paid Currency"',


### PR DESCRIPTION
Fixes #8386 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR removes the `(UTC)` from the `Date / Time` label on the Transactions listing page.

| Before | After |
|--------|--------|
| ![Before](https://github.com/Automattic/woocommerce-payments/assets/57298/42d9286b-0f3b-4e53-bb3b-e4395290a1c8) | ![After](https://github.com/Automattic/woocommerce-payments/assets/57298/97b424d4-a925-402d-ab3e-18660879c410) | 

This label was incorrectly changed in  https://github.com/Automattic/woocommerce-payments/issues/7591. While the label says UTC the time is always rendered in the Merchant's timezone.

I have created #8522 to clarify that CSV's use UTC.

#### Testing instructions

* Go to Payments > Transactions
* See `Date / Time` as column header and times in local time.

-------------------

- [x] Run `npm run changelog` 
- [x] Covered with tests 
- [x] Tested on mobile 

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
