### PR TITLE
Ensure we avoid an infinite recursive call stack through any price format filter

### DIFF
--- a/changelog/fix-infinite-recursive-call-for-price-decimal-separator-filter-2
+++ b/changelog/fix-infinite-recursive-call-for-price-decimal-separator-filter-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This suplements a previous fix
+
+

--- a/changelog/fix-infinite-recursive-call-for-price-decimal-separator-filter-2
+++ b/changelog/fix-infinite-recursive-call-for-price-decimal-separator-filter-2
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
-Comment: This suplements a previous fix
+Comment: This supplements a previous fix
 
 

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -270,11 +270,17 @@ class FrontendCurrencies {
 			return $arg;
 		}
 
-		// We remove the filter 'wc_get_price_decimal_separator' here because 'wc_get_order'
-		// can also trigger it, leading to an infinite recursive call.
+		// We remove thes filters here because 'wc_get_order'
+		// can also trigger them, leading to an infinite recursive call.
+		remove_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 900 );
+		remove_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 900 );
 		remove_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );
+		remove_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 900 );
 		$order = ! $arg instanceof WC_Order ? wc_get_order( $arg ) : $arg;
+		add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 900 );
 		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );
+		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 900 );
+		add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 900 );
 
 		if ( $order ) {
 			$this->order_currency = $order->get_currency();

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -270,8 +270,8 @@ class FrontendCurrencies {
 			return $arg;
 		}
 
-		// We remove thes filters here because 'wc_get_order'
-		// can also trigger them, leading to an infinite recursive call.
+		// We remove these filters here because 'wc_get_order'
+		// can trigger them, leading to an infinitely recursive call.
 		remove_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 900 );
 		remove_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 900 );
 		remove_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 900 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR supplements the fix from #8625. Removing only `wc_get_price_decimals` already fixed the issue, but I also removed `get_price_thousand_separator` and `woocommerce_price_format` to be extra sure.

#### Testing instructions
**Regression Test: Ensure Currency Formatting Still Applied Correctly**
* Switch to the `fix/infinite-recursive-call-for-price-decimal-separator-filter` branch.
* Ensure the cart page is using the WCBlocks-cart.
* Enable multi-currency.
* Change the store's currency to one whose format you are familiar with.
* Modify the other currency options so that they are non-standard, such as:
  - Change the currency position to `Left`
  - Change the thousands separator to `-`
  - Change the decimal separator to `*`
  - Change the number of decimals to `4`
* Save your settings.
* Change your presentment currency to match the site's default.
* Add enough product to your cart to increase the value so that a thousand separator is displayed
* Ensure that the currency position, thousands separator, number of decimals, and decimal separator all match the settings configured in Step 3.

**Test: Ensure We Avoid An Infinite Recursive Call Through `wc_get_price_decimal_separator` Filter**
We were unable to reproduce a second time. So, in order to test this, read through the code to ensure the following stack trace will not be reproducible:
```
- WCPay\MultiCurrency\FrontendCurrencies->get_price_decimals() /var/www/html/wp-includes/class-wp-hook.php:324
- WCPay\MultiCurrency\FrontendCurrencies->get_currency_code() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:176
- WCPay\MultiCurrency\FrontendCurrencies->init_order_currency_from_query_vars() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:374
- WCPay\MultiCurrency\FrontendCurrencies->init_order_currency() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:298
- wc_get_order() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:276
- WC_Order_Factory::get_order() /var/www/html/wp-content/plugins/woocommerce/includes/wc-order-functions.php:86
- Automattic\WooCommerce\Admin\Overrides\Order->__construct() /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-order-factory.php:49
- WC_Data_Store->read() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php:130
- WC_Order_Data_Store_CPT->read() /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-data-store.php:159
- WC_Order_Data_Store_CPT->read_order_data() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php:151
- WC_Order_Data_Store_CPT->read_order_data() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php:114
- WC_Order_Data_Store_CPT->set_order_props() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php:419
- Automattic\WooCommerce\Admin\Overrides\Order->set_props() /var/www/html/wp-content/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php:172
- Automattic\WooCommerce\Admin\Overrides\Order->set_shipping_tax() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-data.php:801
- Automattic\WooCommerce\Admin\Overrides\Order->set_total_tax() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php:745
- wc_get_price_decimals() /var/www/html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php:767
- apply_filters() /var/www/html/wp-content/plugins/woocommerce/includes/wc-formatting-functions.php:539
- WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:205
- WCPay\MultiCurrency\FrontendCurrencies->get_price_decimals() /var/www/html/wp-includes/class-wp-hook.php:324
- WCPay\MultiCurrency\FrontendCurrencies->get_currency_code() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:176
- WCPay\MultiCurrency\FrontendCurrencies->init_order_currency_from_query_vars() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:374
- WCPay\MultiCurrency\FrontendCurrencies->init_order_currency() /var/www/html/wp-content/plugins/woocommerce-payments/includes/multi-currency/FrontendCurrencies.php:298
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
