### PR TITLE
Add new process payment exception

### DIFF
--- a/changelog/add-new-process-payment-exception
+++ b/changelog/add-new-process-payment-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add New_Process_Payment_Exception

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1072,8 +1072,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * and if the answer is yes, uses it and returns the result.
 	 *
 	 * @param WC_Order $order Order that needs payment.
-	 * @return array|null     Array if processed, null if the new process is not supported.
-	 * @throws Exception      If the payment process could not be completed.
+	 * @return array|null Array  if processed, null if the new process is not supported.
+	 * @throws New_Process_Payment_Exception Error processing the payment.
 	 */
 	public function new_process_payment( WC_Order $order ) {
 		$manual_capture = $this->get_capture_type() === Payment_Capture_Type::MANUAL();
@@ -1119,7 +1119,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			];
 		}
 
-		throw new Exception( __( 'The payment process could not be completed.', 'woocommerce-payments' ) );
+		throw new New_Process_Payment_Exception( __( 'The payment process could not be completed.', 'woocommerce-payments' ) );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1073,7 +1073,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @param WC_Order $order Order that needs payment.
 	 * @return array|null Array  if processed, null if the new process is not supported.
-	 * @throws New_Process_Payment_Exception Error processing the payment.
+	 * @throws Exception Error processing the payment.
 	 */
 	public function new_process_payment( WC_Order $order ) {
 		$manual_capture = $this->get_capture_type() === Payment_Capture_Type::MANUAL();
@@ -1119,7 +1119,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			];
 		}
 
-		throw new New_Process_Payment_Exception( __( 'The payment process could not be completed.', 'woocommerce-payments' ) );
+		throw new Exception( __( 'The payment process could not be completed.', 'woocommerce-payments' ), 0, new New_Process_Payment_Exception() );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -18,7 +18,7 @@ use WCPay\Constants\Payment_Initiated_By;
 use WCPay\Constants\Intent_Status;
 use WCPay\Constants\Payment_Type;
 use WCPay\Constants\Payment_Method;
-use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Invalid_Address_Exception, Fraud_Prevention_Enabled_Exception, Invalid_Phone_Number_Exception, Rate_Limiter_Enabled_Exception, Order_ID_Mismatch_Exception, Order_Not_Found_Exception };
+use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Invalid_Address_Exception, Fraud_Prevention_Enabled_Exception, Invalid_Phone_Number_Exception, Rate_Limiter_Enabled_Exception, Order_ID_Mismatch_Exception, Order_Not_Found_Exception, New_Process_Payment_Exception };
 use WCPay\Core\Server\Request\Cancel_Intention;
 use WCPay\Core\Server\Request\Capture_Intention;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1119,7 +1119,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			];
 		}
 
