### PR TITLE
Avoid updating billing details for legacy card objects

### DIFF
--- a/changelog/2024-04-18-09-06-44-606607
+++ b/changelog/2024-04-18-09-06-44-606607
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Avoid updating billing details for legacy card objects.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1516,7 +1516,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 					$is_legacy_card_object = strpos( $payment_information->get_payment_method() ?? '', 'card_' ) === 0;
 
-					// Don't update billing details for legacy card objects because they are not supported.
+					// Not updating billing details for legacy card objects because they have a different structure and are no longer supported.
 					if ( ! empty( $billing_details ) && ! $is_legacy_card_object ) {
 						$request->set_payment_method_update_data( [ 'billing_details' => $billing_details ] );
 					}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1514,7 +1514,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( $payment_information->is_using_saved_payment_method() ) {
 					$billing_details = WC_Payments_Utils::get_billing_details_from_order( $order );
 
-					if ( ! empty( $billing_details ) ) {
+					$is_legacy_card_object = strpos( $payment_information->get_payment_method() ?? '', 'card_' ) === 0;
+
+					// Don't update billing details for legacy card objects because they are not supported.
+					if ( ! empty( $billing_details ) && ! $is_legacy_card_object ) {
 						$request->set_payment_method_update_data( [ 'billing_details' => $billing_details ] );
 					}
 				}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -257,6 +257,18 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_payment_metadata' )
 			->willReturn( [] );
 		wcpay_get_test_container()->replace( OrderService::class, $mock_order_service );
+		$checkout_fields                  = [
+			'billing' => [
+				'billing_company'   => '',
+				'billing_country'   => '',
+				'billing_address_1' => '',
+				'billing_address_2' => '',
+				'billing_city'      => '',
+				'billing_state'     => '',
+				'billing_phone'     => '',
+			],
+		];
+		WC()->checkout()->checkout_fields = $checkout_fields;
 	}
 
 	/**
@@ -292,6 +304,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		}
 
 		wcpay_get_test_container()->reset_all_replacements();
+		WC()->checkout()->checkout_fields = null;
 	}
 
 	public function test_process_redirect_payment_intent_processing() {
@@ -2429,20 +2442,40 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
 	}
 
-	public function test_billing_details_update_if_not_empty() {
-		$fields                           = [
-			'billing' => [
-				'billing_company'   => '',
-				'billing_country'   => '',
-				'billing_address_1' => '',
-				'billing_address_2' => '',
-				'billing_city'      => '',
-				'billing_state'     => '',
-				'billing_phone'     => '',
-			],
-		];
-		wc()->checkout()->checkout_fields = $fields;
+	public function test_no_billing_details_update_for_legacy_card_object() {
+		$legacy_card = 'card_mock';
 
+		// There is no payment method data within the request. This is the case e.g. for the automatic subscription renewals.
+		$_POST['payment_method'] = '';
+
+		$token = WC_Helper_Token::create_token( $legacy_card );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'USD' );
+		$order->set_total( 100 );
+		$order->add_payment_token( $token );
+		$order->save();
+
+		$pi             = new Payment_Information( $legacy_card, $order, null, $token, null, null, null, '', 'card' );
+		$payment_intent = WC_Helper_Intention::create_intention(
+			[
+				'status' => 'success',
+			]
+		);
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will( $this->returnValue( $payment_intent ) );
+
+		$request->expects( $this->never() )
+			->method( 'set_payment_method_update_data' );
+
+		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
+	}
+
+	public function test_billing_details_update_if_not_empty() {
 		// There is no payment method data within the request. This is the case e.g. for the automatic subscription renewals.
 		$_POST['payment_method'] = '';
 
@@ -2470,51 +2503,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->will( $this->returnValue( $payment_intent ) );
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_update_data' );
-
-		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
-	}
-
-	public function test_no_billing_details_update_for_legacy_card_object() {
-		$legacy_card                      = 'card_mock';
-		$fields                           = [
-			'billing' => [
-				'billing_company'   => '',
-				'billing_country'   => '',
-				'billing_address_1' => '',
-				'billing_address_2' => '',
-				'billing_city'      => '',
-				'billing_state'     => '',
-				'billing_phone'     => '',
-			],
-		];
-		wc()->checkout()->checkout_fields = $fields;
-
-		// There is no payment method data within the request. This is the case e.g. for the automatic subscription renewals.
-		$_POST['payment_method'] = '';
-
-		$token = WC_Helper_Token::create_token( $legacy_card );
-
-		$order = WC_Helper_Order::create_order();
-		$order->set_currency( 'USD' );
-		$order->set_total( 100 );
-		$order->add_payment_token( $token );
-		$order->save();
-
-		$pi             = new Payment_Information( $legacy_card, $order, null, $token, null, null, null, '', 'card' );
-		$payment_intent = WC_Helper_Intention::create_intention(
-			[
-				'status' => 'success',
-			]
-		);
-
-		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'format_response' )
-			->will( $this->returnValue( $payment_intent ) );
-
-		$request->expects( $this->never() )
 			->method( 'set_payment_method_update_data' );
 
 		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8405

#### Changes proposed in this Pull Request
Legacy card object [[ref](https://docs.stripe.com/api/cards/object)] has different schema than the payment method object [[ref](https://docs.stripe.com/api/payment_methods/object)]. This PR avoids updating billing details for legacy card objects to not face the error coming from Stripe API due to object schema incompatibility.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

``` 
💡 To create the legacy card object for your account, send the following request while inserting your customer ID, account ID and test API key

curl https://api.stripe.com/v1/customers/${customer_id}/sources \
-u ${test_api_key}: \
-H "Stripe-Account:${acct_id}" \
```
* Ensure that you have the saved payment method on your store which is legacy card from the request above
* On this branch, purchase a subscription with this saved payment method, confirm the successful purchase 
* Revert the fix commit, navigate to subscription details, process renewal, confirm that the error message is the same as in https://github.com/Automattic/woocommerce-payments/issues/8405
* Remove the revert so that the fix is in place
* In the failed order details options, choose `Retry renewal payment`
* Navigate to subscription details, process renewal and confirm the renewal was successful this time

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
