### PR TITLE
misc: fix warning during plugin update due to problems with initialization

### DIFF
--- a/changelog/fix-fatals-on-plugin-update
+++ b/changelog/fix-fatals-on-plugin-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Avoid warnings about fatal error during plugin update due to problems with plugin initialization.

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -8,7 +8,6 @@
 use WCPay\Constants\Country_Code;
 use WCPay\Fraud_Prevention\Fraud_Risk_Tools;
 use WCPay\Constants\Track_Events;
-use WCPay\Duplicates_Detection_Service;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -37,34 +36,22 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 */
 	protected $account;
 
-
-	/**
-	 * Duplicates detection service.
-	 *
-	 * @var Duplicates_Detection_Service
-	 */
-	private $duplicates_detection_service;
-
-
 	/**
 	 * WC_REST_Payments_Settings_Controller constructor.
 	 *
-	 * @param WC_Payments_API_Client       $api_client WC_Payments_API_Client instance.
-	 * @param WC_Payment_Gateway_WCPay     $wcpay_gateway WC_Payment_Gateway_WCPay instance.
-	 * @param WC_Payments_Account          $account  Account class instance.
-	 * @param Duplicates_Detection_Service $duplicates_detection_service Duplicates detection service.
+	 * @param WC_Payments_API_Client   $api_client WC_Payments_API_Client instance.
+	 * @param WC_Payment_Gateway_WCPay $wcpay_gateway WC_Payment_Gateway_WCPay instance.
+	 * @param WC_Payments_Account      $account  Account class instance.
 	 */
 	public function __construct(
 		WC_Payments_API_Client $api_client,
 		WC_Payment_Gateway_WCPay $wcpay_gateway,
-		WC_Payments_Account $account,
-		Duplicates_Detection_Service $duplicates_detection_service
+		WC_Payments_Account $account
 	) {
 		parent::__construct( $api_client );
 
-		$this->wcpay_gateway                = $wcpay_gateway;
-		$this->account                      = $account;
-		$this->duplicates_detection_service = $duplicates_detection_service;
+		$this->wcpay_gateway = $wcpay_gateway;
+		$this->account       = $account;
 	}
 
 	/**
@@ -486,7 +473,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'enabled_payment_method_ids'          => $enabled_payment_methods,
 				'available_payment_method_ids'        => $available_upe_payment_methods,
 				'payment_method_statuses'             => $this->wcpay_gateway->get_upe_enabled_payment_method_statuses(),
-				'duplicated_payment_method_ids'       => $this->duplicates_detection_service->find_duplicates(),
+				'duplicated_payment_method_ids'       => $this->wcpay_gateway->find_duplicates(),
 				'is_wcpay_enabled'                    => $this->wcpay_gateway->is_enabled(),
 				'is_manual_capture_enabled'           => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
 				'is_test_mode_enabled'                => WC_Payments::mode()->is_test(),

--- a/includes/class-duplicates-detection-service.php
+++ b/includes/class-duplicates-detection-service.php
@@ -11,7 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use Exception;
 use WC_Payments;
 use WCPay\Payment_Methods\Affirm_Payment_Method;
 use WCPay\Payment_Methods\Afterpay_Payment_Method;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -30,6 +30,7 @@ use WCPay\Core\Server\Request\Get_Setup_Intention;
 use WCPay\Core\Server\Request\List_Charge_Refunds;
 use WCPay\Core\Server\Request\Refund_Charge;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Fraud_Prevention\Fraud_Risk_Tools;
 use WCPay\Internal\Payment\State\AuthenticationRequiredState;
@@ -197,6 +198,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	protected $duplicate_payment_prevention_service;
 
 	/**
+	 * Duplicate payment methods detection service
+	 *
+	 * @var Duplicates_Detection_Service
+	 */
+	protected $duplicate_payment_methods_detection_service;
+
+	/**
 	 * WC_Payments_Localization_Service instance.
 	 *
 	 * @var WC_Payments_Localization_Service
@@ -246,6 +254,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param Duplicate_Payment_Prevention_Service $duplicate_payment_prevention_service - Service for preventing duplicate payments.
 	 * @param WC_Payments_Localization_Service     $localization_service                 - Localization service instance.
 	 * @param WC_Payments_Fraud_Service            $fraud_service                        - Fraud service instance.
+	 * @param Duplicates_Detection_Service         $duplicate_payment_methods_detection_service - Service for finding duplicate enabled payment methods.
 	 */
 	public function __construct(
 		WC_Payments_API_Client $payments_api_client,
@@ -259,22 +268,24 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		WC_Payments_Order_Service $order_service,
 		Duplicate_Payment_Prevention_Service $duplicate_payment_prevention_service,
 		WC_Payments_Localization_Service $localization_service,
-		WC_Payments_Fraud_Service $fraud_service
+		WC_Payments_Fraud_Service $fraud_service,
+		Duplicates_Detection_Service $duplicate_payment_methods_detection_service
 	) {
 		$this->payment_methods = $payment_methods;
 		$this->payment_method  = $payment_method;
 		$this->stripe_id       = $payment_method->get_id();
 
-		$this->payments_api_client                  = $payments_api_client;
-		$this->account                              = $account;
-		$this->customer_service                     = $customer_service;
-		$this->token_service                        = $token_service;
-		$this->action_scheduler_service             = $action_scheduler_service;
-		$this->failed_transaction_rate_limiter      = $failed_transaction_rate_limiter;
-		$this->order_service                        = $order_service;
-		$this->duplicate_payment_prevention_service = $duplicate_payment_prevention_service;
-		$this->localization_service                 = $localization_service;
-		$this->fraud_service                        = $fraud_service;
+		$this->payments_api_client                         = $payments_api_client;
+		$this->account                                     = $account;
+		$this->customer_service                            = $customer_service;
+		$this->token_service                               = $token_service;
+		$this->action_scheduler_service                    = $action_scheduler_service;
+		$this->failed_transaction_rate_limiter             = $failed_transaction_rate_limiter;
+		$this->order_service                               = $order_service;
+		$this->duplicate_payment_prevention_service        = $duplicate_payment_prevention_service;
+		$this->localization_service                        = $localization_service;
+		$this->fraud_service                               = $fraud_service;
+		$this->duplicate_payment_methods_detection_service = $duplicate_payment_methods_detection_service;
 
 		$this->id                 = static::GATEWAY_ID;
 		$this->icon               = $this->get_theme_icon();
@@ -4344,6 +4355,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return $description;
+	}
+
+	/**
+	 * Calls duplicate payment methods detection service to find duplicates.
+	 * This method acts as a wrapper. The approach should be reverted once
+	 * https://github.com/Automattic/woocommerce-payments/issues/7464 is resolved.
+	 */
+	public function find_duplicates() {
+		return $this->duplicate_payment_methods_detection_service->find_duplicates();
 	}
 
 	// Start: Deprecated functions.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -538,7 +538,7 @@ class WC_Payments {
 		foreach ( $payment_methods as $payment_method ) {
 			self::$payment_method_map[ $payment_method->get_id() ] = $payment_method;
 
-			$split_gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $payment_method, $payment_methods, self::$failed_transaction_rate_limiter, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service, self::$fraud_service );
+			$split_gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $payment_method, $payment_methods, self::$failed_transaction_rate_limiter, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service, self::$fraud_service, self::$duplicates_detection_service );
 
 			// Card gateway hooks are registered once below.
 			if ( 'card' !== $payment_method->get_id() ) {
@@ -1020,7 +1020,7 @@ class WC_Payments {
 		$reporting_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-settings-controller.php';
-		$settings_controller = new WC_REST_Payments_Settings_Controller( self::$api_client, self::get_gateway(), self::$account, self::$duplicates_detection_service );
+		$settings_controller = new WC_REST_Payments_Settings_Controller( self::$api_client, self::get_gateway(), self::$account );
 		$settings_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-reader-controller.php';

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -175,9 +175,10 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			$order_service,
 			$mock_dpps,
 			$this->mock_localization_service,
-			$this->mock_fraud_service
+			$this->mock_fraud_service,
+			$this->mock_duplicates_detection_service
 		);
-		$this->controller = new WC_REST_Payments_Settings_Controller( $this->mock_api_client, $this->gateway, $this->mock_wcpay_account, $this->mock_duplicates_detection_service );
+		$this->controller = new WC_REST_Payments_Settings_Controller( $this->mock_api_client, $this->gateway, $this->mock_wcpay_account );
 
 		$this->mock_api_client
 			->method( 'is_server_connected' )

--- a/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Add_Account_Tos_Agreement;
 use WCPay\Database_Cache;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 
@@ -55,16 +56,17 @@ class WC_REST_Payments_Tos_Controller_Test extends WCPAY_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$mock_wcpay_account       = $this->createMock( WC_Payments_Account::class );
-		$mock_fraud_service       = $this->createMock( WC_Payments_Fraud_Service::class );
-		$mock_db_cache            = $this->createMock( Database_Cache::class );
-		$mock_session_service     = $this->createMock( WC_Payments_Session_Service::class );
-		$customer_service         = new WC_Payments_Customer_Service( $mock_api_client, $mock_wcpay_account, $mock_db_cache, $mock_session_service );
-		$token_service            = new WC_Payments_Token_Service( $mock_api_client, $customer_service );
-		$order_service            = new WC_Payments_Order_Service( $this->createMock( WC_Payments_API_Client::class ) );
-		$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $mock_api_client, $order_service );
-		$mock_dpps                = $this->createMock( Duplicate_Payment_Prevention_Service::class );
-		$mock_payment_method      = $this->createMock( CC_Payment_Method::class );
+		$mock_wcpay_account                = $this->createMock( WC_Payments_Account::class );
+		$mock_fraud_service                = $this->createMock( WC_Payments_Fraud_Service::class );
+		$mock_db_cache                     = $this->createMock( Database_Cache::class );
+		$mock_session_service              = $this->createMock( WC_Payments_Session_Service::class );
+		$customer_service                  = new WC_Payments_Customer_Service( $mock_api_client, $mock_wcpay_account, $mock_db_cache, $mock_session_service );
+		$token_service                     = new WC_Payments_Token_Service( $mock_api_client, $customer_service );
+		$order_service                     = new WC_Payments_Order_Service( $this->createMock( WC_Payments_API_Client::class ) );
+		$action_scheduler_service          = new WC_Payments_Action_Scheduler_Service( $mock_api_client, $order_service );
+		$mock_dpps                         = $this->createMock( Duplicate_Payment_Prevention_Service::class );
+		$mock_payment_method               = $this->createMock( CC_Payment_Method::class );
+		$mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		$this->gateway    = new WC_Payment_Gateway_WCPay(
 			$mock_api_client,
@@ -78,7 +80,8 @@ class WC_REST_Payments_Tos_Controller_Test extends WCPAY_UnitTestCase {
 			$order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$mock_fraud_service
+			$mock_fraud_service,
+			$mock_duplicates_detection_service
 		);
 		$this->controller = new WC_REST_Payments_Tos_Controller( $mock_api_client, $this->gateway, $mock_wcpay_account );
 

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -172,6 +172,13 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	private $mock_fraud_service;
 
 	/**
+	 * Mock Duplicates Detection Service.
+	 *
+	 * @var Duplicates_Detection_Service
+	 */
+	private $mock_duplicates_detection_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -231,8 +238,9 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$this->mock_dpps = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 
-		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );
-		$this->mock_fraud_service        = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_localization_service         = $this->createMock( WC_Payments_Localization_Service::class );
+		$this->mock_fraud_service                = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		$this->mock_payment_methods = [];
 		$payment_method_classes     = [
@@ -295,7 +303,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->setMethods(
@@ -950,7 +958,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_fees' )
 			->willReturn( $payment_methods );
-		$mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		$gateway = new WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
@@ -965,7 +972,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			$this->mock_dpps,
 			$this->mock_localization_service,
 			$this->mock_fraud_service,
-			$mock_duplicates_detection_service
+			$this->mock_duplicates_detection_service
 		);
 
 		$this->assertEquals( $expected_result, $gateway->get_upe_available_payment_methods() );

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -33,6 +33,7 @@ use WCPay\Duplicate_Payment_Prevention_Service;
 use WC_Payments_Localization_Service;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 use WCPay\Database_Cache;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Internal\Service\Level3Service;
 use WCPay\Internal\Service\OrderService;
 
@@ -948,6 +949,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_fees' )
 			->willReturn( $payment_methods );
+		$mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		$gateway = new WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
@@ -961,7 +963,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			$this->mock_order_service,
 			$this->mock_dpps,
 			$this->mock_localization_service,
-			$this->mock_fraud_service
+			$this->mock_fraud_service,
+			$mock_duplicates_detection_service
 		);
 
 		$this->assertEquals( $expected_result, $gateway->get_upe_available_payment_methods() );

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -295,6 +295,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods(

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -159,6 +159,13 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	 */
 	private $mock_fraud_service;
 
+		/**
+		 * Mock Duplicates Detection Service.
+		 *
+		 * @var Duplicates_Detection_Service
+		 */
+	private $mock_duplicates_detection_service;
+
 	/**
 	 * Mapping for payment ID to payment method.
 	 *
@@ -248,8 +255,9 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$this->mock_dpps = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 
-		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );
-		$this->mock_fraud_service        = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_localization_service         = $this->createMock( WC_Payments_Localization_Service::class );
+		$this->mock_fraud_service                = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		// Arrange: Define a $_POST array which includes the payment method,
 		// so that get_payment_method_from_request() does not throw error.
@@ -282,7 +290,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 						$this->mock_dpps,
 						$this->mock_localization_service,
 						$this->mock_fraud_service,
-						$this->createMock( Duplicates_Detection_Service::class ),
+						$this->mock_duplicates_detection_service,
 					]
 				)
 				->setMethods(
@@ -1062,7 +1070,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->setMethods( [ 'get_payment_methods_from_gateway_id' ] )
@@ -1108,7 +1116,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->setMethods( [ 'get_payment_methods_from_gateway_id' ] )
@@ -1153,7 +1161,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->setMethods(
@@ -1207,7 +1215,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->onlyMethods(

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -35,6 +35,7 @@ use WC_Payments;
 use WC_Payments_Localization_Service;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 use WCPay\Database_Cache;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Internal\Service\Level3Service;
 use WCPay\Internal\Service\OrderService;
 /**
@@ -281,6 +282,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 						$this->mock_dpps,
 						$this->mock_localization_service,
 						$this->mock_fraud_service,
+						$this->createMock( Duplicates_Detection_Service::class ),
 					]
 				)
 				->setMethods(
@@ -1060,6 +1062,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods( [ 'get_payment_methods_from_gateway_id' ] )
@@ -1105,6 +1108,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods( [ 'get_payment_methods_from_gateway_id' ] )
@@ -1149,6 +1153,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods(
@@ -1202,6 +1207,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->onlyMethods(

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 use WCPay\Constants\Payment_Method;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
@@ -153,6 +154,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WCPAY_UnitTestCase {
 					$mock_dpps,
 					$this->createMock( WC_Payments_Localization_Service::class ),
 					$this->createMock( WC_Payments_Fraud_Service::class ),
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods(

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -15,6 +15,7 @@ use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Connection_Exception;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Constants\Payment_Method;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 
 // Need to use WC_Mock_Data_Store.
@@ -167,6 +168,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->createMock( WC_Payments_Localization_Service::class ),
 					$this->createMock( WC_Payments_Fraud_Service::class ),
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods(

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -12,6 +12,7 @@ use WCPay\Core\Server\Request\List_Charge_Refunds;
 use WCPay\Core\Server\Request\Refund_Charge;
 use WCPay\Core\Server\Response;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
@@ -104,7 +105,8 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 			$this->mock_order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$this->createMock( WC_Payments_Fraud_Service::class )
+			$this->createMock( WC_Payments_Fraud_Service::class ),
+			$this->createMock( Duplicates_Detection_Service::class )
 		);
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 
@@ -139,7 +140,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 			$this->mock_order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$this->createMock( WC_Payments_Fraud_Service::class )
+			$this->createMock( WC_Payments_Fraud_Service::class ),
+			$this->createMock( Duplicates_Detection_Service::class ),
 		);
 		$this->wcpay_gateway->init_hooks();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -10,6 +10,7 @@ use WCPay\Core\Server\Request\Create_And_Confirm_Setup_Intention;
 use WCPay\Constants\Order_Status;
 use WCPay\Constants\Intent_Status;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 
@@ -160,6 +161,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 					$mock_dpps,
 					$this->createMock( WC_Payments_Localization_Service::class ),
 					$this->createMock( WC_Payments_Fraud_Service::class ),
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->setMethods(

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -103,6 +103,13 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 	 */
 	private $mock_fraud_service;
 
+	/**
+	 * Mock Duplicates Detection Service.
+	 *
+	 * @var Duplicates_Detection_Service
+	 */
+	private $mock_duplicates_detection_service;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -137,8 +144,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 
 		$this->mock_dpps = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 
-		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );
-		$this->mock_fraud_service        = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_localization_service         = $this->createMock( WC_Payments_Localization_Service::class );
+		$this->mock_fraud_service                = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		$mock_payment_method = $this->getMockBuilder( CC_Payment_Method::class )
 			->setConstructorArgs( [ $this->mock_token_service ] )
