### PR TITLE
Fix charm pricing and rounding for non-decimal currencies

### DIFF
--- a/changelog/fix-mccy-charm-and-rounding-for-non-decimal-currencies
+++ b/changelog/fix-mccy-charm-and-rounding-for-non-decimal-currencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Charm pricing and rounding options corrected for all currencies that aren't presented with decimal points.

--- a/includes/multi-currency/Currency.php
+++ b/includes/multi-currency/Currency.php
@@ -197,8 +197,7 @@ class Currency implements \JsonSerializable {
 	 * @return  string  Currency position (left/right).
 	 */
 	public function get_symbol_position(): string {
-		$localization_service = new WC_Payments_Localization_Service();
-		return $localization_service->get_currency_format( $this->code )['currency_pos'];
+		return $this->localization_service->get_currency_format( $this->code )['currency_pos'];
 	}
 
 	/**

--- a/includes/multi-currency/Currency.php
+++ b/includes/multi-currency/Currency.php
@@ -76,7 +76,7 @@ class Currency implements \JsonSerializable {
 	/**
 	 * Constructor.
 	 *
-	 * @param WC_Payments_Localization_Service $localization_service Three letter currency code.
+	 * @param WC_Payments_Localization_Service $localization_service Localization service instance.
 	 * @param string                           $code Three letter currency code.
 	 * @param float                            $rate The conversion rate.
 	 * @param int|null                         $last_updated The time this currency was last updated.

--- a/includes/multi-currency/Currency.php
+++ b/includes/multi-currency/Currency.php
@@ -67,23 +67,31 @@ class Currency implements \JsonSerializable {
 	private $last_updated;
 
 	/**
+	 * Instance of WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param string   $code Three letter currency code.
-	 * @param float    $rate The conversion rate.
-	 * @param int|null $last_updated The time this currency was last updated.
+	 * @param WC_Payments_Localization_Service $localization_service Three letter currency code.
+	 * @param string                           $code Three letter currency code.
+	 * @param float                            $rate The conversion rate.
+	 * @param int|null                         $last_updated The time this currency was last updated.
 	 */
-	public function __construct( string $code = '', float $rate = 1.0, $last_updated = null ) {
-		$this->code = $code;
-		$this->rate = $rate;
+	public function __construct( WC_Payments_Localization_Service $localization_service, $code = '', float $rate = 1.0, $last_updated = null ) {
+		$this->localization_service = $localization_service;
+		$this->code                 = $code;
+		$this->rate                 = $rate;
 
 		if ( get_woocommerce_currency() === $code ) {
 			$this->is_default = true;
 		}
 
-		if ( in_array( strtolower( $code ), WC_Payments_Utils::zero_decimal_currencies(), true ) ) {
-			$this->is_zero_decimal = true;
-		}
+		// Set zero-decimal style based on WC locale information.
+		$this->is_zero_decimal = 0 === $this->localization_service->get_currency_format( $code )['num_decimals'];
 
 		if ( ! is_null( $last_updated ) ) {
 			$this->last_updated = $last_updated;

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -624,7 +624,7 @@ class MultiCurrency {
 	private function initialize_available_currencies() {
 		// Add default store currency with a rate of 1.0.
 		$woocommerce_currency                                = get_woocommerce_currency();
-		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
+		$this->available_currencies[ $woocommerce_currency ] = new Currency( $this->localization_service, $woocommerce_currency, 1.0 );
 
 		$available_currencies = [];
 
@@ -634,7 +634,7 @@ class MultiCurrency {
 		foreach ( $currencies as $currency_code ) {
 			$currency_rate = $cache_data['currencies'][ $currency_code ] ?? 1.0;
 			$update_time   = $cache_data['updated'] ?? null;
-			$new_currency  = new Currency( $currency_code, $currency_rate, $update_time );
+			$new_currency  = new Currency( $this->localization_service, $currency_code, $currency_rate, $update_time );
 
 			// Add this to our list of available currencies.
 			$available_currencies[ $new_currency->get_name() ] = $new_currency;
@@ -727,7 +727,7 @@ class MultiCurrency {
 			$this->init();
 		}
 
-		return $this->default_currency ?? new Currency( get_woocommerce_currency() );
+		return $this->default_currency ?? new Currency( $this->localization_service, get_woocommerce_currency() );
 	}
 
 	/**

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
@@ -45,6 +45,13 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WCPAY_UnitTestCase 
 	private $woocommerce_bookings;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -54,6 +61,7 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WCPAY_UnitTestCase 
 		$this->mock_utils               = $this->createMock( Utils::class );
 		$this->mock_frontend_currencies = $this->createMock( FrontendCurrencies::class );
 		$this->woocommerce_bookings     = new WooCommerceBookings( $this->mock_multi_currency, $this->mock_utils, $this->mock_frontend_currencies );
+		$this->localization_service     = new WC_Payments_Localization_Service();
 	}
 
 	public function test_get_price_returns_empty_string() {
@@ -152,7 +160,7 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WCPAY_UnitTestCase 
 			'price_format'       => '%1$s%2$s',
 		];
 
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $expected['currency'] ) );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, $expected['currency'] ) );
 		$this->mock_frontend_currencies->method( 'get_price_decimal_separator' )->willReturn( $expected['decimal_separator'] );
 		$this->mock_frontend_currencies->method( 'get_price_thousand_separator' )->willReturn( $expected['thousand_separator'] );
 		$this->mock_frontend_currencies->method( 'get_price_decimals' )->willReturn( $expected['decimals'] );

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-name-your-price.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-name-your-price.php
@@ -39,15 +39,23 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	private $woocommerce_nyp;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function setUp(): void {
 		parent::setUp();
 
 		// Create the class instances needed for testing.
-		$this->mock_multi_currency = $this->createMock( MultiCurrency::class );
-		$this->mock_utils          = $this->createMock( Utils::class );
-		$this->woocommerce_nyp     = new WooCommerceNameYourPrice( $this->mock_multi_currency, $this->mock_utils );
+		$this->mock_multi_currency  = $this->createMock( MultiCurrency::class );
+		$this->mock_utils           = $this->createMock( Utils::class );
+		$this->woocommerce_nyp      = new WooCommerceNameYourPrice( $this->mock_multi_currency, $this->mock_utils );
+		$this->localization_service = new WC_Payments_Localization_Service();
 
 		// Set is_nyp to return false by default.
 		$this->set_is_nyp( false );
@@ -95,7 +103,7 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// Check to make sure the proper elements are added to the cart_item array.
 	public function test_add_initial_currency_returns_modified_cart_item() {
 		// Arrange: Set up the currency used for the test.
-		$currency = new Currency( 'EUR', 2.0 );
+		$currency = new Currency( $this->localization_service, 'EUR', 2.0 );
 
 		// Arrange: Set up the cart_item and expected cart_item, set is_nyp to return true.
 		$nyp_value          = 12.34;
@@ -144,7 +152,7 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// If the selected currency matches the currency of the item, then it should just return the item.
 	public function test_convert_cart_currency_returns_cart_item_with_original_value() {
 		// Arrange: Set up the currency used for the test.
-		$currency = new Currency( 'EUR', 2.0 );
+		$currency = new Currency( $this->localization_service, 'EUR', 2.0 );
 
 		// Arrange: Set up the cart_item.
 		$nyp_value = 12.34;
@@ -174,8 +182,8 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// Convert the amount of the item to the selected currency.
 	public function test_convert_cart_currency_returns_cart_item_with_converted_value() {
 		// Arrange: Set up the currencies used for the test.
-		$item_currency     = new Currency( 'EUR', 2.0 );
-		$selected_currency = new Currency( 'GBP', 0.5 );
+		$item_currency     = new Currency( $this->localization_service, 'EUR', 2.0 );
+		$selected_currency = new Currency( $this->localization_service, 'GBP', 0.5 );
 
 		// Arrange: Set up the cart_item.
 		$nyp_value = 12.34;
@@ -214,8 +222,8 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// Convert the amount of the item into the default (selected) currency.
 	public function test_convert_cart_currency_returns_cart_item_with_converted_value_with_default_currency() {
 		// Arrange: Set up the currencies used for the test.
-		$item_currency     = new Currency( 'EUR', 2.0 );
-		$selected_currency = new Currency( 'USD', 1 );
+		$item_currency     = new Currency( $this->localization_service, 'EUR', 2.0 );
+		$selected_currency = new Currency( $this->localization_service, 'USD', 1 );
 
 		// Arrange: Set up the cart_item.
 		$nyp_value = 12.34;
@@ -260,7 +268,7 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// If the meta value is already set on the product, the method should return false.
 	public function test_should_convert_product_price_returns_false_when_product_is_already_converted() {
 		// Arrange: Set up the currency used for the test.
-		$selected_currency = new Currency( 'EUR', 2.0 );
+		$selected_currency = new Currency( $this->localization_service, 'EUR', 2.0 );
 
 		// Arrange: Set up the product, and add the meta data to it.
 		$product = WC_Helper_Product::create_simple_product();
@@ -282,7 +290,7 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// If the product is tagged a a nyp product, false should be returned.
 	public function test_should_convert_product_price_returns_false_when_product_is_a_nyp_product() {
 		// Arrange: Set up the currency and product used for the test.
-		$selected_currency = new Currency( 'EUR', 2.0 );
+		$selected_currency = new Currency( $this->localization_service, 'EUR', 2.0 );
 		$product           = WC_Helper_Product::create_simple_product();
 
 		// Arrange: Set up the mock_multi_currency method mock.
@@ -301,7 +309,7 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	// If no tests return true, method should return true.
 	public function test_should_convert_product_price_returns_true_when_no_matches() {
 		// Arrange: Set up the currency and product used for the test.
-		$selected_currency = new Currency( 'EUR', 2.0 );
+		$selected_currency = new Currency( $this->localization_service, 'EUR', 2.0 );
 		$product           = WC_Helper_Product::create_simple_product();
 
 		// Arrange: Set up the mock_multi_currency method mock.
@@ -319,7 +327,7 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 
 	public function test_edit_in_cart_args() {
 		// Arrange: Set up the currency  used for the test.
-		$selected_currency = new Currency( 'EUR', 2.0 );
+		$selected_currency = new Currency( $this->localization_service, 'EUR', 2.0 );
 
 		// Arrange: Set up the mock_multi_currency method mock.
 		$this->mock_multi_currency
@@ -342,8 +350,8 @@ class WCPay_Multi_Currency_WooCommerceNameYourPrice_Tests extends WCPAY_UnitTest
 	public function test_get_initial_price( $initial_price, $suffix, $request, $get_selected_currency, $get_raw_conversion ) {
 		// Arrange: Set the initial expected price and the currencies that may be used.
 		$expected_price    = $initial_price;
-		$selected_currency = new Currency( 'EUR', 2.0 );
-		$store_currency    = new Currency( 'USD', 1 );
+		$selected_currency = new Currency( $this->localization_service, 'EUR', 2.0 );
+		$store_currency    = new Currency( $this->localization_service, 'USD', 1 );
 
 		// Arrange: Set expectations for calls to get_selected_currency method.
 		if ( $get_selected_currency ) {

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-points-and-rewards.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-points-and-rewards.php
@@ -37,13 +37,21 @@ class WCPay_Multi_Currency_WooCommercePointsAndRewards_Tests extends WCPAY_UnitT
 	private $wc_points_rewards;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_multi_currency = $this->createMock( MultiCurrency::class );
-		$this->mock_utils          = $this->createMock( Utils::class );
+		$this->mock_multi_currency  = $this->createMock( MultiCurrency::class );
+		$this->mock_utils           = $this->createMock( Utils::class );
+		$this->localization_service = new WC_Payments_Localization_Service();
 
 		$this->wc_points_rewards = new WooCommercePointsAndRewards( $this->mock_multi_currency, $this->mock_utils );
 	}
@@ -97,7 +105,7 @@ class WCPay_Multi_Currency_WooCommercePointsAndRewards_Tests extends WCPAY_UnitT
 		$this->mock_multi_currency
 			->expects( $this->once() )
 			->method( 'get_selected_currency' )
-			->willReturn( new Currency( 'EUR' ) );
+			->willReturn( new Currency( $this->localization_service, 'EUR' ) );
 
 		$this->mock_utils
 			->expects( $this->once() )
@@ -115,7 +123,7 @@ class WCPay_Multi_Currency_WooCommercePointsAndRewards_Tests extends WCPAY_UnitT
 		$this->mock_multi_currency
 			->expects( $this->once() )
 			->method( 'get_selected_currency' )
-			->willReturn( new Currency( 'EUR', $rate ) );
+			->willReturn( new Currency( $this->localization_service, 'EUR', $rate ) );
 
 		$this->mock_utils
 			->expects( $this->once() )

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -52,6 +52,13 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	private $mock_available_currencies = [];
 
 	/**
+	 * The localization service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -81,6 +88,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 			->willReturn( $this->get_mock_available_currencies() );
 
 		$this->analytics = new Analytics( $this->mock_multi_currency );
+
+		$this->localization_service = new WC_Payments_Localization_Service();
 
 		remove_filter( 'user_has_cap', $cb );
 	}
@@ -157,7 +166,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	public function test_update_order_stats_data_with_multi_currency_order() {
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$args  = $this->order_args_provider( 123, 0, 1, 15.50, 1.50, 0, 14.00 );
 		$order = wc_create_order();
@@ -172,7 +181,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	public function test_update_order_stats_data_with_large_order() {
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$args  = $this->order_args_provider( 123, 0, 1, 130500.75, 20000, 10000, 100500.75 );
 		$order = wc_create_order();
@@ -187,7 +196,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	public function test_update_order_stats_data_with_stripe_exchange_rate() {
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$args  = $this->order_args_provider( 123, 0, 1, 15.50, 1.50, 0, 15.00 );
 		$order = wc_create_order();
@@ -566,13 +575,14 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	}
 
 	private function get_mock_available_currencies() {
+		$this->localization_service = new WC_Payments_Localization_Service();
 		if ( empty( $this->mock_available_currencies ) ) {
 			$this->mock_available_currencies = [
-				'GBP' => new Currency( 'GBP', 1.2 ),
-				'USD' => new Currency( 'USD', 1 ),
-				'EUR' => new Currency( 'EUR', 0.9 ),
-				'ISK' => new Currency( 'ISK', 30.52 ),
-				'NZD' => new Currency( 'NZD', 1.4 ),
+				'GBP' => new Currency( $this->localization_service, 'GBP', 1.2 ),
+				'USD' => new Currency( $this->localization_service, 'USD', 1 ),
+				'EUR' => new Currency( $this->localization_service, 'EUR', 0.9 ),
+				'ISK' => new Currency( $this->localization_service, 'ISK', 30.52 ),
+				'NZD' => new Currency( $this->localization_service, 'NZD', 1.4 ),
 			];
 		}
 

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -36,14 +36,22 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 	private $mock_utils;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_multi_currency = $this->createMock( MultiCurrency::class );
-		$this->mock_utils          = $this->createMock( Utils::class );
-		$this->compatibility       = new Compatibility( $this->mock_multi_currency, $this->mock_utils );
+		$this->mock_multi_currency  = $this->createMock( MultiCurrency::class );
+		$this->mock_utils           = $this->createMock( Utils::class );
+		$this->compatibility        = new Compatibility( $this->mock_multi_currency, $this->mock_utils );
+		$this->localization_service = new WC_Payments_Localization_Service();
 	}
 
 	public function test_init_compatibility_classes_does_not_add_classes_if_one_enabled_currencies() {
@@ -100,7 +108,7 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$this->mock_utils->expects( $this->once() )
 			->method( 'is_call_in_backtrace' )
@@ -124,7 +132,7 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$this->mock_utils->expects( $this->once() )
 			->method( 'is_call_in_backtrace' )
@@ -145,7 +153,7 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$this->mock_utils->expects( $this->once() )
 			->method( 'is_call_in_backtrace' )
@@ -169,7 +177,7 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 
 		$this->mock_multi_currency->expects( $this->once() )
 			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
+			->willReturn( new Currency( $this->localization_service, 'USD', 1.0 ) );
 
 		$this->mock_utils->expects( $this->once() )
 			->method( 'is_call_in_backtrace' )

--- a/tests/unit/multi-currency/test-class-currency-switcher-block.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-block.php
@@ -36,16 +36,24 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 	 */
 	protected $mock_currencies;
 
+	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_multi_currency = $this->createMock( MultiCurrency::class );
-		$this->mock_compatibility  = $this->createMock( Compatibility::class );
-		$this->mock_currencies     = [
-			new Currency( 'USD', 1 ),
-			new Currency( 'CAD', 1.206823 ),
-			new Currency( 'GBP', 0.708099 ),
-			new Currency( 'EUR', 0.826381 ),
+		$this->mock_multi_currency  = $this->createMock( MultiCurrency::class );
+		$this->mock_compatibility   = $this->createMock( Compatibility::class );
+		$this->localization_service = new WC_Payments_Localization_Service();
+		$this->mock_currencies      = [
+			new Currency( $this->localization_service, 'USD', 1 ),
+			new Currency( $this->localization_service, 'CAD', 1.206823 ),
+			new Currency( $this->localization_service, 'GBP', 0.708099 ),
+			new Currency( $this->localization_service, 'EUR', 0.826381 ),
 		];
 
 		$this->currency_switcher_block = new CurrencySwitcherBlock(
@@ -211,8 +219,8 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 			->method( 'get_enabled_currencies' )
 			->willReturn(
 				[
-					new Currency( 'USD' ),
-					new Currency( $currency_code, 1 ),
+					new Currency( $this->localization_service, 'USD' ),
+					new Currency( $this->localization_service, $currency_code, 1 ),
 				]
 			);
 
@@ -267,7 +275,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 		$this->mock_multi_currency
 			->expects( $this->once() )
 			->method( 'get_enabled_currencies' )
-			->willReturn( [ new Currency( 'USD' ) ] );
+			->willReturn( [ new Currency( $this->localization_service, 'USD' ) ] );
 
 		// Act/Assert: Confirm that when calling the renger method nothing is returned.
 		$this->assertSame( '', $this->currency_switcher_block->render_block_widget( [], '' ) );

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -33,21 +33,29 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 	private $currency_switcher_widget;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_compatibility  = $this->createMock( WCPay\MultiCurrency\Compatibility::class );
-		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->mock_compatibility   = $this->createMock( WCPay\MultiCurrency\Compatibility::class );
+		$this->mock_multi_currency  = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->localization_service = new WC_Payments_Localization_Service();
 		$this->mock_multi_currency
 			->method( 'get_enabled_currencies' )
 			->willReturn(
 				[
-					new Currency( 'USD' ),
-					new Currency( 'CAD', 1.2 ),
-					new Currency( 'EUR', 0.8 ),
-					new Currency( 'CHF', 1.1 ),
+					new Currency( $this->localization_service, 'USD' ),
+					new Currency( $this->localization_service, 'CAD', 1.2 ),
+					new Currency( $this->localization_service, 'EUR', 0.8 ),
+					new Currency( $this->localization_service, 'CHF', 1.1 ),
 				]
 			);
 
@@ -100,7 +108,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 
 	public function test_widget_selects_selected_currency() {
 		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'CAD' ) );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'CAD' ) );
 		$this->expectOutputRegex( '/<option value="CAD" selected>&#36; CAD/' );
 		$this->render_widget();
 	}
@@ -126,7 +134,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 			->method( 'get_enabled_currencies' )
 			->willReturn(
 				[
-					new Currency( 'USD' ),
+					new Currency( $this->localization_service, 'USD' ),
 				]
 			);
 

--- a/tests/unit/multi-currency/test-class-currency.php
+++ b/tests/unit/multi-currency/test-class-currency.php
@@ -24,13 +24,21 @@ class WCPay_Multi_Currency_Currency_Tests extends WCPAY_UnitTestCase {
 	private $timestamp_for_testing;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
 		$this->timestamp_for_testing = strtotime( '1 January 2021' );
-		$this->currency              = new Currency( 'USD', 1.0, $this->timestamp_for_testing );
+		$this->localization_service  = new WC_Payments_Localization_Service();
+		$this->currency              = new Currency( $this->localization_service, 'USD', 1.0, $this->timestamp_for_testing );
 	}
 
 	public function test_should_include_all_data_when_serialized() {
@@ -43,7 +51,7 @@ class WCPay_Multi_Currency_Currency_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_should_decode_entities_when_serialized() {
-		$json = wp_json_encode( new Currency( 'WST' ) );
+		$json = wp_json_encode( new Currency( $this->localization_service, 'WST' ) );
 
 		$this->assertSame(
 			'{"code":"WST","rate":1,"name":"Samoan t\u0101l\u0101","id":"wst","is_default":false,"flag":"\ud83c\uddfc\ud83c\uddf8","symbol":"T","symbol_position":"left","is_zero_decimal":false,"last_updated":null}',
@@ -52,8 +60,8 @@ class WCPay_Multi_Currency_Currency_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_zero_decimal_returns_right_value() {
-		$decimal_currency      = new Currency( 'USD' );
-		$zero_decimal_currency = new Currency( 'BIF' );
+		$decimal_currency      = new Currency( $this->localization_service, 'USD' );
+		$zero_decimal_currency = new Currency( $this->localization_service, 'BIF' );
 
 		$this->assertFalse( $decimal_currency->get_is_zero_decimal() );
 		$this->assertTrue( $zero_decimal_currency->get_is_zero_decimal() );

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -33,13 +33,21 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 	private $frontend_prices;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_compatibility  = $this->createMock( WCPay\MultiCurrency\Compatibility::class );
-		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->mock_compatibility   = $this->createMock( WCPay\MultiCurrency\Compatibility::class );
+		$this->mock_multi_currency  = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->localization_service = new WC_Payments_Localization_Service();
 
 		$this->frontend_prices = new WCPay\MultiCurrency\FrontendPrices( $this->mock_multi_currency, $this->mock_compatibility );
 		$this->frontend_prices->init_hooks();
@@ -329,7 +337,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_add_order_meta_skips_default_currency() {
-		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( new WCPay\MultiCurrency\Currency( 'USD' ) );
+		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( new WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ) );
 
 		$order = wc_create_order();
 		$order->set_currency( 'USD' );
@@ -344,7 +352,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_add_order_meta() {
-		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( new WCPay\MultiCurrency\Currency( 'USD' ) );
+		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( new WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ) );
 		$this->mock_multi_currency->method( 'get_price' )->with( 1, 'exchange_rate' )->willReturn( 0.71 );
 
 		$order = wc_create_order();

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -81,7 +81,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 	 *
 	 * @var WC_Payments_Localization_Service
 	 */
-	private $mock_localization_service;
+	private $localization_service;
 
 	/**
 	 * Mock of Database_Cache.
@@ -99,6 +99,8 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
+
+		$this->localization_service = new WC_Payments_Localization_Service();
 
 		$this->mock_currency_settings(
 			'GBP',
@@ -246,7 +248,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 		$expected = [];
 		foreach ( $mock_currencies as $code => $rate ) {
-			$currency = new WCPay\MultiCurrency\Currency( $code, $rate );
+			$currency = new WCPay\MultiCurrency\Currency( $this->localization_service, $code, $rate );
 			$currency->set_charm( 0.00 );
 			$currency->set_rounding( '1.00' );
 			$currency->set_last_updated( $this->timestamp_for_testing );
@@ -436,7 +438,6 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_update_selected_currency_by_geolocation_does_not_set_session_when_currency_not_enabled() {
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
-		$this->mock_localization_service->method( 'get_country_locale_data' )->with( 'CL' )->willReturn( [ 'currency_code' => 'CLP' ] );
 
 		add_filter(
 			'woocommerce_geolocate_ip',
@@ -452,7 +453,6 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_update_selected_currency_by_geolocation_does_not_set_session_cookie() {
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
-		$this->mock_localization_service->method( 'get_country_locale_data' )->with( Country_Code::CANADA )->willReturn( [ 'currency_code' => 'CAD' ] );
 		add_filter(
 			'woocommerce_geolocate_ip',
 			function () {
@@ -477,8 +477,6 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 			}
 		);
 
-		$this->mock_localization_service->method( 'get_country_locale_data' )->with( Country_Code::CANADA )->willReturn( [ 'currency_code' => 'CAD' ] );
-
 		$this->multi_currency->update_selected_currency_by_geolocation();
 
 		$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
@@ -493,8 +491,6 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 				return Country_Code::CANADA;
 			}
 		);
-
-		$this->mock_localization_service->method( 'get_country_locale_data' )->with( Country_Code::CANADA )->willReturn( [ 'currency_code' => 'CAD' ] );
 
 		$this->multi_currency->update_selected_currency_by_geolocation();
 
@@ -517,12 +513,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 			}
 		);
 
-		// Arrange: Set the expected calls and retruns for our mock classes.
-		$this->mock_localization_service
-			->method( 'get_country_locale_data' )
-			->with( Country_Code::CANADA )
-			->willReturn( [ 'currency_code' => 'CAD' ] );
-
+		// Arrange: Set the expected calls and returns for our mock classes.
 		$this->mock_utils
 			->expects( $this->never() )
 			->method( 'set_customer_session_cookie' );
@@ -546,8 +537,6 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 				return Country_Code::CANADA;
 			}
 		);
-
-		$this->mock_localization_service->method( 'get_country_locale_data' )->with( Country_Code::CANADA )->willReturn( [ 'currency_code' => 'CAD' ] );
 
 		$this->multi_currency->display_geolocation_currency_update_notice();
 
@@ -906,7 +895,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_get_available_currencies_returns_store_currency_with_no_stripe_connection() {
 		$expected = [
-			'USD' => new WCPay\MultiCurrency\Currency( 'USD', 1 ),
+			'USD' => new WCPay\MultiCurrency\Currency( $this->localization_service, 'USD', 1 ),
 		];
 		$this->init_multi_currency( null, false );
 		$this->assertEquals( $expected, $this->multi_currency->get_available_currencies() );
@@ -1431,18 +1420,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->mock_account = $mock_account ?? $this->createMock( WC_Payments_Account::class );
 		$this->mock_account->method( 'is_stripe_connected' )->willReturn( $wcpay_account_connected );
 
-		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );
-
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
-
-		$this->mock_localization_service->method( 'get_currency_format' )->willReturn(
-			[
-				'currency_pos' => 'left',
-				'thousand_sep' => ',',
-				'decimal_sep'  => '.',
-				'num_decimals' => 2,
-			]
-		);
 
 		$this->mock_database_cache = $this->createMock( Database_Cache::class );
 		$this->mock_database_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
@@ -1452,7 +1430,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->multi_currency = new MultiCurrency(
 			$mock_api_client ?? $this->mock_api_client,
 			$this->mock_account,
-			$this->mock_localization_service,
+			$this->localization_service,
 			$mock_database_cache ?? $this->mock_database_cache,
 			$this->mock_utils
 		);

--- a/tests/unit/multi-currency/test-class-payment-methods-compatibility.php
+++ b/tests/unit/multi-currency/test-class-payment-methods-compatibility.php
@@ -31,6 +31,13 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WCPAY_Uni
 	private $payment_methods_compatibility;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -63,6 +70,8 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WCPAY_Uni
 
 		$this->payment_methods_compatibility = new \WCPay\MultiCurrency\PaymentMethodsCompatibility( $this->multi_currency_mock, $this->gateway_mock );
 		$this->payment_methods_compatibility->init_hooks();
+
+		$this->localization_service = new WC_Payments_Localization_Service();
 	}
 
 	public function test_it_should_not_update_available_currencies_when_enabled_payment_methods_do_not_need_it() {
@@ -87,13 +96,13 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WCPAY_Uni
 		$this->gateway_mock->expects( $this->atLeastOnce() )->method( 'get_account_domestic_currency' )->willReturn( 'USD' );
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_enabled_currencies' )->willReturn(
 			[
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
 			]
 		);
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_available_currencies' )->willReturn(
 			[
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
-				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
+				'USD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ),
 			]
 		);
 		$this->multi_currency_mock->expects( $this->never() )->method( 'set_enabled_currencies' );
@@ -115,14 +124,14 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WCPAY_Uni
 		$this->gateway_mock->expects( $this->atLeastOnce() )->method( 'get_account_domestic_currency' )->willReturn( 'USD' );
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_enabled_currencies' )->willReturn(
 			[
-				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
+				'USD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ),
 			]
 		);
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_available_currencies' )->willReturn(
 			[
-				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
-				'AUD' => new \WCPay\MultiCurrency\Currency( 'AUD' ),
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
+				'USD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ),
+				'AUD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'AUD' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
 			]
 		);
 		$this->multi_currency_mock
@@ -151,15 +160,15 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WCPAY_Uni
 		$this->gateway_mock->expects( $this->atLeastOnce() )->method( 'get_account_domestic_currency' )->willReturn( 'USD' );
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_enabled_currencies' )->willReturn(
 			[
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
-				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
+				'USD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ),
 			]
 		);
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_available_currencies' )->willReturn(
 			[
-				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
-				'AUD' => new \WCPay\MultiCurrency\Currency( 'AUD' ),
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
+				'USD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ),
+				'AUD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'AUD' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
 			]
 		);
 		$this->multi_currency_mock->expects( $this->never() )->method( 'set_enabled_currencies' );
@@ -177,13 +186,13 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WCPAY_Uni
 		$this->gateway_mock->expects( $this->atLeastOnce() )->method( 'get_account_domestic_currency' )->willReturn( 'USD' );
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_enabled_currencies' )->willReturn(
 			[
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
 			]
 		);
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_available_currencies' )->willReturn(
 			[
-				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
+				'USD' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( $this->localization_service, 'EUR' ),
 			]
 		);
 		$this->multi_currency_mock

--- a/tests/unit/multi-currency/test-class-tracking.php
+++ b/tests/unit/multi-currency/test-class-tracking.php
@@ -95,14 +95,23 @@ class WCPay_Multi_Currency_Tracking_Tests extends WCPAY_UnitTestCase {
 	private $mock_multi_currency;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
+		$this->localization_service = new WC_Payments_Localization_Service();
+
 		$this->set_up_mock_enabled_currencies();
 		$this->add_mock_orders_with_meta();
-		$this->mock_default_currency = new WCPay\MultiCurrency\Currency( get_woocommerce_currency(), 1 );
+		$this->mock_default_currency = new WCPay\MultiCurrency\Currency( $this->localization_service, get_woocommerce_currency(), 1 );
 
 		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
 		$this->mock_multi_currency
@@ -246,7 +255,7 @@ class WCPay_Multi_Currency_Tracking_Tests extends WCPAY_UnitTestCase {
 
 	private function set_up_mock_enabled_currencies() {
 		foreach ( $this->mock_currencies as $code => $settings ) {
-			$currency = new WCPay\MultiCurrency\Currency( $code, $settings['rate'] );
+			$currency = new WCPay\MultiCurrency\Currency( $this->localization_service, $code, $settings['rate'] );
 
 			if ( isset( $settings['rate_type'] ) ) {
 				update_option( 'wcpay_multi_currency_exchange_rate_' . $currency->get_id(), $settings['rate_type'] );

--- a/tests/unit/multi-currency/test-class-user-settings.php
+++ b/tests/unit/multi-currency/test-class-user-settings.php
@@ -19,6 +19,13 @@ class WCPay_Multi_Currency_User_Settings_Tests extends WCPAY_UnitTestCase {
 	private $mock_multi_currency;
 
 	/**
+	 * WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $localization_service;
+
+	/**
 	 * WCPay\MultiCurrency\UserSettings instance.
 	 *
 	 * @var WCPay\MultiCurrency\UserSettings
@@ -31,14 +38,15 @@ class WCPay_Multi_Currency_User_Settings_Tests extends WCPAY_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->mock_multi_currency  = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->localization_service = new WC_Payments_Localization_Service();
 		$this->mock_multi_currency
 			->method( 'get_enabled_currencies' )
 			->willReturn(
 				[
-					new Currency( 'USD' ),
-					new Currency( 'GBP' ),
-					new Currency( 'EUR' ),
+					new Currency( $this->localization_service, 'USD' ),
+					new Currency( $this->localization_service, 'GBP' ),
+					new Currency( $this->localization_service, 'EUR' ),
 				]
 			);
 
@@ -65,7 +73,7 @@ class WCPay_Multi_Currency_User_Settings_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_add_presentment_currency_switch_selects_selected_currency() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'EUR' ) );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
 		$this->user_settings->add_presentment_currency_switch();
 		$this->expectOutputRegex( '/<option value="GBP">&pound; GBP.+<option value="EUR" selected>&euro; EUR/s' );
 	}


### PR DESCRIPTION
Fixes #7724

# Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Use `WC_Payments_Localization_Service` to determine the number of decimals for a given currency.
    * This means decimals are now based on information in WC Core.

# Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!WARNING]
> Testing this PR requires a lot of repetitive work. You may want to set aside ~6 hours for the testing + breaks, and possibly split the testing into several sessions.

## Setup

1. Go to **WooCommerce &rarr; Settings &rarr; Multi-currency** and make sure you add one of each of the following types of currencies:
    1. A currency with decimals that's not the store currency (e.g. `USD`, `EUR`, `CAD`).
    2. A currency that has no decimals in either WooCommerce or Stripe (e.g. `JPY`).
    3. A currency that has decimals in Stripe, but no decimals in WooCommerce (e.g. `ISK`).

## Simple Products

### Buy products in all those currencies

Start with your store currency and:

1. Add a simple product to your cart and go to the **Checkout** page.
2. Complete a payment with any success test card, e.g. `4242 4242 4242 4242`.
3. Note down the total amount charged.

<img width="473" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/41f5856b-c392-4f08-840c-7086250ff6c0">

4. Go to **wp-admin &rarr; WooPayments &rarr; Transactions** and make sure the amount charged is correct.

<img width="1056" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/f1c2ecb3-8e6e-4619-8c6b-0c7ed711989a">

6. Go to **wp-admin &rarr; Orders**, find the order you just created, and make sure the amounts displayed in the order details are correct.

Repeat this for the 3 other currencies you configured in the **Setup** section.

## Subscriptions

### Subscriptions compatibility

Repeat the test from above with a simple subscription product. In other words:

1. Add a subscription product to your cart and go to the **Checkout** page.
2. Complete a payment with any success test card, e.g. `4242 4242 4242 4242`.
3. Note down the total amount charged.
4. Go to **wp-admin &rarr; WooPayments &rarr; Transactions** and make sure the amount charged is correct.
5. Go to **wp-admin &rarr; Orders**, find the order you just created, and make sure the amounts displayed in the order details are correct.
6. Go to **wp-admin &rarr; Subscriptions**, find the subscription you just created.
7. Select **Process Renewal** from the **Order actions** drop-down and click **Update**.

<img width="1479" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/13835680/f6407c6d-5d38-44ed-9a8e-dc9ad79dc169">

8. Go to **wp-admin &rarr; WooPayments &rarr; Transactions** and make sure the amount charged for the renewal order is correct.
9. Go to **wp-admin &rarr; Orders**, find the order for the subscription renewal, and make sure the amounts displayed in the order details are correct.

Then repeat for the 3 other currencies you configured in the **Setup** section.

## Rounding and charm pricing

### Configuration

For each of the currencies you added in the **Setup** section:

1. Go to **WooCommerce &rarr; Settings &rarr; Multi-currency** and select **Configure** for the currency you're testing.
2. Make sure the rounding and charm pricing options are correct:
    1. Rounding options:
        1. Currency with decimals in WC (e.g. `EUR`): 0.25, 0.50, 1.00, 5.00, 10.00.
        2. Currency with 0-decimals in WC (e.g. `JPY`): 1, 10, 25, 50, 100, 500, 1000.
    3. Charm pricing options:
        1. Currency with decimals in WC (e.g. `EUR`): -0.01, -0.05.
        2. Currency with 0-decimals in WC (e.g. `JPY`): -1, -5, -10, -20, -25, -50, -100.
3. Make sure different combinations of rounding and charm pricing options are shown correctly in the preview.

### Process payments

> [!NOTE]
> If you want to be extra thorough here you can test multiple combinations of rounding and charm pricing options for all the currencies, but I figured it'd be easier to test just 1 configuration per currency.

For each of the 4 currencies (store currency and the 3 extra currencies configured in **Setup**):

1. Configure your currencies such that each has different rounding and charm pricing options set:
    1. Example configuration:
        * Store currency (`USD`): no rounding, no charm pricing (the default setting).
        * Currency w/ decimals (`EUR`): Some rounding, no charm pricing.
        * Currency w/ no decimals in WC + Stripe (`JPY`): No rounding, some charm pricing.
        * Currency w/ no decimals in WC, decimals in Stripe (`ISK`): Some rounding, some charm pricing.
2. Repeat all the testing from above for simple and subscription products, i.e. simple product with all currencies and subscription product with all currencies.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
