### PR TITLE
Sending payment_method_update_data param to intent API

### DIFF
--- a/changelog/update-billing-address-saved-card
+++ b/changelog/update-billing-address-saved-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Updating saved payment method billing address before processing the payment

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -23,6 +23,27 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 	protected $rest_base = 'payments/charges';
 
 	/**
+	 * WC_Payments_Order_Service instance
+	 *
+	 * @var WC_Payments_Order_Service
+	 */
+	private $order_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Payments_API_Client    $api_client    WooCommerce Payments API client.
+	 * @param WC_Payments_Order_Service $order_service Order service.
+	 */
+	public function __construct(
+		WC_Payments_API_Client $api_client,
+		WC_Payments_Order_Service $order_service
+	) {
+		parent::__construct( $api_client );
+		$this->order_service = $order_service;
+	}
+
+	/**
 	 * Configure REST API routes.
 	 */
 	public function register_routes() {
@@ -81,7 +102,7 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 
 		$currency        = $order->get_currency();
 		$amount          = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
-		$billing_details = WC_Payments_Utils::get_billing_details_from_order( $order );
+		$billing_details = $this->order_service->get_billing_data_from_order( $order );
 		$date_created    = $order->get_date_created();
 		$intent_id       = $order->get_meta( '_intent_id' );
 		$intent_status   = $order->get_meta( '_intent_status' );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1402,19 +1402,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		];
 		list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order, $customer_details_options );
 
-		// Update saved payment method async to include billing details, if missing.
-		if ( $payment_information->is_using_saved_payment_method() ) {
-			$this->action_scheduler_service->schedule_job(
-				time(),
-				self::UPDATE_SAVED_PAYMENT_METHOD,
-				[
-					'payment_method' => $payment_information->get_payment_method(),
-					'order_id'       => $order->get_id(),
-					'is_test_mode'   => WC_Payments::mode()->is_test(),
-				]
-			);
-		}
-
 		$intent_failed  = false;
 		$payment_needed = $amount > 0;
 
@@ -1432,6 +1419,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// We need to make sure the saved payment method is saved to the order so we can
 				// charge the payment method for a future payment.
 				$this->add_token_to_order( $order, $payment_information->get_payment_token() );
