### PR TITLE
perf: unneeded WooPay scripts

### DIFF
--- a/changelog/fix-woopay-save-user-on-non-checkout-pages
+++ b/changelog/fix-woopay-save-user-on-non-checkout-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: remove WooPay checkout pages scripts from non-checkout pages

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -36,6 +36,10 @@ class WooPay_Save_User {
 	 * Load scripts and styles for checkout page.
 	 */
 	public function register_checkout_page_scripts() {
+		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) ) {
+			return;
+		}
+
 		// Don't enqueue checkout page scripts when WCPay isn't available.
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 		if ( ! isset( $gateways['woocommerce_payments'] ) ) {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

[The `client/checkout/woopay/index.js` scripts](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/woopay/index.js) are used on checkout pages to render the "save user" section.

I noticed these scripts are enqueued on every page, even product pages.
Together with these, more than half a dozen additional WC Blocks scripts are being enqueued.

Since we don't need to render them on non-checkout pages, let's ensure they are not enqueued.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have WooPay enabled
- Go to a product page
- You should no longer see the `dist/woopay.js` file enqueued
- Go to checkout
- You should see the `dist/woopay.js` file enqueued

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
