### PR TITLE
fix: BNPL announcement link

### DIFF
--- a/changelog/fix-bnpl-dialog-link
+++ b/changelog/fix-bnpl-dialog-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: BNPL announcement link.

--- a/client/bnpl-announcement/index.js
+++ b/client/bnpl-announcement/index.js
@@ -14,6 +14,7 @@ import './style.scss';
 import ConfirmationModal from 'wcpay/components/confirmation-modal';
 import AfterpayBanner from 'assets/images/bnpl_announcement_afterpay.png?asset';
 import ClearpayBanner from 'assets/images/bnpl_announcement_clearpay.png?asset';
+import { getAdminUrl } from 'wcpay/utils';
 
 const BannerIcon =
 	window.wcpayBnplAnnouncement?.accountCountry === 'GB'
@@ -49,6 +50,11 @@ const Dialog = () => {
 					</ExternalLink>
 					<Button
 						variant="primary"
+						href={ `${ getAdminUrl( {
+							page: 'wc-settings',
+							tab: 'checkout',
+							section: 'woocommerce_payments',
+						} ) }#payment-methods` }
 						onClick={ () => {
 							recordEvent(
 								'wcpay_bnpl_april15_feature_announcement_enable_click'


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8660

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fixing the link on the BNPL announcement modal.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In order to display the BNPL modal, I'd recommend the following:
<img width="708" alt="Screenshot 2024-04-18 at 9 48 55 AM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/950cae7b-1e13-4573-a9cf-1d0acfdc53b8">
- Ensure you don't have any BNPL methods enabled in the settings
- Comment out these lines in your local `includes/admin/class-wc-payments-bnpl-announcement.php`: https://github.com/Automattic/woocommerce-payments/blob/0025182fe766c5ca17511b6b92c934526770d169/includes/admin/class-wc-payments-bnpl-announcement.php#L76-L78
- Comment out these lines in your local `includes/admin/class-wc-payments-bnpl-announcement.php`: https://github.com/Automattic/woocommerce-payments/blob/0025182fe766c5ca17511b6b92c934526770d169/includes/admin/class-wc-payments-bnpl-announcement.php#L135-L138
- As a store owner, go to Payments > Overview (or any WooPayments page)
- The dialog should appear
- Clicking on "Get started" should redirect you to the settings page, scrolling down to the payment methods section
  - if you're already located on the settings page, the scrolling is less nice, but still functional

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
