### PR TITLE
Bump WP tested up to 6.5 and WC tested up to 8.9.1

### DIFF
--- a/changelog/dev-bump-wc-tested-up-to-8.9.1
+++ b/changelog/dev-bump-wc-tested-up-to-8.9.1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump tested up to version for WP to 6.5 and WC to 8.9.1.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 7.3
 Stable tag: 7.6.0
 License: GPLv2 or later

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 8.7.0
+ * WC tested up to: 8.9.1
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 7.6.0


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Bump `Tested up to` header for WP to 6.5. [Latest release on May 7th](https://wordpress.org/news/category/releases/).
- Bump `WC tested up to` header to 8.9.1. [Latest release](https://github.com/woocommerce/woocommerce/releases/latest) | 9.0.0 major release in June according to team Proton.

Note: For the time being, we have paused bumping min required versions. Context: PaJDYF-6n7-p2

### Testing instructions

- No tests needed, only code review.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.