### PR TITLE
Ignore filesystem sniffs for GH workflows and tests

### DIFF
--- a/changelog/fix-filesystem-phpcs-reports
+++ b/changelog/fix-filesystem-phpcs-reports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Ignore alternative function WordPress PHPCS sniffs in the GH workflows and tests

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,11 +35,6 @@
 		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated" />
 
-		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8435 is closed. -->
-		<exclude name="WordPress.WP.AlternativeFunctions.unlink_unlink" />
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_touch" />
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents" />
-
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8436 is closed. -->
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.Found" />
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
@@ -73,6 +68,11 @@
 
 	<rule ref="WordPress.Security">
 		<exclude-pattern>./tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<exclude-pattern>tests/</exclude-pattern>
+		<exclude-pattern>.github/</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.Security.EscapeOutput">


### PR DESCRIPTION
Fixes #8435 

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Ignore the `WordPress.WP.AlternativeFunctions` sniff for the `.github` and `tests` folder.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm run lint:php` and make sure no issues are reported.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
