### PR TITLE
Fix type error for fraud outcome API

### DIFF
--- a/changelog/fix-5151-fraud-outcome-type-error
+++ b/changelog/fix-5151-fraud-outcome-type-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix type error for fraud outcome API.

--- a/includes/core/server/request/class-list-fraud-outcome-transactions.php
+++ b/includes/core/server/request/class-list-fraud-outcome-transactions.php
@@ -38,8 +38,8 @@ class List_Fraud_Outcome_Transactions extends Paginated {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function get_api(): string {
-		if ( ! Rule::is_valid_fraud_outcome_status( $this->status ) ) {
-			$status = $this->status ?? 'null';
+		$status = $this->status ?? 'null';
+		if ( ! Rule::is_valid_fraud_outcome_status( $status ) ) {
 			throw new Invalid_Request_Parameter_Exception( "Invalid fraud outcome status provided: $status", 'invalid_fraud_outcome_status' );
 		}
 		return WC_Payments_API_Client::FRAUD_OUTCOMES_API . '/status/' . $this->status;

--- a/includes/core/server/request/class-list-fraud-outcome-transactions.php
+++ b/includes/core/server/request/class-list-fraud-outcome-transactions.php
@@ -11,6 +11,7 @@ use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WC_Payments_Utils;
 use WC_Payments_API_Client;
 use WCPay\Constants\Fraud_Meta_Box_Type;
+use WCPay\Fraud_Prevention\Models\Rule;
 
 /**
  * Request class for getting intents.
@@ -37,6 +38,10 @@ class List_Fraud_Outcome_Transactions extends Paginated {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function get_api(): string {
+		if ( ! Rule::is_valid_fraud_outcome_status( $this->status ) ) {
+			$status = $this->status ?? 'null';
+			throw new Invalid_Request_Parameter_Exception( "Invalid fraud outcome status provided: $status", 'invalid_fraud_outcome_status' );
+		}
 		return WC_Payments_API_Client::FRAUD_OUTCOMES_API . '/status/' . $this->status;
 	}
 

--- a/tests/unit/core/server/request/test-class-list-fraud-outcome-transactions-request.php
+++ b/tests/unit/core/server/request/test-class-list-fraud-outcome-transactions-request.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request\List_Fraud_Outcome_Transactions;
 
 /**
@@ -68,6 +69,7 @@ class List_Fraud_Outcome_Transactions_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'GET', $request->get_method() );
 		$this->assertSame( WC_Payments_API_Client::FRAUD_OUTCOMES_API . '/status/' . $status, $request->get_api() );
 	}
+
 	public function test_list_fraud_outcome_transactions_request_using_from_rest_request_function() {
 		$page        = 2;
 		$page_size   = 50;
@@ -568,5 +570,30 @@ class List_Fraud_Outcome_Transactions_Test extends WCPAY_UnitTestCase {
 		];
 
 		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Checks to see if the get_api method throws an exception if an invalid status is passed.
+	 *
+	 * @param ?string $status The status to check.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider provider_get_api_exception_on_invalid_status
+	 */
+	public function test_get_api_exception_on_invalid_status( $status ): void {
+		$request = new List_Fraud_Outcome_Transactions( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_status( $status );
+
+		$status = $status ?? 'null';
+
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$this->expectExceptionMessage( "Invalid fraud outcome status provided: $status" );
+
+		$request->get_api();
+	}
+
+	public function provider_get_api_exception_on_invalid_status(): array {
+		return [ [ 'invalid' ], [ null ] ];
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments-server/issues/5151

#### Changes proposed in this Pull Request

* Throw an exception if the `status` of the `fraud_outcome`s being requested are not a valid status. 

#### Testing instructions

> [!NOTE]
> We haven't been able to determine how this is happening, we are just seeing the API calls on the server, so testing is done through Postman.

* Check out this branch.
* Apply the below diff.
* Use this info in Postman:
  * Method type: GET
  * URL: `https://YOUR_CLIENT_URL/wp-json/wc/v3/payments/transactions/fraud-outcomes?status=block`
* Send the request.
* You should receive a `data` array back with any fraud outcomes with the `block` status.
* Update the URL in Postman to: `https://YOUR_CLIENT_URL/wp-json/wc/v3/payments/transactions/fraud-outcomes?status=invalid`
* Send the request.
* You should receive a fatal error back that includes this message: _Invalid fraud
outcome status provided: invalid_

```diff
diff --git a/includes/admin/class-wc-payments-rest-controller.php b/includes/admin/class-wc-payments-rest-controller.php
index bb1d6ead7..aa3436212 100644
--- a/includes/admin/class-wc-payments-rest-controller.php
+++ b/includes/admin/class-wc-payments-rest-controller.php
@@ -61,6 +61,6 @@ class WC_Payments_REST_Controller extends WP_REST_Controller {
 	 * Override this method if custom permissions required.
 	 */
 	public function check_permission() {
-		return current_user_can( 'manage_woocommerce' );
+		return true;//current_user_can( 'manage_woocommerce' );
 	}
 }

```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
