### PR TITLE
Update WooPay button colors to match new designs

### DIFF
--- a/changelog/update-woopay-button-color
+++ b/changelog/update-woopay-button-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve visibility of WooPay button on light and outline button themes

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -129,9 +129,9 @@
 		sans-serif;
 	letter-spacing: 0.8px;
 	height: 40px;
-	background: #f2deff !important;
+	background: $white !important;
 	border: 1px solid $white !important;
-	color: $studio-woocommerce-purple-60 !important;
+	color: $studio-black !important;
 	width: 100%;
 	border-radius: 4px;
 	padding-top: 1px;
@@ -143,7 +143,7 @@
 	text-transform: none;
 
 	&:not( :disabled ):hover {
-		background: #d9baff !important;
+		background: #e0e0e0 !important;
 		cursor: pointer;
 	}
 
@@ -196,9 +196,9 @@
 	}
 
 	&[data-theme='light-outline'] {
-		border-color: #674399 !important;
+		border-color: $studio-black !important;
 		&:not( :disabled ):hover {
-			background: #d9baff !important;
+			background: #e0e0e0 !important;
 		}
 	}
 

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -334,9 +334,11 @@
 			}
 		}
 
-		&[data-theme='light'],
-		&[data-theme='light-outline'] {
+		&[data-theme='light'] {
 			background: #2b2b2b;
+		}
+		&[data-theme='light-outline'] {
+			background: #f0f0f0;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8811

#### Changes proposed in this Pull Request
This updates the styling of WooPay button in 'light' and 'outline' button themes to match the new designs.

Designs: pc2DNy-42r-p2

Preview screen

![CleanShot 2024-05-15 at 15 54 41](https://github.com/Automattic/woocommerce-payments/assets/6216000/33e52605-b578-442b-837d-c895f9cec370)

Light theme on the product page
![CleanShot 2024-05-15 at 15 57 47](https://github.com/Automattic/woocommerce-payments/assets/6216000/1b58262b-f8d1-4b1e-81af-38f6eff5a8b0)

Outline the theme on the product page
![CleanShot 2024-05-15 at 15 58 28](https://github.com/Automattic/woocommerce-payments/assets/6216000/ad3aecbe-2a33-4a92-af14-dbc2afd24de2)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. As a merchant, go to Payments -> Settings -> Select Customize button under WooPay
2. Set button theme to 'Light'.
3. Preview should show the updated colors in the new design
4. As a shopper, check the button in the Product, Cart, and Checkout pages and make sure the new design shows up.
5. Repeat the above steps for the 'Outline' theme.
6. Make sure 'Dark' theme is not affected. 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.