### PR TITLE
Tweak "Proceed to checkout" event tracking

### DIFF
--- a/changelog/update-proceed-to-checkout-tracking
+++ b/changelog/update-proceed-to-checkout-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update "Proceed to checkout" tracking to take the skip_woopay cookie into account.
+
+

--- a/client/cart/index.js
+++ b/client/cart/index.js
@@ -4,12 +4,13 @@
 import { recordUserEvent } from 'tracks';
 import { getConfig } from 'wcpay/utils/checkout';
 import WooPayDirectCheckout from 'wcpay/checkout/woopay/direct-checkout/woopay-direct-checkout';
+import { shouldSkipWooPay } from 'wcpay/checkout/woopay/utils';
 
 const recordProceedToCheckoutButtonClick = () => {
 	recordUserEvent( 'wcpay_proceed_to_checkout_button_click', {
-		woopay_direct_checkout: Boolean(
-			getConfig( 'isWooPayDirectCheckoutEnabled' )
-		),
+		woopay_direct_checkout:
+			Boolean( getConfig( 'isWooPayDirectCheckoutEnabled' ) ) &&
+			! shouldSkipWooPay(),
 	} );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After #8570, we are adding a cookie to bypass the WooPay checkout flow. This PR updates the `wcpay_proceed_to_checkout_button_click` event recording to take that cookie into account.

If the cookie is set, it means the direct checkout won't be offered, and therefore, the `woopay_direct_checkout` property should be `false`.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Pre-requisites**

1. Ensure the WooPay direct checkout flow is enabled: `npm run wp option update _wcpay_feature_woopay_direct_checkout 1`.
2. Checkout to this branch and build the client assets: `npm run build:client`.

**Regression test: Proceed to Checkout event is tracked as expected**

1. As a customer, log in to WooPay, if needed.
2. Navigate to the merchant site, add an item to the cart and navigate to the cart.
3. Open the dev tools, navigate to the **Network** tab and enable the **Preserve log** option.
4. In the merchant store, click on the **Proceed to checkout** button.
5. You should land on the WooPay checkout page.
6. There should be a request to `admin-ajax.php` in the dev tools. The request payload should contain the event `wcpay_proceed_to_checkout_button_click` and the property `woopay_direct_checkout` should be evaluated to `true`.

**Test: Proceed to Checkout event takes the skip_woopay cookie into account**

1. While you're still in the WooPay checkout page, expand the **Pay with** section.
2. Click on the **Alternative payment methods** link.
3. You should land on the store checkout page and don't get redirected back to WooPay.
4. Navigate to the cart page.
5. Click on the **Proceed to checkout** button.
6. You should land on the store checkout page.
7. There should be a request to `admin-ajax.php` in the dev tools. The request payload should contain the event `wcpay_proceed_to_checkout_button_click` and the property `woopay_direct_checkout` should be evaluated to `false`.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