@@ -158,7 +166,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->mock_dpps,
 			$this->mock_localization_service,
 			$this->mock_fraud_service,
-			$this->createMock( Duplicates_Detection_Service::class ),
+			$this->mock_duplicates_detection_service,
 		);
 		$this->wcpay_gateway->init_hooks();
 		WC_Payments::set_gateway( $this->wcpay_gateway );
@@ -832,7 +840,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->order_service,
 			$this->mock_dpps,
 			$this->mock_localization_service,
-			$this->mock_fraud_service
+			$this->mock_fraud_service,
+			$this->mock_duplicates_detection_service,
 		);
 
 		// Ensure the has_attached_integration_hooks property is set to false so callbacks can be attached in maybe_init_subscriptions().
@@ -866,7 +875,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->order_service,
 			$this->mock_dpps,
 			$this->mock_localization_service,
-			$this->mock_fraud_service
+			$this->mock_fraud_service,
+			$this->mock_duplicates_detection_service,
 		);
 
 		$this->assertFalse( has_action( 'woocommerce_admin_order_data_after_billing_address' ) );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Internal\Service\Level3Service;
 use WCPay\Internal\Service\OrderService;
@@ -156,7 +157,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->order_service,
 			$this->mock_dpps,
 			$this->mock_localization_service,
