### PR TITLE
Disable WooPay for suspended and rejected accounts

### DIFF
--- a/changelog/as-disable-woopay-rejected-suspended-accounts
+++ b/changelog/as-disable-woopay-rejected-suspended-accounts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable WooPay for suspended and rejected accounts.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -215,7 +215,7 @@ class WC_Payments_Features {
 
 		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
 
-		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
+		return is_array( $account ) && isset( $account['platform_checkout_eligible'] ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -213,7 +213,9 @@ class WC_Payments_Features {
 
 		$is_account_rejected = WC_Payments::get_account_service()->is_account_rejected();
 
-		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected ?? false );
+		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
+
+		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -210,7 +210,10 @@ class WC_Payments_Features {
 
 		// read directly from cache, ignore cache expiration check.
 		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
-		return is_array( $account ) && ( $account['platform_checkout_eligible'] ?? false );
+
+		$is_account_rejected = WC_Payments::get_account_service()->is_account_rejected();
+
+		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -215,7 +215,10 @@ class WC_Payments_Features {
 
 		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
 
-		return is_array( $account ) && isset( $account['platform_checkout_eligible'] ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
+		return is_array( $account )
+			&& ( $account['platform_checkout_eligible'] ?? false )
+			&& ! $is_account_rejected
+			&& ! $is_account_under_review;
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -569,7 +569,7 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error on the WooPayment Dev Tools,
+		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error every time the account cache is refreshed,
 		// given that $wp_rewrite is defined right after the `plugins_loaded` action is fired. See #8857.
 		add_action( 'setup_theme', [ __CLASS__, 'maybe_register_woopay_hooks' ] );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1508,12 +1508,10 @@ class WC_Payments {
 	 * @return void
 	 */
 	public static function maybe_register_woopay_hooks() {
-		$is_woopay_eligible      = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
-		$is_woopay_enabled       = 'yes' === self::get_gateway()->get_option( 'platform_checkout', 'no' );
-		$is_account_rejected     = self::get_account_service()->is_account_rejected();
-		$is_account_under_review = self::get_account_service()->is_account_under_review();
+		$is_woopay_eligible = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
+		$is_woopay_enabled  = 'yes' === self::get_gateway()->get_option( 'platform_checkout', 'no' );
 
-		if ( $is_woopay_eligible && $is_woopay_enabled && ! $is_account_rejected && ! $is_account_under_review ) {
+		if ( $is_woopay_eligible && $is_woopay_enabled ) {
 			add_action( 'wc_ajax_wcpay_init_woopay', [ WooPay_Session::class, 'ajax_init_woopay' ] );
 			add_action( 'wc_ajax_wcpay_get_woopay_session', [ WooPay_Session::class, 'ajax_get_woopay_session' ] );
 			add_action( 'wc_ajax_wcpay_get_woopay_signature', [ __CLASS__, 'ajax_get_woopay_signature' ] );
@@ -1555,9 +1553,7 @@ class WC_Payments {
 			}
 
 			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
-		}
-
-		if ( $is_account_rejected || $is_account_under_review ) {
+		} else {
 			WooPay_Order_Status_Sync::remove_webhook();
 		}
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1500,15 +1500,17 @@ class WC_Payments {
 	}
 
 	/**
-	 * Registers woopay hooks if the woopay feature flag is enabled.
+	 * Registers woopay hooks if the woopay feature flag is enabled and the merchant is not suspended or rejected.
 	 *
 	 * @return void
 	 */
 	public static function maybe_register_woopay_hooks() {
-		$is_woopay_eligible = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
-		$is_woopay_enabled  = 'yes' === self::get_gateway()->get_option( 'platform_checkout', 'no' );
+		$is_woopay_eligible      = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
+		$is_woopay_enabled       = 'yes' === self::get_gateway()->get_option( 'platform_checkout', 'no' );
+		$is_account_rejected     = self::get_account_service()->is_account_rejected();
+		$is_account_under_review = self::get_account_service()->is_account_under_review();
 
-		if ( $is_woopay_eligible && $is_woopay_enabled ) {
+		if ( $is_woopay_eligible && $is_woopay_enabled && ! $is_account_rejected && ! $is_account_under_review ) {
 			add_action( 'wc_ajax_wcpay_init_woopay', [ WooPay_Session::class, 'ajax_init_woopay' ] );
 			add_action( 'wc_ajax_wcpay_get_woopay_session', [ WooPay_Session::class, 'ajax_get_woopay_session' ] );
 			add_action( 'wc_ajax_wcpay_get_woopay_signature', [ __CLASS__, 'ajax_get_woopay_signature' ] );
@@ -1550,6 +1552,10 @@ class WC_Payments {
 			}
 
 			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
+		}
+
+		if ( $is_account_rejected || $is_account_under_review ) {
+			WooPay_Order_Status_Sync::remove_webhook();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -569,7 +569,9 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		self::maybe_register_woopay_hooks();
+		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error on the WooPayment Dev Tools,
+		// given that $wp_rewrite is defined right after the `plugins_loaded` action is fired. See #8857.
+		add_action( 'setup_theme', [ __CLASS__, 'maybe_register_woopay_hooks' ] );
 
 		self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
 		self::$apple_pay_registration->init_hooks();
@@ -1500,7 +1502,8 @@ class WC_Payments {
 	}
 
 	/**
-	 * Registers woopay hooks if the woopay feature flag is enabled and the merchant is not suspended or rejected.
+	 * Registers woopay hooks if the woopay feature flag is enabled.
+	 * Removes WooPay webhooks if the merchant is not eligible.
 	 *
 	 * @return void
 	 */

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -18,6 +18,13 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	 */
 	protected $mock_cache;
 
+	/**
+	 * Mock WC_Payments_Account.
+	 *
+	 * @var WC_Payments_Account|MockObject
+	 */
+	private $mock_wcpay_account;
+
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
 		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
 		'_wcpay_feature_documents'               => 'documents',
@@ -29,6 +36,17 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->_cache     = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
 		WC_Payments::set_database_cache( $this->mock_cache );
+
+		// Mock the WCPay Account class to make sure the account is not restricted by default.
+		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+		$this->mock_wcpay_account
+			->method( 'is_account_rejected' )
+			->willReturn( false );
+		$this->mock_wcpay_account
+			->method( 'is_account_under_review' )
+			->willReturn( false );
+
+		WC_Payments::set_account_service( $this->mock_wcpay_account );
 	}
 
 	public function tear_down() {
@@ -88,6 +106,32 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_woopay_eligible_returns_false() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
+		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
+	}
+
+	public function test_is_woopay_eligible_when_account_is_suspended_returns_false() {
+		$mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+		$mock_wcpay_account
+			->method( 'is_account_under_review' )
+			->willReturn( true );
+
+		WC_Payments::set_account_service( $mock_wcpay_account );
+
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
+
+		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
+	}
+
+	public function test_is_woopay_eligible_when_account_is_rejected_returns_false() {
+		$mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+		$mock_wcpay_account
+			->method( 'is_account_rejected' )
+			->willReturn( true );
+
+		WC_Payments::set_account_service( $mock_wcpay_account );
+
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
+
 		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woopay/issues/2641

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Add checks to `WC_Payments_Features::is_woopay_eligible()` to return `false` in case the merchant account is suspended or rejected.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions
---
> [!Warning]  
> Rejecting a merchant account is irreversible. It will inform Stripe about the rejection and it can not be undone.

Since I didn't find a way to reverse a rejection I'm sharing another way to simulate a rejected account.

**a) Reject the account using the MC tool.**
  - In the WCPay Server’ admin area:
  - Go to MC, Enter the Blog ID then click “Open reportcard”.
  - In the “Account Rejection Tool” section.
  - Chose “Refund all” option then click “Reject Account”.
 
**b) Hardcode the account status**

- On the WCPay Server repo.
- Edit `server/wp-content/rest-api-plugins/endpoints/wcpay/class-accounts-controller.php` line `885`
- Change the status to: `'status' => 'rejected.something',`
- Note that this will reject all WCPay accounts. So make sure to discard the changes after you are done testing.

I'd suggest using option "b" if you don't want to go through the hassle of creating a new WCPay account every time you want to test a rejected account.

---

#### Disable WooPay for rejected accounts.

- In the WCPay Server’ admin area:
    - Reject your merchant account using the steps above.
- Go to the WC Pay site’ admin area
    - Go to “WCPay Dev“
    - Clear the "Account cache contents” to apply changes.
    - Go to > Payments. The account should be “Rejected”.
- Go to the Store
    - Add products.
    - Go to the Shortcode Cart page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.
    - Go to the Cart Block page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.
    - Go to Shortcode Checkout page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.
    - Go to Checkout Block page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.

#### Disable WooPay for suspended accounts.

- In the WCPay Server’ admin area:
    - Go to MC, Enter the Blog ID then click “Open reportcard”.
    - In the “Account Tool” section:
    - Select “Hard Block Account” then click “Apply Account Action”.
- Go to the WC Pay site’ admin area
    - Go to “WCPay Dev“
    - Clear the "Account cache contents” to apply changes.
    - Go to > Payments. The account should be “Under review”.
- Go to the Store
    - Add products.
    - Go to the Shortcode Cart page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.
    - Go to the Cart Block page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.
    - Go to Shortcode Checkout page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.
    - Go to Checkout Block page.
        - Check the Network tab in Chrome. It shouldn’t download any Woopay related file.

#### Remove active WooPay webhooks for rejected accounts.

- Go to the WC Pay site’ admin area
    - Reject your merchant account using the steps above.
- Go to the WC Pay site’ admin area
    - Go to “WCPay Dev“
    - Clear the "Account cache contents” to apply changes.
    - Go to > Payments. The account should be “Rejected”.
    - Go to WooCommerce > Settings > Advanced > Webhooks
    - Verify there’s no “WCPay woopay order status sync” webhook.

#### Remove active WooPay webhooks for suspended accounts.

- Make sure to clear the WCPay account on the WC Pay Server using the Account Tool on the Report Card.
- Go to the WC Pay site’ admin area
    - Go to WooCommerce > Settings > Advanced > Webhooks
    - Verify there’s a “WCPay woopay order status sync” active webhook.
- In the WCPay Server’ admin area:
    - Go to MC, Enter the Blog ID then click “Open reportcard”.
    - In the “Account Tool” section:
    - Select “Hard Block Account” then click “Apply Account Action”.
- Go to the WC Pay site’ admin area
    - Go to “WCPay Dev“
    - Clear the "Account cache contents” to apply changes.
    - Go to > Payments. The account should be “Under review”.
    - Go to WooCommerce > Settings > Advanced > Webhooks
    - Verify there’s no “WCPay woopay order status sync” webhook.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
