### PR TITLE
Updated requests classes documentation to link to correct README

### DIFF
--- a/changelog/fix-update-request-classes-docs
+++ b/changelog/fix-update-request-classes-docs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Updated the parent link in request classes documentation
+
+

--- a/includes/core/server/request/class-add-account-tos-agreement.md
+++ b/includes/core/server/request/class-add-account-tos-agreement.md
@@ -1,6 +1,6 @@
 # `Add_Account_Tos_Agreement` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-cancel-intention.md
+++ b/includes/core/server/request/class-cancel-intention.md
@@ -1,6 +1,6 @@
 # `Cancel_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-capture-intention.md
+++ b/includes/core/server/request/class-capture-intention.md
@@ -1,6 +1,6 @@
 # `Capture_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-create-and-confirm-intention.md
+++ b/includes/core/server/request/class-create-and-confirm-intention.md
@@ -1,6 +1,6 @@
 # `Create_and_Confirm_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-create-and-confirm-setup-intention.md
+++ b/includes/core/server/request/class-create-and-confirm-setup-intention.md
@@ -1,6 +1,6 @@
 # `Create_and_Confirm_Setup_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-create-intention.md
+++ b/includes/core/server/request/class-create-intention.md
@@ -1,6 +1,6 @@
 # `Create_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-create-setup-intention.md
+++ b/includes/core/server/request/class-create-setup-intention.md
@@ -1,6 +1,6 @@
 # `Create_Setup_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-account-capital-link.md
+++ b/includes/core/server/request/class-get-account-capital-link.md
@@ -1,6 +1,6 @@
 # `Get_Account_Capital_Link` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-account-login-data.md
+++ b/includes/core/server/request/class-get-account-login-data.md
@@ -1,6 +1,6 @@
 # `Get_Account_Login_Data` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-account.md
+++ b/includes/core/server/request/class-get-account.md
@@ -1,6 +1,6 @@
 # `Get_Account` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md).
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md).
 
 ## Description
 

--- a/includes/core/server/request/class-get-charge.md
+++ b/includes/core/server/request/class-get-charge.md
@@ -1,6 +1,6 @@
 # `Get_Charge` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-intention.md
+++ b/includes/core/server/request/class-get-intention.md
@@ -1,6 +1,6 @@
 # `Get_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-request.md
+++ b/includes/core/server/request/class-get-request.md
@@ -1,7 +1,7 @@
 
 # `Get_Request` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-get-setup-intention.md
+++ b/includes/core/server/request/class-get-setup-intention.md
@@ -1,6 +1,6 @@
 # `Get_Setup_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-authorizations.md
+++ b/includes/core/server/request/class-list-authorizations.md
@@ -1,6 +1,6 @@
 # `List_Authorizations` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-charge-refunds.md
+++ b/includes/core/server/request/class-list-charge-refunds.md
@@ -1,6 +1,6 @@
 # `List_Charge_Refunds` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-deposits.md
+++ b/includes/core/server/request/class-list-deposits.md
@@ -1,6 +1,6 @@
 # `List_Deposits` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-disputes.md
+++ b/includes/core/server/request/class-list-disputes.md
@@ -1,6 +1,6 @@
 # `List_Disputes` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-documents.md
+++ b/includes/core/server/request/class-list-documents.md
@@ -1,6 +1,6 @@
 # `List_Documents` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-fraud-outcome-transactions.md
+++ b/includes/core/server/request/class-list-fraud-outcome-transactions.md
@@ -1,6 +1,6 @@
 # `List_Fraud_Outcome_Transactions` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-list-transactions.md
+++ b/includes/core/server/request/class-list-transactions.md
@@ -1,6 +1,6 @@
 # `List_Transactions` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-refund-charge.md
+++ b/includes/core/server/request/class-refund-charge.md
@@ -1,6 +1,6 @@
 # `Refund_Charge` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-update-account.md
+++ b/includes/core/server/request/class-update-account.md
@@ -1,6 +1,6 @@
 # `Update_Account` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-update-intention.md
+++ b/includes/core/server/request/class-update-intention.md
@@ -1,6 +1,6 @@
 # `Update_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-woopay-create-and-confirm-intention.md
+++ b/includes/core/server/request/class-woopay-create-and-confirm-intention.md
@@ -1,6 +1,6 @@
 # `WooPay_Create_and_Confirm_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-woopay-create-and-confirm-setup-intention.md
+++ b/includes/core/server/request/class-woopay-create-and-confirm-setup-intention.md
@@ -1,6 +1,6 @@
 # `WooPay_Create_and_Confirm_Setup_Intention` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 

--- a/includes/core/server/request/class-woopay-create-intent.md
+++ b/includes/core/server/request/class-woopay-create-intent.md
@@ -1,6 +1,6 @@
 # `WooPay_Create_Intent` request class
 
-[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../requests.md)
+[ℹ️ This document is a part of __WooCommerce Payments Server Requests__](../README.md)
 
 ## Description
 


### PR DESCRIPTION
Issue discovered while reviewing new request class documentation added in #8743 

#### Changes proposed in this Pull Request
Edited reference to `../requests.md` which seems to have been renamed to `../README.md`

#### Testing instructions
Check that file is linked correctly

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] N/A - Covered with tests (or have a good reason not to test in description ☝️)
- [x] N/A - Tested on mobile (or does not apply)

**Post merge**
N/A:
- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
