### PR TITLE
Remove filter from Disputes Report

### DIFF
--- a/changelog/fix-remove-filter-disputes-report
+++ b/changelog/fix-remove-filter-disputes-report
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Made minor fix to disputes report link under feature flag
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -128,7 +128,6 @@ const PaymentActivityData: React.FC = () => {
 					reportLink={ getAdminUrl( {
 						page: 'wc-admin',
 						path: '/payments/disputes',
-						filter: 'awaiting_response',
 					} ) }
 					isLoading={ isLoading }
 				/>

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes&filter=awaiting_response"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes"
                 >
                   View report
                 </a>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Removed filter from Payment Activity -> Disputes Tile -> View Report

#### Testing instructions
Navigate to the Disputes page through Payment Activity -> Disputes Tile -> View Report and check that no filter is applied and all disputes are displayed 

#### Additional Context

p1713363418702459-slack-C06BBFTF6EM

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.