### PR TITLE
Fix failing tests for adding/deleting payment methods on My Account page

### DIFF
--- a/changelog/8520-fix-failing-e2e-test-for-adding-deleting-payment-methods
+++ b/changelog/8520-fix-failing-e2e-test-for-adding-deleting-payment-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Omitted changelog entry since this PR only fixes an e2e test.
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js
@@ -58,8 +58,8 @@ describe( 'Shopper Multi-Currency widget', () => {
 		if ( ! wasMulticurrencyEnabled ) {
 			await merchant.login();
 			await merchantWCP.deactivateMulticurrency();
-			await merchant.logout();
 		}
+		await merchant.logout();
 	} );
 
 	it( 'should display currency switcher widget if multi-currency is enabled', async () => {


### PR DESCRIPTION
Fixes #8520 

#### Changes proposed in this Pull Request
The tests for the `shopper-myaccount-payment-methods-add-delete-success` tests were failing with a `No node found for selector: #username` message. This appears to be happening because when the `shopper` tries to log in, a user is already logged into the site. The `shopper-multi-currency-widget` had a bug where the merchant would not be logged out at the end of the tests and the next test made the assumption that all users would be logged out.

This PR ensures that the `merchant` is logged out at the end of the `shopper-multi-curency-widget` tests.

#### Testing instructions

<img width="375" alt="Screenshot 2024-05-07 at 4 23 28 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1558827/413e6837-30ad-495e-9c0a-752644812646">

* Go to https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml and click `Run workflow`.
* Choose the `8520/fix-failing-e2e-test-for-adding-deleting-payment-methods` branch.
* Click `Run workflow`.
* There are still failing shopper tests, but you should see this in the logs:

```
PASS tests/e2e/specs/wcpay/shopper/shopper-multi-currency-widget.spec.js (88.406 s)
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
