### PR TITLE
Remove risk review references from the transactions page

### DIFF
--- a/changelog/fix-8697-remove-transactions-review
+++ b/changelog/fix-8697-remove-transactions-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove risk review request from the transactions page.

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -156,29 +156,4 @@ describe( 'Fraud protection rule toggle tests', () => {
 			mockContext.protectionSettingsUI.test_rule.enabled
 		).toBeFalsy();
 	} );
-	test.skip( 'sets the value correctly when block is selected', () => {
-		mockContext.protectionSettingsUI.test_rule.enabled = true;
-		const container = render(
-			<FraudPreventionSettingsContext.Provider value={ mockContext }>
-				<FraudProtectionRuleToggle
-					setting={ 'test_rule' }
-					label={ 'Test rule toggle' }
-				>
-					test content
-				</FraudProtectionRuleToggle>
-			</FraudPreventionSettingsContext.Provider>
-		);
-		const blockRadio = container.getByLabelText( 'Block Payment' );
-		const reviewRadio = container.getByLabelText(
-			'Authorize and hold for review'
-		);
-
-		expect( mockContext.protectionSettingsUI.test_rule.block ).toBeFalsy();
-
-		userEvent.click( blockRadio );
-		expect( mockContext.protectionSettingsUI.test_rule.block ).toBeTruthy();
-
-		userEvent.click( reviewRadio );
-		expect( mockContext.protectionSettingsUI.test_rule.block ).toBeFalsy();
-	} );
 } );

--- a/client/transactions/blocked/index.tsx
+++ b/client/transactions/blocked/index.tsx
@@ -47,14 +47,13 @@ export const BlockedList = (): JSX.Element => {
 	const columnsToDisplay = getBlockedListColumns();
 	const { isLoading, transactions } = useFraudOutcomeTransactions(
 		'block',
-		query,
-		'review'
+		query
 	);
 
 	const {
 		transactionsSummary,
 		isLoading: isSummaryLoading,
-	} = useFraudOutcomeTransactionsSummary( 'block', query, 'review' );
+	} = useFraudOutcomeTransactionsSummary( 'block', query );
 
 	const rows = transactions.map( ( transaction ) =>
 		getBlockedListColumnsStructure( transaction, columnsToDisplay )

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -20,10 +20,8 @@ import {
 	useManualCapture,
 	useSettings,
 	useAuthorizationsSummary,
-	useFraudOutcomeTransactionsSummary,
 } from 'wcpay/data';
 import WCPaySettingsContext from '../settings/wcpay-settings-context';
-import RiskReviewList from './risk-review';
 import BlockedList from './blocked';
 
 declare const window: any;
@@ -31,7 +29,6 @@ declare const window: any;
 export const TransactionsPage: React.FC = () => {
 	const currentQuery = getQuery();
 	const initialTab = currentQuery.tab ?? null;
-	const { isFRTReviewFeatureActive } = wcpaySettings;
 
 	const onTabSelected = ( tab: string ) => {
 		// When switching tabs, make sure to revert the query strings to default values
@@ -58,11 +55,6 @@ export const TransactionsPage: React.FC = () => {
 				<Authorizations />
 			</>
 		),
-		'review-page': (
-			<>
-				<RiskReviewList />
-			</>
-		),
 		'blocked-page': (
 			<>
 				<BlockedList />
@@ -76,10 +68,6 @@ export const TransactionsPage: React.FC = () => {
 	const [ getIsManualCaptureEnabled ] = useManualCapture();
 	const { isLoading: isLoadingSettings } = useSettings();
 	const { authorizationsSummary } = useAuthorizationsSummary( {} );
-
-	const {
-		transactionsSummary: riskReviewSummary,
-	} = useFraudOutcomeTransactionsSummary( 'review', {} );
 
 	// The Uncaptured authorizations screen will be shown only if:
 	// 1. The feature is turned on for all accounts
@@ -106,28 +94,11 @@ export const TransactionsPage: React.FC = () => {
 			className: 'authorizations-list',
 		},
 		{
-			name: 'review-page',
-			title: sprintf(
-				/* translators: %1: number of transactions hold for review */
-				__( 'Risk Review (%1$s)', 'woocommerce-payments' ),
-				riskReviewSummary.count ?? '...'
-			),
-			className: 'review-list',
-		},
-		{
 			name: 'blocked-page',
 			title: __( 'Blocked', 'woocommerce-payments' ),
 			className: 'blocked-list',
 		},
 	].filter( ( item ) => {
-		// @todo Remove feature flag
-		if (
-			! isFRTReviewFeatureActive &&
-			[ 'review-page' ].includes( item.name )
-		) {
-			return false;
-		}
-
 		if ( 'uncaptured-page' !== item.name ) return true;
 
 		return isAuthAndCaptureEnabled && shouldShowUncapturedTab;


### PR DESCRIPTION
Fixes #8697

#### Changes proposed in this Pull Request

This PR aims to remove the risk review references from the transactions page since it was impacting the page's performance by dispatching unnecessary HTTP requests.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Unit tests should be passing
* Run `npm run build:client`
* Go to **Payments > Transactions**
* The page should be loaded correctly
* Open the "Blocked" tab
* The tab content should be loaded correctly

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
