### PR TITLE
(Client) Remove obsolete `version` key from `docker-compose.yml` files

### DIFF
--- a/changelog/fix-8672-remove-obsolete-docker-compose-version
+++ b/changelog/fix-8672-remove-obsolete-docker-compose-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove obsolete docker-compose key `version`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 volumes:
   ## Kludge for not having the ./docker directory bound recursively
   dockerdirectory:
@@ -30,7 +28,7 @@ services:
       - dockerdirectory:/var/www/html/wp-content/plugins/woocommerce-payments/docker
       - ./docker/bin:/var/scripts
     extra_hosts:
-      - "host.docker.internal:host-gateway"  
+      - "host.docker.internal:host-gateway"
   db:
     container_name: woocommerce_payments_mysql
     image: mariadb:10.5.8

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   wordpress:
     build: ./wordpress-xdebug


### PR DESCRIPTION
Fixes #8672 

#### Changes proposed in this Pull Request

Removes the `version` key from `docker-compose.yml` files as it is obsolete since Docker Compose version v2.25.0, preventing warnings from showing in the console when running `npm run up` and `npm run test:e2e-up`.

#### Testing instructions

1. Check which version of docker-compose you are running `docker-compose -v`
2. If < v2.25.0, run `npm run up` and `npm run test:e2e-up` – ensure they work as expected.
2. If >= v2.25.0, run `npm run up` and `npm run test:e2e-up` – ensure they work as expected and no warnings are shown.
6. Note you may also see this warning when running `npm run test:e2e-setup` for the server repo `docker-compose.yml` files (`tests/e2e/deps/wcp-server/docker-compose.yml`). This will be addressed as a server issue.


> [!NOTE]  
> Removing `version` should not result in any issues, as it is only informative.
>
> from the [docker-compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements):
> > The top-level `version` property is defined by the Compose Specification for backward compatibility. **It is only informative.**


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests **N/A**
- [x] Tested on mobile **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
