### PR TITLE
Track used gateway when placing the order

### DIFF
--- a/changelog/add-track-gateway-type
+++ b/changelog/add-track-gateway-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Record gateway name when placing the order
+
+


### PR DESCRIPTION
Track the gateway name when a shopper places an order.

Fixes #8494

#### Changes proposed in this Pull Request

- For orders placed using WooPayments, the gateway name will be recorded via Tracks, through the `payment_title` property.
- For non-WooPayments orders, a simple counter will be incremented using bump stats without associating the action with a user.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. As a shopper, place an order using Klarna
2. Open browser dev tools and copy the value of your `tk_ai` cookie. URL decode the value and note it down.
3. In ~5 minutes, go to Tracks Live view in MC and search for the `wcpay_checkout_order_placed` and your Tracks identity noted in Step 2.
4. Make sure the `wcpay_checkout_order_placed` event shows up in Tracks Live view and it contains the `payment_title: Klarna` property
<img width="490" alt="SCR-20240222-jvgc" src="https://github.com/Automattic/woocommerce-payments/assets/6216000/26818b33-5f4b-402b-a0d0-0d9990638f7a">

5. Repeat the above steps with a Credit/Debit card, Affirm, any other payment methods offered via WooPayments, and make sure the correct payment title shows up.
6. Finally, use a non-WooPayments gateway (eg: PayPal, Stripe, Cash on Delivery) and make sure no Tracks event is recorded. Instead, visit `MC_URL/s/wcpay_order_completed_gateway/other/` and ensure the counter is incremented.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
