### PR TITLE
Fix ECE error in the blocks checkout when PRBs are disabled.

### DIFF
--- a/changelog/fix-blocks-checkout-ece-error-when-prb-disabled
+++ b/changelog/fix-blocks-checkout-ece-error-when-prb-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix ECE error in the blocks checkout when PRBs are disabled.

--- a/client/express-checkout/blocks/index.js
+++ b/client/express-checkout/blocks/index.js
@@ -16,7 +16,17 @@ const expressCheckoutElementPaymentMethod = ( api ) => ( {
 	supports: {
 		features: getConfig( 'features' ),
 	},
-	canMakePayment: () => wcpayConfig.isExpressCheckoutElementEnabled,
+	canMakePayment: () => {
+		if ( typeof wcpayExpressCheckoutParams === 'undefined' ) {
+			return false;
+		}
+
+		if ( typeof wcpayConfig !== 'undefined' ) {
+			return wcpayConfig.isExpressCheckoutElementEnabled;
+		}
+
+		return false;
+	},
 } );
 
 export default expressCheckoutElementPaymentMethod;

--- a/client/express-checkout/blocks/index.js
+++ b/client/express-checkout/blocks/index.js
@@ -1,4 +1,4 @@
-/* global wcpayConfig */
+/* global wcpayConfig, wcpayExpressCheckoutParams */
 
 /**
  * Internal dependencies

--- a/client/payment-request/blocks/index.js
+++ b/client/payment-request/blocks/index.js
@@ -1,4 +1,4 @@
-/* global wcpayConfig */
+/* global wcpayConfig, wcpayPaymentRequestParams */
 
 /**
  * Internal dependencies

--- a/client/payment-request/blocks/index.js
+++ b/client/payment-request/blocks/index.js
@@ -28,7 +28,10 @@ const paymentRequestPaymentMethod = ( api ) => ( {
 			return false;
 		}
 
-		if ( wcpayConfig.isExpressCheckoutElementEnabled ) {
+		if (
+			typeof wcpayConfig !== 'undefined' &&
+			wcpayConfig.isExpressCheckoutElementEnabled
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the error `There was an error registering the payment method with id
'woocommerce_payments_express_checkout: ReferenceError: wcpayConfig is not
defined` in the blocks checkout when PRBs are disabled.

#### Testing instructions

**Identify the Bug on `develop`:**

1. Disable all express checkout payment methods (WooPay, Google Pay, Apple Pay).
2. Add a product to the cart and navigate to the checkout (blocks).
3. Observe the error:

![image](https://github.com/Automattic/woocommerce-payments/assets/4153905/77d543a2-89e8-42be-b349-723f09ec7309)

**Confirm this Branch Fixes the Issue:**

1. Switch to this branch. Build the client assets using: `npm run build:client`.
2. Repeat the steps to reproduce the issue and confirm the error no longer appears on the checkout page.
3. Enable all the express checkout payment methods, and verify they are rendering correctly in both the shortcode and blocks checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