-			$this->mock_fraud_service
+			$this->mock_fraud_service,
+			$this->createMock( Duplicates_Detection_Service::class ),
 		);
 		$this->wcpay_gateway->init_hooks();
 		WC_Payments::set_gateway( $this->wcpay_gateway );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -898,6 +898,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->onlyMethods(
@@ -1005,6 +1006,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
+					$this->createMock( Duplicates_Detection_Service::class ),
 				]
 			)
 			->onlyMethods(
@@ -3204,6 +3206,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_dpps,
 			$this->mock_localization_service,
 			$this->mock_fraud_service,
+			$this->createMock( Duplicates_Detection_Service::class ),
 		];
 
 		foreach ( $constructor_replacement as $key => $value ) {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -178,6 +178,13 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	 */
 	private $mock_fraud_service;
 
+		/**
+		 * Mock Duplicates Detection Service.
+		 *
+		 * @var Duplicates_Detection_Service
+		 */
+	private $mock_duplicates_detection_service;
+
 	/**
 	 * Pre-test setup
 	 */
@@ -230,7 +237,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'currency_code' => 'usd',
 				]
 			);
-		$this->mock_fraud_service = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_fraud_service                = $this->createMock( WC_Payments_Fraud_Service::class );
+		$this->mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );
 
 		$this->mock_payment_method = $this->getMockBuilder( CC_Payment_Method::class )
 			->setConstructorArgs( [ $this->mock_token_service ] )
