### PR TITLE
Fix QIT warning in WooPay session endpoint

### DIFF
--- a/changelog/fix-8732-qit-warning
+++ b/changelog/fix-8732-qit-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix QIT warning for discouraged function.
+
+

--- a/includes/admin/class-wc-rest-woopay-session-controller.php
+++ b/includes/admin/class-wc-rest-woopay-session-controller.php
@@ -9,8 +9,6 @@ defined( 'ABSPATH' ) || exit;
 
 use WCPay\WooPay\WooPay_Session;
 use Automattic\Jetpack\Connection\Rest_Authentication;
-use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
-use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Logger;
 
 /**
@@ -56,13 +54,6 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 	 */
 	public function get_session_data( WP_REST_Request $request ): WP_REST_Response {
 		try {
-			$payload = $this->validated_cart_token_payload( $request->get_header( 'cart_token' ) );
-			$user_id = (int) $payload->user_id ?? null;
-
-			if ( is_int( $user_id ) && $user_id > 0 ) {
-				wp_set_current_user( $user_id );
-			}
-
 			// phpcs:ignore
 			/**
 			 * @psalm-suppress UndefinedClass
@@ -70,10 +61,8 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 			$response = WooPay_Session::get_init_session_request( null, null, null, $request );
 
 			return rest_ensure_response( $response );
-		} catch ( Rest_Request_Exception $e ) {
-			$error_code = $e->getCode() === 400 ? 'rest_invalid_param' : 'wcpay_server_error';
-			$error      = new WP_Error( $error_code, $e->getMessage(), [ 'status' => $e->getCode() ] );
-
+		} catch ( Exception $e ) {
+			$error = new WP_Error( 'wcpay_server_error', $e->getMessage(), [ 'status' => 400 ] );
 			Logger::log( 'Error validating cart token from WooPay request: ' . $e->getMessage() );
 
 			return rest_convert_error_to_response( $error );
@@ -87,31 +76,6 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 	 */
 	public function check_permission() {
 		return $this->is_request_from_woopay() && $this->has_valid_request_signature();
-	}
-
-	/**
-	 * Validates the cart token and returns its payload.
-	 *
-	 * @param string|null $cart_token The cart token to validate.
-	 *
-	 * @return object The validated cart token.
-	 *
-	 * @throws Rest_Request_Exception If the cart token is invalid, missing, or cannot be validated.
-	 */
-	public function validated_cart_token_payload( $cart_token ): object {
-		if ( ! $cart_token ) {
-			throw new Rest_Request_Exception( 'Missing cart token.', 400 );
-		}
-
-		if ( ! class_exists( JsonWebToken::class ) ) {
-			throw new Rest_Request_Exception( 'Cannot validate cart token.', 500 );
-		}
-
-		if ( ! JsonWebToken::validate( $cart_token, '@' . wp_salt() ) ) {
-			throw new Rest_Request_Exception( 'Invalid cart token.', 400 );
-		}
-
-		return JsonWebToken::get_parts( $cart_token )->payload;
 	}
 
 	/**

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -47,6 +47,9 @@ class WooPay_Session {
 		'@^\/wc\/store(\/v[\d]+)?\/checkout\/(?P<id>[\d]+)@',
 		'@^\/wc\/store(\/v[\d]+)?\/checkout$@',
 		'@^\/wc\/store(\/v[\d]+)?\/order\/(?P<id>[\d]+)@',
+		// The route below is not a Store API route. However, this REST endpoint is used by WooPay to indirectly reach the Store API.
+		// By adding it to this list, we're able to identify the user and load the correct session for this route.
+		'@^\/wc\/v3\/woopay\/session$@',
 	];
 
 	/**


### PR DESCRIPTION
Fixes #8732.

#### Changes proposed in this Pull Request

This PR tweaks the WooPay session REST endpoint by replacing a `wp_set_current_user` approach with an existent approach designed specifically for WooPay.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Pre-requisites**

1. Ensure the WooPay direct checkout flow is enabled: `npm run wp option update _wcpay_feature_woopay_direct_checkout 1`.
2. As a customer, log in into WooPay, if needed.
3. As a customer, log in into WooPayments, if needed.

**Test: current approach to note current user and customer**

1. Checkout to `develop` branch.
2. Ensure you have third party cookies disabled in your browser.
    2.1. Alternatively, you can comment [this line](https://github.com/Automattic/woocommerce-payments/blob/e217e54410c471816dd168bdca512ead31ec6f9f/client/checkout/woopay/direct-checkout/index.js#L28). But if you're going down this path you'll need to build the assets: `npm run build:client`.
4. Navigate to the merchant site, add an item to the cart and navigate to the cart.
5. Enable the debugger on WooPayments and add a breakpoint to [this line](https://github.com/Automattic/woocommerce-payments/blob/414fb3dc993351c16b70b02ced17df4dd2deaaaf/includes/woopay/class-woopay-session.php#L407).
6. Click on the **Proceed to checkout** button.
7. When you hit the breakpoint, note the user ID and customer ID.
8. After hitting play on the debugger, you should land on the WooPay checkout page.

**Test: determine current user approach works as expected**

1. Checkout to this branch.
2. Ensure you have third party cookies disabled in your browser.
    2.1. Alternatively, you can comment [this line](https://github.com/Automattic/woocommerce-payments/blob/e217e54410c471816dd168bdca512ead31ec6f9f/client/checkout/woopay/direct-checkout/index.js#L28). But if you're going down this path you'll need to build the assets: `npm run build:client`.
3. Navigate to the merchant site, add an item to the cart and navigate to the cart.
4. Enable the debugger on WooPayments and add a breakpoint to [this line](https://github.com/Automattic/woocommerce-payments/blob/414fb3dc993351c16b70b02ced17df4dd2deaaaf/includes/woopay/class-woopay-session.php#L407).
5. Click on the **Proceed to checkout** button.
6. When you hit the breakpoint, verify the user ID and customer ID are the same you noted in step 6 in the previous test.
7. After hitting play on the debugger, you should land on the WooPay checkout page.

**Test: QIT warning has been fixed**

1. Setup [QIT tests](https://github.com/Automattic/woocommerce-payments/blob/develop/tests/qit/README.md#setup-and-running), if needed.
2. Run `npm run test:qit`.
3. [Analyze the results](https://github.com/Automattic/woocommerce-payments/blob/develop/tests/qit/README.md#analysing-results) and make sure the warning reported in #8732 is gone.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
