### PR TITLE
Add notice and notification in Advanced Fraud Settings page

### DIFF
--- a/changelog/fix-6497-advanced-fraud-settings-empty
+++ b/changelog/fix-6497-advanced-fraud-settings-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add notice when no rules are enabled in advanced fraud settings

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -170,9 +170,13 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 
 	const handleSaveSettings = () => {
 		if ( validateSettings( protectionSettingsUI ) ) {
+			const settings = writeRuleset( protectionSettingsUI );
+
 			if ( ! checkAnyRuleFilterEnabled( protectionSettingsUI ) ) {
 				if ( ProtectionLevel.BASIC !== currentProtectionLevel ) {
 					updateProtectionLevel( ProtectionLevel.BASIC );
+					updateAdvancedFraudProtectionSettings( settings );
+					saveSettings();
 				}
 				dispatch( 'core/notices' ).createErrorNotice(
 					__(
@@ -180,6 +184,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 						'woocommerce-payments'
 					)
 				);
+
+				return;
 			} else if ( ProtectionLevel.ADVANCED !== currentProtectionLevel ) {
 				updateProtectionLevel( ProtectionLevel.ADVANCED );
 				dispatch( 'core/notices' ).createSuccessNotice(
@@ -189,8 +195,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 					)
 				);
 			}
-
-			const settings = writeRuleset( protectionSettingsUI );
 
 			// Persist the AVS verification setting until the account cache is updated locally.
 			if (

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -171,8 +171,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 	const handleSaveSettings = () => {
 		if ( validateSettings( protectionSettingsUI ) ) {
 			if ( ! checkAnyRuleFilterEnabled( protectionSettingsUI ) ) {
-				if ( ProtectionLevel.STANDARD !== currentProtectionLevel ) {
-					updateProtectionLevel( ProtectionLevel.STANDARD );
+				if ( ProtectionLevel.BASIC !== currentProtectionLevel ) {
+					updateProtectionLevel( ProtectionLevel.BASIC );
 				}
 				dispatch( 'core/notices' ).createErrorNotice(
 					__(

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -70,20 +70,28 @@ const observerEventMapping: Record< string, string > = {
 };
 
 const Breadcrumb = () => (
-	<h2 className="fraud-protection-header-breadcrumb">
-		<Link
-			type="wp-admin"
-			href={ getAdminUrl( {
-				page: 'wc-settings',
-				tab: 'checkout',
-				section: 'woocommerce_payments',
-			} ) }
-		>
-			{ 'WooPayments' }
-		</Link>
-		&nbsp;&gt;&nbsp;
-		{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
-	</h2>
+	<>
+		<h2 className="fraud-protection-header-breadcrumb">
+			<Link
+				type="wp-admin"
+				href={ getAdminUrl( {
+					page: 'wc-settings',
+					tab: 'checkout',
+					section: 'woocommerce_payments',
+				} ) }
+			>
+				{ 'WooPayments' }
+			</Link>
+			&nbsp;&gt;&nbsp;
+			{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
+		</h2>
+		<p className="fraud-protection-advanced-settings-notice">
+			{ __(
+				'At least one risk filter needs to be enabled for advanced protection.',
+				'woocommerce-payments'
+			) }
+		</p>
+	</>
 );
 
 const SaveFraudProtectionSettingsButton: React.FC = ( { children } ) => {
@@ -154,9 +162,23 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			.every( Boolean );
 	};
 
+	const checkAnySettingEnabled = (
+		settings: ProtectionSettingsUI
+	): boolean => {
+		return Object.values( settings ).some( ( setting ) => setting.enabled );
+	};
+
 	const handleSaveSettings = () => {
 		if ( validateSettings( protectionSettingsUI ) ) {
-			if ( ProtectionLevel.ADVANCED !== currentProtectionLevel ) {
+			if ( ! checkAnySettingEnabled( protectionSettingsUI ) ) {
+				updateProtectionLevel( ProtectionLevel.BASIC );
+				dispatch( 'core/notices' ).createErrorNotice(
+					__(
+						'At least one risk filter needs to be enabled for advanced protection.',
+						'woocommerce-payments'
+					)
+				);
+			} else if ( ProtectionLevel.ADVANCED !== currentProtectionLevel ) {
 				updateProtectionLevel( ProtectionLevel.ADVANCED );
 				dispatch( 'core/notices' ).createSuccessNotice(
 					__(

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -162,7 +162,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			.every( Boolean );
 	};
 
-	const checkAnySettingEnabled = (
+	const checkAnyRuleFilterEnabled = (
 		settings: ProtectionSettingsUI
 	): boolean => {
 		return Object.values( settings ).some( ( setting ) => setting.enabled );
@@ -170,8 +170,10 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 
 	const handleSaveSettings = () => {
 		if ( validateSettings( protectionSettingsUI ) ) {
-			if ( ! checkAnySettingEnabled( protectionSettingsUI ) ) {
-				updateProtectionLevel( ProtectionLevel.BASIC );
+			if ( ! checkAnyRuleFilterEnabled( protectionSettingsUI ) ) {
+				if ( ProtectionLevel.STANDARD !== currentProtectionLevel ) {
+					updateProtectionLevel( ProtectionLevel.STANDARD );
+				}
 				dispatch( 'core/notices' ).createErrorNotice(
 					__(
 						'At least one risk filter needs to be enabled for advanced protection.',

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -180,7 +180,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				}
 				dispatch( 'core/notices' ).createErrorNotice(
 					__(
-						'At least one risk filter needs to be enabled for advanced protection.',
+						'Protection level set to "basic", at least one risk filter needs to be enabled for advanced protection.',
 						'woocommerce-payments'
 					)
 				);

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -66,6 +66,11 @@ Object {
                &gt; 
               Advanced fraud protection
             </h2>
+            <p
+              class="fraud-protection-advanced-settings-notice"
+            >
+              At least one risk filter needs to be enabled for advanced protection.
+            </p>
             <div
               class="fraud-protection-advanced-settings-error-notice"
             >
@@ -1066,6 +1071,11 @@ Object {
              &gt; 
             Advanced fraud protection
           </h2>
+          <p
+            class="fraud-protection-advanced-settings-notice"
+          >
+            At least one risk filter needs to be enabled for advanced protection.
+          </p>
           <div
             class="fraud-protection-advanced-settings-error-notice"
           >
@@ -2149,6 +2159,11 @@ Object {
                &gt; 
               Advanced fraud protection
             </h2>
+            <p
+              class="fraud-protection-advanced-settings-notice"
+            >
+              At least one risk filter needs to be enabled for advanced protection.
+            </p>
             <div
               class="fraud-protection-advanced-settings-error-notice"
             >
@@ -3006,6 +3021,11 @@ Object {
              &gt; 
             Advanced fraud protection
           </h2>
+          <p
+            class="fraud-protection-advanced-settings-notice"
+          >
+            At least one risk filter needs to be enabled for advanced protection.
+          </p>
           <div
             class="fraud-protection-advanced-settings-error-notice"
           >
@@ -3926,6 +3946,11 @@ Object {
              &gt; 
             Advanced fraud protection
           </h2>
+          <p
+            class="fraud-protection-advanced-settings-notice"
+          >
+            At least one risk filter needs to be enabled for advanced protection.
+          </p>
           <div
             class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
             data-wp-c16t="true"
@@ -4746,6 +4771,11 @@ Object {
            &gt; 
           Advanced fraud protection
         </h2>
+        <p
+          class="fraud-protection-advanced-settings-notice"
+        >
+          At least one risk filter needs to be enabled for advanced protection.
+        </p>
         <div
           class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
           data-wp-c16t="true"
@@ -5666,6 +5696,11 @@ Object {
                &gt; 
               Advanced fraud protection
             </h2>
+            <p
+              class="fraud-protection-advanced-settings-notice"
+            >
+              At least one risk filter needs to be enabled for advanced protection.
+            </p>
             <div
               class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
               data-wp-c16t="true"
@@ -6586,6 +6621,11 @@ Object {
              &gt; 
             Advanced fraud protection
           </h2>
+          <p
+            class="fraud-protection-advanced-settings-notice"
+          >
+            At least one risk filter needs to be enabled for advanced protection.
+          </p>
           <div
             class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
             data-wp-c16t="true"

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -4,13 +4,11 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { mocked } from 'ts-jest/utils';
-import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import FraudProtectionAdvancedSettingsPage from '..';
-import { ProtectionLevel } from '../constants';
 import {
 	useAdvancedFraudProtectionSettings,
 	useCurrentProtectionLevel,

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -478,6 +478,6 @@ describe( 'Advanced fraud protection settings', () => {
 			);
 		} );
 
-		expect( protectionLevelState.state ).toBe( 'standard' );
+		expect( protectionLevelState.state ).toBe( 'basic' );
 	} );
 } );

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -478,6 +478,6 @@ describe( 'Advanced fraud protection settings', () => {
 			);
 		} );
 
-		expect( protectionLevelState.state ).toBe( 'basic' );
+		expect( protectionLevelState.state ).toBe( 'standard' );
 	} );
 } );

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -43,7 +43,7 @@
 	}
 	&-header-breadcrumb {
 		margin-top: 0;
-		margin-bottom: 24px;
+		margin-bottom: 8px;
 		@media screen and ( min-width: 961px ) {
 			margin-top: -16px;
 		}
@@ -260,6 +260,10 @@
 			var( --wp-admin-theme-color, #007cba )
 		);
 		cursor: pointer;
+	}
+	&-advanced-settings-notice {
+		margin-top: 0;
+		margin-bottom: 16px;
 	}
 }
 


### PR DESCRIPTION
Fixes #6497 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
Advanced fraud protection should not be enabled if no rules are enabled. Right now, because there is no check when that happens, we save it gracefully but then it's reverted back.

This PR adds a new notice at the top of the page to indicate that at least one rule needs to be enabled, and dispatches an error notice when that's not the case and the user saves its settings.

In order to avoid weird states (such as the user enables Advanced with one rule set, saves it, but then goes back to it and disables the rule set), the level is stored as "basic" when clicking on save without any rule enabled (if the current level is not already "basic").
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
![image](https://github.com/Automattic/woocommerce-payments/assets/2612426/600a9ccc-ffba-49f4-8dcf-8e67d9fef4f2)


![image](https://github.com/Automattic/woocommerce-payments/assets/2612426/73c62e01-22a3-4c06-aedb-b062ab0c8c60)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Payments - Settings
* Browse to the bottom of the page and see if "Basic" is selected as fraud protection
* If it's not selected, select "Basic" and save
* Select "Advanced" now, and click on "Configure"
* Without enabling any rule, click on "Save"
* You'll see the notification "At least one risk filter needs to be enabled for advanced protection."
* Go back to WooPayments settings
* Check that "Basic" is still selected
* Choose "Advanced" again and click on "Configure"
* Enable any number of rulesets (but at least one)
* Click on "Save"
* You shouldn't see the error notification now, but a notification saying "advanced" is set
* Go back to WooPayments Settings and check "Advanced" is selected

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-7.6.0#advanced-fraud-protection-cant-be-enabled-without-enabling-advanced-fraud-rules
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
