### PR TITLE
Ensure “Proceed to Checkout” Button’s Loading Spinner Doesn’t Affect Button Spacing

### DIFF
--- a/changelog/fix-woopay-direct-checkout-button-loading-spinner-spacing
+++ b/changelog/fix-woopay-direct-checkout-button-loading-spinner-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure "Proceed to checkout" button's loading spinner doesn't affect button spacing when Direct Checkout is enabled.

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -250,6 +250,10 @@ class WooPayDirectCheckout {
 			spinner.style.position = 'relative';
 			spinner.style.fontSize = 'unset';
 			spinner.style.display = 'inline';
+			spinner.style.lineHeight = '0';
+			spinner.style.margin = '0';
+			spinner.style.border = '0';
+			spinner.style.padding = '0';
 			// Remove the existing content of the button.
 			// Set innerHTML to '&nbsp;' to keep the button's height.
 			element.innerHTML = '&nbsp;';

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -249,6 +249,7 @@ class WooPayDirectCheckout {
 			spinner.classList.add( 'wc-block-components-spinner' );
 			spinner.style.position = 'relative';
 			spinner.style.fontSize = 'unset';
+			spinner.style.display = 'inline';
 			// Remove the existing content of the button.
 			// Set innerHTML to '&nbsp;' to keep the button's height.
 			element.innerHTML = '&nbsp;';


### PR DESCRIPTION
### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that the `Proceed to checkout` button's loading spinner doesn't readjust the button's spacing when it appears. Previously, if there existed a CSS rule that changed the loading spinner element's `display` style, it would also apply to the loading spinner (which uses a `span`).

For additional context, see the following:
* p1712607263952319/1712602217.782779-slack-C022WMN88KG.

### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test: Ensure the issue is reproducible**
* Ensure you are using the `develop` branch.
* Ensure the WooPay Direct Checkout flow is enabled for the merchant site.
* Add the following CSS rule to [client/checkout/woopay/style.scss](https://github.com/Automattic/woocommerce-payments/blob/193d40998e298e22127c5d7958763ba62c613091/client/checkout/woopay/style.scss):
```css
.button span {
  display: inline-block;
}
```
* As a shopper, navigate to the merchant shop, add an item to your cart, and navigate to the cart.
* Click the `Proceed to checkout` button and observe how the button's spacing is affected (see image below).

![image](https://github.com/Automattic/woocommerce-payments/assets/6844516/79a3c369-14d2-420a-9f2f-05cf6e583928)

**Test: Ensure that the loading spinner doesn't impact the `Proceed to checkout` button's spacing**
* Ensure you are using the `fix/woopay-button-loading-spinner-spacing` branch.
* Ensure the WooPay Direct Checkout flow is enabled for the merchant site.
* Add the following CSS rule to [client/checkout/woopay/style.scss](https://github.com/Automattic/woocommerce-payments/blob/193d40998e298e22127c5d7958763ba62c613091/client/checkout/woopay/style.scss):
```css
.button span {
  display: inline-block;
}
```
* As a shopper, navigate to the merchant shop, add an item to your cart, and navigate to the cart.
* Click the `Proceed to checkout` button.
* Ensure that the loading spinner does not affect the button's spacing.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.