### PR TITLE
Fixed exception that would happen when pre_check_save_my_info was not in the cached $account_data

### DIFF
--- a/changelog/fix-pre-check-sve-my-info-exception
+++ b/changelog/fix-pre-check-sve-my-info-exception
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: just a bug fix for a feature that did not make into the release yet
+
+

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -63,7 +63,7 @@ class WooPay_Save_User {
 			'WCPAY_WOOPAY',
 			'woopayCheckout',
 			[
-				'PRE_CHECK_SAVE_MY_INFO' => $account_data['pre_check_save_my_info']
+				'PRE_CHECK_SAVE_MY_INFO' => isset( $account_data['pre_check_save_my_info'] ) ? $account_data['pre_check_save_my_info'] : false,
 			]
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR  adds a check to prevent errors that would happen when a merchant is running an outdated $account_data version that does not contain pre_check_save_my_info

#### Testing instructions

- Comment  [this server line](https://github.com/Automattic/woocommerce-payments-server/blob/e98ddd8a6dee4d547de35196fca93b386fb17e97/server/wp-content/rest-api-plugins/endpoints/wcpay/class-accounts-controller.php#L949) out
- Go to the merchant site /wp-admin > WC Pay Dev > Clear cache
- Visit the shortcode and blocks checkout pages
- Make sure no error happens

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
