### PR TITLE
Allow non-account-owner admin users to submit the payment activity survey

### DIFF
--- a/changelog/fix-8710-payment-activity-survey-all-admin-users
+++ b/changelog/fix-8710-payment-activity-survey-all-admin-users
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Part of Payment Activity Card behind feature flag. Allow non-accountholder users to submit the feedback survey.
+
+

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -49,7 +49,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 	 * @param array  $args             - The arguments to passed to Jetpack.
 	 * @param string $body             - The body passed on to the HTTP request.
 	 * @param bool   $is_site_specific - If true, the site ID will be included in the request url. Defaults to true.
-	 * @param bool   $use_user_token   - If true, the request will be signed with the user token rather than blog token. Defaults to false.
+	 * @param bool   $use_user_token   - If true, the request will be signed with the Jetpack connection owner user token rather than blog token. Defaults to false.
 	 *
 	 * @return array HTTP response on success.
 	 * @throws API_Exception - If not connected or request failed.


### PR DESCRIPTION
Fixes #8710

#### Changes proposed in this Pull Request

This PR allows non-account-owner WP admin users to submit the Payments activity card survey by sending the POST request as the account-owner user.

Account-owner in this context means the WP admin user who set up the WooPayments account and therefore the Jetpack connection.

The (soft) limit for submitting the survey remains once per site (soft, since deleting the WP option `wcpay_survey_payment_overview_submitted` resets this limitation).



![emoji-survey](https://github.com/Automattic/woocommerce-payments/assets/3147296/a9defcda-2132-4bd9-958b-ac3b0d17d532)


#### Testing instructions

- Enable feature flag: `wp option update _wcpay_feature_payment_overview_widget 1` in CLI (`npm run cli` if docker)
- Run `wp option delete wcpay_survey_payment_overview_submitted` to clear your local submission state (if survey submitted already).
- 🙋 Non-account-holder user:
	- Create and/or log in as a new WP admin user.
	- Visit `Payments > Overview`.
	- Submit a response in the emoji survey and ensure you see the a success message `🙌 We appreciate your feedback!` ✅
	- Refresh the `Payments > Overview` page and ensure that the survey is not rendered, since it has been submitted.
- 🙂 Account-holder user:
	- Log in as the WP admin user who created the initial WooPayments account.
	- Visit `Payments > Overview`.
	- Ensure the survey is not rendered, since it has been submitted.
	- Run `wp option delete wcpay_survey_payment_overview_submitted` to clear your local submission state.
	- Refresh the `Payments > Overview` page and ensure the survey is rendered.
	- Submit a response in the emoji survey and ensure you see the a success message `🙌 We appreciate your feedback!` ✅
- Visit https://mc.a8c.com/marketing/survey/index.php?survey=wcpay-payment-activity and ensure your submissions are visible (download the CSV to observe timestamps).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
