### PR TITLE
Update Decline button loading state when Accept button is click on ToS modal

### DIFF
--- a/changelog/fix-7866-tos-decline-busy
+++ b/changelog/fix-7866-tos-decline-busy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Decline button state for Accept loading on ToS modal

--- a/client/tos/modal/index.js
+++ b/client/tos/modal/index.js
@@ -73,7 +73,11 @@ const TosModalUI = ( { onAccept, onDecline, isBusy, hasError } ) => {
 					{ message }
 				</div>
 				<div className="woocommerce-payments__tos-footer">
-					<Button isSecondary onClick={ onDecline } isBusy={ isBusy }>
+					<Button
+						isSecondary
+						onClick={ onDecline }
+						disabled={ isBusy }
+					>
 						{ __( 'Decline', 'woocommerce-payments' ) }
 					</Button>
 


### PR DESCRIPTION
Fixes #7866

#### Changes proposed in this Pull Request
This PR updates the loading state to disabled during the loading process when the Accept button is clicked on the Terms of Service modal.

#### Testing instructions
- Code review is enough for that change.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
