### PR TITLE
POC for using the new checkout additional fields API

### DIFF
--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -108,5 +108,13 @@ button.wcpay-stripelink-modal-trigger:hover {
 	}
 }
 
+#additional-information-fields {
+	.wc-block-components-address-form__woocommerce-payments--woopay-phone-number {
+		label {
+			left: 100px;
+		}
+	}
+}
+
 @import '../woopay/style';
 @import '../../components/loadable/style';

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -8,6 +8,8 @@ import ReactDOM from 'react-dom';
  * External dependencies
  */
 import CheckoutPageSaveUser from 'wcpay/components/woopay/save-user/checkout-page-save-user';
+import intlTelInput from 'intl-tel-input';
+import utils from 'iti/utils';
 
 const renderSaveUserSection = () => {
 	const saveUserSection = document.getElementsByClassName(
@@ -33,16 +35,34 @@ const renderSaveUserSection = () => {
 		checkoutPageSaveUserContainer.id = 'remember-me';
 
 		if ( paymentOptions ) {
-			// Render right after the payment options block, as a sibling element.
-			paymentOptions.parentNode.insertBefore(
-				checkoutPageSaveUserContainer,
-				paymentOptions.nextSibling
+			const inputWrapper = document.querySelector(
+				'.wc-block-components-text-input.wc-block-components-address-form__woocommerce-payments--woopay-phone-number'
+			);
+			inputWrapper.style.display = 'none';
+
+			const createAccountCheckbox = document.querySelector(
+				'#additional-information-woocommerce-payments--create-woopay-account'
+			);
+			createAccountCheckbox.onchange = function ( e ) {
+				if ( e.target.checked ) {
+					inputWrapper.style.display = 'block';
+				} else {
+					inputWrapper.style.display = 'none';
+				}
+			};
+
+			const input = document.querySelector(
+				'#additional-information-woocommerce-payments--woopay-phone-number'
 			);
 
-			ReactDOM.render(
-				<CheckoutPageSaveUser isBlocksCheckout={ true } />,
-				checkoutPageSaveUserContainer
-			);
+			intlTelInput( input, {
+				customPlaceholder: () => '',
+				separateDialCode: true,
+				hiddenInput: 'full',
+				utilsScript: utils,
+				dropdownContainer: document.body,
+				// ...phoneCountries,
+			} );
 		}
 	} else {
 		const checkoutPageSaveUserContainer = document.createElement( 'div' );

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -50,8 +50,9 @@
 		font-weight: 400;
 		gap: $gap;
 		transition: max-height 0.5s ease-in-out;
-		margin: 0 !important;
-		padding: 0 !important;
+		margin: 0;
+		margin-top: $gap-large;
+		padding-top: 2px;
 		overflow-y: hidden;
 		max-height: 21.875rem;
 
@@ -144,7 +145,6 @@
 // override intl-tel-input styles
 .iti {
 	width: 100%;
-	margin-top: $gap-large;
 
 	&--container {
 		margin-top: 0;

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -63,7 +63,7 @@ const SupportPhoneInput = ( { setInputVallid } ) => {
 				</Notice>
 			) }
 			<BaseControl
-				className="settings__account-business-support-phone-input no-top-margin"
+				className="settings__account-business-support-phone-input"
 				help={ __(
 					'This may be visible on receipts, invoices, and automated emails from your store.',
 					'woocommerce-payments'

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1301,7 +1301,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_information->must_save_payment_method_to_store();
 		}
 
-		if ( $this->woopay_util->should_save_platform_customer() ) {
+		if ( $this->woopay_util->should_save_platform_customer( $order ) ) {
 			do_action( 'woocommerce_payments_save_user_in_woopay' );
 			$payment_information->must_save_payment_method_to_platform();
 		}
@@ -1634,7 +1634,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			} else {
 				$save_user_in_woopay = false;
 
-				if ( $this->woopay_util->should_save_platform_customer() ) {
+				if ( $this->woopay_util->should_save_platform_customer( $order ) ) {
 					$save_user_in_woopay = true;
 					$metadata_from_order = apply_filters(
 						'wcpay_metadata_from_order',

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -83,8 +83,8 @@ class WooPay_Save_User {
 	 * @return array
 	 */
 	public function maybe_add_userdata_to_metadata( $metadata, $order ) {
-		$should_save_platform_customer = $this->woopay_util->should_save_platform_customer();
-		$woopay_phone                  = $this->woopay_util->get_woopay_phone();
+		$should_save_platform_customer = $this->woopay_util->should_save_platform_customer( $order );
+		$woopay_phone                  = $this->woopay_util->get_woopay_phone( $order );
 
 		if ( $should_save_platform_customer && $woopay_phone ) {
 			$woopay_source_url = $this->woopay_util->get_woopay_source_url();

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -427,3 +427,36 @@ add_action(
 		}
 	}
 );
+
+
+add_action(
+	'woocommerce_blocks_loaded',
+	function () {
+		__experimental_woocommerce_blocks_register_checkout_field(
+			[
+				'id'       => 'woocommerce-payments--create-woopay-account',
+				'label'    => __( 'Securely save my information for 1-click checkout', 'woocommerce-payments' ),
+				'location' => 'additional',
+				'type'     => 'checkbox',
+			]
+		);
+	}
+);
+
+add_action(
+	'woocommerce_blocks_loaded',
+	function () {
+		__experimental_woocommerce_blocks_register_checkout_field(
+			[
+				'id'            => 'woocommerce-payments--woopay-phone-number',
+				'label'         => 'Mobile number',
+				'optionalLabel' => 'Mobile number',
+				'location'      => 'additional',
+				'attributes'    => [
+					'autocomplete' => 'phone',
+					'title'        => 'Mobile number',
+				],
+			],
+		);
+	}
+);


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request
This PR is only a POC to test the new blocks [checkout additional fields api](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-blocks/docs/third-party-developers/extensibility/checkout-block/additional-checkout-fields.md) and should not be merged.

#### Testing instructions


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
