### PR TITLE
Migrate woopay skipped tracks event to 'wcpay' prefix 

### DIFF
--- a/changelog/fix-migrate-woopay-skipped-tracks-event
+++ b/changelog/fix-migrate-woopay-skipped-tracks-event
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Complete WooPay Tracks event migration and cleanup migration related code
+
+

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -639,7 +639,7 @@ export const handleWooPayEmailInput = async (
 			dispatchUserExistEvent( true );
 		}, 2000 );
 
-		recordUserEvent( 'woopay_skipped', {}, true );
+		recordUserEvent( 'woopay_skipped', {} );
 
 		searchParams.delete( 'skip_woopay' );
 

--- a/client/tracks/index.ts
+++ b/client/tracks/index.ts
@@ -62,12 +62,10 @@ export const recordEvent = (
  *
  * @param {string}  eventName         Name of the event.
  * @param {Object}  [eventProperties] Event properties (optional).
- * @param {boolean} isLegacy Event properties (optional).
  */
 export const recordUserEvent = (
 	eventName: string,
-	eventProperties: Record< string, unknown > = {},
-	isLegacy = false
+	eventProperties: Record< string, unknown > = {}
 ): void => {
 	const nonce =
 		getConfig( 'platformTrackerNonce' ) ??
@@ -80,7 +78,6 @@ export const recordUserEvent = (
 	body.append( 'action', 'platform_tracks' );
 	body.append( 'tracksEventName', eventName );
 	body.append( 'tracksEventProp', JSON.stringify( eventProperties ) );
-	body.append( 'isLegacy', JSON.stringify( isLegacy ) ); // formData does not allow appending booleans, so we stringify it - it is parsed back to a boolean on the PHP side.
 	fetch( ajaxUrl, {
 		method: 'post',
 		body,

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -22,13 +22,6 @@ defined( 'ABSPATH' ) || exit; // block direct access.
 class WooPay_Tracker extends Jetpack_Tracks_Client {
 
 	/**
-	 * Legacy prefix used for WooPay user events
-	 *
-	 * @var string
-	 */
-	private static $legacy_user_prefix = 'woocommerceanalytics';
-
-	/**
 	 * WCPay user event prefix
 	 *
 	 * @var string
@@ -107,10 +100,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 				$tracks_data = $event_prop;
 			}
 		}
-		// Legacy events are shopper events that still use the woocommerceanalytics prefix.
-		// These need to be migrated to the wcpay prefix.
-		$is_legacy_event = isset( $_REQUEST['isLegacy'] ) ? rest_sanitize_boolean( wc_clean( wp_unslash( $_REQUEST['isLegacy'] ) ) ) : false;
-		$this->maybe_record_event( sanitize_text_field( wp_unslash( $_REQUEST['tracksEventName'] ) ), $tracks_data, $is_legacy_event );
+		$this->maybe_record_event( sanitize_text_field( wp_unslash( $_REQUEST['tracksEventName'] ) ), $tracks_data );
 
 		wp_send_json_success();
 	}
@@ -132,13 +122,11 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 *
 	 * @param string  $event name of the event.
 	 * @param array   $data array of event properties.
-	 * @param boolean $is_legacy indicate whether this is a legacy event.
 	 */
-	public function maybe_record_event( $event, $data = [], $is_legacy = true ) {
+	public function maybe_record_event( $event, $data = [] ) {
 		// Top level events should not be namespaced.
 		if ( '_aliasUser' !== $event ) {
-			$prefix = $is_legacy ? self::$legacy_user_prefix : self::$user_prefix;
-			$event  = $prefix . '_' . $event;
+			$event  = self::$user_prefix . '_' . $event;
 		}
 
 		return $this->tracks_record_event( $event, $data );


### PR DESCRIPTION
Fixes #8562 

#### Changes proposed in this Pull Request
- Rename woocommerceanalytics_woopay_skipped to wcpay_woopay_skipped
- Cleanup migration-related prefix handling.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
As a part of Tracks prefix migration work (paJDYF-9HR-p2), events with `woocommerceanalytics` were updated to use `wcpay` prefix. This PR migrates the last remaining legacy event, `woocommerceanalytics_woopay_skipped` and remove the legacy prefix handling code as it's no longer needed.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a product to the cart.
2. Go to WooPay checkout.
3. On WooPay checkout screen, click "Checkout as guest" option.
<img width="655" alt="SCR-20240403-klei" src="https://github.com/Automattic/woocommerce-payments/assets/6216000/c1832bde-293a-412f-9c85-3df454237a42">

5. In ~5 minutes check MC Tracks live view for the presence of `wcpay_woopay_skipped` event. There should not be a `woocommerceanalytics_woopay_skipped` event from your blog.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.