### PR TITLE
Update post-release-updates GitHub Actions workflow to delete all trailing newlines from Release-testing-instructions.md before adding new entries.

### DIFF
--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -155,8 +155,10 @@ jobs:
               echo ":warning: File "$NEXT_RELEASE_VERSION_INSTRUCTIONS_FILENAME.md" already exists. No action needed." >> $GITHUB_STEP_SUMMARY
           fi
           
-          # If an entry for the next version doesn't exist yet
+          # Check if this release version exists in Release-testing-instructions.md
+          # If not, remove all trailing newlines and add the new version for this release
           if ! grep -q "v$NEXT_RELEASE_VERSION" Release-testing-instructions.md; then
+            perl -pi -e 'BEGIN{undef $/;} s/\n+\z//' Release-testing-instructions.md
             echo -ne "\n* [v$NEXT_RELEASE_VERSION](https://github.com/Automattic/woocommerce-payments/wiki/$NEXT_RELEASE_VERSION_INSTRUCTIONS_FILENAME)" >> Release-testing-instructions.md
             echo "Added a new entry for v$NEXT_RELEASE_VERSION in \"Release-testing-instructions.md\"." >> $GITHUB_STEP_SUMMARY
             HAS_CHANGES=true

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -156,8 +156,8 @@ jobs:
           fi
           
           # Check if this release version exists in Release-testing-instructions.md
-          # If not, remove all trailing newlines and add the new version for this release
           if ! grep -q "v$NEXT_RELEASE_VERSION" Release-testing-instructions.md; then
+            # If it doesn't exist, remove all trailing newlines and add the new version for this release
             perl -pi -e 'BEGIN{undef $/;} s/\n+\z//' Release-testing-instructions.md
             echo -ne "\n* [v$NEXT_RELEASE_VERSION](https://github.com/Automattic/woocommerce-payments/wiki/$NEXT_RELEASE_VERSION_INSTRUCTIONS_FILENAME)" >> Release-testing-instructions.md
             echo "Added a new entry for v$NEXT_RELEASE_VERSION in \"Release-testing-instructions.md\"." >> $GITHUB_STEP_SUMMARY

--- a/changelog/update-post-release-updates
+++ b/changelog/update-post-release-updates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just a minor change in a GitHub Actions workflow to make it more robust.
+
+


### PR DESCRIPTION
Fixes #6816 

#### Context of the issue
The [Release Testing Instructions](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) are automatically updated after every release thanks to the [Handle post-release steps](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/post-release-updates.yml) GitHub Actions workflow.

If we look at the document history, we can see some versions where the bullet list format looks wrong. Examples:
- **Correct format**: [436dfa6](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions/436dfa6f73f413881c05b5fcd1c661af14d70a56)
- **Wrong format**: [abcc18b](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions/abcc18b4afc5ad669f1ca5251723323d48b79833).

This happened when there was a line break between the list and the new item added:
- Item a
- Item b
[line break]
- Item c

<details>

The initial thought was that the script that adds a new entry with the new release version to [Release Testing Instructions](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) had a bug that added a double line break somewhere, but after a deeper investigation, it seems the script works well - it doesn't add any double line break - but the line break was added as part of manual updates on the page.

If we take a closer look at the [page history](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions/_history?page=1), we can see 2 different kinds of titles:
- **Updated Release testing instructions (markdown)**: Most of the updates prior to 4th Nov 2022 had this title (the date when [this process became automated](https://github.com/Automattic/woocommerce-payments/pull/5003)). Therefore, we can assume that every update with this title was done manually.
- Update wiki for release a.b.c: This title format appeared once the process was automated, so we can [confirm](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/post-release-updates.yml#L169) this is the title set by the GH Actions workflow.

The format issue appeared inconsistently, but we can spot a pattern there: It appeared once the process was automated and only on the upcoming of certain manual updates. We can see a manual update in [ba27137](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions/ba27137792a445f5b006864da169577e1897be3c) and then the wrong format in the following automated update in [389d121](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions/389d12146b00f4299d6bc1ea07ebd8b1a3389e0d). **Therefore, we can confirm that this format issue appeared when a manual updated added a line break and then the script continue adding entries to the document**. We can see this pattern repeated multiple times, and you can check that the line breaks are indeed in the document if you clone the [wiki locally](https://github.com/Automattic/woocommerce-payments.wiki.git) and check the history. 
</details>

#### Changes proposed in this Pull Request
Even though the script is fine and the problem is caused by manual updates, there is a way to make the script more robust and avoid this problem from happening again.

This PR updates the `post-release-updates.yml` workflow to make sure the `update-wiki` job trims any trailing line breaks at the bottom of the `Release-testing-instructions` document before adding an entry for the new release.

#### Testing instructions

In order to improve the testability of this PR - as GitHub Actions can be tricky to test - I've created a Dockerfile that you can use locally to simulate the behaviour of these changes running on GitHub Actions. In order to be as similar as possible to the GitHub Actions set up, this Dockerfile runs on `ubuntu:latest` and uses `bash`.

* Copy the entire content from [this markdown file](https://gist.githubusercontent.com/alopezari/07add44cb80481793026a9d29ec0b244/raw/0a4313422d533851108ad50a54cc343e7621ac18/Release-testing-instructions.md) in a local file. Make sure this markdown file has one or more trailing line breaks at the bottom. Name this markdown file as `Release-testing-instructions.md`.
* Copy the content of [this gist](https://gist.githubusercontent.com/alopezari/194ede4ffc345f3808cc37b06f97426c/raw/2c4e2e5e47c2847b4b56a2a38e0e916f847e5308/Dockerfile) to a local `Dockerfile` and place it in the same path as the markdown above.
* Build the Dockerfile with `docker build -t update-md .`.
* Run the container with `docker run --rm -v "$(pwd)":/app update-md`.
* Together with the previous markdown file and the Dockerfile, you should have now another markdown file named `Updated-Release-testing-instructions.md`.
* Compare the content of `Release-testing-instructions.md` and `Updated-Release-testing-instructions.md`. Check that `Updated-Release-testing-instructions.md` no longer has the trailing line breaks from `Release-testing-instructions.md` at the bottom of the file and instead it has a new release entry:
```* [v9.9.9](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-9.9.9)```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