+				// If we are not hitting the API for the intent, we need to update the saved payment method ourselves.
+				$this->action_scheduler_service->schedule_job(
+					time(),
+					self::UPDATE_SAVED_PAYMENT_METHOD,
+					[
+						'payment_method' => $payment_information->get_payment_method(),
+						'order_id'       => $order->get_id(),
+						'is_test_mode'   => WC_Payments::mode()->is_test(),
+					]
+				);
 			}
 
 			if ( $is_changing_payment_method_for_subscription && $payment_information->is_using_saved_payment_method() ) {
@@ -1514,6 +1511,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$request->set_payment_methods( $payment_methods );
 				$request->set_cvc_confirmation( $payment_information->get_cvc_confirmation() );
 				$request->set_hook_args( $payment_information );
+				if ( $payment_information->is_using_saved_payment_method() ) {
+					$billing_details = $this->order_service->get_billing_data_from_order( $order );
+
+					$is_legacy_card_object = strpos( $payment_information->get_payment_method() ?? '', 'card_' ) === 0;
+
+					// Not updating billing details for legacy card objects because they have a different structure and are no longer supported.
+					if ( ! empty( $billing_details ) && ! $is_legacy_card_object ) {
+						$request->set_payment_method_update_data( [ 'billing_details' => $billing_details ] );
+					}
+				}
 				// Add specific payment method parameters to the request.
 				$this->modify_create_intent_parameters_when_processing_payment( $request, $payment_information, $order );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1514,7 +1514,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( $payment_information->is_using_saved_payment_method() ) {
 					$billing_details = $this->order_service->get_billing_data_from_order( $order );
 
-					$is_legacy_card_object = strpos( $payment_information->get_payment_method() ?? '', 'card_' ) === 0;
+					$is_legacy_card_object = (bool) preg_match( '/^(card_|src_)/', $payment_information->get_payment_method() );
 
 					// Not updating billing details for legacy card objects because they have a different structure and are no longer supported.
 					if ( ! empty( $billing_details ) && ! $is_legacy_card_object ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1892,7 +1892,7 @@ class WC_Payments_Account {
 	 *
 	 * @return string Currency code in lowercase.
 	 */
-	public function get_account_default_currency() {
+	public function get_account_default_currency(): string {
 		$account = $this->get_cached_account_data();
 		return $account['store_currencies']['default'] ?? strtolower( Currency_Code::UNITED_STATES_DOLLAR );
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -525,7 +525,7 @@ class WC_Payments_Account {
 	 *
 	 * @return array Fees.
 	 */
-	public function get_fees() {
+	public function get_fees(): array {
 		$account = $this->get_cached_account_data();
 		return ! empty( $account ) && isset( $account['fees'] ) ? $account['fees'] : [];
 	}

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -72,6 +72,13 @@ class WC_Payments_Customer_Service {
 	private $session_service;
 
 	/**
+	 * WC_Payments_Order_Service instance
+	 *
+	 * @var WC_Payments_Order_Service
+	 */
+	private $order_service;
+
+	/**
 	 * Class constructor
 	 *
 	 * @param WC_Payments_API_Client      $payments_api_client Payments API client.
@@ -83,12 +90,14 @@ class WC_Payments_Customer_Service {
 		WC_Payments_API_Client $payments_api_client,
 		WC_Payments_Account $account,
 		Database_Cache $database_cache,
-		WC_Payments_Session_Service $session_service
+		WC_Payments_Session_Service $session_service,
+		WC_Payments_Order_Service $order_service
 	) {
 		$this->payments_api_client = $payments_api_client;
 		$this->account             = $account;
 		$this->database_cache      = $database_cache;
 		$this->session_service     = $session_service;
+		$this->order_service       = $order_service;
 
 		/*
 		 * Adds the WooCommerce Payments customer ID found in the user session
@@ -283,7 +292,7 @@ class WC_Payments_Customer_Service {
 	 * @param WC_Order $order             Order to be used on the update.
 	 */
 	public function update_payment_method_with_billing_details_from_order( $payment_method_id, $order ) {
-		$billing_details = WC_Payments_Utils::get_billing_details_from_order( $order );
+		$billing_details = $this->order_service->get_billing_data_from_order( $order );
 
 		if ( ! empty( $billing_details ) ) {
 			$this->payments_api_client->update_payment_method(

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -338,32 +338,6 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Extract the billing details from the WC order
-	 *
-	 * @param WC_Order $order Order to extract the billing details from.
-	 *
-	 * @return array
-	 */
-	public static function get_billing_details_from_order( $order ) {
-		$billing_details = [
-			'address' => [
-				'city'        => $order->get_billing_city(),
-				'country'     => $order->get_billing_country(),
-				'line1'       => $order->get_billing_address_1(),
-				'line2'       => $order->get_billing_address_2(),
-				'postal_code' => $order->get_billing_postcode(),
-				'state'       => $order->get_billing_state(),
-			],
-			'email'   => $order->get_billing_email(),
-			'name'    => trim( $order->get_formatted_billing_full_name() ),
-			'phone'   => $order->get_billing_phone(),
-		];
-
-		$billing_details['address'] = array_filter( $billing_details['address'] );
-		return array_filter( $billing_details );
-	}
-
-	/**
 	 * Redacts the provided array, removing the sensitive information, and limits its depth to LOG_MAX_RECURSION.
 	 *
 	 * @param object|array $array          The array to redact.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -984,7 +984,7 @@ class WC_Payments {
 		$disputes_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-charges-controller.php';
-		$charges_controller = new WC_REST_Payments_Charges_Controller( self::$api_client, self::$order_service );
+		$charges_controller = new WC_REST_Payments_Charges_Controller( self::$api_client );
 		$charges_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-connection-tokens-controller.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -489,7 +489,7 @@ class WC_Payments {
 		self::$action_scheduler_service             = new WC_Payments_Action_Scheduler_Service( self::$api_client, self::$order_service );
 		self::$session_service                      = new WC_Payments_Session_Service( self::$api_client );
 		self::$account                              = new WC_Payments_Account( self::$api_client, self::$database_cache, self::$action_scheduler_service, self::$session_service );
-		self::$customer_service                     = new WC_Payments_Customer_Service( self::$api_client, self::$account, self::$database_cache, self::$session_service );
+		self::$customer_service                     = new WC_Payments_Customer_Service( self::$api_client, self::$account, self::$database_cache, self::$session_service, self::$order_service );
 		self::$token_service                        = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
 		self::$remote_note_service                  = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
 		self::$fraud_service                        = new WC_Payments_Fraud_Service( self::$api_client, self::$customer_service, self::$account, self::$session_service, self::$database_cache );
@@ -984,7 +984,7 @@ class WC_Payments {
 		$disputes_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-charges-controller.php';
-		$charges_controller = new WC_REST_Payments_Charges_Controller( self::$api_client );
+		$charges_controller = new WC_REST_Payments_Charges_Controller( self::$api_client, self::$order_service );
 		$charges_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-connection-tokens-controller.php';

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -20,6 +20,7 @@ class Create_And_Confirm_Intention extends Create_Intention {
 		'amount',
 		'currency',
 		'payment_method',
+		'payment_method_update_data',
 		'return_url',
 	];
 
@@ -88,6 +89,17 @@ class Create_And_Confirm_Intention extends Create_Intention {
 	 */
 	public function set_payment_methods( array $payment_methods ) {
 		$this->set_param( 'payment_method_types', $payment_methods );
+	}
+
+	/**
+	 * Payment method update data setter.
+	 *
+	 * @param array $payment_method_update_data Data to update on payment method.
+	 *
+	 * @return void
+	 */
+	public function set_payment_method_update_data( array $payment_method_update_data ) {
+		$this->set_param( 'payment_method_update_data', $payment_method_update_data );
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -123,9 +123,9 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->mock_wcpay_account                = $this->createMock( WC_Payments_Account::class );
 		$this->mock_db_cache                     = $this->createMock( Database_Cache::class );
 		$this->mock_session_service              = $this->createMock( WC_Payments_Session_Service::class );
-		$customer_service                        = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_wcpay_account, $this->mock_db_cache, $this->mock_session_service );
-		$token_service                           = new WC_Payments_Token_Service( $this->mock_api_client, $customer_service );
 		$order_service                           = new WC_Payments_Order_Service( $this->mock_api_client );
+		$customer_service                        = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_wcpay_account, $this->mock_db_cache, $this->mock_session_service, $order_service );
+		$token_service                           = new WC_Payments_Token_Service( $this->mock_api_client, $customer_service );
 		$action_scheduler_service                = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client, $order_service );
 		$mock_rate_limiter                       = $this->createMock( Session_Rate_Limiter::class );
 		$mock_dpps                               = $this->createMock( Duplicate_Payment_Prevention_Service::class );

--- a/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
@@ -59,9 +59,9 @@ class WC_REST_Payments_Tos_Controller_Test extends WCPAY_UnitTestCase {
 		$mock_fraud_service       = $this->createMock( WC_Payments_Fraud_Service::class );
 		$mock_db_cache            = $this->createMock( Database_Cache::class );
 		$mock_session_service     = $this->createMock( WC_Payments_Session_Service::class );
-		$customer_service         = new WC_Payments_Customer_Service( $mock_api_client, $mock_wcpay_account, $mock_db_cache, $mock_session_service );
-		$token_service            = new WC_Payments_Token_Service( $mock_api_client, $customer_service );
 		$order_service            = new WC_Payments_Order_Service( $this->createMock( WC_Payments_API_Client::class ) );
+		$customer_service         = new WC_Payments_Customer_Service( $mock_api_client, $mock_wcpay_account, $mock_db_cache, $mock_session_service, $order_service );
+		$token_service            = new WC_Payments_Token_Service( $mock_api_client, $customer_service );
 		$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $mock_api_client, $order_service );
 		$mock_dpps                = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 		$mock_payment_method      = $this->createMock( CC_Payment_Method::class );

--- a/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
+++ b/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
@@ -62,7 +62,7 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 			'wc_payments_http',
 			[ $this, 'replace_http_client' ]
 		);
-		$this->customer_service     = new WC_Payments_Customer_Service( WC_Payments::create_api_client(), WC_Payments::get_account_service(), WC_Payments::get_database_cache(), WC_Payments::get_session_service() );
+		$this->customer_service     = new WC_Payments_Customer_Service( WC_Payments::create_api_client(), WC_Payments::get_account_service(), WC_Payments::get_database_cache(), WC_Payments::get_session_service(), WC_Payments::get_order_service() );
 		$this->customer_service_api = new WC_Payments_Customer_Service_API( $this->customer_service );
 	}
 
@@ -339,15 +339,16 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 						'test_mode'       => false,
 						'billing_details' => [
 							'address' => [
-								'city'        => $order->get_billing_city(),
 								'country'     => $order->get_billing_country(),
 								'line1'       => $order->get_billing_address_1(),
-								'postal_code' => $order->get_billing_postcode(),
+								'line2'       => $order->get_billing_address_2(),
+								'city'        => $order->get_billing_city(),
 								'state'       => $order->get_billing_state(),
+								'postal_code' => $order->get_billing_postcode(),
 							],
+							'phone'   => $order->get_billing_phone(),
 							'email'   => $order->get_billing_email(),
 							'name'    => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
-							'phone'   => $order->get_billing_phone(),
 						],
 					]
 				),

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -1209,17 +1209,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->willReturn( $intent );
 
 		$this->mock_action_scheduler_service
-			->expects( $this->once() )
-			->method( 'schedule_job' )
-			->with(
-				$this->anything(),
-				WC_Payment_Gateway_WCPay::UPDATE_SAVED_PAYMENT_METHOD,
-				[
-					'payment_method' => 'pm_mock',
-					'order_id'       => $order_id,
-					'is_test_mode'   => false,
-				]
-			);
+			->expects( $this->never() )
+			->method( 'schedule_job' );
 
 		$this->mock_wcpay_gateway->process_payment( $order_id );
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -257,6 +257,18 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_payment_metadata' )
 			->willReturn( [] );
 		wcpay_get_test_container()->replace( OrderService::class, $mock_order_service );
+		$checkout_fields                  = [
+			'billing' => [
+				'billing_company'   => '',
+				'billing_country'   => '',
+				'billing_address_1' => '',
+				'billing_address_2' => '',
+				'billing_city'      => '',
+				'billing_state'     => '',
+				'billing_phone'     => '',
+			],
+		];
+		WC()->checkout()->checkout_fields = $checkout_fields;
 	}
 
 	/**
@@ -292,6 +304,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		}
 
 		wcpay_get_test_container()->reset_all_replacements();
+		WC()->checkout()->checkout_fields = null;
 	}
 
 	public function test_process_redirect_payment_intent_processing() {
@@ -2425,6 +2438,72 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'success' ] ) );
+
+		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
+	}
+
+	public function test_no_billing_details_update_for_legacy_card_object() {
+		$legacy_card = 'card_mock';
+
+		// There is no payment method data within the request. This is the case e.g. for the automatic subscription renewals.
+		$_POST['payment_method'] = '';
+
+		$token = WC_Helper_Token::create_token( $legacy_card );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'USD' );
+		$order->set_total( 100 );
+		$order->add_payment_token( $token );
+		$order->save();
+
+		$pi             = new Payment_Information( $legacy_card, $order, null, $token, null, null, null, '', 'card' );
+		$payment_intent = WC_Helper_Intention::create_intention(
+			[
+				'status' => 'success',
+			]
+		);
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will( $this->returnValue( $payment_intent ) );
+
+		$request->expects( $this->never() )
+			->method( 'set_payment_method_update_data' );
+
+		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
+	}
+
+	public function test_billing_details_update_if_not_empty() {
+		// There is no payment method data within the request. This is the case e.g. for the automatic subscription renewals.
+		$_POST['payment_method'] = '';
+
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
+
+		$expected_upe_payment_method = 'card';
+		$order                       = WC_Helper_Order::create_order();
+		$order->set_currency( 'USD' );
+		$order->set_total( 100 );
+		$order->add_payment_token( $token );
+		$order->save();
+
+		$pi = new Payment_Information( 'pm_mock', $order, null, $token, null, null, null, '', 'card' );
+
+		$payment_intent = WC_Helper_Intention::create_intention(
+			[
+				'status' => 'success',
+			]
+		);
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will( $this->returnValue( $payment_intent ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_update_data' );
 
 		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -257,18 +257,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_payment_metadata' )
 			->willReturn( [] );
 		wcpay_get_test_container()->replace( OrderService::class, $mock_order_service );
-		$checkout_fields                  = [
-			'billing' => [
-				'billing_company'   => '',
-				'billing_country'   => '',
-				'billing_address_1' => '',
-				'billing_address_2' => '',
-				'billing_city'      => '',
-				'billing_state'     => '',
-				'billing_phone'     => '',
-			],
-		];
-		WC()->checkout()->checkout_fields = $checkout_fields;
 	}
 
 	/**
@@ -304,7 +292,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		}
 
 		wcpay_get_test_container()->reset_all_replacements();
-		WC()->checkout()->checkout_fields = null;
 	}
 
 	public function test_process_redirect_payment_intent_processing() {

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -511,15 +511,19 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_payment_method_with_billing_details_from_checkout_fields() {
-		$fields = wc()->checkout()->checkout_fields;
-		unset( $fields['billing']['billing_company'] );
-		unset( $fields['billing']['billing_country'] );
-		unset( $fields['billing']['billing_address_1'] );
-		unset( $fields['billing']['billing_address_2'] );
-		unset( $fields['billing']['billing_city'] );
-		unset( $fields['billing']['billing_state'] );
-		unset( $fields['billing']['billing_phone'] );
-		wc()->checkout()->checkout_fields = $fields;
+		add_filter(
+			'woocommerce_billing_fields',
+			function ( $fields ) {
+				unset( $fields['billing_company'] );
+				unset( $fields['billing_country'] );
+				unset( $fields['billing_address_1'] );
+				unset( $fields['billing_address_2'] );
+				unset( $fields['billing_city'] );
+				unset( $fields['billing_state'] );
+				unset( $fields['billing_phone'] );
+				return $fields;
+			}
+		);
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'update_payment_method' )

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -487,12 +487,44 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 							'city'        => 'WooCity',
 							'country'     => Country_Code::UNITED_STATES,
 							'line1'       => 'WooAddress',
+							'line2'       => '',
 							'postal_code' => '12345',
 							'state'       => 'NY',
 						],
 						'email'   => 'admin@example.org',
 						'name'    => 'Jeroen Sormani',
 						'phone'   => '555-32123',
+					],
+				]
+			);
+
+		$order = WC_Helper_Order::create_order();
+
+		$this->customer_service->update_payment_method_with_billing_details_from_order( 'pm_mock', $order );
+	}
+
+	public function test_update_payment_method_with_billing_details_from_checkout_fields() {
+		$fields = wc()->checkout()->checkout_fields;
+		unset( $fields['billing']['billing_company'] );
+		unset( $fields['billing']['billing_country'] );
+		unset( $fields['billing']['billing_address_1'] );
+		unset( $fields['billing']['billing_address_2'] );
+		unset( $fields['billing']['billing_city'] );
+		unset( $fields['billing']['billing_state'] );
+		unset( $fields['billing']['billing_phone'] );
+		wc()->checkout()->checkout_fields = $fields;
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_payment_method' )
+			->with(
+				'pm_mock',
+				[
+					'billing_details' => [
+						'address' => [
+							'postal_code' => '12345',
+						],
+						'email'   => 'admin@example.org',
+						'name'    => 'Jeroen Sormani',
 					],
 				]
 			);

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -70,9 +70,8 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_account         = $this->createMock( WC_Payments_Account::class );
 		$this->mock_db_cache        = $this->createMock( Database_Cache::class );
 		$this->mock_session_service = $this->createMock( WC_Payments_Session_Service::class );
-		$this->mock_order_service   = $this->createMock( WC_Payments_Order_Service::class );
 
-		$this->customer_service = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_account, $this->mock_db_cache, $this->mock_session_service, $this->mock_order_service );
+		$this->customer_service = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_account, $this->mock_db_cache, $this->mock_session_service, WC_Payments::get_order_service() );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -54,6 +54,13 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 	private $mock_session_service;
 
 	/**
+	 * Mock WC_Payments_Order_Service.
+	 *
+	 * @var WC_Payments_Order_Service|MockObject
+	 */
+	private $mock_order_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -63,8 +70,9 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_account         = $this->createMock( WC_Payments_Account::class );
 		$this->mock_db_cache        = $this->createMock( Database_Cache::class );
 		$this->mock_session_service = $this->createMock( WC_Payments_Session_Service::class );
+		$this->mock_order_service   = $this->createMock( WC_Payments_Order_Service::class );
 
-		$this->customer_service = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_account, $this->mock_db_cache, $this->mock_session_service );
+		$this->customer_service = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_account, $this->mock_db_cache, $this->mock_session_service, $this->mock_order_service );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5951
Fixes #8158

#### Changes proposed in this Pull Request

- Replaced `get_billing_details_from_order()` usage with `$order_service->get_billing_data_from_order()` so we can use `WC()` as it is not in Utils.
- Updated `$order_service->get_billing_data_from_order()` logic similar to how it was done before 7.5.2, but uses the Country method instead of the Checkout method to get the available fields.
- Sets `get_fees` return type to `array` to fix an error in tests `array_keys() expects parameter 1 to be array` in `includes/class-wc-payment-gateway-wcpay.php:3946`.
- Sets `get_account_default_currency` return type to `string` to fix a similar error.

#### Testing instructions

##### Sending payment_method_update_data param to intent API

1. Make sure your server is running the branch from the PR above
1. Place an order saving a new card with a billing address
1. Place an order using the saved card from the previous step but using a new billing address
1. Check the intents in Stripe dashboard and ensure it used the new billing address in the second payment

##### Avoid updating billing details for legacy card objects

``` 
💡 To create the legacy card object for your account, send the following request while inserting your customer ID, account ID and test API key

curl https://api.stripe.com/v1/customers/${customer_id}/sources \
-u ${test_api_key}: \
-H "Stripe-Account:${acct_id}" \
```
* Ensure that you have the saved payment method on your store which is legacy card from the request above
* On this branch, purchase a subscription with this saved payment method, confirm the successful purchase 
* Revert the fix commit, navigate to subscription details, process renewal, confirm that the error message is the same as in https://github.com/Automattic/woocommerce-payments/issues/8405
* Remove the revert so that the fix is in place
* In the failed order details options, choose `Retry renewal payment`
* Navigate to subscription details, process renewal and confirm the renewal was successful this time

##### Remove filtering of billing address details

1. Make a purchase saving a card using a billing address with address line 2.
2. Make a new purchase using the saved card from before but with an empty line 2.
3. Check Stripe dashboard. The second address should not have line 2.

##### Filtering billing details from order based on checkout fields

1. Create a simple subscription product
3. Install [Checkout Field Editor](https://woo.com/products/woocommerce-checkout-field-editor/?aff=10486&cid=1131038)
4. Remove all billing fields except ZIP code, email, and first/last name
5. Purchase a subscription via shortcode checkout (CFE is not compatible with the checkout block)
7. Process a renewal by running the woocommerce_scheduled_subscription_payment hook in the action scheduler.
8. The renewal should work

##### Subscription renewals can fail due to "meta_exists() on null" action scheduler error

> ❗ Important

Follow the reproduction steps from #8678 using WooPayments 7.5.1 and ensure you can reproduce the error, then switch to this branch and ensure it doesn't fail.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
