### PR TITLE
Update URLs to prevent redirects and missing anchors

### DIFF
--- a/changelog/Update URLs and anchors.
+++ b/changelog/Update URLs and anchors.
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: PR updates URLs but does not resolve any 404 errors or other functionality. Very little changes that an end-user will notice.
+
+

--- a/client/bnpl-announcement/index.js
+++ b/client/bnpl-announcement/index.js
@@ -44,7 +44,7 @@ const Dialog = () => {
 							);
 							setIsHidden( true );
 						} }
-						href="https://woo.com/document/woopayments/payment-methods/buy-now-pay-later/"
+						href="https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/"
 					>
 						{ __( 'Learn more', 'woocommerce-payments' ) }
 					</ExternalLink>

--- a/client/payment-methods/capability-request/capability-request-map.ts
+++ b/client/payment-methods/capability-request/capability-request-map.ts
@@ -27,7 +27,7 @@ const CapabilityRequestList: Array< CapabilityRequestMap > = [
 				),
 				actions: 'link',
 				actionUrl:
-					'https://woocommerce.com/document/woopayments/payment-methods/#jcb',
+					'https://woocommerce.com/document/woopayments/payment-methods/jcb-for-merchants-in-japan/',
 				actionsLabel: __( 'Finish setup', 'woocommerce-payments' ),
 			},
 			pending: {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -122,7 +122,7 @@ export const formatMethodFeesTooltip = (
 			? 1 - accountFees.discount[ 0 ].discount
 			: 1;
 
-	// Per https://woo.com/es/terms-conditions/woopayments-promotion-2023/ we exclude FX fees from discounts.
+	// Per https://woocommerce.com/terms-conditions/woopayments-promotion-2023/ we exclude FX fees from discounts.
 	const total = {
 		percentage_rate:
 			accountFees.base.percentage_rate * discountAdjustedFeeRate +

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -26,7 +26,7 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/ssl-and-https/#section-7';
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/ssl-and-https/#how-to-set-up-ssl-with-woocommerce';
 
 	/**
 	 * Checks if a note can and should be added.

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -26,7 +26,7 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/ssl-and-https/#how-to-set-up-ssl-with-woocommerce';
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/ssl-and-https/#woocommerce-force-ssl-setting';
 
 	/**
 	 * Checks if a note can and should be added.


### PR DESCRIPTION
Fixes #8880

#### Changes proposed in this Pull Request

Updates URLs, so no tests necessary.

- Updates SSL notice URL to have the correct anchor.
- Updates JCB URL to direct to the proper page.
- Updates domains to reference `woocommerce.com` instead of `woo.com`.
- Removes `/es/` from a URL.

I haven't added a changelog entry because I am not entirely sure how 😅 Since this change isn't significant, it may not warrant a changelog entry.

**Edit**: I _think_ I figured it out! 
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trigger the HTTPS notice per https://github.com/Automattic/woocommerce-payments/pull/1231 and ensure the `Read more` link uses the `#woocommerce-force-ssl-setting` anchor.
* Trigger the BNPL announcement per  https://github.com/Automattic/woocommerce-payments/pull/8605 and ensure that any documentation links use the `woocommerce.com` domain.

**Note**: It doesn't appear as though we reference the JCB documentation when onboarding as a JP merchant, even though `/client/payment-methods/capability-request/capability-request-map.ts` and https://github.com/Automattic/woocommerce-payments/pull/7224 suggest otherwise.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.