### PR TITLE
Reporting: Fix `View report` link on Disputes tile in Payment activity widget

### DIFF
--- a/changelog/fix-8704-fix-disputes-view-report-link
+++ b/changelog/fix-8704-fix-disputes-view-report-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix for the `View report` link on Disputes tile of Payment activity widget. Changes behind a feature flag.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -52,6 +52,8 @@ const searchTermsForViewReportLink = {
 		'payment_refund',
 		'payment_failure_refund',
 	],
+
+	dispute: [ 'dispute', 'dispute_reversal' ],
 };
 
 const getSearchParams = ( searchTerms: string[] ) => {
@@ -205,7 +207,7 @@ const PaymentActivityData: React.FC = () => {
 					amount={ disputes }
 					reportLink={ getAdminUrl( {
 						page: 'wc-admin',
-						path: '/payments/disputes',
+						path: '/payments/transactions',
 						filter: 'advanced',
 						'date_between[0]': moment(
 							getDateRange().date_start
@@ -213,7 +215,9 @@ const PaymentActivityData: React.FC = () => {
 						'date_between[1]': moment(
 							getDateRange().date_end
 						).format( 'YYYY-MM-DD' ),
-						status_is: 'needs_response',
+						...getSearchParams(
+							searchTermsForViewReportLink.dispute
+						),
 					} ) }
 					tracksSource="disputes"
 					isLoading={ isLoading }

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&status_is=needs_response"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-04-02&date_between%5B1%5D=2024-04-08&search%5B0%5D=dispute&search%5B1%5D=dispute_reversal"
                 >
                   View report
                 </a>


### PR DESCRIPTION
Fixes #8704 

#### Changes proposed in this Pull Request

The PR fixes the correct destination on the `View report`link, to lead to transactions page showing `disputes` and `dispute_reversals` over the last 7 days ( or selected period in an upcoming date selector )


#### Testing instructions

* Make sure you have the feature flat `_wcpay_feature_payment_overview_widget` enabled on your local test site
* Checkout this branch and create a few test dispute transactions, by using any dispute test card such as `4000000000002685` - [Ref test cards](https://docs.stripe.com/testing#disputes) 
* Make one of the disputes as `Won` by submitting `winning_evidence` . 
* Browse to `Payments` and click the `View report` link on `Disputes`
* The search terms should show as `dispute`, and `dispute_reversal`
* The default date range should be of one week

#### Screenshot
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/bb2ffc9e-9314-4a9a-903b-6c7513b3740a)



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
