### PR TITLE
Fix/7.6.0 constructor injection upgrade bug

### DIFF
--- a/changelog/fix-7.6.0-constructor-injection-upgrade-bug
+++ b/changelog/fix-7.6.0-constructor-injection-upgrade-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: a known plugin upgrade issue fixed in the same release that the underlying code was released.
+
+

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -67,7 +67,6 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 		$this->gateway          = $gateway;
 		$this->customer_service = $customer_service;
 		$this->order_service    = $order_service;
-		$this->token_service    = WC_Payments::get_token_service(); // TODO: Inject token_service after #7464 is fixed.
 	}
 
 	/**
@@ -236,7 +235,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 										function_exists( 'wcs_is_manual_renewal_required' ) &&
 										wcs_order_contains_subscription( $order_id );
 				if ( $has_subscriptions ) {
-					$token = $this->token_service->add_payment_method_to_user( $generated_card, $order->get_user() );
+					$token = WC_Payments::get_token_service()->add_payment_method_to_user( $generated_card, $order->get_user() );
 					$this->gateway->add_token_to_order( $order, $token );
 					foreach ( wcs_get_subscriptions_for_order( $order ) as $subscription ) {
 						$subscription->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -67,7 +67,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 		$this->gateway          = $gateway;
 		$this->customer_service = $customer_service;
 		$this->order_service    = $order_service;
-		$this->token_service    = WC_Payments::get_token_service(); // TODO: Inject order_service after #7464 is fixed.
+		$this->token_service    = WC_Payments::get_token_service(); // TODO: Inject token_service after #7464 is fixed.
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -48,13 +48,6 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 	private $order_service;
 
 	/**
-	 * WC_Payments_Token instance for working with customer tokens
-	 *
-	 * @var WC_Payments_Token_Service
-	 */
-	private $token_service;
-
-	/**
 	 * WC_Payments_REST_Controller constructor.
 	 *
 	 * @param WC_Payments_API_Client       $api_client       WooCommerce Payments API client.

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -61,14 +61,13 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 	 * @param WC_Payment_Gateway_WCPay     $gateway          WooCommerce Payments payment gateway.
 	 * @param WC_Payments_Customer_Service $customer_service Customer class instance.
 	 * @param WC_Payments_Order_Service    $order_service    Order Service class instance.
-	 * @param WC_Payments_Token_Service    $token_service    Token Service class instance.
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payment_Gateway_WCPay $gateway, WC_Payments_Customer_Service $customer_service, WC_Payments_Order_Service $order_service, WC_Payments_Token_Service $token_service ) {
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payment_Gateway_WCPay $gateway, WC_Payments_Customer_Service $customer_service, WC_Payments_Order_Service $order_service ) {
 		parent::__construct( $api_client );
 		$this->gateway          = $gateway;
 		$this->customer_service = $customer_service;
 		$this->order_service    = $order_service;
-		$this->token_service    = $token_service;
+		$this->token_service    = WC_Payments::get_token_service(); // TODO: Inject order_service after #7464 is fixed.
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -992,7 +992,7 @@ class WC_Payments {
 		$conn_tokens_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-orders-controller.php';
-		$orders_controller = new WC_REST_Payments_Orders_Controller( self::$api_client, self::get_gateway(), self::$customer_service, self::$order_service, self::$token_service );
+		$orders_controller = new WC_REST_Payments_Orders_Controller( self::$api_client, self::get_gateway(), self::$customer_service, self::$order_service );
 		$orders_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-fraud-outcomes-controller.php';
@@ -1323,6 +1323,15 @@ class WC_Payments {
 	 */
 	public static function get_order_service(): WC_Payments_Order_Service {
 		return self::$order_service;
+	}
+
+	/**
+	 * Returns the token service instance.
+	 *
+	 * @return WC_Payments_Token_Service
+	 */
+	public static function get_token_service(): WC_Payments_Token_Service {
+		return self::$token_service;
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1335,6 +1335,17 @@ class WC_Payments {
 	}
 
 	/**
+	 * Sets the token service instance. This is needed only for tests.
+	 *
+	 * @param WC_Payments_Token_Service $token_service Instance of WC_Payments_Token_Service.
+	 *
+	 * @return void
+	 */
+	public static function set_token_service( WC_Payments_Token_Service $token_service ) {
+		self::$token_service = $token_service;
+	}
+
+	/**
 	 * Sets the customer service instance. This is needed only for tests.
 	 *
 	 * @param WC_Payments_Customer_Service $customer_service_class Instance of WC_Payments_Customer_Service.

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -50,6 +50,11 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	private $mock_token_service;
 
 	/**
+	 * @var WC_Payments_Token_Service
+	 */
+	private $original_token_service;
+
+	/**
 	 * @var string
 	 */
 	private $mock_intent_id = 'pi_mock';
@@ -79,13 +84,19 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			->setMethods( [ 'attach_intent_info_to_order' ] )
 			->getMock();
 
+		$this->original_token_service = WC_Payments::get_token_service();
+		WC_Payments::set_token_service( $this->mock_token_service );
 		$this->controller = new WC_REST_Payments_Orders_Controller(
 			$this->mock_api_client,
 			$this->mock_gateway,
 			$this->mock_customer_service,
 			$this->order_service,
-			$this->mock_token_service
 		);
+	}
+
+	public function tear_down() {
+		WC_Payments::set_token_service( $this->original_token_service );
+		parent::tear_down();
 	}
 
 	public function test_capture_terminal_payment_success() {


### PR DESCRIPTION
Related to #7464 

#### Changes proposed in this Pull Request

There is an issue which breaks the upgrade process, causing a fatal error on upgrade, when REST API constructors are changed.

This reverts a constructor change and gets the token_service via a static function as a workaround.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a JN site with WooPayments installed
* Upgrade the site to use this version of WooPayments (`npm run build` this branch, and upload using the plugin installer in WP-admin
* Verify that there is no fatal error during the upgrade

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
