### PR TITLE
Make PHPCS exclude patterns relative to project root

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,15 +7,15 @@
 	<arg name="extensions" value="php"/>
 
     <!-- Exclude paths -->
-	<exclude-pattern>./dev/*</exclude-pattern>
-	<exclude-pattern>./dist/*</exclude-pattern>
-	<exclude-pattern>./release/*</exclude-pattern>
-	<exclude-pattern>./docker/*</exclude-pattern>
-	<exclude-pattern>./node_modules/*</exclude-pattern>
-	<exclude-pattern>./vendor/*</exclude-pattern>
-	<exclude-pattern>./vendor-dist/*</exclude-pattern>
-	<exclude-pattern>./lib/*</exclude-pattern>
-	<exclude-pattern>./bin/*</exclude-pattern>
+	<exclude-pattern type="relative">./dev/*</exclude-pattern>
+	<exclude-pattern type="relative">./dist/*</exclude-pattern>
+	<exclude-pattern type="relative">./release/*</exclude-pattern>
+	<exclude-pattern type="relative">./docker/*</exclude-pattern>
+	<exclude-pattern type="relative">./node_modules/*</exclude-pattern>
+	<exclude-pattern type="relative">./vendor/*</exclude-pattern>
+	<exclude-pattern type="relative">./vendor-dist/*</exclude-pattern>
+	<exclude-pattern type="relative">./lib/*</exclude-pattern>
+	<exclude-pattern type="relative">./bin/*</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="6.0" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the PHPCS exclude-pattern rules to be relative to the project root. This change aims to resolve an issue where the entire project directory can be ignored if the parent directory shares the same name as one of the directories in the exclusion rules.

Context: https://github.com/Automattic/woocommerce-payments/pull/8556#issuecomment-2035116072

#### Testing instructions

1. Ensure npm run lint:php executes successfully locally.
2. Verify PHP lint tests are working in the CI.
3. Repeat 1 when the project root resides within a folder named `dev`.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
