### PR TITLE
Ensure We Avoid Infinite Recursive Call Through 'wc_get_price_decimal_separator' Filter

### DIFF
--- a/changelog/fix-infinite-recursive-call-for-price-decimal-separator-filter
+++ b/changelog/fix-infinite-recursive-call-for-price-decimal-separator-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure we avoid an infinite recursive call stack through 'wc_get_price_decimal_separator' filter.

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -270,7 +270,11 @@ class FrontendCurrencies {
 			return $arg;
 		}
 
+		// We remove the filters here because 'wc_get_order' triggers the 'wc_get_price_decimal_separator' filter.
+		remove_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );
 		$order = ! $arg instanceof WC_Order ? wc_get_order( $arg ) : $arg;
+		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );
+
 		if ( $order ) {
 			$this->order_currency = $order->get_currency();
 			return $order->get_id();

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -270,7 +270,8 @@ class FrontendCurrencies {
 			return $arg;
 		}
 
-		// We remove the filters here because 'wc_get_order' triggers the 'wc_get_price_decimal_separator' filter.
+		// We remove the filter 'wc_get_price_decimal_separator' here because 'wc_get_order'
+		// can also trigger it, leading to an infinite recursive call.
 		remove_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );
 		$order = ! $arg instanceof WC_Order ? wc_get_order( $arg ) : $arg;
 		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );


### PR DESCRIPTION
Fixes N/A

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure we avoid an infinite recursive call by removing the `wc_get_price_decimal_separator` filter when we call the `wc_get_order( $arg )` function, since the `wc_get_order( $arg )` function also calls the `wc_get_price_decimal_separator` filter.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Regression Test: Ensure Currency Formatting Still Applied Correctly**
* Switch to the `fix/infinite-recursive-call-for-price-decimal-separator-filter` branch.
* Ensure the cart page is using the WCBlocks-cart.
* Enable multi-currency.
* Change the store's currency to one whose format you are familiar with.
* Modify the other currency options so that they are non-standard, such as:
  - Change the currency position to `Left`
  - Change the thousands separator to `-`
  - Change the decimal separator to `*`
  - Change the number of decimals to `4`
* Save your settings.
* Change your presentment currency to match the site's default.
* Add enough product to your cart to increase the value so that a thousand separator is displayed
* Ensure that the currency position, thousands separator, number of decimals, and decimal separator all match the settings configured in Step 3.

**Test: Ensure We Avoid An Infinite Recursive Call Through `wc_get_price_decimal_separator` Filter**
We were unable to reproduce a second time. So, in order to test this, read through the code to ensure the following stack trace will not be reproducible:
```
- WCPay\MultiCurrency\FrontendCurrencies->get_price_decimal_separator() /var/www/html/wp-includes/class-wp-hook.php:324 
- WCPay\MultiCurrency\FrontendCurrencies->get_currency_code() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:191 
- WCPay\MultiCurrency\FrontendCurrencies->init_order_currency_from_query_vars() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:369 
- WCPay\MultiCurrency\FrontendCurrencies->init_order_currency() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:293 
- wc_get_order() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:273 
- WC_Order_Factory::get_order() /var/www/html/wp-content/plugins/woocommerce/includes/wc-order-functions.php:86 
- Automattic\WooCommerce\Admin\Overrides\Order->__construct() /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-order-factory.php:49 
- WC_Data_Store->read() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php:130 
- WC_Order_Data_Store_CPT->read() /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-data-store.php:159 
- WC_Order_Data_Store_CPT->read_order_data() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php:151 
- WC_Order_Data_Store_CPT->read_order_data() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php:114 
- WC_Order_Data_Store_CPT->set_order_props() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php:419 
- Automattic\WooCommerce\Admin\Overrides\Order->set_props() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php:172 
- Automattic\WooCommerce\Admin\Overrides\Order->set_discount_total() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-data.php:801 
- wc_format_decimal() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php:714 
- wc_get_price_decimal_separator() /var/www/html/wp-content/plugins/woocommerce/includes/wc-formatting-functions.php:292 
- apply_filters() /var/www/html/wp-content/plugins/woocommerce/includes/wc-formatting-functions.php:528 
- WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:205 
- WCPay\MultiCurrency\FrontendCurrencies->get_price_decimal_separator() /var/www/html/wp-includes/class-wp-hook.php:324 
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
