### PR TITLE
Fix WooPay tracks user ID for logged in users

### DIFF
--- a/changelog/fix-woopay-tracks-userid-for-logged-in-users
+++ b/changelog/fix-woopay-tracks-userid-for-logged-in-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay tracks user ID for logged in users.

--- a/client/tracks/index.ts
+++ b/client/tracks/index.ts
@@ -111,36 +111,35 @@ export const getTracksIdentity = async (): Promise< string | undefined > => {
 	// if cookie is set, get identity from the cookie.
 	// eslint-disable-next-line
 	let _ui = getIdentityCookieValue();
+	if ( _ui ) {
+		const data = { _ut: 'anon', _ui: _ui };
+		return JSON.stringify( data );
+	}
 	// Otherwise get it via an Ajax request.
-	if ( ! _ui ) {
-		const nonce =
-			getConfig( 'platformTrackerNonce' ) ??
-			getPaymentRequestData( 'nonce' )?.platform_tracker;
-		const ajaxUrl =
-			getConfig( 'ajaxUrl' ) ?? getPaymentRequestData( 'ajax_url' );
-		const body = new FormData();
+	const nonce =
+		getConfig( 'platformTrackerNonce' ) ??
+		getPaymentRequestData( 'nonce' )?.platform_tracker;
+	const ajaxUrl =
+		getConfig( 'ajaxUrl' ) ?? getPaymentRequestData( 'ajax_url' );
+	const body = new FormData();
 
-		body.append( 'tracksNonce', nonce );
-		body.append( 'action', 'get_identity' );
-		try {
-			const response = await fetch( ajaxUrl, {
-				method: 'post',
-				body,
-			} );
-			if ( ! response.ok ) {
-				return undefined;
-			}
-
-			const data = await response.json();
-			if ( data.success && data.data ) {
-				_ui = data.data._ui;
-			} else {
-				return undefined;
-			}
-		} catch ( error ) {
+	body.append( 'tracksNonce', nonce );
+	body.append( 'action', 'get_identity' );
+	try {
+		const response = await fetch( ajaxUrl, {
+			method: 'post',
+			body,
+		} );
+		if ( ! response.ok ) {
 			return undefined;
 		}
+
+		const data = await response.json();
+		if ( data.success && data.data && data.data._ui && data.data._ut ) {
+			return JSON.stringify( data.data );
+		}
+		return undefined;
+	} catch ( error ) {
+		return undefined;
 	}
-	const data = { _ut: 'anon', _ui: _ui };
-	return JSON.stringify( data );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fix the `getTracksIdentity` function so it no longer passes the `_ut` parameter as `anon` on all requests. Now, it will use the value received from the ajax request when the `tk_ai` cookie is not present.

#### Testing instructions
2661-gh-Automattic/woopay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.