### PR TITLE
Remove auto redirect to WooPay on page load

### DIFF
--- a/changelog/as-remove-auto-redirect
+++ b/changelog/as-remove-auto-redirect
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Remove auto-redirect to WooPay on page load.
+Do not auto-redirect to WooPay on page load.

--- a/changelog/as-remove-auto-redirect
+++ b/changelog/as-remove-auto-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove auto-redirect to WooPay on page load.

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -36,7 +36,6 @@ jest.mock( 'tracks', () => ( {
 	events: {
 		WOOPAY_EMAIL_CHECK: 'checkout_email_address_woopay_check',
 		WOOPAY_OFFERED: 'checkout_woopay_save_my_info_offered',
-		WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
 		WOOPAY_SKIPPED: 'woopay_skipped',
 		WOOPAY_BUTTON_LOAD: 'woopay_button_load',
 		WOOPAY_BUTTON_CLICK: 'woopay_button_click',

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -39,7 +39,6 @@ jest.mock( 'tracks', () => ( {
 	events: {
 		WOOPAY_EMAIL_CHECK: 'checkout_email_address_woopay_check',
 		WOOPAY_OFFERED: 'checkout_woopay_save_my_info_offered',
-		WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
 		WOOPAY_SKIPPED: 'woopay_skipped',
 		WOOPAY_BUTTON_LOAD: 'woopay_button_load',
 		WOOPAY_BUTTON_CLICK: 'woopay_button_click',

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -96,7 +96,6 @@ export type Event =
 	| 'checkout_save_my_info_privacy_policy_click'
 	| 'checkout_save_my_info_tooltip_click'
 	| 'checkout_save_my_info_tooltip_learn_more_click'
-	| 'checkout_woopay_auto_redirect'
 	| 'woopay_skipped'
 	| 'woopay_button_load'
 	| 'woopay_button_click'


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8398

#### Changes proposed in this Pull Request

We are removing code related to the auto-redirect redirect feature in the Shortcode-based checkout and the Checkout Block.

Changes on WooPay will remain, as we want to continue supporting merchants that run outdated versions of WooPayments.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

To be able to test this PR we need a merchant site that's connected to WooPay.

Skip to "Apply changes to the merchant store" in case you already have a merchant store linked to your sandboxed WooPay.

**Before testing:**

Make sure your sandbox is running and your hosts file is pointing `pay.woo.com` to your sandbox’s IP.

**Testing Steps:**

<details>
<summary>• Setup a merchant store</summary>

- Go to `jurassic.ninja`.
- Click “See more options”.
- Select WooCommerce, WooCommerce Payments Dev Tools and Code Snippets.
- Select “Enable Sandbox Access”.
- Click "Launch site".
- Go through the WooCommerce onboarding.
- To start with products right away then, on the WooCommerce main page:
    - Click “Add your products” from the list.
    - Click “View more product types”.
    - Click “Load Sample Products”.
- Not necessary but you can install the “Storefront” theme so the store looks better.
</details>

<details>
<summary>• Connect your store to WooCommerce & WooPay</summary>

- Go to Payments then click “Connect your store”.
- Go through the steps then you’ll be redirecteed to Stripe to complete the sign up.
- Go through the Stripe onboarding. Make sure you are in “Test mode”.
- After that go to Payments > settings.
- Enable WooPayments and WooPay.
</details>

<details>
<summary>• Tweak the merchant store</summary>

- Go to “Snippets” then click “Add New”
- Add the following snippet
```php
add_filter( 'pre_http_request', 'maybe_redirect_api_request', 10, 3 );
function maybe_redirect_api_request( $preempt, $args, $url ) {
    if ( false !== $preempt ) {
        return $preempt;
    }
 
    // detect the WooPay requests
    if ( 1 !== preg_match( '/^https?:\/\/pay\.woo\.com\/(.*)/', $url, $matches ) ) {
        return $preempt;
    }
 
    // requests to `pay.woo.com` are redirected to my personal sandbox
    $redirect_to = trailingslashit( 'https://YOUR_SANDBOX_ADDRESS/' );
    // but you also need to specify the "Host" header,
    // so that your sandbox understands that the request should be handled by the platform site.
    $args['headers'] = $args['headers'] ?? [];
    $args['headers']['Host'] = 'pay.woo.com';
 
    return wp_remote_request( $redirect_to . $matches[1], $args );
}
```
- Make sure to replace `YOUR_SANDBOX_ADDRESS` with your sandbox URL. e.g. `asumaran.foo.bar.baz.com`
- Save and activate.
</details>
<details>
<summary>• Create WooPay account</summary>

- Make a purchase on the JN site and make sure to select “Securely save my information for 1-click checkout”.
- Go to your email and validate your email.
</details>

<details>
<summary>• Apply changes to the merchant store</summary>

- Switch to the PR's branch
- Run `npm run build:release`
- A .zip file should have been generated at the root directory of the repo.
- Upload the .zip file to the merchant store as a plugin.
- Replace the current WooPayments plugin with the uploaded one.
</details>


**Test cases:**

- Logged in on WooPay
  - Checkout Block
    - On Page Load
      - Non valid WooPay pre-populated
        - [x] Does nothing. No spinner, No iframe popup, Does not redirect to WooPay.
      - Valid WooPay pre-populated
        - [x] Does nothing, No spinner, No iframe popup, Does not redirect to WooPay
    - After page load
      - Types in non valid WooPay
        - [x] Spinner is displayed, No iframe popup, Does not redirect to WooPay.
      - Types in valid WooPay Email
        - [x] Spinner is displayed, Iframe popup is displayed, Redirects to WooPay
  - Shortcode Checkout
    - On Page Load
      - Non valid WooPay pre-populated
        - [x] Does nothing. No spinner, No iframe popup, Does not redirect to WooPay.
      - Valid WooPay pre-populated
        - [x] Does nothing, No spinner, No iframe popup, Does not redirect to WooPay
    - After page load
      - Types in Non Valid WooPay
        - [x] Spinner is displayed, No iframe popup, Does not redirect to WooPay.
      - Types in Valid WooPay Email
        - [x] Spinner is displayed, Iframe popup is displayed, Redirects to WooPay.
- Signed out from WooPay
  - Checkout Block
    - On Page Load
      - Non valid WooPay pre-populated
        - [x] Does nothing. No spinner, No iframe popup, Does not redirect to WooPay.
      - Valid WooPay pre-populated
        - [x] Does nothing, No spinner, No iframe popup, Does not offer OTP flow.
  - After page load
      - Types Non Valid WooPay
        - [x] Shows spinner, No iframe popup, Does not redirect to WooPay.
      - Types Valid WooPay Email
        - [x] Spinner is displayed, Iframe popup is displayed, Offers OTP flow.
  - Shortcode Checkout
    - On Page Load
        - Non valid WooPay pre-populated
          - [x]  Does nothing. No spinner, No iframe popup, Does not redirect to WooPay.
        - Valid WooPay pre-populated
          - [x]  Does nothing, No spinner, No iframe popup, Does not offer OTP flow.
    - After page load
        - Types in Non Valid WooPay
          - [x]  Shows spinner, No iframe popup, Does not offer OTP flow.
        - Types in Valid WooPay Email
          - [x]  Shows spinner, Iframe popup is displayed, Offers OTP flow.
- [x] Express WooPay should work as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
