### PR TITLE
Update payment activity survey key

### DIFF
--- a/changelog/update-payment-activity-survey-key
+++ b/changelog/update-payment-activity-survey-key
@@ -1,0 +1,3 @@
+Significance: patch
+Type: update
+Comment: Not user-facing. Update the payment activity survey key from `wcpay-payments-overview` → `wcpay-payment-activity`

--- a/includes/admin/class-wc-rest-payments-survey-controller.php
+++ b/includes/admin/class-wc-rest-payments-survey-controller.php
@@ -117,7 +117,7 @@ class WC_REST_Payments_Survey_Controller extends WP_REST_Controller {
 			],
 			[
 				'site_id'          => $this->http_client->get_blog_id(),
-				'survey_id'        => 'wcpay-payments-overview',
+				'survey_id'        => 'wcpay-payment-activity',
 				'survey_responses' => [
 					'rating'        => $rating,
 					'comments'      => [ 'text' => $comments ],

--- a/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-survey-controller.php
@@ -76,7 +76,7 @@ class WC_REST_Payments_Survey_Controller_Test extends WP_UnitTestCase {
 					$this->arrayHasKey( 'survey_responses' ),
 					$this->callback(
 						function ( $argument ) {
-							return 'wcpay-payments-overview' === $argument['survey_id'];
+							return 'wcpay-payment-activity' === $argument['survey_id'];
 						}
 					),
 					$this->callback(


### PR DESCRIPTION
Fixes #8693

#### Changes proposed in this Pull Request

This PR updates the key used to identify the payment activity survey from `wcpay-payments-overview` to `wcpay-payment-activity`, as per the change in D140691-code.

> [!IMPORTANT]  
> Please review this in unison with D140691-code


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- run `wp option update _wcpay_feature_payment_overview_widget 1` in CLI (`npm run cli` if docker)
- change your host file to point `public-api.wordpress.com` and `dev-mc.a8c.com` to your sandbox's IP address if you didn't already
- log-in to your sandbox
- apply the patch created in #8314 to your dev server (`arc patch D140691`)
- in the client admin panel, go to `Payments -> Overview`
- click one of the first 3 emoji, a textarea for comments should appear
- add a comment and submit
- after submitting the results, go to https://dev-mc.a8c.com/marketing/survey/index.php?survey=wcpay-payment-activity and check the answers.
- to re-submit, run `wp option delete wcpay_survey_payment_overview_submitted` to clear your local submission state


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
