### PR TITLE
Update shopper Tracks/BumpStats tracking parameters

### DIFF
--- a/changelog/fix-shopper-bump-stats-conditions
+++ b/changelog/fix-shopper-bump-stats-conditions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug in Tracks where shopper events are not fired properly.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -230,7 +230,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		// 1. Only site pages are tracked.
 		// 2. Site Admin activity in site pages are not tracked.
 		// 3. If track_on_all_stores is enabled, track all events regardless of WooPay eligibility.
-		// 3. Otherwise, track only when WooPay is active.
+		// 4. Otherwise, track only when WooPay is active.
 
 		// Track only site pages.
 		if ( is_admin() && ! wp_doing_ajax() ) {

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -469,6 +469,17 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @return bool
 	 */
 	public function bump_stats( $group, $stat_name ) {
+		$is_admin_event = false;
+		$track_on_all_stores = true;
+
+		if ( ! $this->should_enable_tracking( $is_admin_event, $track_on_all_stores ) ) {
+			return false;
+		}
+
+		if ( WC_Payments::mode()->is_test() ) {
+			return false;
+		}
+
 		$pixel_url = sprintf(
 			self::$pixel_base_url . '?v=wpcom-no-pv&x_%s=%s',
 			$group,

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -13,7 +13,6 @@ use WC_Payments;
 use WC_Payments_Features;
 use WCPay\Constants\Country_Code;
 use WP_Error;
-use Exception;
 
 defined( 'ABSPATH' ) || exit; // block direct access.
 

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -151,7 +151,10 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			$event = self::$user_prefix . '_' . $event;
 		}
 
-		return $this->tracks_record_event( $event, $data );
+		$is_admin_event = false;
+		$track_on_all_stores = true;
+
+		return $this->tracks_record_event( $event, $data, $is_admin_event, $track_on_all_stores);
 	}
 
 	/**
@@ -189,11 +192,12 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	/**
 	 * Override parent method to omit the jetpack TOS check and include custom tracking conditions.
 	 *
-	 * @param bool $is_admin_event Indicate whether the event is emitted from admin area.
+	 * @param bool $is_admin_event      Indicate whether the event is emitted from admin area.
+	 * @param bool $track_on_all_stores Indicate whether the event should be tracked on all stores.
 	 *
 	 * @return bool
 	 */
-	public function should_enable_tracking( $is_admin_event = false ) {
+	public function should_enable_tracking( $is_admin_event = false, $track_on_all_stores = false) {
 
 		// Don't track if the gateway is not enabled.
 		$gateway = \WC_Payments::get_gateway();
@@ -225,6 +229,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		// For all other events ensure:
 		// 1. Only site pages are tracked.
 		// 2. Site Admin activity in site pages are not tracked.
+		// 3. If track_on_all_stores is enabled, track all events regardless of WooPay eligibility.
 		// 3. Otherwise, track only when WooPay is active.
 
 		// Track only site pages.
@@ -235,6 +240,10 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		// Don't track site admins.
 		if ( is_user_logged_in() && in_array( 'administrator', wp_get_current_user()->roles, true ) ) {
 			return false;
+		}
+
+		if ( $track_on_all_stores ) {
+			return true;
 		}
 
 		// For the remaining events, don't track when woopay is disabled.
@@ -253,10 +262,11 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @param string $event_name             The name of the event.
 	 * @param array  $properties             Custom properties to send with the event.
 	 * @param bool   $is_admin_event         Indicate whether the event is emitted from admin area.
+	 * @param bool   $track_on_all_stores    Indicate whether the event should be tracked on all stores.
 	 *
 	 * @return bool|array|\WP_Error|\Jetpack_Tracks_Event
 	 */
-	public function tracks_record_event( $event_name, $properties = [], $is_admin_event = false ) {
+	public function tracks_record_event( $event_name, $properties = [], $is_admin_event = false, $track_on_all_stores = false) {
 
 		$user = wp_get_current_user();
 
@@ -265,7 +275,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			return false;
 		}
 
-		if ( ! $this->should_enable_tracking( $is_admin_event ) ) {
+		if ( ! $this->should_enable_tracking( $is_admin_event, $track_on_all_stores ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes the following changes.
1. Updates Bump Stats to follow the same tracking conditions defined in `should_enable_tracking` function. https://github.com/Automattic/woocommerce-payments/commit/046a63e4310cc0c46fb2205dd47994cf9dea5df9
2. Updates Bump Stats to not fire for sites in Test mode. https://github.com/Automattic/woocommerce-payments/commit/046a63e4310cc0c46fb2205dd47994cf9dea5df9
3. Remove woopay-eligibility condition from the shopper events https://github.com/Automattic/woocommerce-payments/commit/5ce8c0a3f995cea0e4234fd02c3a345172405149
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

It's hard to test the outcome of these changes so we will test whether correct code paths are reached.

##### Setup
1. Disable WooPay from the Payments -> Settings page on your local merchant site.

##### Test Bump Stats
1. Go to MC_URL/wcpay_order_completed_gateway/test/ and note the current daily count.
2. Add two breakpoints [here](https://github.com/Automattic/woocommerce-payments/blob/d58aacc6e1522b8929b3ec7671e613f91a20d010/includes/class-woopay-tracker.php#L475) and [here](https://github.com/Automattic/woocommerce-payments/blob/d58aacc6e1522b8929b3ec7671e613f91a20d010/includes/class-woopay-tracker.php#L246)
3. Change the second parameter in this [line](https://github.com/Automattic/woocommerce-payments/blob/d58aacc6e1522b8929b3ec7671e613f91a20d010/includes/class-woopay-tracker.php#L524) from `other` to `test`.
4. Comment out [this](https://github.com/Automattic/woocommerce-payments/blob/d58aacc6e1522b8929b3ec7671e613f91a20d010/includes/class-woopay-tracker.php#L479) block of code so that it doesn't return early on test_mode.
5. As a shopper, go through the checkout flow and choose a non woopayments gateway (eg: Cash on delivery, check) to complete the order.
6. Both the breakpoints set in step 1 should be reached. 
7. Revisit MC_URL/wcpay_order_completed_gateway/test/ and make sure the counter is incremented. 
8. Remove all breakpoints.

##### Test shopper Tracks
1. Add a breakpoint to this [line](https://github.com/Automattic/woocommerce-payments/blob/d58aacc6e1522b8929b3ec7671e613f91a20d010/includes/class-woopay-tracker.php#L246)
2. As a shopper, add a product to the cart and go to the checkout page.
3. Make sure the breakpoint is reached for the `checkout_page_view` event.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
