### PR TITLE
Fix "Pay for order" infinite loading

### DIFF
--- a/changelog/fix-8883-pay-for-order-blocked-ui
+++ b/changelog/fix-8883-pay-for-order-blocked-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix "Pay for order" infinite loading when submitting form without payment details.

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { getUPEConfig } from 'wcpay/utils/checkout';
@@ -63,8 +68,8 @@ async function initializeAppearance( api ) {
  *
  * @param {Object} $form The jQuery object for the form.
  */
-export function blockUI( $form ) {
-	$form.addClass( 'processing' ).block( {
+export async function blockUI( $form ) {
+	await $form.addClass( 'processing' ).block( {
 		message: null,
 		overlayCSS: {
 			background: '#fff',
@@ -515,18 +520,24 @@ export const processPayment = (
 		return;
 	}
 
-	const { elements, isPaymentInformationComplete } = gatewayUPEComponents[
-		paymentMethodType
-	];
-	if ( ! isPaymentInformationComplete ) {
-		showErrorCheckout( 'Your payment information is incomplete.' );
-		return false;
-	}
-
-	blockUI( $form );
-
 	( async () => {
 		try {
+			await blockUI( $form );
+
+			const {
+				elements,
+				isPaymentInformationComplete,
+			} = gatewayUPEComponents[ paymentMethodType ];
+
+			if ( ! isPaymentInformationComplete ) {
+				throw new Error(
+					__(
+						'Your payment information is incomplete.',
+						'woocommerce-payments'
+					)
+				);
+			}
+
 			await validateElements( elements );
 			const paymentMethodObject = await createStripePaymentMethod(
 				api,

--- a/client/checkout/classic/test/payment-processing.test.js
+++ b/client/checkout/classic/test/payment-processing.test.js
@@ -457,6 +457,8 @@ describe( 'Payment processing', () => {
 		};
 
 		await processPayment( apiMock, checkoutForm, 'card' );
+		// Wait for promises to resolve.
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
 
 		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
 			elements: expect.any( Object ),
@@ -499,6 +501,8 @@ describe( 'Payment processing', () => {
 		};
 
 		await processPayment( apiMock, checkoutForm, 'card' );
+		// Wait for promises to resolve.
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
 
 		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
 			elements: expect.any( Object ),
@@ -537,6 +541,8 @@ describe( 'Payment processing', () => {
 		};
 
 		await processPayment( apiMock, checkoutForm, 'card' );
+		// Wait for promises to resolve.
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
 
 		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
 			elements: expect.any( Object ),
@@ -572,6 +578,8 @@ describe( 'Payment processing', () => {
 		};
 
 		await processPayment( apiMock, checkoutForm, 'card' );
+		// Wait for promises to resolve.
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
 
 		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
 			elements: expect.any( Object ),
@@ -605,6 +613,8 @@ describe( 'Payment processing', () => {
 		};
 
 		await processPayment( apiMock, addPaymentMethodForm, 'card' );
+		// Wait for promises to resolve.
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
 
 		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith( {
 			elements: expect.any( Object ),


### PR DESCRIPTION
Fixes #8883 

#### Changes proposed in this Pull Request

Fix infinite loading on "Pay for order" page when there's no payment information provided.

#### Testing instructions

**Setup**
- Switch to this branch.
- Run `npm run build:client`.

**Test 1: Ensure the "Pay for order" page is unblocked**

1. As a merchant, navigate to **WooCommerce > Orders > Add order**.
2. Create a "Pending payment" order with an item below USD 1000000.
3. After you click "Create", navigate to the "Customer payment page →".
4. As a shopper, try to click "Pay for order" without providing any payment information.
5. Ensure there's a notice "Your payment information is incomplete." and the UI **is unblocked**. Whereas in `develop` the UI is blocked in an infinite loading.

**Test 2: Ensure there are no regressions to the "error message on 1M+ amount"**
- See testing instructions at https://github.com/Automattic/woocommerce-payments/pull/8793

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
