### PR TITLE
Use correct currency in Payment Activity Card

### DIFF
--- a/changelog/fix-8700-payment-activity-card-default-account-currency
+++ b/changelog/fix-8700-payment-activity-card-default-account-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update Payment Activity Card to use correct currency for rendering amounts.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -41,14 +41,14 @@ const PaymentActivityData: React.FC = () => {
 	const fees = paymentActivityData?.fees ?? 0;
 	const disputes = paymentActivityData?.disputes ?? 0;
 	const refunds = paymentActivityData?.refunds ?? 0;
-	const { storeCurrency } = wcpaySettings;
+	const currency = paymentActivityData?.currency;
 
 	return (
 		<div className="wcpay-payment-activity-data">
 			<PaymentDataTile
 				id="wcpay-payment-activity-data__total-payment-volume"
 				label={ __( 'Total payment volume', 'woocommerce-payments' ) }
-				currencyCode={ storeCurrency }
+				currencyCode={ currency }
 				tooltip={
 					<ClickTooltip
 						className="wcpay-payment-activity-data__total-payment-volume__tooltip"
@@ -100,7 +100,7 @@ const PaymentActivityData: React.FC = () => {
 				<PaymentDataTile
 					id="wcpay-payment-data-highlights__charges"
 					label={ __( 'Charges', 'woocommerce-payments' ) }
-					currencyCode={ storeCurrency }
+					currencyCode={ currency }
 					tooltip={
 						<ClickTooltip
 							className="payment-data-highlights__charges__tooltip"
@@ -132,7 +132,7 @@ const PaymentActivityData: React.FC = () => {
 				<PaymentDataTile
 					id="wcpay-payment-data-highlights__refunds"
 					label={ __( 'Refunds', 'woocommerce-payments' ) }
-					currencyCode={ storeCurrency }
+					currencyCode={ currency }
 					amount={ refunds }
 					reportLink={ getAdminUrl( {
 						page: 'wc-admin',
@@ -151,7 +151,7 @@ const PaymentActivityData: React.FC = () => {
 				<PaymentDataTile
 					id="wcpay-payment-data-highlights__disputes"
 					label={ __( 'Disputes', 'woocommerce-payments' ) }
-					currencyCode={ storeCurrency }
+					currencyCode={ currency }
 					amount={ disputes }
 					reportLink={ getAdminUrl( {
 						page: 'wc-admin',
@@ -170,7 +170,7 @@ const PaymentActivityData: React.FC = () => {
 				<PaymentDataTile
 					id="wcpay-payment-data-highlights__fees"
 					label={ __( 'Fees', 'woocommerce-payments' ) }
-					currencyCode={ storeCurrency }
+					currencyCode={ currency }
 					tooltip={
 						<ClickTooltip
 							className="payment-data-highlights__fees__tooltip"

--- a/client/components/payment-activity/payment-data-tile.tsx
+++ b/client/components/payment-activity/payment-data-tile.tsx
@@ -8,10 +8,10 @@ import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-
 import { formatCurrency } from 'wcpay/utils/currency';
 import Loadable from '../loadable';
 import './style.scss';
+
 interface PaymentDataTileProps {
 	/**
 	 * The id for the tile, can be used for CSS styling.
@@ -24,7 +24,7 @@ interface PaymentDataTileProps {
 	/**
 	 * The currency code for the amount displayed.
 	 */
-	currencyCode: string;
+	currencyCode?: string;
 	/**
 	 * For optionally passing a ClickTooltip component.
 	 */

--- a/client/components/payment-activity/payment-data-tile.tsx
+++ b/client/components/payment-activity/payment-data-tile.tsx
@@ -53,9 +53,9 @@ const PaymentDataTile: React.FC< PaymentDataTileProps > = ( {
 	reportLink,
 } ) => {
 	return (
-		<div id={ id } className="wcpay-payment-data-highlights__item">
+		<div className="wcpay-payment-data-highlights__item">
 			<p className="wcpay-payment-data-highlights__item__label">
-				<span>{ label }</span>
+				<span id={ id }>{ label }</span>
 				{ ! isLoading && tooltip }
 			</p>
 			<div className="wcpay-payment-data-highlights__item__wrapper">

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -27,12 +27,13 @@ exports[`PaymentActivity component should render 1`] = `
         >
           <div
             class="wcpay-payment-data-highlights__item"
-            id="wcpay-payment-activity-data__total-payment-volume"
           >
             <p
               class="wcpay-payment-data-highlights__item__label"
             >
-              <span>
+              <span
+                id="wcpay-payment-activity-data__total-payment-volume"
+              >
                 Total payment volume
               </span>
               <button
@@ -71,7 +72,7 @@ exports[`PaymentActivity component should render 1`] = `
                 aria-labelledby="wcpay-payment-activity-data__total-payment-volume"
                 class="wcpay-payment-data-highlights__item__wrapper__amount"
               >
-                $1,234.56
+                €1.234,56
               </p>
               <a
                 data-link-type="wc-admin"
@@ -86,12 +87,13 @@ exports[`PaymentActivity component should render 1`] = `
           >
             <div
               class="wcpay-payment-data-highlights__item"
-              id="wcpay-payment-data-highlights__charges"
             >
               <p
                 class="wcpay-payment-data-highlights__item__label"
               >
-                <span>
+                <span
+                  id="wcpay-payment-data-highlights__charges"
+                >
                   Charges
                 </span>
                 <button
@@ -130,7 +132,7 @@ exports[`PaymentActivity component should render 1`] = `
                   aria-labelledby="wcpay-payment-data-highlights__charges"
                   class="wcpay-payment-data-highlights__item__wrapper__amount"
                 >
-                  $98.76
+                  €98,76
                 </p>
                 <a
                   data-link-type="wc-admin"
@@ -142,12 +144,13 @@ exports[`PaymentActivity component should render 1`] = `
             </div>
             <div
               class="wcpay-payment-data-highlights__item"
-              id="wcpay-payment-data-highlights__refunds"
             >
               <p
                 class="wcpay-payment-data-highlights__item__label"
               >
-                <span>
+                <span
+                  id="wcpay-payment-data-highlights__refunds"
+                >
                   Refunds
                 </span>
               </p>
@@ -158,7 +161,7 @@ exports[`PaymentActivity component should render 1`] = `
                   aria-labelledby="wcpay-payment-data-highlights__refunds"
                   class="wcpay-payment-data-highlights__item__wrapper__amount"
                 >
-                  $44.44
+                  €44,44
                 </p>
                 <a
                   data-link-type="wc-admin"
@@ -170,12 +173,13 @@ exports[`PaymentActivity component should render 1`] = `
             </div>
             <div
               class="wcpay-payment-data-highlights__item"
-              id="wcpay-payment-data-highlights__disputes"
             >
               <p
                 class="wcpay-payment-data-highlights__item__label"
               >
-                <span>
+                <span
+                  id="wcpay-payment-data-highlights__disputes"
+                >
                   Disputes
                 </span>
               </p>
@@ -186,7 +190,7 @@ exports[`PaymentActivity component should render 1`] = `
                   aria-labelledby="wcpay-payment-data-highlights__disputes"
                   class="wcpay-payment-data-highlights__item__wrapper__amount"
                 >
-                  $55.55
+                  €55,55
                 </p>
                 <a
                   data-link-type="wc-admin"
@@ -198,12 +202,13 @@ exports[`PaymentActivity component should render 1`] = `
             </div>
             <div
               class="wcpay-payment-data-highlights__item"
-              id="wcpay-payment-data-highlights__fees"
             >
               <p
                 class="wcpay-payment-data-highlights__item__label"
               >
-                <span>
+                <span
+                  id="wcpay-payment-data-highlights__fees"
+                >
                   Fees
                 </span>
                 <button
@@ -242,7 +247,7 @@ exports[`PaymentActivity component should render 1`] = `
                   aria-labelledby="wcpay-payment-data-highlights__fees"
                   class="wcpay-payment-data-highlights__item__wrapper__amount"
                 >
-                  $12.34
+                  €12,34
                 </p>
               </div>
             </div>

--- a/client/components/payment-activity/test/__snapshots__/payment-data-tile.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/payment-data-tile.test.tsx.snap
@@ -4,12 +4,13 @@ exports[`PaymentDataTile renders correctly 1`] = `
 <div>
   <div
     class="wcpay-payment-data-highlights__item"
-    id="total-payment"
   >
     <p
       class="wcpay-payment-data-highlights__item__label"
     >
-      <span>
+      <span
+        id="total-payment"
+      >
         Total payment volume
       </span>
     </p>

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -38,7 +38,7 @@ const mockUsePaymentActivityData = usePaymentActivityData as jest.MockedFunction
 
 mockUsePaymentActivityData.mockReturnValue( {
 	paymentActivityData: {
-		currency: 'EUR',
+		currency: 'eur',
 		total_payment_volume: 123456,
 		charges: 9876,
 		fees: 1234,

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -44,6 +44,10 @@ mockUsePaymentActivityData.mockReturnValue( {
 		fees: 1234,
 		disputes: 5555,
 		refunds: 4444,
+		date_start: '2024-01-01',
+		date_end: '2024-01-31',
+		timezone: 'UTC',
+		interval: 'daily',
 	},
 	isLoading: false,
 } );

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -38,6 +38,7 @@ const mockUsePaymentActivityData = usePaymentActivityData as jest.MockedFunction
 
 mockUsePaymentActivityData.mockReturnValue( {
 	paymentActivityData: {
+		currency: 'EUR',
 		total_payment_volume: 123456,
 		charges: 9876,
 		fees: 1234,
@@ -83,10 +84,10 @@ describe( 'PaymentActivity component', () => {
 					},
 				},
 			},
-			accountDefaultCurrency: 'USD',
+			accountDefaultCurrency: 'EUR',
 			zeroDecimalCurrencies: [],
 			connect: {
-				country: 'US',
+				country: 'DE',
 			},
 			currencyData: {
 				US: {
@@ -117,10 +118,16 @@ describe( 'PaymentActivity component', () => {
 	} );
 
 	it( 'should render', () => {
-		const { container, getByText } = render( <PaymentActivity /> );
+		const { container, getByText, getByLabelText } = render(
+			<PaymentActivity />
+		);
 
 		// Check survey is rendered.
 		getByText( 'Are those metrics helpful?' );
+
+		// Check correct currency/value is displayed.
+		const tpvElement = getByLabelText( 'Total payment volume' );
+		expect( tpvElement ).toHaveTextContent( '€1.234,56' );
 
 		expect( container ).toMatchSnapshot();
 	} );

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -88,7 +88,7 @@ describe( 'PaymentActivity component', () => {
 					},
 				},
 			},
-			accountDefaultCurrency: 'EUR',
+			accountDefaultCurrency: 'eur',
 			zeroDecimalCurrencies: [],
 			connect: {
 				country: 'DE',

--- a/client/components/payment-activity/test/payment-data-tile.test.tsx
+++ b/client/components/payment-activity/test/payment-data-tile.test.tsx
@@ -22,7 +22,7 @@ declare const global: {
 
 describe( 'PaymentDataTile', () => {
 	global.wcpaySettings = {
-		accountDefaultCurrency: 'USD',
+		accountDefaultCurrency: 'usd',
 		zeroDecimalCurrencies: [],
 		connect: {
 			country: 'US',
@@ -43,7 +43,7 @@ describe( 'PaymentDataTile', () => {
 		const { container } = render(
 			<PaymentDataTile
 				id="total-payment"
-				currencyCode="USD"
+				currencyCode="usd"
 				label="Total payment volume"
 			/>
 		);
@@ -55,7 +55,7 @@ describe( 'PaymentDataTile', () => {
 		render(
 			<PaymentDataTile
 				id="total-payment"
-				currencyCode="USD"
+				currencyCode="usd"
 				label={ label }
 				amount={ 123 }
 			/>
@@ -66,7 +66,7 @@ describe( 'PaymentDataTile', () => {
 
 	test( 'renders amount correctly', () => {
 		const amount = 10000;
-		const currencyCode = 'USD';
+		const currencyCode = 'usd';
 		render(
 			<PaymentDataTile
 				id="charges-test-tile"
@@ -86,7 +86,7 @@ describe( 'PaymentDataTile', () => {
 				id="charges-test-tile"
 				label="Charges"
 				amount={ 10000 }
-				currencyCode="USD"
+				currencyCode="usd"
 				reportLink={ reportLink }
 			/>
 		);

--- a/client/components/payment-activity/test/payment-data-tile.test.tsx
+++ b/client/components/payment-activity/test/payment-data-tile.test.tsx
@@ -57,10 +57,11 @@ describe( 'PaymentDataTile', () => {
 				id="total-payment"
 				currencyCode="USD"
 				label={ label }
+				amount={ 123 }
 			/>
 		);
-		const labelElement = screen.getByText( label );
-		expect( labelElement ).toBeInTheDocument();
+		expect( screen.getByText( label ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( label ) ).toHaveTextContent( '$1.23' );
 	} );
 
 	test( 'renders amount correctly', () => {

--- a/client/data/payment-activity/resolvers.ts
+++ b/client/data/payment-activity/resolvers.ts
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { NAMESPACE } from '../constants';
 import { updatePaymentActivity } from './actions';
-import { PaymentActivityData, QueryDate } from './types';
+import type { PaymentActivityData, PaymentActivityQuery } from './types';
 
 /**
  * Retrieves payment activity data from the reporting API.
@@ -21,7 +21,7 @@ import { PaymentActivityData, QueryDate } from './types';
  * @param {string} query Data on which to parameterize the selection.
  */
 export function* getPaymentActivityData(
-	query: QueryDate
+	query: PaymentActivityQuery
 ): Generator< unknown > {
 	const path = addQueryArgs(
 		`${ NAMESPACE }/reporting/payment_activity`,

--- a/client/data/payment-activity/selectors.ts
+++ b/client/data/payment-activity/selectors.ts
@@ -6,6 +6,8 @@
 import { State } from 'wcpay/data/types';
 import { PaymentActivityData } from './types';
 
-export const getPaymentActivityData = ( state: State ): PaymentActivityData => {
-	return state?.paymentActivity?.paymentActivityData || {};
+export const getPaymentActivityData = (
+	state: State
+): PaymentActivityData | undefined => {
+	return state?.paymentActivity?.paymentActivityData;
 };

--- a/client/data/payment-activity/test/hooks.test.ts
+++ b/client/data/payment-activity/test/hooks.test.ts
@@ -13,6 +13,7 @@ jest.mock( '@wordpress/data' );
 describe( 'usePaymentActivityData', () => {
 	test( 'should return the correct payment activity data and loading state', () => {
 		const mockPaymentActivityData = {
+			currency: 'JPY',
 			total_payment_volume: 2500,
 			charges: 3000,
 			fees: 300,

--- a/client/data/payment-activity/test/hooks.test.ts
+++ b/client/data/payment-activity/test/hooks.test.ts
@@ -13,7 +13,7 @@ jest.mock( '@wordpress/data' );
 describe( 'usePaymentActivityData', () => {
 	test( 'should return the correct payment activity data and loading state', () => {
 		const mockPaymentActivityData = {
-			currency: 'JPY',
+			currency: 'jpy',
 			total_payment_volume: 2500,
 			charges: 3000,
 			fees: 300,

--- a/client/data/payment-activity/test/reducer.test.ts
+++ b/client/data/payment-activity/test/reducer.test.ts
@@ -12,7 +12,7 @@ describe( 'receivePaymentActivity', () => {
 		fees: 300,
 		disputes: 315,
 		refunds: 200,
-		currency: 'JPY',
+		currency: 'jpy',
 		timezone: 'UTC',
 		date_start: '2024-01-01',
 		date_end: '2024-01-31',

--- a/client/data/payment-activity/test/reducer.test.ts
+++ b/client/data/payment-activity/test/reducer.test.ts
@@ -12,6 +12,11 @@ describe( 'receivePaymentActivity', () => {
 		fees: 300,
 		disputes: 315,
 		refunds: 200,
+		currency: 'JPY',
+		timezone: 'UTC',
+		date_start: '2024-01-01',
+		date_end: '2024-01-31',
+		interval: 'daily',
 	};
 
 	test( 'should set payment activity data correctly', () => {

--- a/client/data/payment-activity/types.d.ts
+++ b/client/data/payment-activity/types.d.ts
@@ -1,11 +1,18 @@
 /** @format */
 
 export interface PaymentActivityData {
-	total_payment_volume?: number; // Total payment volume
-	charges?: number; // Charges
-	fees?: number; // Fees
-	disputes?: number; // Disputes
-	refunds?: number; // Refunds
+	/** The currency code for the amounts below, e.g. `usd` */
+	currency?: string;
+	/** Total payment volume amount */
+	total_payment_volume?: number;
+	/** Charges total amount */
+	charges?: number;
+	/** Fees total amount */
+	fees?: number;
+	/** Disputes total amount */
+	disputes?: number;
+	/** Refunds total amount */
+	refunds?: number;
 }
 
 export interface PaymentActivityState {

--- a/client/data/payment-activity/types.d.ts
+++ b/client/data/payment-activity/types.d.ts
@@ -2,17 +2,25 @@
 
 export interface PaymentActivityData {
 	/** The currency code for the amounts below, e.g. `usd` */
-	currency?: string;
+	currency: string;
 	/** Total payment volume amount */
-	total_payment_volume?: number;
+	total_payment_volume: number;
 	/** Charges total amount */
-	charges?: number;
+	charges: number;
 	/** Fees total amount */
-	fees?: number;
+	fees: number;
 	/** Disputes total amount */
-	disputes?: number;
+	disputes: number;
 	/** Refunds total amount */
-	refunds?: number;
+	refunds: number;
+	/** The timezone used to calculate the date range, e.g. 'UTC' */
+	timezone: string;
+	/** The date range start date */
+	date_start: string;
+	/** The date range end date */
+	date_end: string;
+	/** The interval used to calculate transaction data, e.g. 'daily' */
+	interval: string;
 }
 
 export interface PaymentActivityState {

--- a/client/data/payment-activity/types.d.ts
+++ b/client/data/payment-activity/types.d.ts
@@ -33,11 +33,6 @@ export interface PaymentActivityAction {
 	data: PaymentActivityData;
 }
 
-export interface QueryDate {
-	date_start: string;
-	date_end: string;
-}
-
 export interface PaymentActivityQuery {
 	date_start: string;
 	date_end: string;

--- a/client/data/payment-activity/types.d.ts
+++ b/client/data/payment-activity/types.d.ts
@@ -15,9 +15,9 @@ export interface PaymentActivityData {
 	refunds: number;
 	/** The timezone used to calculate the date range, e.g. 'UTC' */
 	timezone: string;
-	/** The date range start date */
+	/** The date range start datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */
 	date_start: string;
-	/** The date range end date */
+	/** The date range end datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */
 	date_end: string;
 	/** The interval used to calculate transaction data, e.g. 'daily' */
 	interval: string;
@@ -34,7 +34,10 @@ export interface PaymentActivityAction {
 }
 
 export interface PaymentActivityQuery {
+	/** The date range start datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */
 	date_start: string;
+	/** The date range end datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */
 	date_end: string;
+	/** The timezone used to calculate the transaction data date range, e.g. 'UTC' */
 	timezone?: string;
 }


### PR DESCRIPTION
Fixes #8700

#### Changes proposed in this Pull Request

This PR ensures the Payment Activity Card shows amounts in the correct currency by using the `currency` property returned by the `reporting/payment_activity` endpoint response.

I've also updated the interface for the `reporting/payment_activity` API response to reflect the server response ([response code ref](https://github.com/Automattic/woocommerce-payments-server/blob/f61c8880fc043477f3cfb1e9de0913547e973dac/server/wp-content/rest-api-plugins/endpoints/wcpay/class-reporting-controller.php#L132-L141)):

https://github.com/Automattic/woocommerce-payments/blob/5e99257730c5f83d988e81a6fc1c6324ddb8a2ef/client/data/payment-activity/types.d.ts#L3-L24


#### Testing instructions

- Use a store that does not use `USD` (or any other dollar) as a default currency, e.g. onboard a German WCPay account with `NOK` or `CHF` as the default currency.
- Enable the feature flag: run `wp option update _wcpay_feature_payment_overview_widget 1` in CLI (`npm run cli` if docker)
- Go to `Payments -> Overview`
- Ensure that the Payment Activity renders amounts with the correct currency symbol (e.g. `CHF`, not `$`).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
