### PR TITLE
Declare compatibility with the Cart and Checkout blocks

### DIFF
--- a/changelog/update-declare-compatibility-width-cart-and-checkout-block
+++ b/changelog/update-declare-compatibility-width-cart-and-checkout-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Declare compatibility with the Cart and Checkout blocks.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -423,7 +423,8 @@ add_action(
 	'before_woocommerce_init',
 	function () {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-payments/woocommerce-payments.php', true );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
 	}
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/woocommerce/woocommerce/issues/47920, @gedex reported that various extensions are listed as incompatible in `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&paged=1&s` due to the Cart and Checkout blocks. While looking into this issue, I noticed that `WooCommerce Stripe Payment Gateway` also appears as an incompatible extension. The reason for that is, that this extension does not explicitly declared compatibility. In [FAQ: Cart and Checkout Blocks by Default](https://developer.woocommerce.com/2023/11/06/faq-extending-cart-and-checkout-blocks/), detailed information about declaring compatibility can be found. 

This PR declared compatibility to the Cart and Checkout blocks, but adding the following code:
```php
\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
```

#### Testing instructions

### User facing

1. Before checking out this PR, ensure to have a testing site where both `WooCommerce` and `WooCommerce Payments` are installed and activated.
2. Go to `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&paged=1&s`.
3. Verify that `WooCommerce Payments` is listed as an incompatible extension. 

<img width="1346" alt="Screenshot 2024-05-30 at 21 07 26" src="https://github.com/Automattic/woocommerce-payments/assets/3323310/0bbdb5b9-e44a-4156-a203-3eb89d694106">

4. Check out this PR.
5. Go to `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&paged=1&s` again.
6. Verify that `WooCommerce Payments` is no longer listed as an incompatible extension. 

<img width="1343" alt="Screenshot 2024-05-30 at 21 11 17" src="https://github.com/Automattic/woocommerce-payments/assets/3323310/71feb050-acc0-4e46-a06c-8f0c861b31ab">

### Developer facing

1. Before checking out this PR, ensure to have a testing site where both `WooCommerce` and `WooCommerce Payments` are installed and activated and a testing environment with WP-CLI.
2. Open a terminal.
3. Run the following command:
```sh
wp eval 'do_action("before_woocommerce_init"); print_r(Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_features_for_plugin("woocommerce-payments/woocommerce-payments.php"));'
```
4. Verify to see this result:
```sh
Array
(
    [compatible] => Array
        (
            [0] => custom_order_tables
        )

    [incompatible] => Array
        (
        )

    [uncertain] => Array
        (
            [0] => analytics
            [1] => new_navigation
            [2] => product_block_editor
            [3] => cart_checkout_blocks
            [4] => marketplace
            [5] => order_attribution
            [6] => hpos_fts_indexes
        )
)
```
5. Check out this PR.
6. Run the command from step 3. again.
7. Verify to see this result now:
```sh
Array
(
    [compatible] => Array
        (
            [0] => cart_checkout_blocks
            [1] => custom_order_tables
        )

    [incompatible] => Array
        (
        )

    [uncertain] => Array
        (
            [0] => analytics
            [1] => new_navigation
            [2] => product_block_editor
            [3] => marketplace
            [4] => order_attribution
            [5] => hpos_fts_indexes
        )
)
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