@@ -898,7 +906,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->onlyMethods(
@@ -1006,7 +1014,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					$this->mock_dpps,
 					$this->mock_localization_service,
 					$this->mock_fraud_service,
-					$this->createMock( Duplicates_Detection_Service::class ),
+					$this->mock_duplicates_detection_service,
 				]
 			)
 			->onlyMethods(
@@ -3206,7 +3214,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_dpps,
 			$this->mock_localization_service,
 			$this->mock_fraud_service,
-			$this->createMock( Duplicates_Detection_Service::class ),
+			$this->mock_duplicates_detection_service,
 		];
 
 		foreach ( $constructor_replacement as $key => $value ) {
@@ -3693,7 +3701,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 				$this->mock_dpps,
 				$this->mock_localization_service,
 				$this->mock_fraud_service,
-				$this->createMock( Duplicates_Detection_Service::class )
+				$this->mock_duplicates_detection_service
 			);
 		}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -17,6 +17,7 @@ use WCPay\Constants\Order_Status;
 use WCPay\Constants\Intent_Status;
 use WCPay\Constants\Payment_Method;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Process_Payment_Exception;
@@ -3688,7 +3689,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 				$this->order_service,
 				$this->mock_dpps,
 				$this->mock_localization_service,
-				$this->mock_fraud_service
+				$this->mock_fraud_service,
+				$this->createMock( Duplicates_Detection_Service::class )
 			);
 		}
 

