### PR TITLE
Improve survey controller validation and remove upe from route path

### DIFF
--- a/changelog/update-survey-controller-validation
+++ b/changelog/update-survey-controller-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix survey controller param validation and remove upe from the route path.
+
+

--- a/client/components/payment-activity/survey/context.tsx
+++ b/client/components/payment-activity/survey/context.tsx
@@ -28,7 +28,7 @@ const useContextValue = ( initialState: OverviewSurveyFields = {} ) => {
 			setResponseStatus( 'pending' );
 			try {
 				await apiFetch( {
-					path: `${ NAMESPACE }/survey/payment-overview`,
+					path: `${ NAMESPACE }/survey/payments-overview`,
 					method: 'POST',
 					data: answers,
 				} );

--- a/client/components/payment-activity/survey/context.tsx
+++ b/client/components/payment-activity/survey/context.tsx
@@ -28,7 +28,7 @@ const useContextValue = ( initialState: OverviewSurveyFields = {} ) => {
 			setResponseStatus( 'pending' );
 			try {
 				await apiFetch( {
-					path: `${ NAMESPACE }/upe_survey/payments-overview`,
+					path: `${ NAMESPACE }/survey/payment-overview`,
 					method: 'POST',
 					data: answers,
 				} );

--- a/includes/admin/class-wc-rest-payments-survey-controller.php
+++ b/includes/admin/class-wc-rest-payments-survey-controller.php
@@ -57,15 +57,13 @@ class WC_REST_Payments_Survey_Controller extends WP_REST_Controller {
 				'args'                => [
 					'rating'   => [
 						'type'              => 'string',
-						'items'             => [
-							'type' => 'string',
-							'enum' => [
-								'very-unhappy',
-								'unhappy',
-								'neutral',
-								'happy',
-								'very-happy',
-							],
+						'required'          => true,
+						'enum'              => [
+							'very-unhappy',
+							'unhappy',
+							'neutral',
+							'happy',
+							'very-happy',
 						],
 						'validate_callback' => 'rest_validate_request_arg',
 					],

--- a/includes/admin/class-wc-rest-payments-survey-controller.php
+++ b/includes/admin/class-wc-rest-payments-survey-controller.php
@@ -90,7 +90,7 @@ class WC_REST_Payments_Survey_Controller extends WP_REST_Controller {
 		$comments = $request->get_param( 'comments' ) ?? '';
 		$rating   = $request->get_param( 'rating' ) ?? '';
 
-		if ( empty( $comments ) && empty( $rating ) ) {
+		if ( empty( $rating ) ) {
 			return new WP_REST_Response(
 				[
 					'success' => false,

--- a/includes/admin/class-wc-rest-payments-survey-controller.php
+++ b/includes/admin/class-wc-rest-payments-survey-controller.php
@@ -24,7 +24,7 @@ class WC_REST_Payments_Survey_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'payments/upe_survey';
+	protected $rest_base = 'payments/survey';
 
 	/**
 	 * The HTTP client, used to forward the request to WPCom.

--- a/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
@@ -13,7 +13,7 @@ class WC_REST_Payments_Survey_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Tested REST route.
 	 */
-	const ROUTE = '/wc/v3/payments/upe_survey';
+	const ROUTE = '/wc/v3/payments/survey';
 
 	/**
 	 * The system under test.

--- a/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
@@ -50,6 +50,19 @@ class WC_REST_Payments_Survey_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
+	public function test_empty_rating_returns_400_status_code() {
+		$request = new WP_REST_Request( 'POST', self::ROUTE . '/payments-overview' );
+		$request->set_body_params(
+			[
+				'comments' => 'test comment',
+			]
+		);
+
+		$response = $this->controller->submit_payments_overview_survey( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
 	public function test_valid_request_forwards_data_to_jetpack() {
 		$this->http_client_stub
 			->expects( $this->any() )

--- a/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
@@ -81,7 +81,7 @@ class WC_REST_Payments_Survey_Controller_Test extends WP_UnitTestCase {
 					),
 					$this->callback(
 						function ( $argument ) {
-							return '4' === $argument['survey_responses']['rating'];
+							return 'happy' === $argument['survey_responses']['rating'];
 						}
 					),
 					$this->callback(
@@ -101,7 +101,7 @@ class WC_REST_Payments_Survey_Controller_Test extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', self::ROUTE . '/payments-overview' );
 		$request->set_body_params(
 			[
-				'rating'   => '4',
+				'rating'   => 'happy',
 				'comments' => 'test comment',
 			]
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As I was reviewing https://github.com/Automattic/woocommerce-payments/issues/8314, I see some potential improvements:
- Remove 'upe' from the survey route path. Was it intentionally left there? I thought since this survey is not related to UPE, we don't need it in the route path.
- Improve / fix param validation for the payment activity survey by enforcing enum. I notice the args definition structure is not correct (CMIIW) as I stepped through [rest_validate_value_from_schema()](https://github.com/WordPress/WordPress/blob/46356f02157a9f5b7b05aba19be901691d47d882/wp-includes/rest-api.php#L2208).
- Erroring out when 'rating' param is empty even though 'comments' param is not.

ps:
- All the above changes are just for code-correctness. Without them, survey functionality still works because the rating value is enforced by Javascript.
- Some of the problems aren't caught by the unit tests because the they call the controller `submit_payments_overview_survey()` method directly while in reality, the request will go through validation callbacks first before gets to the callback function `submit_payments_overview_survey()`. A more proper testing will involve calling something like `doRequest()` in server code but I think it's not too necessary here.

#### Testing instructions

* Enable feature flag, `wp option update _wcpay_feature_payment_overview_widget 1`.
* Change your host file to point public-api.wordpress.com and dev-mc.a8c.com to your sandbox's IP address if you didn't already.
* Log-in to your sandbox
* Apply the patch created in https://github.com/Automattic/woocommerce-payments/issues/8314 to your dev server (arc patch D140691)
* To re-submit, run `wp option delete wcpay_survey_payment_overview_submitted` to clear your local submission state.

#### Test case 1

With base branch, if comments is specified and rating is not, it won't error out. It should.

* Modify locally this [line](https://github.com/Automattic/woocommerce-payments/blob/91a064604c2f0580300a629832d616de3caf9c76/client/components/payment-activity/survey/context.tsx#L33):

```diff
- data: answers,
+ data: { comments: 'abc' },
```

* With base branch, there won't be an error. With PR branch, you should see an error.

#### Test case 2

With base branch, if rating is not one of: very-unhappy, unhappy, neutral, happy, very-happy, you won't get an error. It should.

* Modify locally this [line](https://github.com/Automattic/woocommerce-payments/blob/91a064604c2f0580300a629832d616de3caf9c76/client/components/payment-activity/survey/context.tsx#L33):

```diff
- data: answers,
+ data: { rating: 'abc' },
```

* With base branch, there won't be an error. With PR branch, you should see an error.

#### Test case 3

Remove the above local changes and make sure this PR branch does not break survey feature, ie user still can rate without problem.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
