### PR TITLE
Add PRBs support for `express_checkout_enabled ` settings while detecting duplicates

### DIFF
--- a/changelog/add-third-party-plugin-support-for-duplicates-detection
+++ b/changelog/add-third-party-plugin-support-for-duplicates-detection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add support of a third-party plugin with PRBs into duplicates detection mechanism.

--- a/includes/class-duplicates-detection-service.php
+++ b/includes/class-duplicates-detection-service.php
@@ -150,6 +150,9 @@ class Duplicates_Detection_Service {
 					} elseif ( 'yes' === $gateway->get_option( 'payment_request' ) && 'woocommerce_payments' === $gateway->id ) {
 						$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
 						break;
+					} elseif ( 'yes' === $gateway->get_option( 'express_checkout_enabled' ) ) {
+						$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/8741

#### Changes proposed in this Pull Request
This PR adds support for detecting PRBs enabled by plugins which use the `express_checkout_enabled` settings to manage the PRB enablement.

So far, there's only one plugin we're aware of (see more details in the parent issue), but there might be more.



#### Testing instructions

* install [this plugin](https://wordpress.org/plugins/checkout-plugins-stripe-woo/) on your store
* skip Stripe onboarding for this plugin and navigate to its settings
* `Enable Stripe Gateway` under `page=wc-settings&tab=checkout&section=cpsw_stripe` and `Activate Express Checkout` under `?page=wc-settings&tab=checkout&section=cpsw_express_checkout`
* Open WooPayments' Payments settings screen, enable Apple Pay/Google Pay and confirm the duplicates notification is shown
* Turn off WooPayments Apple Pay/Google Pay, refresh the page, the notice should be gone
* Turn back WooPayments Apple Pay/Google Pay on and the notice should be back
* Turn off express checkout under `?page=wc-settings&tab=checkout&section=cpsw_express_checkout` and the notice is gone again

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
