### PR TITLE
Fix fatal error when connecting jetpack to localhost

### DIFF
--- a/changelog/fix-8301-fatal-error-when-connecting-jetpack-to-locqlhost
+++ b/changelog/fix-8301-fatal-error-when-connecting-jetpack-to-locqlhost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Fatal Error showing when connect to Jetpack on localhost

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2053,7 +2053,12 @@ class WC_Payments_Account {
 		);
 
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			$this->payments_api_client->start_server_connection( $onboarding_url );
+			try {
+				$this->payments_api_client->start_server_connection( $onboarding_url );
+			} catch ( API_Exception $e ) {
+				// If we can't connect to the server, return, the error will be shown on the relevant page.
+				return;
+			}
 		} else {
 			$this->redirect_to( $onboarding_url );
 		}


### PR DESCRIPTION
Fixes #8301 #7677 

#### Changes proposed in this Pull Request

Fix fatal error when connecting jetpack to localhost

#### Testing instructions

* Checkout to branch `fix/8301-fatal-error-when-connecting-jetpack-to-locqlhost`
* On a local, clear blog and user tokens using Jetpack Debug Tools -> Broken Token utility
* Have your local account deleted or mark as deleted so you can see Connect your store button
* Go to http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect page
* Press Connect your store
* See the notice instead of fatal error

<img width="795" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/79862886/95e0efc6-14f0-40e6-b493-8a8ab2aa7c83">

* Clear blog token using Jetpack Debug Tools -> Broken Token utility
* Run `npm run tube:start`
* Try connecting Jetpack from tube site and it should be successful

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _ 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