-		throw new Exception( __( 'The payment process could not be completed.', 'woocommerce-payments' ), 0, new New_Process_Payment_Exception() );
+		throw new Exception(
+			__( 'The payment process could not be completed.', 'woocommerce-payments' ),
+			0,
+			new New_Process_Payment_Exception(
+				__( 'The payment process could not be completed.', 'woocommerce-payments' ),
+				'new_process_payment'
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -428,6 +428,7 @@ class WC_Payments {
 		include_once __DIR__ . '/exceptions/class-invalid-price-exception.php';
 		include_once __DIR__ . '/exceptions/class-fraud-ruleset-exception.php';
 		include_once __DIR__ . '/exceptions/class-fraud-prevention-enabled-exception.php';
+		include_once __DIR__ . '/exceptions/class-new-process-payment-exception.php';
 		include_once __DIR__ . '/exceptions/class-order-not-found-exception.php';
 		include_once __DIR__ . '/exceptions/class-order-id-mismatch-exception.php';
 		include_once __DIR__ . '/exceptions/class-rate-limiter-enabled-exception.php';

--- a/includes/exceptions/class-new-process-payment-exception.php
+++ b/includes/exceptions/class-new-process-payment-exception.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Class New_Process_Payment_Exception
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Exceptions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exception for throwing an error when failed on processing payment.
+ */
+class New_Process_Payment_Exception extends Process_Payment_Exception {
+}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -3666,7 +3666,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->card_gateway->process_payment( $order->get_id() );
 
-		$this->expectException( New_Process_Payment_Exception::class );
+		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'The payment process could not be completed.' );
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -3661,6 +3661,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
+	public function test_new_process_payment_throw_exception() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->card_gateway->process_payment( $order->get_id() );
+
+		$this->expectException( New_Process_Payment_Exception::class );
+		$this->expectExceptionMessage( 'The payment process could not be completed.' );
+	}
+
 	public function test_process_payment_rate_limiter_enabled_throw_exception() {
 		$order = WC_Helper_Order::create_order();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -27,6 +27,7 @@ use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Internal\Payment\Factor;
 use WCPay\Internal\Payment\Router;
 use WCPay\Internal\Payment\State\CompletedState;
+use WCPay\Internal\Payment\State\PaymentErrorState;
 use WCPay\Internal\Service\Level3Service;
 use WCPay\Internal\Service\OrderService;
 use WCPay\Internal\Service\PaymentProcessingService;
@@ -3662,12 +3663,31 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_new_process_payment_throw_exception() {
-		$order = WC_Helper_Order::create_order();
+		// The new payment process is only accessible in dev mode.
+		WC_Payments::mode()->dev();
 
-		$this->card_gateway->process_payment( $order->get_id() );
+		$mock_service = $this->createMock( PaymentProcessingService::class );
+		$mock_router  = $this->createMock( Router::class );
+		$order        = WC_Helper_Order::create_order();
+		$mock_state   = $this->createMock( PaymentErrorState::class );
+
+		wcpay_get_test_container()->replace( PaymentProcessingService::class, $mock_service );
+		wcpay_get_test_container()->replace( Router::class, $mock_router );
+
+		$mock_router->expects( $this->once() )
+			->method( 'should_use_new_payment_process' )
+			->willReturn( true );
+
+		// Assert: The new service is called.
+		$mock_service->expects( $this->once() )
+			->method( 'process_payment' )
+			->with( $order->get_id() )
+			->willReturn( $mock_state );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'The payment process could not be completed.' );
+
+		$this->card_gateway->process_payment( $order->get_id() );
 	}
 
 	public function test_process_payment_rate_limiter_enabled_throw_exception() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR is an extension of the [Pass previous Exception with Exception PR](https://github.com/Automattic/woocommerce-payments/pull/8824).  [The new_process_payment is still on dev mode only](https://github.com/Automattic/woocommerce-payments/blob/b9811debb59f7b14d0d5bea6bb22ab9f317e0308/includes/class-wc-payment-gateway-wcpay.php#L993) but I think it's still good to have it early on.

The [new_process_payment](https://github.com/Automattic/woocommerce-payments/blob/b9811debb59f7b14d0d5bea6bb22ab9f317e0308/includes/class-wc-payment-gateway-wcpay.php#L1138) is being used outside of the `try` so this PR pass the `New_Process_Payment_Exception` as previous error with the exception thrown in the `new_process_payment`, so we can [use the previous class added in the $additional_data in WC](https://github.com/woocommerce/woocommerce/pull/47489) when `new_process_payment` is compatible with Blocks checkout.

Note: `new_process_payment` is incompatible with Blocks checkout.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Test with legacy/shortcode checkout because `new_process_payment` is incompatible with Blocks checkout.
2. [Update this condition](https://github.com/Automattic/woocommerce-payments/blob/b9811debb59f7b14d0d5bea6bb22ab9f317e0308/includes/class-wc-payment-gateway-wcpay.php#L1137) to `true`
3. Force throwing `throw new Exception( __( 'The payment process could not be completed.', 'woocommerce-payments' ), 0, new New_Process_Payment_Exception() );` in `new_process_payment`.
4. [Error log below inside the catch of `process_checkout` ](https://github.com/woocommerce/woocommerce/blob/e75c6b9cf0e74ff81550fdd1633c9f4150a7612d/plugins/woocommerce/includes/class-wc-checkout.php#L1298)
```
error_log(get_class($e->getPrevious()));
```
5. As a shopper, checkout with legacy/shortcode checkout
6. See error notice `The payment process could not be completed.` on the checkout page  
7. Check the error log on the merchant site and should see `WCPay\Exceptions\New_Process_Payment_Exception`
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
