### PR TITLE
Fixes "Invalid recurring shipping method" errors when purchasing multiple subscriptions with Apple / Google Pay

### DIFF
--- a/changelog/fix-8029-prb-invalid-recurring-shipping-method
+++ b/changelog/fix-8029-prb-invalid-recurring-shipping-method
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Resolve i"Invalid recurring shipping method" error when purchasing multiple subscriptions with Apple Pay and Google Pay.
+Resolves "Invalid recurring shipping method" errors when purchasing multiple subscriptions with Apple Pay and Google Pay.

--- a/changelog/fix-8029-prb-invalid-recurring-shipping-method
+++ b/changelog/fix-8029-prb-invalid-recurring-shipping-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Resolve i"Invalid recurring shipping method" error when purchasing multiple subscriptions with Apple Pay and Google Pay.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -943,6 +943,8 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 			WC()->cart->calculate_totals();
 
+			$this->maybe_restore_recurring_chosen_shipping_methods( $chosen_shipping_methods );
+
 			$data          += $this->express_checkout_helper->build_display_items( $itemized_display_items );
 			$data['result'] = 'success';
 		} catch ( Exception $e ) {
@@ -1506,5 +1508,43 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		// Normally there should be a single tax, but `calc_tax` returns an array, let's use it.
 		return WC_Tax::calc_tax( $price, $rates, false );
+	}
+
+	/**
+	 * Restores the shipping methods previously chosen for each recurring cart after shipping was reset and recalculated
+	 * during the Payment Request get_shipping_options flow.
+	 *
+	 * When the cart contains multiple subscriptions with different billing periods, customers are able to select different shipping
+	 * methods for each subscription, however, this is not supported when purchasing with Apple Pay and Google Pay as it's
+	 * only concerned about handling the initial purchase.
+	 *
+	 * In order to avoid Woo Subscriptions's `WC_Subscriptions_Cart::validate_recurring_shipping_methods` throwing an error, we need to restore
+	 * the previously chosen shipping methods for each recurring cart.
+	 *
+	 * This function needs to be called after `WC()->cart->calculate_totals()` is run, otherwise `WC()->cart->recurring_carts` won't exist yet.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $previous_chosen_methods The previously chosen shipping methods.
+	 */
+	private function maybe_restore_recurring_chosen_shipping_methods( $previous_chosen_methods ) {
+		if ( empty( WC()->cart->recurring_carts ) || ! method_exists( 'WC_Subscriptions_Cart', 'get_recurring_shipping_package_key' ) ) {
+			return;
+		}
+
+		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+
+		foreach ( WC()->cart->recurring_carts as $recurring_cart_key => $recurring_cart ) {
+			foreach ( $recurring_cart->get_shipping_packages() as $recurring_cart_package_index => $recurring_cart_package ) {
+				$package_key = WC_Subscriptions_Cart::get_recurring_shipping_package_key( $recurring_cart_key, $recurring_cart_package_index );
+
+				// If the recurring cart package key is found in the previous chosen methods, but not in the current chosen methods, restore it.
+				if ( isset( $previous_chosen_methods[ $package_key ] ) && ! isset( $chosen_shipping_methods[ $package_key ] ) ) {
+					$chosen_shipping_methods[ $package_key ] = $previous_chosen_methods[ $package_key ];
+				}
+			}
+		}
+
+		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
 	}
 }

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -893,7 +893,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			$data = [];
 
 			// Remember current shipping method before resetting.
-			$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+			$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods', [] );
 			$this->calculate_shipping( apply_filters( 'wcpay_payment_request_shipping_posted_values', $shipping_address ) );
 
 			$packages = WC()->shipping->get_packages();
@@ -1523,16 +1523,14 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 *
 	 * This function needs to be called after `WC()->cart->calculate_totals()` is run, otherwise `WC()->cart->recurring_carts` won't exist yet.
 	 *
-	 * @since 8.3.0
-	 *
 	 * @param array $previous_chosen_methods The previously chosen shipping methods.
 	 */
-	private function maybe_restore_recurring_chosen_shipping_methods( $previous_chosen_methods ) {
+	private function maybe_restore_recurring_chosen_shipping_methods( $previous_chosen_methods = [] ) {
 		if ( empty( WC()->cart->recurring_carts ) || ! method_exists( 'WC_Subscriptions_Cart', 'get_recurring_shipping_package_key' ) ) {
 			return;
 		}
 
-		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods', [] );
 
 		foreach ( WC()->cart->recurring_carts as $recurring_cart_key => $recurring_cart ) {
 			foreach ( $recurring_cart->get_shipping_packages() as $recurring_cart_package_index => $recurring_cart_package ) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -25,11 +25,9 @@
     </UndefinedClass>
   </file>
   <file src="includes/class-wc-payments-payment-request-button-handler.php">
-    <UndefinedClass occurrences="4">
+    <UndefinedClass occurrences="5">
       <code>WC_Pre_Orders_Product</code>
       <code>WC_Subscriptions_Product</code>
-      <code>WC_Subscriptions_Product</code>
-      <code>WC_Subscriptions_Cart</code>
       <code>WC_Subscriptions_Cart</code>
     </UndefinedClass>
   </file>


### PR DESCRIPTION
Fixes #8029

Relevant slack thread: p1712735606268559-slack-C7U3Y3VMY
Supersedes #8602


#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When attempting to purchase multiple subscriptions of varying periods with Apple/Google Pay, you will get an "Invalid recurring shipping method." error:

![image](https://github.com/Automattic/woocommerce-payments/assets/2275145/5e474977-08da-4c86-b070-cc0c27023430)

This issue is caused by our `get_shipping_options()` function wiping the chosen shipping methods when it recalculates shipping packages and available shipping methods, and then when Woo Subscriptions validates the checkout data on `process_checkout`, it throws an error because the recurring shipping methods are no longer set.

This PR fixes these issues by restoring any chosen shipping methods that were wiped which belong to a recurring cart.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install and activate the Woo Subscriptions extension
2. Enable Apple Pay and Google Pay
3. Create two subscription products, one that renews monthly and another that renews weekly
4. Add both of these products to your cart, and then visit the checkout page
5. Choose to pay for these subscriptions with Google Pay.
6. While on `develop` when you click on the Pay button, you will be hit with a checkout error:
![image](https://github.com/Automattic/woocommerce-payments/assets/2275145/01cbace0-8083-4b65-97eb-e35ba4d68a89)
7. While on this branch, the payment will process and you will have 2 new subscriptions with the correct shipping methods.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
