### PR TITLE
Fix Payment block error while editing the blocks checkout page.

### DIFF
--- a/changelog/fix-stripe-pmme-editor-error
+++ b/changelog/fix-stripe-pmme-editor-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Payment block render error while editing the block checkout page.

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -18,15 +18,19 @@ export default ( {
 	const bnplMethods = [ 'affirm', 'afterpay_clearpay', 'klarna' ];
 
 	// Stripe expects the amount to be sent as the minor unit of 2 digits.
-	const amount = normalizeCurrencyToMinorUnit(
-		cartData.totals.total_price,
-		cartData.totals.currency_minor_unit
+	const amount = parseInt(
+		normalizeCurrencyToMinorUnit(
+			cartData.totals.total_price,
+			cartData.totals.currency_minor_unit
+		),
+		10
 	);
 
 	// Customer's country or base country of the store.
 	const currentCountry =
 		cartData.billingAddress.country ||
-		window.wcBlocksCheckoutData.storeCountry;
+		window?.wcBlocksCheckoutData?.storeCountry ||
+		'US';
 
 	return (
 		<>
@@ -34,7 +38,9 @@ export default ( {
 				{ upeConfig.title }
 				{ bnplMethods.includes( upeName ) &&
 					( upeConfig.countries.length === 0 ||
-						upeConfig.countries.includes( currentCountry ) ) && (
+						upeConfig.countries.includes( currentCountry ) ) &&
+					amount > 0 &&
+					currentCountry && (
 						<>
 							<Elements
 								stripe={ api.getStripeForUPE( upeName ) }
@@ -44,7 +50,7 @@ export default ( {
 							>
 								<PaymentMethodMessagingElement
 									options={ {
-										amount: parseInt( amount, 10 ) || 0,
+										amount: amount || 0,
 										currency:
 											cartData.totals.currency_code ||
 											'USD',

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -29,7 +29,7 @@ export default ( {
 	// Customer's country or base country of the store.
 	const currentCountry =
 		cartData.billingAddress.country ||
-		window?.wcBlocksCheckoutData?.storeCountry ||
+		window.wcBlocksCheckoutData?.storeCountry ||
 		'US';
 
 	return (

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -74,20 +74,18 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 		WC_Payments::register_script_with_dependencies( 'WCPAY_BLOCKS_CHECKOUT', 'dist/blocks-checkout', [ 'stripe' ] );
 		wp_set_script_translations( 'WCPAY_BLOCKS_CHECKOUT', 'woocommerce-payments' );
 
-		if ( WC()->cart ) {
-			wp_add_inline_script(
-				'WCPAY_BLOCKS_CHECKOUT',
-				'var wcBlocksCheckoutData = ' . wp_json_encode(
-					[
-						'amount'         => WC()->cart->get_total( '' ),
-						'currency'       => get_woocommerce_currency(),
-						'storeCountry'   => WC()->countries->get_base_country(),
-						'billingCountry' => WC()->customer->get_billing_country(),
-					]
-				) . ';',
-				'before'
-			);
-		}
+		wp_add_inline_script(
+			'WCPAY_BLOCKS_CHECKOUT',
+			'var wcBlocksCheckoutData = ' . wp_json_encode(
+				[
+					'amount'         => WC()->cart ? WC()->cart->get_total( '' ) : 0,
+					'currency'       => get_woocommerce_currency(),
+					'storeCountry'   => WC()->countries->get_base_country(),
+					'billingCountry' => WC()->customer ? WC()->customer->get_billing_country() : 'US',
+				]
+			) . ';',
+			'before'
+		);
 
 		Fraud_Prevention_Service::maybe_append_fraud_prevention_token();
 


### PR DESCRIPTION
Fixes #8676 

#### Changes proposed in this Pull Request
This PR makes a few edits to make sure the PMME block has the info it needs to render in the block editor. Prior to this PR, the `wcBlocksCheckoutData` JS variable was added to the page **only when** `WC()->cart` existed - it does not exist in the block editor. This PR makes sure that this variable is always added and uses `WC()->cart` and `WC()->customer` for the values when available, but falls back to defaults when it doesn't.

This PR also conditionally checks for the existence of `window.wcBlocksCheckoutData?.storeCountry` when setting the `currentCountry`. It also only displays the PMME when the amount is greater than `0` and when we have a `currentCountry` set.

![image](https://github.com/Automattic/woocommerce-payments/assets/1558827/8b4874c9-2b0e-4d20-9968-f4977ab2bc2d)

#### Testing instructions

* Go the edit screen for the block checkout page in wp-admin
* Observe the block error in the Payment block.
* Apply this PR.
* The Payment block should render correctly.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
