### PR TITLE
Reporting: Fix the `View report` link URL on Total payment volume tile, within Payment activity widget

### DIFF
--- a/changelog/fix-8706-tpv-view-report-link
+++ b/changelog/fix-8706-tpv-view-report-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix the `View report` link on Total payment volume tile on the Payment activity widget. Changes behind feature flag, and part of larger change that adds the wPayment activity widget.
+
+

--- a/changelog/fix-8706-tpv-view-report-link
+++ b/changelog/fix-8706-tpv-view-report-link
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
-Comment: Fix the `View report` link on Total payment volume tile on the Payment activity widget. Changes behind feature flag, and part of larger change that adds the wPayment activity widget.
+Comment: Comment: Fix the `View report` link on Total payment volume tile on the Payment activity widget. Changes behind feature flag, and part of larger change that adds the Payment activity widget.
 
 

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -43,6 +43,18 @@ const PaymentActivityData: React.FC = () => {
 	const refunds = paymentActivityData?.refunds ?? 0;
 	const { storeCurrency } = wcpaySettings;
 
+	const searchTermsForTPV = [
+		'charge',
+		'payment',
+		'payment_failure_refund',
+		'payment_refund',
+		'refund',
+		'refund_failure',
+		'dispute',
+		'dispute_reversal',
+		'card_reader_fee',
+	];
+
 	return (
 		<div className="wcpay-payment-activity-data">
 			<PaymentDataTile
@@ -92,7 +104,13 @@ const PaymentActivityData: React.FC = () => {
 					'date_between[1]': moment( getDateRange().date_end ).format(
 						'YYYY-MM-DD'
 					),
-					filter: 'advanced',
+					...searchTermsForTPV.reduce(
+						( acc, term, index ) => ( {
+							...acc,
+							[ `search[${ index }]` ]: term,
+						} ),
+						{}
+					),
 				} ) }
 				isLoading={ isLoading }
 			/>

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -17,7 +17,6 @@ import { usePaymentActivityData } from 'wcpay/data';
 import { getAdminUrl } from 'wcpay/utils';
 import type { DateRange } from './types';
 import './style.scss';
