### PR TITLE
Fix WooPay button in classic cart/product pages

### DIFF
--- a/changelog/fix-blocks-page-detection-for-woopay
+++ b/changelog/fix-blocks-page-detection-for-woopay
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes an unreleased bug
+
+

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -172,7 +172,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			userEmail = email;
 			urlParams.append( 'email', email );
 		}
-		urlParams.append( 'is_blocks', !! wcSettings.wcBlocksConfig );
+		urlParams.append( 'is_blocks', !! window.wcBlocksCheckoutData );
 		urlParams.append( 'is_express', 'true' );
 		urlParams.append( 'express_context', context );
 		urlParams.append( 'source_url', window.location.href );

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -172,7 +172,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			userEmail = email;
 			urlParams.append( 'email', email );
 		}
-		urlParams.append( 'is_blocks', !! window.wcBlocksCheckoutData );
+		urlParams.append( 'is_blocks', !! window.wcSettings?.wcBlocksConfig );
 		urlParams.append( 'is_express', 'true' );
 		urlParams.append( 'express_context', context );
 		urlParams.append( 'source_url', window.location.href );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
With https://github.com/Automattic/woocommerce-payments/pull/8829/commits/a355f76b5dd723716490a41e76a1cc45c327b800, we remove unnecessary WooPay-related scripts from loading on non-checkout pages. As a side effect, `wcSettings` is no longer set on classic product and cart pages. This breaks the WooPay button on those pages due to the `wcSettings.wcBlocksConfig` reference.
 
This fixes it via optional chaining.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

****Replicate the issue****
1. On current `develop`, add a product to the cart and visit the classic cart page.
2. Click on the WooPay button.
3. WooPay flow does not start, following error is printed on to the console.
4. Repeat the steps on a product page and observe the same error.

```
Uncaught (in promise) ReferenceError: wcSettings is not defined
```

****Test the fix****
1. Switch to this branch.
2. Go to the cart page and click the WooPay button.
3. WooPay checkout should start. No errors should be printed on console.
4. Repeat the steps on the product page.

****(Regression) Test whether is_blocks is set correctly****
1. On the classic cart page, click on the WooPay button.
2. Wait for the iframe to open.
3. Inspect the iframe URL and make sure `is_blocks` parameter is set to false.
4. Go to blocks cart page and repeat the above steps.
5. `is_blocks` should be set to true.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
