### PR TITLE
Fix Klarna E2E tests

### DIFF
--- a/changelog/fix-8416-klarna-e2e-tests-final
+++ b/changelog/fix-8416-klarna-e2e-tests-final
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix Klarna E2E tests.

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -116,16 +116,19 @@ describe( 'Klarna checkout', () => {
 		let klarnaIframe = await getNewKlarnaIframe();
 
 		const frameNavigationHandler = async ( frame ) => {
-			const newKlarnaIframe = await getNewKlarnaIframe();
-			if ( frame === newKlarnaIframe ) {
-				klarnaIframe = newKlarnaIframe;
+			if ( frame.url().includes( 'klarna.com' ) ) {
+				const newKlarnaIframe = await getNewKlarnaIframe();
+
+				if ( frame === newKlarnaIframe ) {
+					klarnaIframe = newKlarnaIframe;
+				}
 			}
 		};
 
 		// Add frame navigation event listener.
 		page.on( 'framenavigated', frameNavigationHandler );
 
-		// waiting for the redirect & the Klarna iframe to load within the Stripe test page.
+		// Waiting for the redirect & the Klarna iframe to load within the Stripe test page.
 		// this is the "confirm phone number" page - we just click "continue".
 		await klarnaIframe.waitForSelector( '#phone' );
 		await klarnaIframe

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -14,8 +14,6 @@ const UPE_METHOD_CHECKBOXES = [
 	"//label[contains(text(), 'Klarna')]/preceding-sibling::span/input[@type='checkbox']",
 ];
 
-const checkoutPaymentMethodSelector = `//*[@id='payment']/ul/li/label[contains(text(), 'Klarna')]`;
-
 describe( 'Klarna checkout', () => {
 	beforeAll( async () => {
 		await merchant.login();
@@ -51,7 +49,7 @@ describe( 'Klarna checkout', () => {
 			if ( element ) {
 				element.click();
 			}
-		}, 'button[aria-label="Open Learn More Modal"]' );
+		}, 'a[aria-label="Open Learn More Modal"]' );
 
 		// Wait for the iframe to be added by Stripe JS after clicking on the element.
 		await page.waitFor( 1000 );
@@ -85,17 +83,23 @@ describe( 'Klarna checkout', () => {
 				// https://docs.klarna.com/resources/test-environment/sample-customer-data/#united-states-of-america
 				email: 'customer@email.us',
 				phone: '+13106683312',
+				firstname: 'Test',
+				lastname: 'Person-us',
 			},
 			[ [ 'Beanie', 3 ] ]
 		);
 
 		await uiUnblocked();
 
-		await page.waitForXPath( checkoutPaymentMethodSelector );
-		const [ paymentMethodLabel ] = await page.$x(
-			checkoutPaymentMethodSelector
-		);
-		await paymentMethodLabel.click();
+		await page.evaluate( async () => {
+			const paymentMethodLabel = document.querySelector(
+				'label[for="payment_method_woocommerce_payments_klarna"]'
+			);
+			if ( paymentMethodLabel ) {
+				paymentMethodLabel.click();
+			}
+		} );
+
 		await shopper.placeOrder();
 
 		// Klarna is rendered in an iframe, so we need to get its reference.
@@ -123,55 +127,50 @@ describe( 'Klarna checkout', () => {
 
 		// waiting for the redirect & the Klarna iframe to load within the Stripe test page.
 		// this is the "confirm phone number" page - we just click "continue".
-		await klarnaIframe.waitForSelector( '#collectPhonePurchaseFlow' );
-		(
-			await klarnaIframe.waitForSelector(
-				'#onContinue[data-testid="kaf-button"]'
-			)
-		 ).click();
-		// this is where the OTP code is entered.
+		await klarnaIframe.waitForSelector( '#phone' );
+		await klarnaIframe
+			.waitForSelector( '#onContinue' )
+			.then( ( button ) => button.click() );
+
+		// This is where the OTP code is entered.
 		await klarnaIframe.waitForSelector( '#phoneOtp' );
-		await expect( klarnaIframe ).toFill(
-			'[data-testid="kaf-field"]',
-			'000000'
-		);
-
-		await klarnaIframe.waitForSelector(
-			'button[data-testid="select-payment-category"'
-		);
-
-		await klarnaIframe.waitForSelector( '.skeleton-wrapper' );
-		await klarnaIframe.waitFor(
-			() => ! document.querySelector( '.skeleton-wrapper' )
-		);
+		await expect( klarnaIframe ).toFill( 'input#otp_field', '123456' );
 
 		// Select Payment Plan - 4 weeks & click continue.
 		await klarnaIframe
-			.waitForSelector( 'input[type="radio"][id*="pay_in_n"]' )
-			.then( ( input ) => input.click() );
+			.waitForSelector( 'button[id*="pay_in_n"]' )
+			.then( ( button ) => button.click() );
+
+		await page.waitFor( 2000 );
+
 		await klarnaIframe
 			.waitForSelector( 'button[data-testid="select-payment-category"' )
 			.then( ( button ) => button.click() );
+
+		await page.waitFor( 2000 );
 
 		// Payment summary page. Click continue.
 		await klarnaIframe
 			.waitForSelector( 'button[data-testid="pick-plan"]' )
 			.then( ( button ) => button.click() );
 
-		// at this point, the event listener is not needed anymore.
+		await page.waitFor( 2000 );
+
+		// At this point, the event listener is not needed anymore.
 		page.removeListener( 'framenavigated', frameNavigationHandler );
+
+		await page.waitFor( 2000 );
 
 		// Confirm payment.
 		await klarnaIframe
-			.waitForSelector(
-				'button[data-testid="confirm-and-pay"]:not(:disabled)'
-			)
+			.waitForSelector( 'button#buy_button' )
 			.then( ( button ) => button.click() );
 
 		// Wait for the order confirmation page to load.
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );
+
 		await expect( page ).toMatch( 'Order received' );
 	} );
 } );

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -141,7 +141,7 @@ describe( 'Klarna checkout', () => {
 
 		// Select Payment Plan - 4 weeks & click continue.
 		await klarnaIframe
-			.waitForSelector( 'button[id*="pay_in_n"]' )
+			.waitForSelector( 'button#pay_over_time__label' )
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );


### PR DESCRIPTION
Fixes #8416

### Changes proposed in this Pull Request

The Klarna test environment UI has been updated.

This PR updates the selectors as needed and adds a few 2s intervals to account for page transition and animations.

### Testing instructions

No testing is required, but ensure [the workflow run for this branch](https://github.com/Automattic/woocommerce-payments/actions/runs/9184811190) passes for `wcpay - shopper` Klarna checkout spec:

```
PASS tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
```

We still have other specs failing at this branch, but in `develop` all Klarna tests are failing: [E2E Tests - All](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
