### PR TITLE
Update View Report link of Charges data highlight tile.

### DIFF
--- a/changelog/fix-8705-charges-view-report
+++ b/changelog/fix-8705-charges-view-report
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Behind fPayment Activity Card feature flag, fix View Report link of Charges tile.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -43,6 +43,7 @@ const searchTermsForViewReportLink = {
 		'dispute_reversal',
 		'card_reader_fee',
 	],
+	charge: [ 'charge', 'payment' ],
 };
 
 const getSearchParams = ( searchTerms: string[] ) => {
@@ -153,7 +154,15 @@ const PaymentActivityData: React.FC = () => {
 						page: 'wc-admin',
 						path: '/payments/transactions',
 						filter: 'advanced',
-						type_is: 'charge',
+						'date_between[0]': moment(
+							getDateRange().date_start
+						).format( 'YYYY-MM-DD' ),
+						'date_between[1]': moment(
+							getDateRange().date_end
+						).format( 'YYYY-MM-DD' ),
+						...getSearchParams(
+							searchTermsForViewReportLink.charge
+						),
 					} ) }
 					tracksSource="charges"
 					isLoading={ isLoading }

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&type_is=charge"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment"
                 >
                   View report
                 </a>


### PR DESCRIPTION
Fixes #8705

#### Changes proposed in this Pull Request

Fix the View Report link by adding date and type of transactions to display.

#### Testing instructions
* Click on View Report and ensure that the Report linked shows `charge` and `payment` transactions for the requested time period.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**


- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
