### PR TITLE
Remove the feature flag for the pay-for-order flow

### DIFF
--- a/changelog/remove-feature-flag-for-the-pay-for-order-flow
+++ b/changelog/remove-feature-flag-for-the-pay-for-order-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove feature flag for the pay-for-order flow

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -21,7 +21,6 @@ class WC_Payments_Features {
 	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME = '_wcpay_feature_woopay_first_party_auth';
 	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME  = '_wcpay_feature_woopay_direct_checkout';
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
-	const PAY_FOR_ORDER_FLOW                = '_wcpay_feature_pay_for_order_flow';
 	const DISPUTE_ISSUER_EVIDENCE           = '_wcpay_feature_dispute_issuer_evidence';
 	const STREAMLINE_REFUNDS_FLAG_NAME      = '_wcpay_feature_streamline_refunds';
 	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME = '_wcpay_feature_payment_overview_widget';
@@ -352,15 +351,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether the pay for order flow is enabled
-	 *
-	 * @return bool
-	 */
-	public static function is_pay_for_order_flow_enabled() {
-		return '1' === get_option( self::PAY_FOR_ORDER_FLOW, '0' );
-	}
-
-	/**
 	 * Checks whether Dispute issuer evidence feature should be enabled. Disabled by default.
 	 *
 	 * @return bool
@@ -392,7 +382,6 @@ class WC_Payments_Features {
 				'clientSecretEncryption'         => self::is_client_secret_encryption_enabled(),
 				'woopayExpressCheckout'          => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled'        => self::is_auth_and_capture_enabled(),
-				'isPayForOrderFlowEnabled'       => self::is_pay_for_order_flow_enabled(),
 				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 				'isRefundControlsEnabled'        => self::is_streamline_refunds_enabled(),
 				'isPaymentOverviewWidgetEnabled' => self::is_payment_overview_widget_ui_enabled(),

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -130,7 +130,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	 * @return bool
 	 */
 	private function is_pay_for_order_flow_supported() {
-		return ( WC_Payments_Features::is_pay_for_order_flow_enabled() && class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '11.1.0', '>=' ) );
+		return ( class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '11.1.0', '>=' ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Remove the feature flag for the pay-for-order flow

**NOTE: 
1. WooCommerce Pre-Orders `2.1.0` is incompatible with Blocks checkout. Issue [here](https://github.com/woocommerce/woocommerce-pre-orders/issues/510)**
2. Pre-Orders is on the incompatible plugins list on [MC tools](https://mc.a8c.com/woopay/) so WooPay won't be available for any store that has the pre-orders plugin installed

#### Testing instructions
1. Test with [dev tools PR](https://github.com/Automattic/woocommerce-payments-dev-tools/pull/117)
2. If you would like to test all the scenarios, you can follow [the testing file](https://docs.google.com/spreadsheets/d/1BX8kLgVtNqMQQcQoqb25MtZhb_CjYa5y8xgz3ULhpxE/edit#gid=0). Otherwise, test with WooCommerce Bookings and WooCommerce Deposits with logged in user and logged out user.


-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
