### PR TITLE
Fix Payment Activity card Safari padding bug

### DIFF
--- a/changelog/fix-8571-payment-activity-card-safari-visual-bug
+++ b/changelog/fix-8571-payment-activity-card-safari-visual-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Not user-facing: hidden behind feature flag. Fixes payment activity visual bug in safari.
+
+

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -198,11 +198,9 @@ const OverviewPage = () => {
 						{
 							/* Show Payment Activity widget only when feature flag is set. To be removed before go live */
 							isPaymentOverviewWidgetEnabled && (
-								<Card>
-									<ErrorBoundary>
-										<PaymentActivity />
-									</ErrorBoundary>
-								</Card>
+								<ErrorBoundary>
+									<PaymentActivity />
+								</ErrorBoundary>
 							)
 						}
 						<DepositsOverview />


### PR DESCRIPTION
Fixes #8571


#### Changes proposed in this Pull Request

> [!NOTE]  
> Hidden behind feature flag `_wcpay_feature_payment_overview_widget`

This 🤏 tiny PR fixes a styling bug that occurs with the Payment Activity in Safari (macOS and iOS).

It removes the duplicate `Card` that was wrapping the `PaymentActivity` `Card`:

https://github.com/Automattic/woocommerce-payments/blob/4c920686544641fc47f2ef7b10406060602c0424/client/components/payment-activity/index.tsx#L14-L17


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable feature flag `_wcpay_feature_payment_overview_widget`
	* `wp option update _wcpay_feature_payment_overview_widget 1`
* Navigate to **Payments → Overview**
* On `develop`, notice the visual padding bug at the bottom of the Payment Activity card
<img width="500" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/a5b01585-ee0e-47de-82af-cacf1167f443">

* On this branch, the bug should no longer occur
<img width="500" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/5f577c17-5c23-4ed3-94b5-8e2e2b7a5f7d">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile Tested on mobile safari

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
