### PR TITLE
Prevent WooPay button from submitting the checkout forms when the customer presses "enter" on their keyboard

### DIFF
--- a/changelog/fix-woopay-button-submit-when-enter-pressed
+++ b/changelog/fix-woopay-button-submit-when-enter-pressed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make it so that the WooPay button is not triggered on Checkout pages when the "Enter" key is pressed on a keyboard.

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -346,6 +346,7 @@ export const WoopayExpressCheckoutButton = ( {
 			data-width-type={ buttonWidthType }
 			style={ { height: `${ height }px` } }
 			disabled={ isLoading }
+			type="button"
 		>
 			{ isLoading ? (
 				<span className="wc-block-components-spinner" />


### PR DESCRIPTION
Fixes #8862

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Set the WooPay button's type to `"button"` to prevent it from automatically being a type `"submit"` (the default value).
    - This makes it so the button doesn't submit forms.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Reproduce on `develop`

1. Add a product to your cart and go to a Blocks-based Checkout page.
2. Highlight any input field and hit <kbd>Enter</kbd>.
3. Notice that the WooPay button is triggered.
4. Repeat steps (1)-(3) but use the Shortcode-based Checkout page.

### Verify fix on this branch

1. Add a product to your cart and go to a Blocks-based Checkout page.
2. Highlight any input field and hit <kbd>Enter</kbd>.
3. Notice that the WooPay button **is not** triggered.
4. Repeat steps (1)-(3) but use the Shortcode-based Checkout page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable.
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
