### PR TITLE
Fix/5223 payment activity adjustment

### DIFF
--- a/changelog/fix-5223-payment-activity-adjustment
+++ b/changelog/fix-5223-payment-activity-adjustment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Added adjustment type to charges data highlight on Payment Activity Card
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -44,7 +44,7 @@ const searchTermsForViewReportLink = {
 		'card_reader_fee',
 	],
 
-	charge: [ 'charge', 'payment' ],
+	charge: [ 'charge', 'payment', 'adjustment' ],
 
 	refunds: [
 		'refund',

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=adjustment"
                 >
                   View report
                 </a>


### PR DESCRIPTION
Partially addresses https://github.com/Automattic/woocommerce-payments-server/issues/5223

#### Changes proposed in this Pull Request
- Added `adjustment` type to charges data highlight tile in front-end ( It is already included in server query, which leads to discrepancy otherwise)
Additional Context: p1714716606694009-slack-C06BBFTF6EM
 
#### Testing instructions
Test with positive and negative `adjustment` type in Transactions cache.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->
N/A
- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.