### PR TITLE
Remove legacy `has_adapted_extension_installed` method from `WooPay_Utilities`

### DIFF
--- a/changelog/fix-remove-legacy-code-in-class-woopay-utilities
+++ b/changelog/fix-remove-legacy-code-in-class-woopay-utilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove legacy method from `WooPay_Utilities`.

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -253,23 +253,8 @@ class WooPay_Utilities {
 	}
 
 	/**
-	 * Returns true if an extension WooPay supports is installed .
-	 *
-	 * @return bool
-	 */
-	public function has_adapted_extension_installed() {
-		foreach ( self::ADAPTED_EXTENSIONS as $supported_extension ) {
-			if ( in_array( $supported_extension, apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Return an array with encrypted and signed data.
-	 * 
+	 *
 	 * @param array $data The data to be encrypted and signed.
 	 * @return array The encrypted and signed data.
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Remove unused legacy `has_adapted_extension_installed` method from `WooPay_Utilities`.

#### Testing instructions

- Ensure the method is not being used in the codebase.
- Ensure all CI tests pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
