### PR TITLE
Add order id mismatch exception

### DIFF
--- a/changelog/add-order-id-mismatch-exception
+++ b/changelog/add-order-id-mismatch-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add Order_ID_Mismatch_Exception

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1411,7 +1411,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 * @throws API_Exception
-	 * @throws Exception
+	 * @throws Exception When amount too small.
 	 * @throws Invalid_Address_Exception
 	 * @throws Order_Not_Found_Exception
 	 * @throws Order_ID_Mismatch_Exception When the payment intent could not be authenticated.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -18,7 +18,7 @@ use WCPay\Constants\Payment_Initiated_By;
 use WCPay\Constants\Intent_Status;
 use WCPay\Constants\Payment_Type;
 use WCPay\Constants\Payment_Method;
-use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Invalid_Address_Exception, Fraud_Prevention_Enabled_Exception, Invalid_Phone_Number_Exception, Rate_Limiter_Enabled_Exception, Order_ID_Mismatch_Exception };
+use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Invalid_Address_Exception, Fraud_Prevention_Enabled_Exception, Invalid_Phone_Number_Exception, Rate_Limiter_Enabled_Exception, Order_ID_Mismatch_Exception, Order_Not_Found_Exception };
 use WCPay\Core\Server\Request\Cancel_Intention;
 use WCPay\Core\Server\Request\Capture_Intention;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -429,6 +429,7 @@ class WC_Payments {
 		include_once __DIR__ . '/exceptions/class-fraud-ruleset-exception.php';
 		include_once __DIR__ . '/exceptions/class-fraud-prevention-enabled-exception.php';
 		include_once __DIR__ . '/exceptions/class-order-not-found-exception.php';
+		include_once __DIR__ . '/exceptions/class-order-id-mismatch-exception.php';
 		include_once __DIR__ . '/exceptions/class-rate-limiter-enabled-exception.php';
 		include_once __DIR__ . '/constants/class-base-constant.php';
 		include_once __DIR__ . '/constants/class-country-code.php';

--- a/includes/exceptions/class-order-id-mismatch-exception.php
+++ b/includes/exceptions/class-order-id-mismatch-exception.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Class Order_ID_Mismatch_Exception
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Exceptions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exception for throwing an error when payment processing is not possible or fails.
+ */
+class Order_ID_Mismatch_Exception extends Base_Exception {
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR is an extension of the [Pass previous Exception with Exception PR](https://github.com/Automattic/woocommerce-payments/pull/8824) and creates an unique exception `Order_ID_Mismatch` when getting generic error message like `We're not able to process this request. Please refresh the page and try again.` so it would be easier for us to identify where the error is coming from later on.

#### Testing instructions
1. Update [this condition](https://github.com/Automattic/woocommerce-payments/blob/d9702fc94b190947f12fe688edd9bd0d0d24d712/includes/class-wc-payment-gateway-wcpay.php#L1519) to `true`
2. As a shopper, checkout with WooPay
3. See error notice `Oops, we couldn't complete the order and your card has been refunded. Please try again.`
4. Check the WooPay logger and see `"previous": "WCPay\\Exceptions\\Order_ID_Mismatch_Exception"`. Example below:
```
Response Body: {
     "code": "woocommerce_rest_checkout_process_payment_error",
     "message": "We&#039;re not able to process this payment. Please try again later. WooPayMeta: intent_meta_order_id: 3116, order_id: 3116",
     "data": {
          "previous": "WCPay\\Exceptions\\Order_ID_Mismatch_Exception",
          "status": 400
      }
} 
```
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
