### PR TITLE
Ensure payment method is stored on subscriptions paid with 3DS cards

### DIFF
--- a/changelog/fix-8611-3DS-subscription-pm
+++ b/changelog/fix-8611-3DS-subscription-pm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Small change to ensure tokens are stored on 3DS subscriptions.
+
+

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3462,11 +3462,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// For $0 orders, fetch the Setup Intent instead.
 				$setup_intent_request = Get_Setup_Intention::create( $intent_id );
 				/** @var WC_Payments_API_Setup_Intention $setup_intent */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-				$intent            = $setup_intent_request->send();
-				$status            = $intent->get_status();
-				$charge_id         = '';
-				$payment_method_id = $intent->get_payment_method_id();
+				$intent    = $setup_intent_request->send();
+				$status    = $intent->get_status();
+				$charge_id = '';
 			}
+
+			$payment_method_id = $intent->get_payment_method_id();
 
 			if ( Intent_Status::SUCCEEDED === $status ) {
 				$this->duplicate_payment_prevention_service->remove_session_processing_order( $order->get_id() );


### PR DESCRIPTION
Fixes #8611 

#### Changes proposed in this Pull Request

While working on https://github.com/Automattic/woocommerce-payments/issues/8122, I had a feeling #8611 would be solved with the fix there - [see note](https://github.com/Automattic/woocommerce-payments/pull/8764#discussion_r1588638527). That assumption was correct but only for free-trial subscriptions(setup intents) using 3DS cards. This PR ensures we have the payment method ID needed to store tokens for both [intents](https://github.com/Automattic/woocommerce-payments/pull/8786/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124L3448-L3460) and [setup intents](https://github.com/Automattic/woocommerce-payments/pull/8786/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124L3463-L3468) when updating 3DS orders.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the WooPayments settings, uncheck **Enable payments via saved cards** and save
* Purchase a subscription using a 3DS card, `4000002500003155`
* Open the subscription in the admin and check that the payment method appears in the Billing Details under **Saved payment method**
* <img width="346" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3473953/484b4bea-1c4d-46cc-bb5c-274b339c00dc">

* Process a renewal and using the Subscription actions dropdown
* <img width="290" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3473953/2909f944-1032-4e01-8b73-abbdacf23e3f">
* Check that renewal processed successfully



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
