### PR TITLE
Clear WP cache on writes inside Database_Cache

### DIFF
--- a/changelog/fix-cached-db-cache
+++ b/changelog/fix-cached-db-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Clear WP cache on writes inside Database_Cache

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -185,6 +185,8 @@ class Database_Cache {
 	 */
 	public function delete( string $key ) {
 		delete_option( $key );
+
+		// Clear WP Cache to ensure the new data is fetched by other processes.
 		wp_cache_delete( $key, 'options' );
 	}
 
@@ -299,6 +301,8 @@ class Database_Cache {
 
 		// Create or update the option cache.
 		update_option( $key, $cache_contents, 'no' );
+
+		// Clear WP Cache to ensure the new data is fetched by other processes.
 		wp_cache_delete( $key, 'options' );
 
 		return $cache_contents;

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -185,6 +185,7 @@ class Database_Cache {
 	 */
 	public function delete( string $key ) {
 		delete_option( $key );
+		wp_cache_delete( $key, 'options' );
 	}
 
 	/**
@@ -297,11 +298,8 @@ class Database_Cache {
 		$cache_contents['errored'] = $errored;
 
 		// Create or update the option cache.
-		if ( false === get_option( $key ) ) {
-			add_option( $key, $cache_contents, '', 'no' );
-		} else {
-			update_option( $key, $cache_contents, 'no' );
-		}
+		update_option( $key, $cache_contents, 'no' );
+		wp_cache_delete( $key, 'options' );
 
 		return $cache_contents;
 	}


### PR DESCRIPTION
Fixes #8600

#### Changes proposed in this Pull Request

- Replace the conditional `add/update_option` with just `update_option` - it does the same thing more effectively under the hood.
- Clear the cache whenever `update_option` or `delete_option` is called.

#### Testing instructions

* Unit tests should pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
