### PR TITLE
Prevent duplicate queries from PRB on checkout 

### DIFF
--- a/changelog/fix-8716-duplicate-query-checkout
+++ b/changelog/fix-8716-duplicate-query-checkout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: A small defensive check for PRB gateway title filtering.
+
+

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -433,10 +433,14 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @param string $id    Gateway ID.
 	 */
 	public function filter_gateway_title( $title, $id ) {
+		if ( 'woocommerce_payments' !== $id || ! is_admin() ) {
+			return $title;
+		}
+
 		$order        = $this->get_current_order();
 		$method_title = is_object( $order ) ? $order->get_payment_method_title() : '';
 
-		if ( 'woocommerce_payments' === $id && ! empty( $method_title ) ) {
+		if ( ! empty( $method_title ) ) {
 			if (
 				strpos( $method_title, 'Apple Pay' ) === 0
 				|| strpos( $method_title, 'Google Pay' ) === 0

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -667,4 +667,40 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 			$this->pr->get_button_settings()
 		);
 	}
+
+	public function test_filter_gateway_title() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method_title' )->willReturn( 'Apple Pay' );
+
+		global $theorder;
+		$theorder = $order;
+
+		$this->set_is_admin( true );
+		$this->assertEquals( 'Apple Pay', $this->pr->filter_gateway_title( 'Original Title', 'woocommerce_payments' ) );
+
+		$this->set_is_admin( false );
+		$this->assertEquals( 'Original Title', $this->pr->filter_gateway_title( 'Original Title', 'woocommerce_payments' ) );
+
+		$this->set_is_admin( true );
+		$this->assertEquals( 'Original Title', $this->pr->filter_gateway_title( 'Original Title', 'another_gateway' ) );
+	}
+
+	/**
+	 * @param bool $is_admin
+	 */
+	private function set_is_admin( bool $is_admin ) {
+		global $current_screen;
+
+		if ( ! $is_admin ) {
+			$current_screen = null; // phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
+			return;
+		}
+
+		// phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
+		$current_screen = $this->getMockBuilder( \stdClass::class )
+			->setMethods( [ 'in_admin' ] )
+			->getMock();
+
+		$current_screen->method( 'in_admin' )->willReturn( $is_admin );
+	}
 }


### PR DESCRIPTION
Fixes #8716 

#### Changes proposed in this Pull Request

This PR adds a check to ensure we're in the admin when filtering the PRB gateway title. Additionally, it returns early if the gateway is not `woocommerce_payments`. `WC_Payments_Payment_Request_Button_Handler::filter_gateway_title()` was intended to set the correct payment method title for orders in the admin. Until recently, it was silently running on the checkout page without causing any real issues. After `get_current_order()` [was introduced](https://github.com/Automattic/woocommerce-payments/pull/8150/files) as a fix for payment method titles on sites using HPOS, duplicate queries were running on the shortcode checkout page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install [Query Monitor](https://wordpress.org/plugins/query-monitor/)
* Enable HPOS if not already enabled
* Enable Payment Requests
* Add a product to the cart
* Visit the shortcode checkout
* Check that this query isn't appearing under duplicate queries

![image](https://github.com/Automattic/woocommerce-payments/assets/3473953/5476efed-4eae-4793-898d-de7fd9ee3a1c)

* Place an order with Google Pay or Apple Pay
* Open the order in the admin to check that payment method title is correct

<img width="305" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3473953/a232e7d4-0feb-40a7-9b12-05dd00b0f4db">



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
