### PR TITLE
Only register cart block PMME when BNPL is enabled

### DIFF
--- a/changelog/fix-register-pmme-bnpl-enabled
+++ b/changelog/fix-register-pmme-bnpl-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Defensive check for cart block PMME which hasn't yet been deployed.

--- a/client/cart/blocks/index.js
+++ b/client/cart/blocks/index.js
@@ -2,11 +2,26 @@
  * Internal dependencies
  */
 import { renderBNPLCartMessaging } from './product-details';
+import { getUPEConfig } from 'wcpay/utils/checkout';
 
 const { registerPlugin } = window.wp.plugins;
 
-// Register BNPL site messaging on the cart block.
-registerPlugin( 'bnpl-site-messaging', {
-	render: renderBNPLCartMessaging,
-	scope: 'woocommerce-checkout',
-} );
+const paymentMethods = getUPEConfig( 'paymentMethodsConfig' );
+
+const BNPL_PAYMENT_METHODS = {
+	AFFIRM: 'affirm',
+	AFTERPAY: 'afterpay_clearpay',
+	KLARNA: 'klarna',
+};
+
+const bnplPaymentMethods = Object.values(
+	BNPL_PAYMENT_METHODS
+).filter( ( method ) => Object.keys( paymentMethods ).includes( method ) );
+
+if ( bnplPaymentMethods.length ) {
+	// Register BNPL site messaging on the cart block.
+	registerPlugin( 'bnpl-site-messaging', {
+		render: renderBNPLCartMessaging,
+		scope: 'woocommerce-checkout',
+	} );
+}

--- a/client/cart/blocks/index.js
+++ b/client/cart/blocks/index.js
@@ -14,9 +14,9 @@ const BNPL_PAYMENT_METHODS = {
 	KLARNA: 'klarna',
 };
 
-const bnplPaymentMethods = Object.values(
-	BNPL_PAYMENT_METHODS
-).filter( ( method ) => Object.keys( paymentMethods ).includes( method ) );
+const bnplPaymentMethods = Object.values( BNPL_PAYMENT_METHODS ).filter(
+	( method ) => method in paymentMethods
+);
 
 if ( bnplPaymentMethods.length ) {
 	// Register BNPL site messaging on the cart block.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On `develop`, an error is displayed on the cart block when no BNPL payment methods are enabled. This is because the PMME component was being registered while scripts it depends on were not. This adds a check to ensure BNPL payment methods are enabled before registering the component.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<img width="400" src="https://github.com/Automattic/woocommerce-payments/assets/3473953/6c0fa6f4-6daf-434e-9676-ba2e0ced2d9e" />

<p>

Related: p1712858862185459/1712858745.223069-slack-CGGCLBN58

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Disable all BNPL payment methods
* Visit the cart block and check that no errors appear above the "Proceed to Checkout" button or in the console.
* Enable some BNPL methods and check that the PMME appears on the cart block

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.