--- a/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 use WCPay\WooPay\WooPay_Utilities;
@@ -177,7 +178,8 @@ class WC_Payments_Express_Checkout_Button_Display_Handler_Test extends WCPAY_Uni
 			$mock_order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$this->createMock( WC_Payments_Fraud_Service::class )
+			$this->createMock( WC_Payments_Fraud_Service::class ),
+			$this->createMock( Duplicates_Detection_Service::class )
 		);
 	}
 

--- a/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 
@@ -91,7 +92,8 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 			$mock_order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$this->createMock( WC_Payments_Fraud_Service::class )
+			$this->createMock( WC_Payments_Fraud_Service::class ),
+			$this->createMock( Duplicates_Detection_Service::class )
 		);
 	}
 

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -7,6 +7,7 @@
 
 use WCPay\Constants\Country_Code;
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 
@@ -223,7 +224,8 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 			$mock_order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$this->createMock( WC_Payments_Fraud_Service::class )
+			$this->createMock( WC_Payments_Fraud_Service::class ),
+			$this->createMock( Duplicates_Detection_Service::class )
 		);
 	}
 

--- a/tests/unit/test-class-wc-payments-woopay-button-handler.php
+++ b/tests/unit/test-class-wc-payments-woopay-button-handler.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Duplicate_Payment_Prevention_Service;
+use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 use WCPay\WooPay\WooPay_Utilities;
@@ -163,7 +164,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			$mock_order_service,
 			$mock_dpps,
 			$this->createMock( WC_Payments_Localization_Service::class ),
