### PR TITLE
Revert account rejected check before registering WooPay order webhook

### DIFF
--- a/changelog/fix-dont-register-woopay-order-webhook-if-account-rejected
+++ b/changelog/fix-dont-register-woopay-order-webhook-if-account-rejected
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Don't register WooPay Order Webhook if account is rejected.

--- a/includes/woopay/class-woopay-order-status-sync.php
+++ b/includes/woopay/class-woopay-order-status-sync.php
@@ -73,7 +73,7 @@ class WooPay_Order_Status_Sync {
 			return;
 		}
 
-		if ( ! $this->account->is_stripe_connected() || $this->account->is_account_under_review() ) {
+		if ( ! $this->account->is_stripe_connected() || $this->account->is_account_under_review() || $this->account->is_account_rejected() ) {
 			return;
 		}
 

--- a/tests/unit/woopay/test-class-woopay-order-status-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-status-sync.php
@@ -97,6 +97,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 
 		$this->account_mock->method( 'is_stripe_connected' )->willReturn( true );
 		$this->account_mock->method( 'is_account_under_review' )->willReturn( false );
+		$this->account_mock->method( 'is_account_rejected' )->willReturn( false );
 
 		// Create the WebHook with WooPay specific delivery URL.
 		$this->webhook_sync_mock->maybe_create_woopay_order_webhook();
@@ -143,6 +144,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_user->ID );
 		$this->account_mock->method( 'is_stripe_connected' )->willReturn( true );
 		$this->account_mock->method( 'is_account_under_review' )->willReturn( false );
+		$this->account_mock->method( 'is_account_rejected' )->willReturn( false );
 
 		$this->assertEmpty( WooPay_Order_Status_Sync::get_webhook() );
 
@@ -158,6 +160,23 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_user->ID );
 		$this->account_mock->method( 'is_stripe_connected' )->willReturn( true );
 		$this->account_mock->method( 'is_account_under_review' )->willReturn( true );
+		$this->account_mock->method( 'is_account_rejected' )->willReturn( false );
+
+		$this->assertEmpty( WooPay_Order_Status_Sync::get_webhook() );
+
+		$this->webhook_sync_mock->maybe_create_woopay_order_webhook();
+
+		$this->assertEmpty( WooPay_Order_Status_Sync::get_webhook() );
+	}
+
+	/**
+	 * Tests that the webhook is not created for rejected WCPay accounts.
+	 */
+	public function test_webhook_is_not_created_for_rejected() {
+		wp_set_current_user( self::$admin_user->ID );
+		$this->account_mock->method( 'is_stripe_connected' )->willReturn( true );
+		$this->account_mock->method( 'is_account_under_review' )->willReturn( false );
+		$this->account_mock->method( 'is_account_rejected' )->willReturn( true );
 
 		$this->assertEmpty( WooPay_Order_Status_Sync::get_webhook() );
 
@@ -173,6 +192,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_user->ID );
 		$this->account_mock->method( 'is_stripe_connected' )->willReturn( true );
 		$this->account_mock->method( 'is_account_under_review' )->willReturn( false );
+		$this->account_mock->method( 'is_account_rejected' )->willReturn( false );
 
 		$this->webhook_sync_mock->maybe_create_woopay_order_webhook();
 		$this->assertNotEmpty( WooPay_Order_Status_Sync::get_webhook() );


### PR DESCRIPTION
Context: 4868-gh-Automattic/woocommerce-payments-server#issuecomment-2048197126

#### Changes proposed in this Pull Request

- Revert the `rejected` status check since the account can still show that status if rejected by Stripe.

#### Testing instructions

**Test that the webhook gets registered for rejected accounts**

1. Ensure you're in `develop`
2. Ensure WooPay is enabled and working.
3. Change [this line](https://github.com/Automattic/woocommerce-payments-server/blob/b7eb5a06b51bd5ed9277876262d76fcf24de14e5/server/wp-content/rest-api-plugins/endpoints/wcpay/class-accounts-controller.php#L886) so that the `status` returns `rejected.terms_of_service` to simulate that the account was rejected by Stripe.
4. From the merchant store dev tools plugin, clear the account cache.
5. Ensure the `status` prop is `rejected.terms_of_service`.
6. From the merchant store, navigate to **wp-admin > WooCommerce > Settings > Advanced > Webhooks**.
7. Ensure you have one active `WCPay woopay order status sync` webhook.
8. Delete the active webhook and refresh the page.
9. Ensure you see a request to `/accounts/platform_checkout` endpoint from WooPayments server's `logstash.log` file.
10. Refresh the Webhooks page and ensure you see a repeated request in WooPayments server's `logstash.log`.

**Test that the webhook doesn't get registered for rejected accounts**

1. Checkout to this branch.
2. Delete any active `WCPay woopay order status sync` webhooks and refresh the WooCommerce Webhooks page.
4. Ensure there are no new request logs in the WCPay server's `logstash.log`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
