### PR TITLE
Revert Add Multi-Currency Support to Page Caching via Cookies

### DIFF
--- a/changelog/revert-8534-8130-add-cookie-product-cache-per-currency
+++ b/changelog/revert-8534-8130-add-cookie-product-cache-per-currency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Revert: Add Multi-Currency Support to Page Caching via Cookies.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -316,8 +316,6 @@ class MultiCurrency {
 		// Update the customer currencies option after an order status change.
 		add_action( 'woocommerce_order_status_changed', [ $this, 'maybe_update_customer_currencies_option' ] );
 
-		$this->maybe_add_cache_cookie();
-
 		static::$is_initialized = true;
 	}
 
@@ -830,8 +828,6 @@ class MultiCurrency {
 		} else {
 			add_action( 'wp_loaded', [ $this, 'recalculate_cart' ] );
 		}
-
-		$this->maybe_add_cache_cookie();
 	}
 
 	/**
@@ -1656,18 +1652,5 @@ class MultiCurrency {
 	 */
 	private function is_customer_currencies_data_valid( $currencies ) {
 		return ! empty( $currencies ) && is_array( $currencies );
-	}
-
-	/**
-	 * Sets the cache cookie for currency code and exchange rate.
-	 *
-	 * This private method sets the 'wcpay_currency' cookie if HTTP headers
-	 * have not been sent. This cookie stores the selected currency's code and its exchange rate,
-	 * and is intended exclusively for caching purposes, not for application logic.
-	 */
-	private function maybe_add_cache_cookie() {
-		if ( ! headers_sent() && ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_api_request() ) {
-			wc_setcookie( 'wcpay_currency', sprintf( '%s_%s', $this->get_selected_currency()->get_code(), $this->get_selected_currency()->get_rate() ), time() + HOUR_IN_SECONDS );
-		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Revert Automattic/woocommerce-payments#8534
- Fixes #8679 

#### Testing instructions

**Prerequisites**

- Switch to this branch.
- Enable the multi-currency feature in WooPayments settings and configure a few different currencies.

**Test 1: Ensure the `wcpay_currency` cookie is no longer set**

1. Clear your browser cookies to ensure a fresh start for this test.
2. Visit your site and switch to a different currency using the currency switcher provided by WooPayments.
3. After switching currencies, check your browser's developer tools under the Application > Storage tab and ensure there is no `wcpay_currency` cookie.

**Test 2: Ensure product pages are served from Batcache**

1. Clear your browser cookies to ensure a fresh start for this test.
2. Follow the instructions on how to set up Batcache on your local environment: pcrvl0-1cG-p2
3. Visit a product page and refresh it once.
4. Ensure the page is served from Batcache by inspecting the page source code.

**Note:** It's expected that the page is not served from cache if there's an active WP session, or if you have switched the store currency. To ensure a clear state for this test, clear your browser cookies.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.