### PR TITLE
Reporting: Fix the `View report` link on the Refunds tile of Payment activity widget

### DIFF
--- a/changelog/fix-8702-fix-refunds-view-report-link
+++ b/changelog/fix-8702-fix-refunds-view-report-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: The PR fixes the correct landing links on `View report` for the Refunds tile in Payment activity widget. Changes are behind a feature flag.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -43,6 +43,13 @@ const searchTermsForViewReportLink = {
 		'dispute_reversal',
 		'card_reader_fee',
 	],
+
+	refunds: [
+		'refund',
+		'refund_failure',
+		'payment_refund',
+		'payment_failure_refund',
+	],
 };
 
 const getSearchParams = ( searchTerms: string[] ) => {
@@ -167,13 +174,15 @@ const PaymentActivityData: React.FC = () => {
 						page: 'wc-admin',
 						path: '/payments/transactions',
 						filter: 'advanced',
-						type_is: 'refund',
 						'date_between[0]': moment(
 							getDateRange().date_start
 						).format( 'YYYY-MM-DD' ),
 						'date_between[1]': moment(
 							getDateRange().date_end
 						).format( 'YYYY-MM-DD' ),
+						...getSearchParams(
+							searchTermsForViewReportLink.refunds
+						),
 					} ) }
 					tracksSource="refunds"
 					isLoading={ isLoading }

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&type_is=refund&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&search%5B0%5D=refund&search%5B1%5D=refund_failure&search%5B2%5D=payment_refund&search%5B3%5D=payment_failure_refund"
                 >
                   View report
                 </a>


### PR DESCRIPTION
Fixes #8702 

The PR fixes the `View report` link on the Refunds tile, to make it open transactions report including types - `refund`, `refund_failure`, `payment_refund` and `payment_failure_refund` .

Filtration of multiple types in the transactions page, is done using the exact search for types, introduced in #8726 

#### Testing instructions
* Check in to this branch and make sure the feature flag `_wcpay_feature_payment_overview_widget` is enabled
* Create a few refund transactions.
* Browse to `Payments`
* Click on `View report` on the Refunds tile
* You should see a URL that looks like 
```
http://your-test-site/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-26&date_between%5B1%5D=2024-05-02&search%5B0%5D=refund&search%5B1%5D=refund_failure&search%5B2%5D=payment_refund&search%5B3%5D=payment_failure_refund
```
( dates would change depending on when you test ) 

* The resulting page should be the transactions page and have filters as seen in the screenshot. 

![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/973c9b5e-3fd8-489f-8332-369b552e25af)

* The total at the bottom of the page should match the amount we see on the tile.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
