### PR TITLE
Add tracking for the `Finish setup` and `Start receiving deposits` buttons.

### DIFF
--- a/changelog/add-8615-account-management-track-events
+++ b/changelog/add-8615-account-management-track-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Adding a tracking event for external redirects to finish setup and start receiving deposits.

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -12,6 +12,7 @@ import strings from './strings';
 import './styles.scss';
 import ResetAccountModal from 'wcpay/overview/modal/reset-account';
 import { trackAccountReset } from 'wcpay/onboarding/tracking';
+import { recordEvent } from 'wcpay/tracks';
 
 interface Props {
 	accountLink: string;
@@ -43,6 +44,14 @@ export const AccountTools: React.FC< Props > = ( props: Props ) => {
 					{ ! detailsSubmitted && (
 						<Button
 							variant={ 'secondary' }
+							onClick={ () =>
+								recordEvent(
+									'wcpay_account_details_finish_setup_clicked',
+									{
+										source: 'account-details',
+									}
+								)
+							}
 							href={ accountLink }
 							target={ '_blank' }
 						>

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -46,9 +46,10 @@ export const AccountTools: React.FC< Props > = ( props: Props ) => {
 							variant={ 'secondary' }
 							onClick={ () =>
 								recordEvent(
-									'wcpay_account_details_finish_setup_clicked',
+									'wcpay_account_details_link_clicked',
 									{
-										source: 'account-details',
+										source:
+											'account-tools__finish-setup-button',
 									}
 								)
 							}

--- a/client/overview/task-list/tasks/po-task.tsx
+++ b/client/overview/task-list/tasks/po-task.tsx
@@ -10,6 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies.
  */
 import strings from '../strings';
+import { recordEvent } from 'wcpay/tracks';
 
 const tpvLimit = 5000;
 
@@ -27,6 +28,10 @@ export const getVerifyBankAccountTask = (): any => {
 	} = wcpaySettings.accountStatus;
 
 	const handleClick = () => {
+		recordEvent( 'wcpay_account_details_task_receiving_deposits_clicked', {
+			source: 'po-task',
+		} );
+
 		window.location.href = addQueryArgs( wcpaySettings.connectUrl, {
 			collect_payout_requirements: true,
 		} );

--- a/client/overview/task-list/tasks/po-task.tsx
+++ b/client/overview/task-list/tasks/po-task.tsx
@@ -28,8 +28,8 @@ export const getVerifyBankAccountTask = (): any => {
 	} = wcpaySettings.accountStatus;
 
 	const handleClick = () => {
-		recordEvent( 'wcpay_account_details_task_receiving_deposits_clicked', {
-			source: 'po-task',
+		recordEvent( 'wcpay_account_details_link_clicked', {
+			source: 'overview-page__receive-deposits-task',
 		} );
 
 		window.location.href = addQueryArgs( wcpaySettings.connectUrl, {

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -11,6 +11,8 @@ export type Event =
 	| 'page_view'
 	| 'wcpay_connect_account_clicked'
 	| 'wcpay_account_details_link_clicked'
+	| 'wcpay_account_details_finish_setup_clicked'
+	| 'wcpay_account_details_task_receiving_deposits_clicked'
 	| 'wcpay_welcome_learn_more'
 	| 'wcpay_stripe_connected'
 	| 'wcpay_connect_account_kyc_modal_opened'

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -11,8 +11,6 @@ export type Event =
 	| 'page_view'
 	| 'wcpay_connect_account_clicked'
 	| 'wcpay_account_details_link_clicked'
-	| 'wcpay_account_details_finish_setup_clicked'
-	| 'wcpay_account_details_task_receiving_deposits_clicked'
 	| 'wcpay_welcome_learn_more'
 	| 'wcpay_stripe_connected'
 	| 'wcpay_connect_account_kyc_modal_opened'


### PR DESCRIPTION
Fixes #8615

#### Changes proposed in this Pull Request
Add tracking events for the following buttons:
- Tracking click event of 'Finish setup' under `Account Details`.
- Tracking click event of 'Start receiving deposits' PO task.

#### Testing instructions
- Use [Tracks Vigilante 2 ](https://github.com/Automattic/tracks-vigilante-2-chrome-extension)to be able to see local tracking events getting fired. Open a new Tracks Vigilante window to monitor events on your store.
- Run npm run watch to build the JS.
- Make sure you have opted in to tracking on your local store (you can check Settings > Advanced > Woo.com).
- Onboard an account without finishing the Stripe KYC.
- Click the `Finish setup` button under `Account details` section.
- Verify that the `wcpay_account_details_finish_setup_clicked` event is fired.
- Continue and fill the Stripe KYC, without connecting a bank account.
- Navigate back to `Overview` page.
- Click the `Start receiving deposits` button under the Progressive Onboarding task list.
- Verfiy that the `wcpay_account_details_task_receiving_deposits_clicked`event is fired.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
