### PR TITLE
Pre check save my info for certain countries

### DIFF
--- a/changelog/add-pre-check-save-my-info
+++ b/changelog/add-pre-check-save-my-info
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Pre check save my info for eligible contries

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -44,10 +44,10 @@ button.wcpay-stripelink-modal-trigger:hover {
 	border-color: transparent;
 }
 
-.wc-block-checkout__payment-method
-	.wc-block-components-radio-control__label
-	span {
-	width: 95%;
+.wc-block-checkout__payment-method {
+	.wc-block-components-radio-control__label {
+		span {
+			width: 95%;
 
 	&:has( .StripeElement ) {
 		display: grid;
@@ -72,6 +72,17 @@ button.wcpay-stripelink-modal-trigger:hover {
 			grid-row: 1 / span 2;
 			grid-column: 2;
 		}
+	}
+}
+
+#remember-me {
+	margin-top: 36px;
+
+	h2 {
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 21.6px;
+		letter-spacing: -0.01em;
 	}
 }
 

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -45,32 +45,32 @@ button.wcpay-stripelink-modal-trigger:hover {
 }
 
 .wc-block-checkout__payment-method {
-	.wc-block-components-radio-control__label {
-		span {
-			width: 95%;
+	.wc-block-components-radio-control__label span {
+		width: 95%;
 
-	&:has( .StripeElement ) {
-		display: grid;
-		grid-template-columns: 1fr auto;
-	}
+		&:has( .StripeElement ) {
+			display: grid;
+			grid-template-columns: 1fr auto;
+		}
 
-	img {
-		float: right;
-		border: 0;
-		padding: 0;
-		height: 24px;
-		max-height: 24px;
-	}
+		img {
+			float: right;
+			border: 0;
+			padding: 0;
+			height: 24px;
+			max-height: 24px;
+		}
 
-	.StripeElement {
-		width: 100%;
-		grid-column: 1 / span 2;
-		grid-row-start: 2;
-		pointer-events: none;
+		.StripeElement {
+			width: 100%;
+			grid-column: 1 / span 2;
+			grid-row-start: 2;
+			pointer-events: none;
 
-		+ img {
-			grid-row: 1 / span 2;
-			grid-column: 2;
+			+ img {
+				grid-row: 1 / span 2;
+				grid-column: 2;
+			}
 		}
 	}
 }

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -421,6 +421,12 @@ export const handleWooPayEmailInput = async (
 					openIframe( email );
 				} else if ( data.code !== 'rest_invalid_param' ) {
 					recordUserEvent( 'checkout_woopay_save_my_info_offered' );
+
+					if ( window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO ) {
+						recordUserEvent( 'checkout_save_my_info_click', {
+							status: 'checked',
+						} );
+					}
 				}
 			} )
 			.catch( ( err ) => {

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -23,21 +23,13 @@ const renderSaveUserSection = () => {
 	);
 
 	if ( blocksCheckout.length ) {
-		const checkoutPageSaveUserContainer = document.createElement(
-			'fieldset'
-		);
+		const checkoutPageSaveUserContainer = document.createElement( 'div' );
 		const paymentOptions = document.getElementsByClassName(
 			'wp-block-woocommerce-checkout-payment-block'
 		)?.[ 0 ];
-		const isPaymentOptionsNumbered = paymentOptions?.classList?.contains(
-			'wc-block-components-checkout-step--with-step-number'
-		);
 
 		checkoutPageSaveUserContainer.className =
-			'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block ' +
-			`wc-block-components-checkout-step wc-block-components-checkout-step${
-				isPaymentOptionsNumbered ? '--with-step-number' : ''
-			}`;
+			'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block ';
 		checkoutPageSaveUserContainer.id = 'remember-me';
 
 		if ( paymentOptions ) {

--- a/client/components/woopay/save-user/additional-information.js
+++ b/client/components/woopay/save-user/additional-information.js
@@ -7,8 +7,7 @@ const AdditionalInformation = () => {
 	return (
 		<div className="additional-information">
 			{ __(
-				'Next time you checkout here or on other WooPay enabled stores, you’ll receive ' +
-					'a code by text message to checkout quicker. We never share your full financial information with sellers.',
+				"Next time you buy here and on other Woo-powered stores, we'll send you a code to securely purchase with WooPay.",
 				'woocommerce-payments'
 			) }
 		</div>

--- a/client/components/woopay/save-user/agreement.js
+++ b/client/components/woopay/save-user/agreement.js
@@ -11,7 +11,7 @@ const Agreement = () => {
 		<div className="tos">
 			{ interpolateComponents( {
 				mixedString: __(
-					"By placing an order, you agree to WooPay's {{termsOfService/}} and {{privacyPolicy/}}, and to receive text messages at the mobile number provided.",
+					"By continuing, you agree to WooPay's {{termsOfService/}} and {{privacyPolicy/}}.",
 					'woocommerce-payments'
 				),
 				components: {

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -6,9 +6,6 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line import/no-unresolved
 import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
-import { Icon, info } from '@wordpress/icons';
-import interpolateComponents from '@automattic/interpolate-components';
-import LockIconG from 'gridicons/dist/lock';
 
 /**
  * Internal dependencies
@@ -20,7 +17,6 @@ import Agreement from './agreement';
 import Container from './container';
 import useWooPayUser from '../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../hooks/use-selected-payment-method';
-import WooPayIcon from 'assets/images/woopay.svg?asset';
 import { recordUserEvent } from 'tracks';
 import './style.scss';
 
@@ -31,12 +27,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const [ phoneNumber, setPhoneNumber ] = useState( '' );
 	const [ isPhoneValid, onPhoneValidationChange ] = useState( null );
 	const [ userDataSent, setUserDataSent ] = useState( false );
-	const [ isInfoFlyoutVisible, setIsInfoFlyoutVisible ] = useState( false );
-	const [ hasShownInfoFlyout, setHasShownInfoFlyout ] = useState( false );
 
-	const toggleTooltip = () => {
-		setIsInfoFlyoutVisible( ! isInfoFlyoutVisible );
-	};
 	const isRegisteredUser = useWooPayUser();
 	const { isWCPayChosen, isNewPaymentTokenChosen } = useSelectedPaymentMethod(
 		isBlocksCheckout
@@ -121,16 +112,6 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			recordUserEvent( 'checkout_woopay_save_my_info_mobile_enter' );
 		}
 	}, [ isPhoneValid ] );
-
-	useEffect( () => {
-		// Record Tracks event when user clicks on the info icon for the first time.
-		if ( isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
-			setHasShownInfoFlyout( true );
-			recordUserEvent( 'checkout_save_my_info_tooltip_click' );
-		} else if ( ! isInfoFlyoutVisible && ! hasShownInfoFlyout ) {
-			setHasShownInfoFlyout( false );
-		}
-	}, [ isInfoFlyoutVisible, hasShownInfoFlyout ] );
 
 	useEffect( () => {
 		const formSubmitButton = isBlocksCheckout
@@ -229,66 +210,12 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 								</svg>
 							) }
 							<span>
-								{ isBlocksCheckout
-									? __(
-											'Save my information for a faster and secure checkout',
-											'woocommerce-payments'
-									  )
-									: __(
-											'Save my information for a faster checkout',
-											'woocommerce-payments'
-									  ) }
+								{ __(
+									'Securely save my information for 1-click checkout',
+									'woocommerce-payments'
+								) }
 							</span>
 						</label>
-					</div>
-					<img
-						src={ WooPayIcon }
-						className="woopay-logo"
-						alt="WooPay"
-					/>
-					<button
-						className={ `info-button ${
-							isInfoFlyoutVisible ? 'flyout-visible' : ''
-						}` }
-						type="button"
-						onClick={ toggleTooltip }
-						onBlur={ toggleTooltip }
-					>
-						<Icon icon={ info } size={ 20 } className="info-icon" />
-					</button>
-					<div className="save-details-flyout">
-						<div>
-							<LockIconG size={ 16 } />
-						</div>
-						<span>
-							{ interpolateComponents( {
-								mixedString: __(
-									'We use {{woopayBold/}} to securely store your information in this WooCommerce store and others. ' +
-										"Next time at checkout, we'll send you a code by SMS to authenticate your purchase. {{learnMore/}}",
-									'woocommerce-payments'
-								),
-								components: {
-									woopayBold: <b>WooPay</b>,
-									learnMore: (
-										<a
-											target="_blank"
-											href="https://woocommerce.com/document/woopay-customer-documentation/"
-											rel="noopener noreferrer"
-											onClick={ () => {
-												recordUserEvent(
-													'checkout_save_my_info_tooltip_learn_more_click'
-												);
-											} }
-										>
-											{ __(
-												'Learn more',
-												'woocommerce-payments'
-											) }
-										</a>
-									),
-								},
-							} ) }
-						</span>
 					</div>
 				</div>
 				{ isSaveDetailsChecked && (

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -35,11 +35,15 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
 
-	if ( window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO ) {
-		recordUserEvent( 'checkout_save_my_info_click', {
-			status: 'checked',
-		} );
-	}
+	useEffect( () => {
+		if ( window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO ) {
+			recordUserEvent( 'checkout_save_my_info_click', {
+				status: 'checked',
+			} );
+		}
+		// We only want to run this once.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const getPhoneFieldValue = () => {
 		let phoneFieldValue = '';

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -35,16 +35,6 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
 
-	useEffect( () => {
-		if ( window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO ) {
-			recordUserEvent( 'checkout_save_my_info_click', {
-				status: 'checked',
-			} );
-		}
-		// We only want to run this once.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
-
 	const getPhoneFieldValue = () => {
 		let phoneFieldValue = '';
 		if ( isBlocksCheckout ) {

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -35,6 +35,12 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
 
+	if ( window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO ) {
+		recordUserEvent( 'checkout_save_my_info_click', {
+			status: 'checked',
+		} );
+	}
+
 	const getPhoneFieldValue = () => {
 		let phoneFieldValue = '';
 		if ( isBlocksCheckout ) {

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -25,7 +25,9 @@ import { recordUserEvent } from 'tracks';
 import './style.scss';
 
 const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
-	const [ isSaveDetailsChecked, setIsSaveDetailsChecked ] = useState( false );
+	const [ isSaveDetailsChecked, setIsSaveDetailsChecked ] = useState(
+		window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO || false
+	);
 	const [ phoneNumber, setPhoneNumber ] = useState( '' );
 	const [ isPhoneValid, onPhoneValidationChange ] = useState( null );
 	const [ userDataSent, setUserDataSent ] = useState( false );

--- a/client/components/woopay/save-user/container.js
+++ b/client/components/woopay/save-user/container.js
@@ -7,23 +7,9 @@ const Container = ( { children, isBlocksCheckout } ) => {
 	if ( ! isBlocksCheckout ) return children;
 	return (
 		<>
-			<legend className="screen-reader-text">
-				{ __( 'Remember me', 'woocommerce-payments' ) }
-			</legend>
-			<div className="wc-block-components-checkout-step__heading">
-				<h2
-					className="wc-block-components-title wc-block-components-checkout-step__title"
-					aria-hidden={ true }
-				>
-					{ __( 'Remember me', 'woocommerce-payments' ) }
-				</h2>
-			</div>
-			<div className="wc-block-components-checkout-step__container">
-				<div className="wc-block-components-checkout-step__content">
-					<div className="woopay-save-new-user-container">
-						{ children }
-					</div>
-				</div>
+			<div className="woopay-save-new-user-container">
+				<h2>{ __( 'Save my info' ) }</h2>
+				{ children }
 			</div>
 		</>
 	);

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -2,11 +2,6 @@
 @import '../../../stylesheets/abstracts/variables';
 
 .woopay-save-new-user-container {
-	.save-details {
-		padding: $gap-small;
-		border: 1px solid rgba( 109, 109, 109, 0.3 );
-	}
-
 	.save-details-header {
 		display: flex;
 		align-items: flex-start;
@@ -48,75 +43,6 @@
 				@include breakpoint( '>960px' ) {
 					margin-right: 1.25rem;
 				}
-			}
-		}
-
-		.woopay-logo {
-			height: 1.0625rem;
-			margin-top: 0.375rem;
-		}
-
-		.info-button {
-			border: none;
-			background: transparent;
-			padding: 0;
-
-			&:focus {
-				outline: none;
-			}
-
-			&:focus + .save-details-flyout {
-				display: none;
-			}
-		}
-
-		.info-button.flyout-visible:focus + .save-details-flyout {
-			display: flex;
-		}
-
-		.info-icon {
-			fill: $gray-600;
-			margin-top: 0.1875rem;
-			object-fit: none;
-
-			&:hover,
-			&:focus {
-				fill: #3d9cd2;
-			}
-		}
-
-		.save-details-flyout {
-			display: none;
-			flex-direction: row;
-			gap: $gap-smaller;
-			background-color: #fff;
-			border: 1px solid rgba( 109, 109, 109, 0.3 );
-			border-radius: 3px;
-			padding: $gap-small;
-			position: absolute;
-			width: 16.875rem;
-			font-size: 0.8125rem;
-			line-height: 1.25rem;
-			top: -7.75rem;
-			left: calc( 100% - 8.4375rem );
-
-			&:hover {
-				display: flex;
-			}
-
-			span {
-				color: $gray-900;
-			}
-
-			svg {
-				fill: currentColor;
-				color: $alert-green;
-			}
-
-			@include breakpoint( '<800px' ) {
-				left: initial;
-				right: 0;
-				top: -8.125rem;
 			}
 		}
 	}

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -1,6 +1,12 @@
 @import '../../../stylesheets/abstracts/colors';
 @import '../../../stylesheets/abstracts/variables';
 
+.woocommerce-checkout-payment {
+	.woopay-save-new-user-container {
+		padding: 1.41575em;
+	}
+}
+
 .woopay-save-new-user-container {
 	.save-details-header {
 		display: flex;

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -99,12 +99,12 @@ describe( 'CheckoutPageSaveUser', () => {
 		render( <CheckoutPageSaveUser /> );
 		expect(
 			screen.queryByLabelText(
-				'Save my information for a faster checkout'
+				'Securely save my information for 1-click checkout'
 			)
 		).toBeInTheDocument();
 		expect(
 			screen.queryByLabelText(
-				'Save my information for a faster checkout'
+				'Securely save my information for 1-click checkout'
 			)
 		).not.toBeChecked();
 	} );
@@ -115,7 +115,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		render( <CheckoutPageSaveUser /> );
 		expect(
 			screen.queryByLabelText(
-				'Save my information for a faster checkout'
+				'Securely save my information for 1-click checkout'
 			)
 		).not.toBeInTheDocument();
 	} );
@@ -126,7 +126,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		render( <CheckoutPageSaveUser /> );
 		expect(
 			screen.queryByLabelText(
-				'Save my information for a faster checkout'
+				'Securely save my information for 1-click checkout'
 			)
 		).not.toBeInTheDocument();
 	} );
@@ -139,7 +139,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		render( <CheckoutPageSaveUser /> );
 		expect(
 			screen.queryByLabelText(
-				'Save my information for a faster checkout'
+				'Securely save my information for 1-click checkout'
 			)
 		).not.toBeInTheDocument();
 	} );
@@ -148,7 +148,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		render( <CheckoutPageSaveUser /> );
 
 		const label = screen.getByLabelText(
-			'Save my information for a faster checkout'
+			'Securely save my information for 1-click checkout'
 		);
 
 		expect( label ).not.toBeChecked();
@@ -169,7 +169,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		} );
 
 		const label = screen.getByLabelText(
-			'Save my information for a faster and secure checkout'
+			'Securely save my information for 1-click checkout'
 		);
 
 		expect( label ).not.toBeChecked();
@@ -194,7 +194,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		// click on the checkbox
 		userEvent.click(
 			screen.queryByLabelText(
-				'Save my information for a faster checkout'
+				'Securely save my information for 1-click checkout'
 			)
 		);
 
@@ -207,7 +207,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		} );
 
 		const label = screen.getByLabelText(
-			'Save my information for a faster and secure checkout'
+			'Securely save my information for 1-click checkout'
 		);
 
 		expect( label ).not.toBeChecked();
@@ -250,7 +250,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		} );
 
 		const saveMyInfoCheckbox = screen.getByLabelText(
-			'Save my information for a faster and secure checkout'
+			'Securely save my information for 1-click checkout'
 		);
 		// initial state
 		expect( saveMyInfoCheckbox ).not.toBeChecked();
@@ -303,7 +303,7 @@ describe( 'CheckoutPageSaveUser', () => {
 		} );
 
 		const label = screen.getByLabelText(
-			'Save my information for a faster and secure checkout'
+			'Securely save my information for 1-click checkout'
 		);
 
 		expect( label ).not.toBeChecked();

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -156,6 +156,7 @@ const PhoneNumberInput = ( {
 				ref={ inputRef }
 				value={ removeInternationalPrefix( value ) }
 				onChange={ handlePhoneNumberInputChange }
+				placeholder={ __( 'Mobile number', 'woocommerce-payments' ) }
 				aria-label={
 					inputProps.ariaLabel ||
 					__( 'Mobile phone number', 'woocommerce-payments' )

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -65,11 +65,19 @@
 		}
 
 		.additional-information {
-			font-size: 0.875rem;
+			font-size: 14px;
+			font-weight: 400;
+			line-height: 21px;
+			text-align: left;
+			color: #000;
 		}
 
 		.tos {
-			font-size: 0.8125rem;
+			font-size: 12px;
+			color: #6d6d6d;
+			:link {
+				color: #6d6d6d;
+			}
 		}
 
 		.error-text {
@@ -95,6 +103,11 @@
 			border-radius: 5px;
 			margin-left: 0.125rem;
 			width: calc( 100% - 0.25rem );
+
+			&::placeholder {
+				font-weight: 400;
+				color: #a7aaad;
+			}
 
 			&.has-error {
 				outline-color: $alert-red;
@@ -144,6 +157,7 @@
 
 .iti__selected-flag {
 	background-color: inherit !important;
+	padding: 0 6px 0 12px;
 
 	.iti__flag {
 		transform: scale( 1.1 );

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -42,7 +42,7 @@ class WooPay_Save_User {
 			return;
 		}
 
-		if ( ! $this->woopay_util->is_country_available( $gateways['woocommerce_payments'] ) ) {
+		if ( ! $this->woopay_util->is_country_available() ) {
 			return;
 		}
 

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -57,6 +57,16 @@ class WooPay_Save_User {
 		);
 		WC_Payments::register_script_with_dependencies( 'WCPAY_WOOPAY', 'dist/woopay' );
 
+		$account_data = WC_Payments::get_account_service()->get_cached_account_data();
+
+		wp_localize_script(
+			'WCPAY_WOOPAY',
+			'woopayCheckout',
+			[
+				'PRE_CHECK_SAVE_MY_INFO' => $account_data['pre_check_save_my_info']
+			]
+		);
+
 		wp_enqueue_script( 'WCPAY_WOOPAY' );
 	}
 


### PR DESCRIPTION
⚠️ https://github.com/Automattic/woopay/pull/2617 needs to be merged and deployed before this PR gets merged

#### Changes proposed in this Pull Request

This PR adds a pre check to the Save my info checkbox for certain countries.

#### Testing instructions

- Checkout to this branch
- Checkout to https://github.com/Automattic/woocommerce-payments-server/pull/5100
- Add the following code to [this function](https://github.com/Automattic/woocommerce-payments-server/blob/93ae9d85e525255b790ef065f5260b2b89b8d728/woocommerce-payments-server.php#L26). You might need to tweak the country
```
add_filter( 'get_automattic_meta', function () {
	return [ 'US' ];
});
```

- As a merchant go to /wp-admin > WC Pay Dev Tools
- Click Clear Account cache contents
- Make sure `pre_check_save_my_info` is set to `true` in the contents
- As a shopper add a product to your cart
- Go to the checkout page
- Make sure the `save my info checkbox` is pre checked
- Make sure the design matches the one in figma 2JyXNimI4oGeJZhgQNZE9V-fi-1143%3A9115
<img width="705" alt="Screenshot 2024-04-09 at 4 35 36 PM" src="https://github.com/Automattic/woocommerce-payments/assets/6342964/2822a7e1-1e39-4782-acf5-2c66f54f009c">
<img width="567" alt="Screenshot 2024-04-09 at 4 36 05 PM" src="https://github.com/Automattic/woocommerce-payments/assets/6342964/d9e50f8a-0a03-4c40-b2ec-9c54a8920e76">

- Open the console on your browser
- Add a breakpoint to [this line](https://github.com/Automattic/woocommerce-payments/blob/a6a9915f695b8d91b91a247bced7342db7262ded/client/checkout/woopay/email-input-iframe.js#L417-L419)
- Type an email that is not associated with a WooPay account into the email input
- Make sure the code execution stopped at the breakpoint
- Add a breakpoint to [this line](https://github.com/Automattic/woocommerce-payments/blob/a6a9915f695b8d91b91a247bced7342db7262ded/client/components/woopay/save-user/checkout-page-save-user.js#L104-L106)
- Click the save my info checkbox
- Make sure the code execution stopped at the breakpoint
- Click again
- Make sure the code execution stopped at the breakpoint
- Remove the country from the filter you created in the first steps
- Clear Account cache content again
- Reload the checkout page
- Make sure the save my info is not checked this time

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.