### PR TITLE
misc: remove deprecated param from asset data registry

### DIFF
--- a/changelog/remove-deprecated-param-from-asset-data-registry
+++ b/changelog/remove-deprecated-param-from-asset-data-registry
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove deprecated param from asset data registry interface.

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -138,7 +138,7 @@ class Analytics {
 		}
 
 		$data_registry = Package::container()->get( AssetDataRegistry::class );
-		$data_registry->add( 'customerCurrencies', $currency_options, true );
+		$data_registry->add( 'customerCurrencies', $currency_options );
 	}
 
 	/**

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -114,6 +114,11 @@ class Analytics {
 	 * @return void
 	 */
 	public function register_customer_currencies() {
+		$data_registry = Package::container()->get( AssetDataRegistry::class );
+		if ( $data_registry->exists( 'customerCurrencies' ) ) {
+			return;
+		}
+
 		$currencies           = $this->multi_currency->get_all_customer_currencies();
 		$available_currencies = $this->multi_currency->get_available_currencies();
 		$currency_options     = [];
@@ -137,7 +142,6 @@ class Analytics {
 			];
 		}
 
-		$data_registry = Package::container()->get( AssetDataRegistry::class );
 		$data_registry->add( 'customerCurrencies', $currency_options );
 	}
 

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -109,27 +109,17 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Test for the register_customer_currencies method. Note that this function is called in the constructor,
+	 * and the customerCurrencies data key cannot be re-registered, so this test is only to ensure that it exists.
+	 */
 	public function test_register_customer_currencies() {
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_all_customer_currencies' )
-			->willReturn( $this->mock_customer_currencies );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_available_currencies' )
-			->willReturn( $this->get_mock_available_currencies() );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
-
-		$this->analytics->register_customer_currencies();
-
 		$data_registry = Package::container()->get(
 			AssetDataRegistry::class
 		);
-
 		$this->assertTrue( $data_registry->exists( 'customerCurrencies' ) );
 	}
+
 
 	public function test_has_multi_currency_orders() {
 
@@ -141,30 +131,6 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$result = $method->invoke( $this->analytics );
 
 		$this->assertTrue( $result );
-	}
-
-	public function test_register_customer_currencies_for_empty_customer_currencies() {
-		delete_option( MultiCurrency::CUSTOMER_CURRENCIES_KEY );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_all_customer_currencies' )
-			->willReturn( [] );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_available_currencies' )
-			->willReturn( $this->get_mock_available_currencies() );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
-
-		$this->analytics->register_customer_currencies();
-
-		$data_registry = Package::container()->get(
-			AssetDataRegistry::class
-		);
-
-		$this->assertTrue( $data_registry->exists( 'customerCurrencies' ) );
 	}
 
 	public function test_update_order_stats_data_with_non_multi_currency_order() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8662

#### Changes proposed in this Pull Request
`$check_key_exists` param was deprecated in https://github.com/woocommerce/woocommerce/pull/46139 and it's being mentioned that 

```
an optional param $check_key_exists with the default value set to false, which in practice doesn't have any impact in the end results
```

so it seems to be safe to remove this and thus make unit tests pass with newer WC version.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
* all unit tests pass for this PR
* first two testing instructions steps from https://github.com/Automattic/woocommerce-payments/pull/4441 are working well 

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.