### PR TITLE
Add skeleton loading element to cart page page BNPL messaging

### DIFF
--- a/changelog/cart-pmme-total-updates
+++ b/changelog/cart-pmme-total-updates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Adding skeleton component to BNPL messaging on cart page which has not yet been deployed.
+
+

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -199,7 +199,7 @@ export const initializeBnplSiteMessaging = async () => {
 					);
 
 					pmme.style.setProperty( '--wc-bnpl-margin-bottom', '-4px' );
-				}, '1000' );
+				}, 2000 );
 			}
 		} );
 	}

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -149,6 +149,58 @@ export const initializeBnplSiteMessaging = async () => {
 			document
 				.getElementById( 'payment-method-message' )
 				.classList.add( 'ready' );
+
+			// On the cart page, get the height of the PMME after it's rendered and store it in a CSS variable. This helps
+			// prevent layout shifts when the PMME is loaded asynchronously upon cart total update.
+			if ( isCart ) {
+				// An element that won't be removed with the cart total update.
+				const cartCollaterals = document.querySelector(
+					'.cart-collaterals'
+				);
+				const wcBnplHeight = getComputedStyle( cartCollaterals )
+					.getPropertyValue( '--wc-bnpl-height' )
+					.trim();
+
+				if ( wcBnplHeight ) {
+					return;
+				}
+
+				const pmme = document.getElementById(
+					'payment-method-message'
+				);
+				const pmmeContainer = document.querySelector(
+					'.cart_totals .__PrivateStripeElement'
+				);
+				setTimeout( () => {
+					const pmmeComputedStyle = window.getComputedStyle( pmme );
+					const pmmeHeight = parseFloat( pmmeComputedStyle.height );
+					const pmmeMarginBottom = parseFloat( bottomMargin );
+					const pmmeTotalHeight = pmmeHeight + pmmeMarginBottom;
+
+					const pmmeContainerComputedStyle = window.getComputedStyle(
+						pmmeContainer
+					);
+					const pmmeContainerHeight = parseFloat(
+						pmmeContainerComputedStyle.height
+					);
+
+					cartCollaterals.style.setProperty(
+						'--wc-bnpl-height',
+						pmmeTotalHeight + 'px'
+					);
+					cartCollaterals.style.setProperty(
+						'--wc-bnpl-container-height',
+						pmmeContainerHeight - 12 + 'px'
+					);
+
+					cartCollaterals.style.setProperty(
+						'--wc-bnpl-loader-margin',
+						pmmeMarginBottom + 2 + 'px'
+					);
+
+					pmme.style.setProperty( '--wc-bnpl-margin-bottom', '-4px' );
+				}, '1000' );
+			}
 		} );
 	}
 

--- a/client/product-details/bnpl-site-messaging/style.scss
+++ b/client/product-details/bnpl-site-messaging/style.scss
@@ -17,13 +17,37 @@
 }
 
 .cart_totals {
-	&:has( + #payment-method-message.ready ) {
-		margin-bottom: 0;
+	#payment-method-message {
+		margin: -8px 0 4px;
+		height: var( --wc-bnpl-height );
+		padding: 2px 1em 0;
+		margin-bottom: var( --wc-bnpl-margin-bottom );
+
+		&.pmme-updated {
+			margin: -12px 0 0;
+			padding: 0 1em;
+		}
+
+		&.skeleton {
+			margin-bottom: 4px;
+			background: #afafaf;
+		}
 	}
 
-	#payment-method-message.ready {
-		margin-bottom: var( --wc-bnpl-margin-bottom );
-		padding: 0 1em;
+	.pmme-loading {
+		animation: pmme-loading 1s linear infinite alternate;
+		background: #afafaf;
+		height: var( --wc-bnpl-container-height );
+		margin: -4px 1em var( --wc-bnpl-loader-margin ) 1em;
+	}
+}
+
+@keyframes pmme-loading {
+	0% {
+		background-color: hsl( 204, 10%, 90% );
+	}
+	100% {
+		background-color: hsl( 200, 20%, 95% );
 	}
 }
 

--- a/client/product-details/index.js
+++ b/client/product-details/index.js
@@ -126,9 +126,19 @@ jQuery( async function ( $ ) {
 	} );
 
 	$( document.body ).on( 'updated_cart_totals', () => {
+		$( '#payment-method-message' ).before(
+			'<div class="pmme-loading"></div>'
+		);
+		$( '#payment-method-message' ).hide();
 		bnplGetCartTotal().then( ( response ) => {
 			window.wcpayStripeSiteMessaging.cartTotal = response.total;
-			initializeBnplSiteMessaging();
+			initializeBnplSiteMessaging().then( () => {
+				setTimeout( () => {
+					$( '.pmme-loading' ).remove();
+					$( '#payment-method-message' ).show();
+					$( '#payment-method-message' ).addClass( 'pmme-updated' );
+				}, 1000 );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #8606

#### Changes proposed in this Pull Request

This affects only shortcode cart. When the cart totals update, the BNPL Payment Method Messaging Element is removed by the core update of that section. This requires that it is remounted after the updated HTML is inserted to that section. The skeleton component bridges the loading gap between that insert and the remount of the PMME.

For context and demo, see: https://github.com/Automattic/woocommerce-payments/issues/8144#issuecomment-2040688316

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable BNPL payment methods
* Add a product to the cart and visit the shortcode cart
* Verify that the PMME is present
* Update the cart quantity and verify that the skeleton element appears while the PMME is remounting

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
