### PR TITLE
Track Account Management events

### DIFF
--- a/changelog/dev-track-account-management-links
+++ b/changelog/dev-track-account-management-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Adding a tracking event for external redirects to update account details, more consistent behaviour for redirects.

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -25,6 +25,7 @@ import './style.scss';
 import './shared.scss';
 import { AccountTools } from './account-tools';
 import { isInDevMode } from 'wcpay/utils';
+import { recordEvent } from 'wcpay/tracks';
 
 const AccountStatusCard = ( props ) => {
 	const { title, children, value } = props;
@@ -59,6 +60,7 @@ const AccountStatusError = () => {
 
 const AccountStatusDetails = ( props ) => {
 	const { accountStatus, accountFees } = props;
+
 	const cardTitle = (
 		<>
 			<FlexItem className={ 'account-details' }>
@@ -74,7 +76,16 @@ const AccountStatusDetails = ( props ) => {
 				/>
 			</FlexBlock>
 			<FlexItem className={ 'edit-details' }>
-				<Button isLink href={ accountStatus.accountLink }>
+				<Button
+					variant={ 'link' }
+					onClick={ () =>
+						recordEvent( 'wcpay_account_details_link_clicked', {
+							source: 'account-details',
+						} )
+					}
+					href={ accountStatus.accountLink }
+					target={ '_blank' }
+				>
 					{ __( 'Edit details', 'woocommerce-payments' ) }
 				</Button>
 			</FlexItem>

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -12,6 +12,7 @@ import { ExternalLink } from '@wordpress/components';
  * Internal dependencies
  */
 import InlineNotice from 'components/inline-notice';
+import { recordEvent } from 'wcpay/tracks';
 
 /**
  * Renders a notice informing the user that their deposits are suspended.
@@ -234,7 +235,16 @@ export const DepositFailureNotice: React.FC< {
 				'woocommerce-payments'
 			),
 			components: {
-				updateLink: <ExternalLink href={ updateAccountLink } />,
+				updateLink: (
+					<ExternalLink
+						onClick={ () =>
+							recordEvent( 'wcpay_account_details_link_clicked', {
+								source: 'deposit-notices',
+							} )
+						}
+						href={ updateAccountLink }
+					/>
+				),
 			},
 		} ) }
 	</InlineNotice>

--- a/client/deposits/index.tsx
+++ b/client/deposits/index.tsx
@@ -20,6 +20,7 @@ import { useAllDepositsOverviews } from 'data';
 import { useSettings } from 'wcpay/data';
 import DepositsList from './list';
 import { hasAutomaticScheduledDeposits } from 'wcpay/deposits/utils';
+import { recordEvent } from 'wcpay/tracks';
 
 const useNextDepositNoticeState = () => {
 	const { updateOptions } = useDispatch( 'wc/admin/options' );
@@ -99,6 +100,7 @@ const NextDepositNotice: React.FC = () => {
 
 const DepositFailureNotice: React.FC = () => {
 	const { hasErroredExternalAccount } = useAccountStatus();
+	const accountLink = wcpaySettings.accountStatus.accountLink;
 
 	return hasErroredExternalAccount ? (
 		<BannerNotice
@@ -115,7 +117,13 @@ const DepositFailureNotice: React.FC = () => {
 				components: {
 					updateLink: (
 						<ExternalLink
-							href={ wcpaySettings.accountStatus.accountLink }
+							onClick={ () =>
+								recordEvent(
+									'wcpay_account_details_link_clicked',
+									{ source: 'deposits' }
+								)
+							}
+							href={ accountLink }
 						/>
 					),
 				},

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -12,6 +12,7 @@ import moment from 'moment';
  */
 import strings from './strings';
 import './index.scss';
+import { recordEvent } from 'wcpay/tracks';
 
 interface Props {
 	errorMessages: Array< string >;
@@ -33,6 +34,9 @@ const UpdateBusinessDetailsModal = ( {
 	};
 
 	const openAccountLink = () => {
+		recordEvent( 'wcpay_account_details_link_clicked', {
+			source: 'update-business-details',
+		} );
 		window.open( accountLink, '_blank' );
 	};
 
@@ -76,11 +80,11 @@ const UpdateBusinessDetailsModal = ( {
 					</div>
 					<hr />
 					<div className="wcpay-update-business-details-modal__footer">
-						<Button isSecondary onClick={ closeModal }>
+						<Button type={ 'secondary' } onClick={ closeModal }>
 							{ strings.cancel }
 						</Button>
 
-						<Button isPrimary onClick={ openAccountLink }>
+						<Button type={ 'primary' } onClick={ openAccountLink }>
 							{ strings.updateBusinessDetails }
 						</Button>
 					</div>

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -80,11 +80,14 @@ const UpdateBusinessDetailsModal = ( {
 					</div>
 					<hr />
 					<div className="wcpay-update-business-details-modal__footer">
-						<Button type={ 'secondary' } onClick={ closeModal }>
+						<Button variant={ 'secondary' } onClick={ closeModal }>
 							{ strings.cancel }
 						</Button>
 
-						<Button type={ 'primary' } onClick={ openAccountLink }>
+						<Button
+							variant={ 'primary' }
+							onClick={ openAccountLink }
+						>
 							{ strings.updateBusinessDetails }
 						</Button>
 					</div>

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -83,14 +83,14 @@ exports[`Overview: update business details modal renders correctly when opened f
       class="wcpay-update-business-details-modal__footer"
     >
       <button
-        class="components-button"
-        type="secondary"
+        class="components-button is-secondary"
+        type="button"
       >
         Cancel
       </button>
       <button
-        class="components-button"
-        type="primary"
+        class="components-button is-primary"
+        type="button"
       >
         Update business details
       </button>
@@ -182,14 +182,14 @@ exports[`Overview: update business details modal renders correctly when opened f
       class="wcpay-update-business-details-modal__footer"
     >
       <button
-        class="components-button"
-        type="secondary"
+        class="components-button is-secondary"
+        type="button"
       >
         Cancel
       </button>
       <button
-        class="components-button"
-        type="primary"
+        class="components-button is-primary"
+        type="button"
       >
         Update business details
       </button>
@@ -281,14 +281,14 @@ exports[`Overview: update business details modal renders correctly when opened f
       class="wcpay-update-business-details-modal__footer"
     >
       <button
-        class="components-button"
-        type="secondary"
+        class="components-button is-secondary"
+        type="button"
       >
         Cancel
       </button>
       <button
-        class="components-button"
-        type="primary"
+        class="components-button is-primary"
+        type="button"
       >
         Update business details
       </button>

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -83,14 +83,14 @@ exports[`Overview: update business details modal renders correctly when opened f
       class="wcpay-update-business-details-modal__footer"
     >
       <button
-        class="components-button is-secondary"
-        type="button"
+        class="components-button"
+        type="secondary"
       >
         Cancel
       </button>
       <button
-        class="components-button is-primary"
-        type="button"
+        class="components-button"
+        type="primary"
       >
         Update business details
       </button>
@@ -182,14 +182,14 @@ exports[`Overview: update business details modal renders correctly when opened f
       class="wcpay-update-business-details-modal__footer"
     >
       <button
-        class="components-button is-secondary"
-        type="button"
+        class="components-button"
+        type="secondary"
       >
         Cancel
       </button>
       <button
-        class="components-button is-primary"
-        type="button"
+        class="components-button"
+        type="primary"
       >
         Update business details
       </button>
@@ -281,14 +281,14 @@ exports[`Overview: update business details modal renders correctly when opened f
       class="wcpay-update-business-details-modal__footer"
     >
       <button
-        class="components-button is-secondary"
-        type="button"
+        class="components-button"
+        type="secondary"
       >
         Cancel
       </button>
       <button
-        class="components-button is-primary"
-        type="button"
+        class="components-button"
+        type="primary"
       >
         Update business details
       </button>

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -12,6 +12,7 @@ import type { TaskItemProps } from '../types';
 import UpdateBusinessDetailsModal from 'wcpay/overview/modal/update-business-details';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
+import { recordEvent } from 'wcpay/tracks';
 
 export const getUpdateBusinessDetailsTask = (
 	errorMessages: string[],
@@ -105,6 +106,9 @@ export const getUpdateBusinessDetailsTask = (
 		if ( hasMultipleErrors ) {
 			renderModal();
 		} else {
+			recordEvent( 'wcpay_account_details_link_clicked', {
+				source: 'update-business-details',
+			} );
 			window.open( accountLink, '_blank' );
 		}
 	};

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -226,11 +226,15 @@ const Deposits = () => {
 						) }{ ' ' }
 						<ExternalLink
 							href={ accountLink }
-							onClick={ () =>
+							onClick={ () => {
 								recordEvent(
 									'wcpay_settings_deposits_manage_in_stripe_click'
-								)
-							}
+								);
+								recordEvent(
+									'wcpay_account_details_link_clicked',
+									{ source: 'settings-deposits' }
+								);
+							} }
 						>
 							{ __( 'Manage in Stripe', 'woocommerce-payments' ) }
 						</ExternalLink>

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -10,6 +10,7 @@ export type Event =
 	| 'applepay_button_load'
 	| 'page_view'
 	| 'wcpay_connect_account_clicked'
+	| 'wcpay_account_details_link_clicked'
 	| 'wcpay_welcome_learn_more'
 	| 'wcpay_stripe_connected'
 	| 'wcpay_connect_account_kyc_modal_opened'


### PR DESCRIPTION
Fixes #8582 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

* Track the "Account Management" link clicks
* More conistent behaviour of external link click on account management (previously we opened in a new tab in most places, but not all, now it happens in all cases). I think this is a better experience because in some cases there is no "return" button when the user is taken to the Stripe Express dashboard.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use [Tracks Vigilante 2 ](https://github.com/Automattic/tracks-vigilante-2-chrome-extension) to be able to see local tracking events getting fired. Open a new Tracks Vigilante window to monitor events on your store.
* Run `npm run watch` to build the JS.
* Make sure you have opted in to tracking on your local store (you can check `Settings > Advanced > Woo.com`)
* Go to the `Payments > Overview` page, and click the `Edit details` link on the Account Status card. 
* Verify that the `wcadmin_wcpay_account_details_link_clicked` event is fired.
* Look at the other instances in the code, and ensure that they make sense and are firing the correct event, and the `source` values look appropriate.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
