### PR TITLE
fix: checkout warning with Stripe Link

### DIFF
--- a/changelog/fix-stripe-link-terms-warning
+++ b/changelog/fix-stripe-link-terms-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: Stripe terms warning at checkout when Link is enabled

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -13,7 +13,9 @@ import { getPaymentMethodsConstants } from '../constants';
  */
 export const getTerms = ( paymentMethodsConfig, value = 'always' ) => {
 	const reusablePaymentMethods = Object.keys( paymentMethodsConfig ).filter(
-		( method ) => paymentMethodsConfig[ method ].isReusable
+		( method ) =>
+			// Stripe link doesn't need the "terms" - adding this property causes a warning in the console.
+			method !== 'link' && paymentMethodsConfig[ method ].isReusable
 	);
 
 	return reusablePaymentMethods.reduce( ( obj, method ) => {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Reported internally here: p1713912099548759-slack-CU6SYV31A

When Stripe Link is enabled, one of these warnings can appear on both Shortcode and Blocks checkout:
> [Stripe.js] Unrecognized elements.create('payment') parameter: terms.link is not a recognized parameter. This may cause issues with your integration in the future.
> [Stripe.js] Unrecognized payment.update() parameter: terms.link is not a recognized parameter. This may cause issues with your integration in the future.

Making a minor change to exclude the terms for Stripe Link.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have Stripe Link enabled in the settings
- You don't need to be a logged-in customer for this issue to appear. If you are a logged in customer, the issue will _also_ appear when you click on "save for future purchases" on shortcode checkout.
- Go to shortcode checkout
	- Select WooPayments' "card" as a payment method (if it isn't already selected)
	- Warning should no longer appear
- Go to Blocks checkout
	- Select WooPayments' "card" as a payment method (if it isn't already selected)
	- Warning should no longer appear

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.