### PR TITLE
Pass merchant timezone to Reporting Payment Activity API

### DIFF
--- a/changelog/fix-8742-merchant-timezone-payment-activity
+++ b/changelog/fix-8742-merchant-timezone-payment-activity
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Adding some fixes to the Payment Activity component, reporting controller aand associated classes.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -32,9 +32,10 @@ const getDateRange = (): DateRange => {
 };
 
 const PaymentActivityData: React.FC = () => {
-	const { paymentActivityData, isLoading } = usePaymentActivityData(
-		getDateRange()
-	);
+	const { paymentActivityData, isLoading } = usePaymentActivityData( {
+		...getDateRange(),
+		timezone: moment( new Date() ).format( 'Z' ),
+	} );
 
 	const totalPaymentVolume = paymentActivityData?.total_payment_volume ?? 0;
 	const charges = paymentActivityData?.charges ?? 0;

--- a/client/data/payment-activity/test/hooks.test.ts
+++ b/client/data/payment-activity/test/hooks.test.ts
@@ -36,6 +36,7 @@ describe( 'usePaymentActivityData', () => {
 		const result = usePaymentActivityData( {
 			date_start: '2021-01-01',
 			date_end: '2021-01-31',
+			timezone: 'UTC',
 		} );
 
 		expect( result ).toEqual( {

--- a/client/data/payment-activity/test/resolver.test.ts
+++ b/client/data/payment-activity/test/resolver.test.ts
@@ -15,12 +15,13 @@ import { getPaymentActivityData } from '../resolvers';
 const query = {
 	date_start: '2020-04-29T04:00:00',
 	date_end: '2020-04-29T03:59:59',
+	timezone: '+2:30',
 };
 
 describe( 'getPaymentActivityData resolver', () => {
 	const successfulResponse: any = { amount: 3000 };
 	const expectedQueryString =
-		'date_start=2020-04-29T04%3A00%3A00&date_end=2020-04-29T03%3A59%3A59';
+		'date_start=2020-04-29T04%3A00%3A00&date_end=2020-04-29T03%3A59%3A59&timezone=%2B2%3A30';
 	const errorResponse = new Error(
 		'Error retrieving payment activity data.'
 	);

--- a/client/data/payment-activity/types.d.ts
+++ b/client/data/payment-activity/types.d.ts
@@ -39,5 +39,5 @@ export interface PaymentActivityQuery {
 	/** The date range end datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */
 	date_end: string;
 	/** The timezone used to calculate the transaction data date range, e.g. 'UTC' */
-	timezone?: string;
+	timezone: string;
 }

--- a/includes/core/server/request/class-get-reporting-payment-activity.md
+++ b/includes/core/server/request/class-get-reporting-payment-activity.md
@@ -1,0 +1,27 @@
+# `Get_Intention` request class
+
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+
+## Description
+
+The `WCPay\Core\Server\Request\Get_Intention` class is used to construct the request for retrieving an intention.
+
+## Parameters
+
+When creating `Get_Intention` requests, the item ID must be provided to the `::create()` method. The identifier should be in the `pi_XXX` format.
+There are no additional parameters for this request.
+
+## Filter
+
+When using this request, provide the following filter and arguments:
+
+- Name: `wcpay_get_intent_request`
+- Arguments: `WC_Order $order`
+
+## Example:
+
+```php
+$request = Get_Intention::create( $id );
+$request->set_hook_args( $order )
+$request->send();
+```

--- a/includes/core/server/request/class-get-reporting-payment-activity.md
+++ b/includes/core/server/request/class-get-reporting-payment-activity.md
@@ -15,6 +15,7 @@ The `WCPay\Core\Server\Request\Get_Reporting_Payment_Activity` class is used to 
 | `timezone`  | `set_timezone( string $timezone )`        |    No     |    Yes   |       -       |
 
 The `date_start` and `date_end` parameters should be in the 'YYYY-MM-DDT00:00:00' format.
+The `timezone` parameter can be passed as an offset or as a [timezone name](https://www.php.net/manual/en/timezones.php).
 
 ## Filter
 

--- a/includes/core/server/request/class-get-reporting-payment-activity.md
+++ b/includes/core/server/request/class-get-reporting-payment-activity.md
@@ -1,6 +1,6 @@
 # `Get_Reporting_Payment_Activity` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-reporting-payment-activity.md
+++ b/includes/core/server/request/class-get-reporting-payment-activity.md
@@ -1,27 +1,37 @@
-# `Get_Intention` request class
+# `Get_Reporting_Payment_Activity` request class
 
 [ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
 
 ## Description
 
-The `WCPay\Core\Server\Request\Get_Intention` class is used to construct the request for retrieving an intention.
+The `WCPay\Core\Server\Request\Get_Reporting_Payment_Activity` class is used to construct the request for retrieving payment activity.
 
 ## Parameters
 
-When creating `Get_Intention` requests, the item ID must be provided to the `::create()` method. The identifier should be in the `pi_XXX` format.
-There are no additional parameters for this request.
+| Parameter   | Setter                                    | Immutable | Required | Default value |
+|-------------|-------------------------------------------|:---------:|:--------:|:-------------:|
+| `date_start`| `set_date_start( string $date_start )`    |    No     |    Yes   |       -       |
+| `date_end`  | `set_date_end( string $date_end )`        |    No     |    Yes   |       -       |
+| `timezone`  | `set_timezone( string $timezone )`        |    No     |    Yes   |       -       |
+
+The `date_start` and `date_end` parameters should be in the 'YYYY-MM-DDT00:00:00' format.
 
 ## Filter
 
 When using this request, provide the following filter and arguments:
 
-- Name: `wcpay_get_intent_request`
-- Arguments: `WC_Order $order`
+- Name: `wcpay_get_payment_activity`
 
 ## Example:
 
 ```php
-$request = Get_Intention::create( $id );
-$request->set_hook_args( $order )
+$request = Get_Reporting_Payment_Activity::create();
+$request->set_date_start( $date_start );
+$request->set_date_end( $date_end );
+$request->set_timezone( $timezone );
 $request->send();
 ```
+
+## Exceptions
+
+- `Invalid_Request_Parameter_Exception` - Thrown when the provided date is not in the 'YYYY-MM-DDT00:00:00' format.

--- a/includes/core/server/request/class-get-reporting-payment-activity.md
+++ b/includes/core/server/request/class-get-reporting-payment-activity.md
@@ -35,4 +35,4 @@ $request->send();
 
 ## Exceptions
 
-- `Invalid_Request_Parameter_Exception` - Thrown when the provided date is not in the 'YYYY-MM-DDT00:00:00' format.
+- `Invalid_Request_Parameter_Exception` - Thrown when the provided date or timezone is not in expected format.

--- a/includes/core/server/request/class-get-reporting-payment-activity.php
+++ b/includes/core/server/request/class-get-reporting-payment-activity.php
@@ -51,6 +51,8 @@ class Get_Reporting_Payment_Activity extends Request {
 	 *
 	 * @param string $date_start The start date in the format 'YYYY-MM-DDT00:00:00'.
 	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception Exception if the date is not in valid format.
 	 */
 	public function set_date_start( string $date_start ) {
 		$this->validate_date( $date_start, 'Y-m-d\TH:i:s' );
@@ -62,6 +64,8 @@ class Get_Reporting_Payment_Activity extends Request {
 	 *
 	 * @param string $date_end The end date in the format 'YYYY-MM-DDT00:00:00'.
 	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception Exception if the date is not in valid format.
 	 */
 	public function set_date_end( string $date_end ) {
 		$this->validate_date( $date_end, 'Y-m-d\TH:i:s' );

--- a/includes/core/server/request/class-get-reporting-payment-activity.php
+++ b/includes/core/server/request/class-get-reporting-payment-activity.php
@@ -61,7 +61,7 @@ class Get_Reporting_Payment_Activity extends Request {
 	/**
 	 * Sets the end date for the payment activity data.
 	 *
-	 * @param string $date_end The end date in the format 'YYYY-MM-DDT00:00:00' or null.
+	 * @param string $date_end The end date in the format 'YYYY-MM-DDT00:00:00'.
 	 * @return void
 	 */
 	public function set_date_end( string $date_end ) {

--- a/includes/core/server/request/class-get-reporting-payment-activity.php
+++ b/includes/core/server/request/class-get-reporting-payment-activity.php
@@ -16,7 +16,6 @@ use WC_Payments_API_Client;
  */
 class Get_Reporting_Payment_Activity extends Request {
 
-
 	const REQUIRED_PARAMS = [
 		'date_start',
 		'date_end',
@@ -74,8 +73,24 @@ class Get_Reporting_Payment_Activity extends Request {
 	 *
 	 * @param string $timezone The timezone to set.
 	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception Exception if the timezone is not in valid format.
 	 */
 	public function set_timezone( string $timezone ) {
+		try {
+			new \DateTimeZone( $timezone );
+		} catch ( \Exception $e ) {
+			throw new Invalid_Request_Parameter_Exception(
+				esc_html(
+					sprintf(
+						// Translators: %s is a provided timezone.
+						__( '%s is not a valid timezone.', 'woocommerce-payments' ),
+						$timezone,
+					)
+				),
+				'wcpay_core_invalid_request_parameter_invalid_timezone'
+			);
+		}
 		$this->set_param( 'timezone', $timezone );
 	}
 }

--- a/includes/core/server/request/class-get-reporting-payment-activity.php
+++ b/includes/core/server/request/class-get-reporting-payment-activity.php
@@ -50,32 +50,32 @@ class Get_Reporting_Payment_Activity extends Request {
 	/**
 	 * Sets the start date for the payment activity data.
 	 *
-	 * @param string|null $date_start The start date in the format 'YYYY-MM-DDT00:00:00' or null.
+	 * @param string $date_start The start date in the format 'YYYY-MM-DDT00:00:00' or null.
 	 * @return void
 	 */
-	public function set_date_start( ?string $date_start ) {
-		// TBD - validation.
+	public function set_date_start( string $date_start ) {
+		$this->validate_date( $date_start, 'Y-m-d\TH:i:s' );
 		$this->set_param( 'date_start', $date_start );
 	}
 
 	/**
 	 * Sets the end date for the payment activity data.
 	 *
-	 * @param string|null $date_end The end date in the format 'YYYY-MM-DDT00:00:00' or null.
+	 * @param string $date_end The end date in the format 'YYYY-MM-DDT00:00:00' or null.
 	 * @return void
 	 */
 	public function set_date_end( string $date_end ) {
-		// TBD - validation.
+		$this->validate_date( $date_end, 'Y-m-d\TH:i:s' );
 		$this->set_param( 'date_end', $date_end );
 	}
 
 	/**
 	 * Sets the timezone for the reporting data.
 	 *
-	 * @param string|null $timezone The timezone to set or null.
+	 * @param string $timezone The timezone to set or null.
 	 * @return void
 	 */
-	public function set_timezone( ?string $timezone ) {
-		$this->set_param( 'timezone', $timezone ?? 'UTC' );
+	public function set_timezone( string $timezone ) {
+		$this->set_param( 'timezone', $timezone );
 	}
 }

--- a/includes/core/server/request/class-get-reporting-payment-activity.php
+++ b/includes/core/server/request/class-get-reporting-payment-activity.php
@@ -50,7 +50,7 @@ class Get_Reporting_Payment_Activity extends Request {
 	/**
 	 * Sets the start date for the payment activity data.
 	 *
-	 * @param string $date_start The start date in the format 'YYYY-MM-DDT00:00:00' or null.
+	 * @param string $date_start The start date in the format 'YYYY-MM-DDT00:00:00'.
 	 * @return void
 	 */
 	public function set_date_start( string $date_start ) {

--- a/includes/core/server/request/class-get-reporting-payment-activity.php
+++ b/includes/core/server/request/class-get-reporting-payment-activity.php
@@ -72,7 +72,7 @@ class Get_Reporting_Payment_Activity extends Request {
 	/**
 	 * Sets the timezone for the reporting data.
 	 *
-	 * @param string $timezone The timezone to set or null.
+	 * @param string $timezone The timezone to set.
 	 * @return void
 	 */
 	public function set_timezone( string $timezone ) {


### PR DESCRIPTION
Fixes #8742 

#### Changes proposed in this Pull Request

- Pass the timezone parameter from the component
- Make `timezone` parameter mandatory and remove all defaults.
- Improvements & Documentation for Payment Activity request class.

#### Testing instructions
- Check that merchant timezone is passed to the API from the Payment Activity API.
- If `timezone` is not passed, API throws error.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
