### PR TITLE
chore: EPMs to always send shipping phone

### DIFF
--- a/changelog/chore-epms-always-send-shipping-phone
+++ b/changelog/chore-epms-always-send-shipping-phone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+chore: EPMs to always send shipping phone

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -30,10 +30,14 @@ export const normalizeLineItems = ( displayItems ) => {
 export const normalizeOrderData = ( event, paymentMethodId ) => {
 	const name = event?.billingDetails?.name;
 	const email = event?.billingDetails?.email ?? '';
-	const phone = event?.billingDetails?.phone ?? '';
 	const billing = event?.billingDetails?.address ?? {};
 	const shipping = event?.shippingAddress ?? {};
 	const fraudPreventionTokenValue = window.wcpayFraudPreventionToken ?? '';
+
+	const phone =
+		event?.billingDetails?.phone ??
+		event?.payerPhone?.replace( '/[() -]/g', '' ) ??
+		'';
 
 	return {
 		billing_first_name:
@@ -41,8 +45,7 @@ export const normalizeOrderData = ( event, paymentMethodId ) => {
 		billing_last_name: name?.split( ' ' )?.slice( 1 )?.join( ' ' ) || '-',
 		billing_company: billing?.organization ?? '',
 		billing_email: email ?? event?.payerEmail ?? '',
-		billing_phone:
-			phone ?? event?.payerPhone?.replace( '/[() -]/g', '' ) ?? '',
+		billing_phone: phone,
 		billing_country: billing?.country ?? '',
 		billing_address_1: billing?.line1 ?? '',
 		billing_address_2: billing?.line2 ?? '',
@@ -54,6 +57,7 @@ export const normalizeOrderData = ( event, paymentMethodId ) => {
 		shipping_last_name:
 			shipping?.name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
 		shipping_company: shipping?.organization ?? '',
+		shipping_phone: phone,
 		shipping_country: shipping?.address?.country ?? '',
 		shipping_address_1: shipping?.address?.line1 ?? '',
 		shipping_address_2: shipping?.address?.line2 ?? '',

--- a/client/payment-request/utils/normalize.js
+++ b/client/payment-request/utils/normalize.js
@@ -32,7 +32,6 @@ export const normalizeOrderData = ( paymentData ) => {
 		paymentData?.paymentMethod?.billing_details?.name ??
 		paymentData.payerName;
 	const email = paymentData?.paymentMethod?.billing_details?.email ?? '';
-	const phone = paymentData?.paymentMethod?.billing_details?.phone ?? '';
 	const billing = paymentData?.paymentMethod?.billing_details?.address ?? {};
 	const shipping = paymentData?.shippingAddress ?? {};
 	const fraudPreventionTokenValue = window.wcpayFraudPreventionToken ?? '';
@@ -44,14 +43,17 @@ export const normalizeOrderData = ( paymentData ) => {
 		paymentRequestType = 'google_pay';
 	}
 
+	const phone =
+		paymentData?.paymentMethod?.billing_details?.phone ??
+		paymentData?.payerPhone?.replace( '/[() -]/g', '' ) ??
+		'';
 	return {
 		billing_first_name:
 			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
 		billing_last_name: name?.split( ' ' )?.slice( 1 )?.join( ' ' ) || '-',
 		billing_company: billing?.organization ?? '',
 		billing_email: email ?? paymentData?.payerEmail ?? '',
-		billing_phone:
-			phone ?? paymentData?.payerPhone?.replace( '/[() -]/g', '' ) ?? '',
+		billing_phone: phone,
 		billing_country: billing?.country ?? '',
 		billing_address_1: billing?.line1 ?? '',
 		billing_address_2: billing?.line2 ?? '',
@@ -63,6 +65,7 @@ export const normalizeOrderData = ( paymentData ) => {
 		shipping_last_name:
 			shipping?.recipient?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
 		shipping_company: shipping?.organization ?? '',
+		shipping_phone: phone,
 		shipping_country: shipping?.country ?? '',
 		shipping_address_1: shipping?.addressLine?.[ 0 ] ?? '',
 		shipping_address_2: shipping?.addressLine?.[ 1 ] ?? '',

--- a/client/tokenized-payment-request/transformers/stripe-to-wc.js
+++ b/client/tokenized-payment-request/transformers/stripe-to-wc.js
@@ -50,6 +50,10 @@ export const transformStripePaymentMethodForStoreApi = ( paymentData ) => {
 	const paymentRequestType =
 		paymentData.walletName === 'applePay' ? 'apple_pay' : 'google_pay';
 
+	const billingPhone =
+		paymentData.paymentMethod?.billing_details?.phone ??
+		paymentData.payerPhone?.replace( '/[() -]/g', '' ) ??
+		'';
 	return {
 		customer_note: paymentData.order_comments,
 		billing_address: {
@@ -66,13 +70,16 @@ export const transformStripePaymentMethodForStoreApi = ( paymentData ) => {
 				paymentData.paymentMethod?.billing_details?.email ??
 				paymentData.payerEmail ??
 				'',
-			phone:
-				paymentData.paymentMethod?.billing_details?.phone ??
-				paymentData.payerPhone?.replace( '/[() -]/g', '' ) ??
-				'',
+			phone: billingPhone,
 		},
 		// refreshing any shipping address data, now that the customer is placing the order.
-		...transformStripeShippingAddressForStoreApi( shipping ),
+		shipping_address: {
+			...transformStripeShippingAddressForStoreApi( shipping )
+				.shipping_address,
+			// adding the phone number, because it might be needed.
+			// Stripe doesn't provide us with a different phone number for shipping, so we're going to use the same phone used for billing.
+			phone: billingPhone,
+		},
 		payment_method: 'woocommerce_payments',
 		payment_data: [
 			{


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Error message is displayed when a combination of [this PR](https://github.com/woocommerce/woocommerce/pull/47062) and phone number is marked as "required".

This PR ensures that we're always sending the shipping phone to the backend - regardless of whether it's required or not.
Stripe doesn't provide us with a different phone number, so we're just going to use the same phone number value used for billing.

I implemented/copied this solution for/to all the variations of the EPMs we currently have.

Discussed internally here: p1717173350842549-slack-CU6SYV31A

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test the scenario without this patch, first**
- Use a non-block-based theme (e.g.: Storefront)
- Ensure you have ApplePay/GooglePay enabled in your WooPayments settings
- Via the customizer, mark the phone number as required
<img width="455" alt="Screenshot 2024-06-04 at 2 34 58 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/30c020e0-c8fe-4aab-95cf-93bb55c2fd3c">

- Install [WC 9.0.0-beta.1](https://github.com/woocommerce/woocommerce/releases/tag/9.0.0-beta.1)
- As an _anonymous_ customer (but not in incognito - we just don't want any previously saved data), go to a physical product
- Add the product to the cart, go to checkout
- Try to use Google Pay to pay for the product
- An error should appear
<img width="596" alt="Screenshot 2024-06-04 at 2 36 05 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/84d3d37b-62a0-45ee-b980-e92ed5d80ba7">

- Apply this patch
- Now the error should no longer appear once you attempt to place the order
- Phone number is saved in the order details page in the admin's backend
<img width="248" alt="Screenshot 2024-06-04 at 2 50 38 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/05bcb4f2-b030-490c-ac3d-9f7b40b32dba">


I also tested this with [WC 8.9.1](https://github.com/woocommerce/woocommerce/releases/tag/8.9.1) for good measure.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.