### PR TITLE
Escape attributes added/edited in #8650

### DIFF
--- a/assets/css/success.rtl.css
+++ b/assets/css/success.rtl.css
@@ -1,11 +1,15 @@
-.wc-payment-gateway-method-name-woopay-wrapper {
+.wc-payment-gateway-method-logo-wrapper {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
 	line-height: 1;
 }
 
-.wc-payment-gateway-method-name-woopay-wrapper img {
+.wc-payment-gateway-method-logo-wrapper img {
 	margin-left: 0.5rem;
 	padding-top: 4px;
+}
+
+.wc-payment-gateway-method-logo-wrapper.wc-payment-bnpl-logo img {
+	max-height: 30px;
 }

--- a/changelog/fix-escaping-from-8650
+++ b/changelog/fix-escaping-from-8650
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: PR related to another issue already in changelog.
+
+

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -136,8 +136,8 @@ class WC_Payments_Order_Success_Page {
 
 		ob_start();
 		?>
-		<div class="wc-payment-gateway-method-logo-wrapper wc-payment-bnpl-logo <?php echo $payment_method->get_id(); ?>">
-			<img alt="<?php echo $payment_method->get_title(); ?>" src="<?php echo esc_url_raw( $method_logo_url ); ?>">
+		<div class="wc-payment-gateway-method-logo-wrapper wc-payment-bnpl-logo <?php echo esc_attr( $payment_method->get_id() ); ?>">
+			<img alt="<?php echo esc_attr( $payment_method->get_title() ); ?>" src="<?php echo esc_url_raw( $method_logo_url ); ?>">
 		</div>
 		<?php
 		return ob_get_clean();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#8650 added or changed some HTML attributes that were not escaped. This PR adds the escaping for those attributes.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
