### PR TITLE
Add more points to the Compatibility service

### DIFF
--- a/changelog/add-more-compatibility-points
+++ b/changelog/add-more-compatibility-points
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add additional data to Compatibility service

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -74,15 +74,23 @@ class Compatibility_Service {
 	 * @return array
 	 */
 	private function get_compatibility_data(): array {
-		$active_plugins   = get_option( 'active_plugins', [] );
-		$post_types_count = $this->get_post_types_count();
+		$active_plugins        = get_option( 'active_plugins', [] );
+		$post_types_count      = $this->get_post_types_count();
+		$wc_permalinks         = get_option( 'woocommerce_permalinks' );
+		$wc_shop_permalink     = get_permalink( wc_get_page_id( 'shop' ) );
+		$wc_cart_permalink     = get_permalink( wc_get_page_id( 'cart' ) );
+		$wc_checkout_permalink = get_permalink( wc_get_page_id( 'checkout' ) );
 
 		return [
-			'woopayments_version' => WCPAY_VERSION_NUMBER,
-			'woocommerce_version' => WC_VERSION,
-			'blog_theme'          => get_stylesheet(),
-			'active_plugins'      => $active_plugins,
-			'post_types_count'    => $post_types_count,
+			'woopayments_version'    => WCPAY_VERSION_NUMBER,
+			'woocommerce_version'    => WC_VERSION,
+			'woocommerce_permalinks' => $wc_permalinks,
+			'woocommerce_shop'       => $wc_shop_permalink,
+			'woocommerce_cart'       => $wc_cart_permalink,
+			'woocommerce_checkout'   => $wc_checkout_permalink,
+			'blog_theme'             => get_stylesheet(),
+			'active_plugins'         => $active_plugins,
+			'post_types_count'       => $post_types_count,
 		];
 	}
 

--- a/tests/unit/test-class-compatibility-service.php
+++ b/tests/unit/test-class-compatibility-service.php
@@ -176,11 +176,15 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 	private function get_mock_compatibility_data( array $args = [] ): array {
 		return array_merge(
 			[
-				'woopayments_version' => WCPAY_VERSION_NUMBER,
-				'woocommerce_version' => WC_VERSION,
-				'blog_theme'          => $this->stylesheet,
-				'active_plugins'      => $this->active_plugins,
-				'post_types_count'    => $this->post_types_count,
+				'woopayments_version'    => WCPAY_VERSION_NUMBER,
+				'woocommerce_version'    => WC_VERSION,
+				'woocommerce_permalinks' => get_option( 'woocommerce_permalinks' ),
+				'woocommerce_shop'       => get_permalink( wc_get_page_id( 'shop' ) ),
+				'woocommerce_cart'       => get_permalink( wc_get_page_id( 'cart' ) ),
+				'woocommerce_checkout'   => get_permalink( wc_get_page_id( 'checkout' ) ),
+				'blog_theme'             => $this->stylesheet,
+				'active_plugins'         => $this->active_plugins,
+				'post_types_count'       => $this->post_types_count,
 			],
 			$args
 		);

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1276,11 +1276,15 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	private function get_mock_compatibility_data( array $args = [] ): array {
 		return array_merge(
 			[
-				'woopayments_version' => WCPAY_VERSION_NUMBER,
-				'woocommerce_version' => WC_VERSION,
-				'blog_theme'          => 'default',
-				'active_plugins'      => [],
-				'post_types_count'    => [
+				'woopayments_version'    => WCPAY_VERSION_NUMBER,
+				'woocommerce_version'    => WC_VERSION,
+				'woocommerce_permalinks' => get_option( 'woocommerce_permalinks' ),
+				'woocommerce_shop'       => get_permalink( wc_get_page_id( 'shop' ) ),
+				'woocommerce_cart'       => get_permalink( wc_get_page_id( 'cart' ) ),
+				'woocommerce_checkout'   => get_permalink( wc_get_page_id( 'checkout' ) ),
+				'blog_theme'             => 'default',
+				'active_plugins'         => [],
+				'post_types_count'       => [
 					'post'       => 0,
 					'page'       => 0,
 					'attachment' => 0,


### PR DESCRIPTION
Part of https://github.com/Automattic/woocommerce-payments-server/pull/5213

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Adds additional data points to the Compatibility service

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions in https://github.com/Automattic/woocommerce-payments-server/pull/5213

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
