### PR TITLE
Only try to load Stripe's PaymentMethodMessagingElement on supported methods on block checkout

### DIFF
--- a/changelog/fix-only-try-to-load-pmme-on-bnpl-methods
+++ b/changelog/fix-only-try-to-load-pmme-on-bnpl-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a quick fix to another item already in the changelog.
+
+

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -15,6 +15,7 @@ export default ( {
 	upeAppearanceTheme,
 } ) => {
 	const cartData = wp.data.select( 'wc/store/cart' ).getCartData();
+	const bnplMethods = [ 'affirm', 'afterpay_clearpay', 'klarna' ];
 
 	// Stripe expects the amount to be sent as the minor unit of 2 digits.
 	const amount = normalizeCurrencyToMinorUnit(
@@ -27,13 +28,11 @@ export default ( {
 		cartData.billingAddress.country ||
 		window.wcBlocksCheckoutData.storeCountry;
 
-	// console.log( currentCountry );
-
 	return (
 		<>
 			<span>
 				{ upeConfig.title }
-				{ upeName !== 'card' &&
+				{ bnplMethods.includes( upeName ) &&
 					( upeConfig.countries.length === 0 ||
 						upeConfig.countries.includes( currentCountry ) ) && (
 						<>


### PR DESCRIPTION
Fixes the PR for #8452
Fixes https://github.com/Automattic/woocommerce-payments/issues/8647

#### Changes proposed in this Pull Request
Originally, the fix for #8452 was only checking that the payment method was not `card` before trying to render the PMME in the checkout block. This was incorrect because there are payment methods other than `card` that are not supported by the PMME (bancontact, for example).

This PR now checks the payment method to positively identify that the method is supported by the PMME before attempting to render it.

#### Testing instructions
* Have a store with the currency set to Euros.
* Enable Bancontact and other non-BNPL payment methods.
* Enable BNPL methods.
* Go to checkout and set your billing country to one supported by a non-BNPL method (Belgium for Bancontact for example).
* Ensure that no JS errors occur on the page and that the payment method section loads properly and allows you to select a payment method and complete checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
