### PR TITLE
add currency code to cart and checkout block totals when mccy is enabled

### DIFF
--- a/changelog/fix-total-amounts-not-displayed-with-explicit-currency-code
+++ b/changelog/fix-total-amounts-not-displayed-with-explicit-currency-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure an explicit currency code is present in the cart and checkout blocks when multi-currency is enabled

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -11,7 +11,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getUPEConfig } from 'utils/checkout';
+import { getUPEConfig, getConfig } from 'utils/checkout';
 import { isLinkEnabled } from '../utils/upe';
 import WCPayAPI from '../api';
 import { SavedTokenHandler } from './saved-token-handler';
@@ -158,3 +158,22 @@ window.addEventListener( 'load', () => {
 	enqueueFraudScripts( getUPEConfig( 'fraudServices' ) );
 	addCheckoutTracking();
 } );
+
+// If multi-currency is enabled, add currency code to total amount in cart and checkout blocks.
+if ( getConfig( 'isMultiCurrencyEnabled' ) ) {
+	const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+	const modifyTotalsPrice = ( defaultValue, extensions, args ) => {
+		const { cart } = args;
+
+		if ( cart?.cartTotals?.currency_code ) {
+			return `<price/> ${ cart.cartTotals.currency_code }`;
+		}
+
+		return defaultValue;
+	};
+
+	registerCheckoutFilters( 'woocommerce-payments', {
+		totalValue: modifyTotalsPrice,
+	} );
+}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -252,6 +252,8 @@ class MultiCurrency {
 			add_action( 'woocommerce_created_customer', [ $this, 'set_new_customer_currency_meta' ] );
 		}
 
+		add_filter( 'wcpay_payment_fields_js_config', [ $this, 'add_props_to_wcpay_js_config' ] );
+
 		$this->currency_switcher_block->init_hooks();
 	}
 
@@ -386,6 +388,19 @@ class MultiCurrency {
 
 		wp_enqueue_script( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
 		WC_Payments_Utils::enqueue_style( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
+	}
+
+	/**
+	 * Add multi-currency specific props to the WCPay JS config.
+	 *
+	 * @param  array $config The JS config that will be loaded on the frontend.
+	 *
+	 * @return array  The updated JS config.
+	 */
+	public function add_props_to_wcpay_js_config( $config ) {
+		$config['isMultiCurrencyEnabled'] = true;
+
+		return $config;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2648 

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Adds an explicit currency code to the totals in the Cart and Checkout Blocks when multi-currency is enabled, just like we do for the Shortcode Cart and Checkout.

### Screenshots

| | Before | After |
|:---:|:---:|:---:|
| Cart | <img width="897" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/0520bb5f-fe25-415f-aa05-1dc4b99b588d"> | <img width="897" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/0e8c3499-d094-43e8-bb81-fde18000ac6d"> |
| Checkout | <img width="897" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/38135159-2a93-4676-aab6-9ece918a4ec4"> | <img width="897" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/5b4c1582-8ed3-4d10-a8d7-ad092df189f9"> |

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> This feature uses a blocks filter introduced in WC v8.8 which has not yet been released. See testing instructions for details.

### Make sure WC 8.7 and/or 8.6 are still properly supported

1. Make sure you're running either WC 8.6 or 8.7 (test both for extra bonus points 🏆 ).
2. Make sure multi-currency is enabled with at least 2 currencies configured.
3. Add a product to your cart.
4. Check the **Cart** page and make sure there are no new JS errors (i.e. compare with `develop`).
5. Check the **Cart** page and make sure there is **not** a currency code added to the total.
6. Check the **Checkout** page and make sure there are no new JS errors (i.e. compare with `develop`).
7. Check the **Checkout** page and make sure there is **not** a currency code added to the total.
8. Change the currency with the currency switcher and check steps (4) - (7) again.

### Make sure currency code is displayed when using WC 8.8

1. Download WC v8.8 from [here](https://wordpress.org/plugins/woocommerce/advanced/) and install it on your store.
2. Make sure multi-currency is enabled with at least 2 currencies configured.
3. Add a product to your cart.
4. Check the **Cart** page and make sure there is now a currency code added to the total.
5. Check the **Checkout** page and make sure there is now a currency code added to the total.
6. Make sure the formatting of the currency code matches the Shortcode version (compare against the Shortcode Cart and Checkout)
7. Change the currency with the currency switcher and check steps (4) - (6) again.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
