### PR TITLE
Fix Shortcode Orders When Using WooPay Direct Checkout

### DIFF
--- a/changelog/fix-8775-direct-checkout-shortcode-orders
+++ b/changelog/fix-8775-direct-checkout-shortcode-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shortcode orders when using WooPay Direct Checkout.

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -44,7 +44,17 @@ class WC_Payments_WooPay_Direct_Checkout {
 			return $order_id;
 		}
 
-		return absint( WC()->session->get( 'store_api_draft_order', $order_id ) );
+		// Use draft order ID, if it exists.
+		$draft_order_id = absint( WC()->session->get( 'store_api_draft_order', $order_id ) );
+		// Set the order status to "pending" payment, so that it can be resumed.
+		$draft_order = wc_get_order( $draft_order_id );
+		$draft_order->set_status( 'pending' );
+		$draft_order->save();
+
+		// Store Order ID in session, so it can be re-used during payment.
+		WC()->session->set( 'order_awaiting_payment', $draft_order_id );
+
+		return $order_id;
 	}
 
 	/**

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -55,7 +55,7 @@ class WC_Payments_WooPay_Direct_Checkout {
 		$draft_order->save();
 
 		// Move $draft_order_id in session, from store_api_draft_order to order_awaiting_payment.
-		wc()->session->set( 'store_api_draft_order', null );
+		WC()->session->set( 'store_api_draft_order', null );
 		WC()->session->set( 'order_awaiting_payment', $draft_order_id );
 
 		return $order_id;

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -27,8 +27,10 @@ class WC_Payments_WooPay_Direct_Checkout {
 	/**
 	 * This filter is used to ensure the session's store_api_draft_order is used, if it exists.
 	 * This prevents a bug where the store_api_draft_order is not used and instead, a new
-	 * order_awaiting_payment is created during the checkout request. Therefore, a product
-	 * would be considered out of stock, even though 1 was available.
+	 * order_awaiting_payment is created during the checkout request. The bug being evident
+	 * if a product had one remaining stock and the store_api_draft_order was reserving it,
+	 * an order would fail to be placed since when order_awaiting_payment is created, it would
+	 * not be able to reserve the one stock.
 	 *
 	 * @param int $order_id The order ID being used.
 	 * @return int|mixed The new order ID to use.

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -43,8 +43,8 @@ class WC_Payments_WooPay_Direct_Checkout {
 		// Only apply this filter if the session doesn't already have an order_awaiting_payment.
 		$is_order_awaiting_payment = isset( WC()->session->order_awaiting_payment );
 		// Only apply this filter if draft order ID exists.
-		$is_draft_order_exists = ! empty( WC()->session->get( 'store_api_draft_order' ) );
-		if ( ! $is_checkout || $is_already_defined_order_id || $is_order_awaiting_payment || ! $is_draft_order_exists ) {
+		$has_draft_order = ! empty( WC()->session->get( 'store_api_draft_order' ) );
+		if ( ! $is_checkout || $is_already_defined_order_id || $is_order_awaiting_payment || ! $has_draft_order ) {
 			return $order_id;
 		}
 

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -40,12 +40,13 @@ class WC_Payments_WooPay_Direct_Checkout {
 		$is_already_defined_order_id = ! empty( $order_id );
 		// Only apply this filter if the session doesn't already have an order_awaiting_payment.
 		$is_order_awaiting_payment = isset( WC()->session->order_awaiting_payment );
-		if ( ! $is_checkout || $is_already_defined_order_id || $is_order_awaiting_payment ) {
+		// Only apply this filter if draft order ID exists.
+		$is_draft_order_exists = ! empty( WC()->session->get( 'store_api_draft_order' ) );
+		if ( ! $is_checkout || $is_already_defined_order_id || $is_order_awaiting_payment || ! $is_draft_order_exists ) {
 			return $order_id;
 		}
 
-		// Use draft order ID, if it exists.
-		$draft_order_id = absint( WC()->session->get( 'store_api_draft_order', $order_id ) );
+		$draft_order_id = absint( WC()->session->get( 'store_api_draft_order' ) );
 		// Set the order status to "pending" payment, so that it can be resumed.
 		$draft_order = wc_get_order( $draft_order_id );
 		$draft_order->set_status( 'pending' );

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -54,7 +54,8 @@ class WC_Payments_WooPay_Direct_Checkout {
 		$draft_order->set_status( 'pending' );
 		$draft_order->save();
 
-		// Store Order ID in session, so it can be re-used during payment.
+		// Move $draft_order_id in session, from store_api_draft_order to order_awaiting_payment.
+		wc()->session->set( 'store_api_draft_order', null );
 		WC()->session->set( 'order_awaiting_payment', $draft_order_id );
 
 		return $order_id;

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -27,7 +27,8 @@ class WC_Payments_WooPay_Direct_Checkout {
 	/**
 	 * This filter is used to ensure the session's store_api_draft_order is used, if it exists.
 	 * This prevents a bug where the store_api_draft_order is not used and instead, a new
-	 * order_awaiting_payment is created during the checkout request.
+	 * order_awaiting_payment is created during the checkout request. Therefore, a product
+	 * would be considered out of stock, even though 1 was available.
 	 *
 	 * @param int $order_id The order ID being used.
 	 * @return int|mixed The new order ID to use.


### PR DESCRIPTION
Fixes #8775 
Fixes #8628 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that when we reuse a draft order, it is updated with all necessary details (address, currency, etc.). 

Previously, when a draft order was created through the Direct Checkout flow, it was re-used to avoid a "stock: 1" bug (see https://github.com/Automattic/woocommerce-payments/issues/7256 for details). However, when reusing the draft order, the order did not include all the necessary information. 

Now, when a draft order is created through the Direct Checkout flow, it will still be re-used to avoid the "stock: 1" bug but the order will also be marked as "pending" so that it gets updated (as it normally would) during checkout.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Confirm issue: Shortcode orders are missing address**
* Switch over to the `develop` branch.
* Confirm the issue is reproducible when following the steps outlined in #8775.

**Confirm solution: Shortcode orders are not missing address**
* Switch over to this branch: `fix/8775-direct-checkout-shortcode-orders`.
* Confirm the issue is not reproducible when following the steps outlined in #8775.

**Confirm issue: Currency switcher doesn't work with shortcode checkout**
* Switch over to the `develop` branch.
* Confirm the issue is reproducible when following the steps outlined in #8628.

**Confirm solution: Currency switcher works with shortcode checkout**
* Switch over to this branch: `fix/8775-direct-checkout-shortcode-orders`.
* Confirm the issue is not reproducible when following the steps outlined in #8628.

**Regression Test: Ensure Purchasing a Product With 1 Stock Does Not Fail** (see #7256 for details)
* Ensure the WooPay Direct Checkout flow is enabled.
* Create an item with only 1 stock and run the following test scenarios (you will have to update the stock back to 1 after each test):
    * Use the WooPay button from the cart page and pay through the WooPay checkout.
    * Navigate to the cart page before going to the Merchant checkout and pay through the Merchant checkout (make sure not to type a valid WooPay address in the email field).
    * Navigate to the cart page before navigating to the Merchant checkout and pay through the WooPay Button.
    * Navigate to the cart page before navigating to the Merchant checkout and pay using the WooPay email input.
    * Navigate directly to the Merchant checkout and pay through the Merchant checkout (make sure not to type a valid woopay address in the email field).
    * Navigate directly to the Merchant checkout and pay through the WooPay button.
    * Navigate directly to the Merchant checkout and pay through the WooPay email input.
* Repeat these tests for both the shortcode cart/checkout and, optionally, the wcBlocks cart/checkout.
* As a merchant, ensure the address appears on each order, in the admin dashboard.
* As a merchant, ensure the address appears on each order, in Stripe.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.