-			$this->createMock( WC_Payments_Fraud_Service::class )
+			$this->createMock( WC_Payments_Fraud_Service::class ),
+			$this->createMock( Duplicates_Detection_Service::class )
 		);
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/8731

#### Changes proposed in this Pull Request
https://github.com/Automattic/woocommerce-payments/issues/7464 describes the problem during plugin update when a new parameter is being added to the class's constructor during initialization. This PR is to fix one of the occurrences of this error, by removing the settings controller parameter and adding this parameter to be used through the gateway. **Once https://github.com/Automattic/woocommerce-payments/issues/7464 is fixed, this PR should be reverted.**


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* create a new JN site with the last WooPayments version available in production (`7.5.3`)
* after onboarding with WooPayments, attempt to update the plugin and confirm the warning with the fatal appears (more details in p1713879105398119-slack-C011ENB20Q1)
    * the `WooCommerce -> Status -> Logs -> fatal errors` entry exists and contains the `ArgumentCountError: Too few arguments to function WC_REST_Payments_Settings_Controller`
    * at this point you should also receive an email with the title `Your Site is Experiencing a Technical Issue`
* create another JN site with `7.5.3`
* onboard with WooPayments, build the plugin from this branch (`fix/fatals-on-plugin-update`) [[you can use this](https://github.com/Automattic/woocommerce-payments/actions/runs/8878489004)], use it to update the plugin on your store and confirm no more warnings during plugin update
    * no email about the error received
    * no `fatal_errors` source under `WooCommerce -> Status -> Logs` because no `ArgumentCountError` was thrown
* navigate to payments settings page and confirm no errors appear there and the content is loaded as expected

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.