### PR TITLE
tweak emoji survey prompt - "these", was "those"

### DIFF
--- a/changelog/fix-8724-are-these-metrics
+++ b/changelog/fix-8724-are-these-metrics
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is covered by emoji survey changelog from #8506
+
+

--- a/client/components/payment-activity/survey/index.tsx
+++ b/client/components/payment-activity/survey/index.tsx
@@ -99,7 +99,7 @@ const Survey: React.FC = () => {
 			<div className="wcpay-payments-activity__survey">
 				<div className="survey_container">
 					{ __(
-						'Are those metrics helpful?',
+						'Are these metrics helpful?',
 						'woocommerce-payments'
 					) }
 

--- a/client/components/payment-activity/survey/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/survey/test/__snapshots__/index.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`WcPayOverviewSurveyContextProvider test survey with comments textbox 1`
         <p
           class="comment_container__disclaimer"
         >
-          Your feedback will be only be shared with WooCommerce and treated pursuant to our
+          Your feedback will be only be shared with WooCommerce and treated pursuant to our 
           <a
             href="https://automattic.com/privacy/"
             rel="noreferrer"

--- a/client/components/payment-activity/survey/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/survey/test/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`WcPayOverviewSurveyContextProvider test survey initial display 1`] = `
       <div
         class="survey_container"
       >
-        Are those metrics helpful?
+        Are these metrics helpful?
         <div
           class="survey_container__emoticons"
         >
@@ -92,7 +92,7 @@ exports[`WcPayOverviewSurveyContextProvider test survey with comments textbox 1`
       <div
         class="survey_container"
       >
-        Are those metrics helpful?
+        Are these metrics helpful?
         <div
           class="survey_container__emoticons"
         >
@@ -201,7 +201,7 @@ exports[`WcPayOverviewSurveyContextProvider test survey with comments textbox 1`
         <p
           class="comment_container__disclaimer"
         >
-          Your feedback will be only be shared with WooCommerce and treated pursuant to our 
+          Your feedback will be only be shared with WooCommerce and treated pursuant to our
           <a
             href="https://automattic.com/privacy/"
             rel="noreferrer"

--- a/client/components/payment-activity/survey/test/index.test.tsx
+++ b/client/components/payment-activity/survey/test/index.test.tsx
@@ -53,7 +53,7 @@ describe( 'WcPayOverviewSurveyContextProvider', () => {
 			</WcPayOverviewSurveyContextProvider>
 		);
 
-		const surveyText = screen.getByText( 'Are those metrics helpful?' );
+		const surveyText = screen.getByText( 'Are these metrics helpful?' );
 		expect( surveyText ).toBeInTheDocument();
 
 		const buttons = screen.getAllByRole( 'button' );

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`PaymentActivity component should render 1`] = `
           <div
             class="survey_container"
           >
-            Are those metrics helpful?
+            Are these metrics helpful?
             <div
               class="survey_container__emoticons"
             >

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -120,7 +120,7 @@ describe( 'PaymentActivity component', () => {
 		const { container, getByText } = render( <PaymentActivity /> );
 
 		// Check survey is rendered.
-		getByText( 'Are those metrics helpful?' );
+		getByText( 'Are these metrics helpful?' );
 
 		expect( container ).toMatchSnapshot();
 	} );
@@ -140,7 +140,7 @@ describe( 'PaymentActivity component', () => {
 		const { queryByText } = render( <PaymentActivity /> );
 
 		expect(
-			queryByText( 'Are those metrics helpful?' )
+			queryByText( 'Are these metrics helpful?' )
 		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes #8724

#### Changes proposed in this Pull Request

Fixes the prompt for the payment activity card emoji user satisfaction / net promoter score (NPS) widget – `these` is clearer.


<img width="895" alt="Screenshot 2024-04-29 at 10 09 27 AM" src="https://github.com/Automattic/woocommerce-payments/assets/4167300/c85d2a40-710f-4bd9-886d-f71ad641ad50">

#### Testing instructions

* Check out this branch, build, ensure payment activity widget is visible (store has sales, feature flag `_wcpay_feature_payment_overview_widget` is 1)
* Ensure emoji survey is rendered, i.e. if you've already submitted may need to clear it
* Check that the prompt is clear and makes sense

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions). n/a, text change does not require dedicated manual QA
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. does not affect a critical flow
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. n/a - covered by payment activity feature announcement
