### PR TITLE
Revert "Ensure Currency Configurations Are Set Correctly When Multi-Currency Is Enabled (#8617)"

### DIFF
--- a/changelog/fix-8559-multi-currency-decimal-separator-not-applying
+++ b/changelog/fix-8559-multi-currency-decimal-separator-not-applying
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Ensure that the currency configurations are set correctly when multi-currency is enabled.

--- a/changelog/revert-8559-multi-currency-decimal-separator-not-applying
+++ b/changelog/revert-8559-multi-currency-decimal-separator-not-applying
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "Ensure Currency Configurations Are Set Correctly When Multi-Currency Is Enabled (#8617)"

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -111,12 +111,18 @@ class FrontendCurrencies {
 			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 900 );
 			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 900 );
-			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );
 			add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 900 );
 			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 900 );
 			add_action( 'before_woocommerce_pay', [ $this, 'init_order_currency_from_query_vars' ] );
 			add_action( 'woocommerce_order_get_total', [ $this, 'maybe_init_order_currency_from_order_total_prop' ], 900, 2 );
 			add_action( 'woocommerce_get_formatted_order_total', [ $this, 'maybe_clear_order_currency_after_formatted_order_total' ], 900, 4 );
+
+			// Note: it's important that 'init_order_currency_from_query_vars' is called before
+			// 'get_price_decimal_separator' because the order currency is often required to
+			// determine the decimal separator. That's why the priority on 'init_order_currency_from_query_vars'
+			// is explicity lower than the priority of 'get_price_decimal_separator'.
+			add_filter( 'wc_get_price_decimal_separator', [ $this, 'init_order_currency_from_query_vars' ], 900 );
+			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 901 );
 		}
 
 		add_filter( 'woocommerce_thankyou_order_id', [ $this, 'init_order_currency' ] );
@@ -270,7 +276,17 @@ class FrontendCurrencies {
 			return $arg;
 		}
 
+		// We remove the filters here becuase 'wc_get_order' triggers the 'wc_get_price_decimal_separator' filter.
+		remove_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 901 );
+		remove_filter( 'wc_get_price_decimal_separator', [ $this, 'init_order_currency_from_query_vars' ], 900 );
 		$order = ! $arg instanceof WC_Order ? wc_get_order( $arg ) : $arg;
+		// Note: it's important that 'init_order_currency_from_query_vars' is called before
+		// 'get_price_decimal_separator' because the order currency is often required to
+		// determine the decimal separator. That's why the priority on 'init_order_currency_from_query_vars'
+		// is explicity lower than the priority of 'get_price_decimal_separator'.
+		add_filter( 'wc_get_price_decimal_separator', [ $this, 'init_order_currency_from_query_vars' ], 900 );
+		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 901 );
+
 		if ( $order ) {
 			$this->order_currency = $order->get_currency();
 			return $order->get_id();
@@ -366,8 +382,6 @@ class FrontendCurrencies {
 	 */
 	private function get_currency_code() {
 		if ( $this->should_use_order_currency() ) {
-			$this->init_order_currency_from_query_vars();
-
 			return $this->order_currency;
 		}
 
@@ -395,7 +409,7 @@ class FrontendCurrencies {
 	 */
 	private function should_use_order_currency(): bool {
 		$pages = [ 'my-account', 'checkout' ];
-		$vars  = [ 'order-received', 'order-pay', 'orders', 'view-order' ];
+		$vars  = [ 'order-received', 'order-pay', 'order-received', 'orders', 'view-order' ];
 
 		if ( $this->utils->is_page_with_vars( $pages, $vars ) ) {
 			return $this->utils->is_call_in_backtrace(


### PR DESCRIPTION
This reverts commit 6483d9a5b34ceab5215a09e89949a89e89127596.

Fixes N/A

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR reverts #8617 in order to prevent an infinite call regression when HPOS is enabled, as indicated in the following thread: p1712862058705099-slack-C01BZUL57SQ.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.