-import { filter } from 'lodash';
 
 /**
  * This will be replaces in the future with a dynamic date range picker.

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -43,17 +43,29 @@ const PaymentActivityData: React.FC = () => {
 	const refunds = paymentActivityData?.refunds ?? 0;
 	const currency = paymentActivityData?.currency;
 
-	const searchTermsForTPV = [
-		'charge',
-		'payment',
-		'payment_failure_refund',
-		'payment_refund',
-		'refund',
-		'refund_failure',
-		'dispute',
-		'dispute_reversal',
-		'card_reader_fee',
-	];
+	const searchTermsForViewReportLink = {
+		totalPaymentVolume: [
+			'charge',
+			'payment',
+			'payment_failure_refund',
+			'payment_refund',
+			'refund',
+			'refund_failure',
+			'dispute',
+			'dispute_reversal',
+			'card_reader_fee',
+		],
+	};
+
+	const getSearchParams = ( searchTerms: string[] ) => {
+		return searchTerms.reduce(
+			( acc, term, index ) => ( {
+				...acc,
+				[ `search[${ index }]` ]: term,
+			} ),
+			{}
+		);
+	};
 
 	return (
 		<div className="wcpay-payment-activity-data">
@@ -105,12 +117,8 @@ const PaymentActivityData: React.FC = () => {
 					'date_between[1]': moment( getDateRange().date_end ).format(
 						'YYYY-MM-DD'
 					),
-					...searchTermsForTPV.reduce(
-						( acc, term, index ) => ( {
-							...acc,
-							[ `search[${ index }]` ]: term,
-						} ),
-						{}
+					...getSearchParams(
+						searchTermsForViewReportLink.totalPaymentVolume
 					),
 				} ) }
 				tracksSource="total_payment_volume"

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -17,6 +17,7 @@ import { usePaymentActivityData } from 'wcpay/data';
 import { getAdminUrl } from 'wcpay/utils';
 import type { DateRange } from './types';
 import './style.scss';
+import { filter } from 'lodash';
 
 /**
  * This will be replaces in the future with a dynamic date range picker.
@@ -98,6 +99,7 @@ const PaymentActivityData: React.FC = () => {
 				reportLink={ getAdminUrl( {
 					page: 'wc-admin',
 					path: '/payments/transactions',
+					filter: 'advanced',
 					'date_between[0]': moment(
 						getDateRange().date_start
 					).format( 'YYYY-MM-DD' ),

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -23,12 +23,36 @@ import './style.scss';
  */
 const getDateRange = (): DateRange => {
 	return {
-		// Subtract 7 days from the current date.
+		// Subtract 6 days from the current date. 7 days including the current day.
 		date_start: moment()
-			.subtract( 7, 'd' )
+			.subtract( 6, 'd' )
 			.format( 'YYYY-MM-DD\\THH:mm:ss' ),
 		date_end: moment().format( 'YYYY-MM-DD\\THH:mm:ss' ),
 	};
+};
+
+const searchTermsForViewReportLink = {
+	totalPaymentVolume: [
+		'charge',
+		'payment',
+		'payment_failure_refund',
+		'payment_refund',
+		'refund',
+		'refund_failure',
+		'dispute',
+		'dispute_reversal',
+		'card_reader_fee',
+	],
+};
+
+const getSearchParams = ( searchTerms: string[] ) => {
+	return searchTerms.reduce(
+		( acc, term, index ) => ( {
+			...acc,
+			[ `search[${ index }]` ]: term,
+		} ),
+		{}
+	);
 };
 
 const PaymentActivityData: React.FC = () => {
@@ -42,30 +66,6 @@ const PaymentActivityData: React.FC = () => {
 	const disputes = paymentActivityData?.disputes ?? 0;
 	const refunds = paymentActivityData?.refunds ?? 0;
 	const currency = paymentActivityData?.currency;
-
-	const searchTermsForViewReportLink = {
-		totalPaymentVolume: [
-			'charge',
-			'payment',
-			'payment_failure_refund',
-			'payment_refund',
-			'refund',
-			'refund_failure',
-			'dispute',
-			'dispute_reversal',
-			'card_reader_fee',
-		],
-	};
-
-	const getSearchParams = ( searchTerms: string[] ) => {
-		return searchTerms.reduce(
-			( acc, term, index ) => ( {
-				...acc,
-				[ `search[${ index }]` ]: term,
-			} ),
-			{}
-		);
-	};
 
 	return (
 		<div className="wcpay-payment-activity-data">

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`PaymentActivity component should render 1`] = `
               </p>
               <a
                 data-link-type="wc-admin"
-                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
+                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
               >
                 View report
               </a>
@@ -165,7 +165,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&type_is=refund&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&type_is=refund&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08"
                 >
                   View report
                 </a>
@@ -194,7 +194,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes&filter=advanced&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08&status_is=needs_response"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&status_is=needs_response"
                 >
                   View report
                 </a>

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`PaymentActivity component should render 1`] = `
               </p>
               <a
                 data-link-type="wc-admin"
-                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08&filter=advanced"
+                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
               >
                 View report
               </a>

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`PaymentActivity component should render 1`] = `
               </p>
               <a
                 data-link-type="wc-admin"
-                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
+                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-01&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
               >
                 View report
               </a>

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -121,10 +121,11 @@ $gap-small: 12px;
 		.woocommerce-search {
 			margin: 0 $gap;
 
-			.woocommerce-select-control__control {
-				height: 38px;
-				overflow: scroll;
-				align-items: flex-start;
+			.components-base-control {
+				&.woocommerce-select-control__control {
+					min-height: 38px;
+					height: auto;
+				}
 			}
 		}
 

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -123,6 +123,8 @@ $gap-small: 12px;
 
 			.woocommerce-select-control__control {
 				height: 38px;
+				overflow: scroll;
+				align-items: flex-start;
 			}
 		}
 


### PR DESCRIPTION
Fixes #8706 

#### Changes proposed in this Pull Request

The PR fixes the `View report` link on Total Payment volume tile to match the requirement as follows: 

* `Total payment volume` should show all types created over the last 7 days (or selected time filter) except for `Loan disbursement` and `Loan repayment`

#### Notes

* The existing advanced filter on the Transaction page, do have `Type is` and `Type is not` filters, but they do not allow selecting more than one types in it, in the current design. 
* Thanks to @shendy-a8c , who drew my attention to the default Disputes link that uses search term params to give a result comprising types - `needs_response` and `warning_needs_response` 
<img width="275" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/4162931/6ffc570d-05e7-4059-bf96-1cc2572b4b3e">

* For segregating transactions matching the above criteria, similar principle has been used :
  * On the server, the [exact search](https://github.com/Automattic/woocommerce-payments-server/blob/b053dfccfe5ba8bd1545c71394a501bcffce02f1/server/wp-content/rest-api-plugins/endpoints/wcpay/repository/class-transaction-repository.php#L43-L47) of `type` has been added in the search fields. 
  * On the client, the `View report` URL was edited to include the search terms. 
  * Some minor CSS changes were done so that the tags that appear in the search box do not warp outside the box. 

A more permanent solution to this would be to have `typeIs` and `typeIsNot` params accept arrays. But this may require higher effort to execute and to ensure backward compatibility. I found using the way similar to Disputes a better option for now.

#### Testing instructions
* On your local server instance, please check out branch `add/type-to-search-by-fields`
* On the local test client setup, make sure your account has sufficient transactions within the last 7 days, and at least one `Loan disbursement` and `Loan repayment` .  See if you can switch to `acct_1OuYn1QpUShfetUA` which has these ( and should remain for the next few days. Else create the loan transactions using the steps in the PdjTHR-31T-p2. 
* Browse to `Payments > Overview` and click the `View report` against `Total payment volume`
* On the transactions report page that lands, you should see all transactions except Loan disbursement and Loan repayment

#### Screenshots

On a wider screen
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/96f08228-eb56-4fa8-b6f6-8a2c3bc29662)

On a narrow screen
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/d9092292-251a-44b1-a3ca-4cf1bc5672d3)

 Without the CSS change, it would appear like this:
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/32134aef-5ab9-4153-8638-9c0264871dbb)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.