### PR TITLE
Patch: Fix subscription renewals exceptions

### DIFF
--- a/changelog/fix-8678-use-legacy-approach-off-session
+++ b/changelog/fix-8678-use-legacy-approach-off-session
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bugfix for failing subscription renewal payments.

--- a/changelog/remove-deprecated-param-from-asset-data-registry
+++ b/changelog/remove-deprecated-param-from-asset-data-registry
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove deprecated param from asset data registry interface.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1512,7 +1512,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$request->set_cvc_confirmation( $payment_information->get_cvc_confirmation() );
 				$request->set_hook_args( $payment_information );
 				if ( $payment_information->is_using_saved_payment_method() ) {
-					$billing_details = WC_Payments_Utils::get_billing_details_from_order( $order );
+					$billing_details = WC_Payments_Utils::get_billing_details_from_order( $order, $payment_information->is_merchant_initiated() );
 
 					$is_legacy_card_object = strpos( $payment_information->get_payment_method() ?? '', 'card_' ) === 0;
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -342,10 +342,31 @@ class WC_Payments_Utils {
 	 * It only returns the fields that are present in the billing section of the checkout.
 	 *
 	 * @param WC_Order $order Order to extract the billing details from.
+	 * @param bool     $legacy Whether to use the legacy way of loading straight from the order.
+	 * @todo The $legacy flag is just a patch for the current approach, fixing the linked issue.
+	 * @see https://github.com/Automattic/woocommerce-payments/issues/8678
 	 *
 	 * @return array
 	 */
-	public static function get_billing_details_from_order( $order ) {
+	public static function get_billing_details_from_order( $order, $legacy = true ) {
+		if ( $legacy ) {
+			$billing_details = [
+				'address' => [
+					'city'        => $order->get_billing_city(),
+					'country'     => $order->get_billing_country(),
+					'line1'       => $order->get_billing_address_1(),
+					'line2'       => $order->get_billing_address_2(),
+					'postal_code' => $order->get_billing_postcode(),
+					'state'       => $order->get_billing_state(),
+				],
+				'email'   => $order->get_billing_email(),
+				'name'    => trim( $order->get_formatted_billing_full_name() ),
+				'phone'   => $order->get_billing_phone(),
+			];
+
+			return array_filter( $billing_details );
+		}
+
 		$billing_fields       = array_keys( WC()->checkout()->get_checkout_fields( 'billing' ) );
 		$address_field_to_key = [
 			'billing_city'      => 'city',

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -114,6 +114,11 @@ class Analytics {
 	 * @return void
 	 */
 	public function register_customer_currencies() {
+		$data_registry = Package::container()->get( AssetDataRegistry::class );
+		if ( $data_registry->exists( 'customerCurrencies' ) ) {
+			return;
+		}
+
 		$currencies           = $this->multi_currency->get_all_customer_currencies();
 		$available_currencies = $this->multi_currency->get_available_currencies();
 		$currency_options     = [];
@@ -137,8 +142,7 @@ class Analytics {
 			];
 		}
 
-		$data_registry = Package::container()->get( AssetDataRegistry::class );
-		$data_registry->add( 'customerCurrencies', $currency_options, true );
+		$data_registry->add( 'customerCurrencies', $currency_options );
 	}
 
 	/**

--- a/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
+++ b/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
@@ -339,16 +339,16 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 						'test_mode'       => false,
 						'billing_details' => [
 							'address' => [
+								'city'        => $order->get_billing_city(),
 								'country'     => $order->get_billing_country(),
 								'line1'       => $order->get_billing_address_1(),
 								'line2'       => $order->get_billing_address_2(),
-								'city'        => $order->get_billing_city(),
-								'state'       => $order->get_billing_state(),
 								'postal_code' => $order->get_billing_postcode(),
+								'state'       => $order->get_billing_state(),
 							],
-							'phone'   => $order->get_billing_phone(),
 							'email'   => $order->get_billing_email(),
 							'name'    => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
+							'phone'   => $order->get_billing_phone(),
 						],
 					]
 				),

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -109,27 +109,17 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Test for the register_customer_currencies method. Note that this function is called in the constructor,
+	 * and the customerCurrencies data key cannot be re-registered, so this test is only to ensure that it exists.
+	 */
 	public function test_register_customer_currencies() {
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_all_customer_currencies' )
-			->willReturn( $this->mock_customer_currencies );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_available_currencies' )
-			->willReturn( $this->get_mock_available_currencies() );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
-
-		$this->analytics->register_customer_currencies();
-
 		$data_registry = Package::container()->get(
 			AssetDataRegistry::class
 		);
-
 		$this->assertTrue( $data_registry->exists( 'customerCurrencies' ) );
 	}
+
 
 	public function test_has_multi_currency_orders() {
 
@@ -141,30 +131,6 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$result = $method->invoke( $this->analytics );
 
 		$this->assertTrue( $result );
-	}
-
-	public function test_register_customer_currencies_for_empty_customer_currencies() {
-		delete_option( MultiCurrency::CUSTOMER_CURRENCIES_KEY );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_all_customer_currencies' )
-			->willReturn( [] );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_available_currencies' )
-			->willReturn( $this->get_mock_available_currencies() );
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
-
-		$this->analytics->register_customer_currencies();
-
-		$data_registry = Package::container()->get(
-			AssetDataRegistry::class
-		);
-
-		$this->assertTrue( $data_registry->exists( 'customerCurrencies' ) );
 	}
 
 	public function test_update_order_stats_data_with_non_multi_currency_order() {

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -484,16 +484,16 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 				[
 					'billing_details' => [
 						'address' => [
-							'city'        => 'WooCity',
 							'country'     => Country_Code::UNITED_STATES,
 							'line1'       => 'WooAddress',
 							'line2'       => '',
-							'postal_code' => '12345',
+							'city'        => 'WooCity',
 							'state'       => 'NY',
+							'postal_code' => '12345',
 						],
+						'phone'   => '555-32123',
 						'email'   => 'admin@example.org',
 						'name'    => 'Jeroen Sormani',
-						'phone'   => '555-32123',
 					],
 				]
 			);
@@ -504,15 +504,6 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_payment_method_with_billing_details_from_checkout_fields() {
-		$fields = wc()->checkout()->checkout_fields;
-		unset( $fields['billing']['billing_company'] );
-		unset( $fields['billing']['billing_country'] );
-		unset( $fields['billing']['billing_address_1'] );
-		unset( $fields['billing']['billing_address_2'] );
-		unset( $fields['billing']['billing_city'] );
-		unset( $fields['billing']['billing_state'] );
-		unset( $fields['billing']['billing_phone'] );
-		wc()->checkout()->checkout_fields = $fields;
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'update_payment_method' )
@@ -522,9 +513,15 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 					'billing_details' => [
 						'address' => [
 							'postal_code' => '12345',
+							'city'        => 'WooCity',
+							'country'     => 'US',
+							'line1'       => 'WooAddress',
+							'line2'       => '',
+							'state'       => 'NY',
 						],
 						'email'   => 'admin@example.org',
 						'name'    => 'Jeroen Sormani',
+						'phone'   => '555-32123',
 					],
 				]
 			);


### PR DESCRIPTION
Fixes #8678

#### Changes proposed in this Pull Request

TBD

#### Testing instructions

See the issue

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
