### PR TITLE
Add the WooPay Direct Checkout flow to the classic mini cart widget

### DIFF
--- a/changelog/add-2688-woopay-direct-checkout-to-mini-cart
+++ b/changelog/add-2688-woopay-direct-checkout-to-mini-cart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the WooPay Direct Checkout flow to the classic mini cart widget.

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -21,6 +21,8 @@ class WooPayDirectCheckout {
 			'.wp-block-woocommerce-proceed-to-checkout-block',
 		BLOCKS_MINI_CART_PROCEED_BUTTON:
 			'a.wp-block-woocommerce-mini-cart-checkout-button-block',
+		CLASSIC_MINI_CART_PROCEED_BUTTON:
+			'.widget_shopping_cart a.button.checkout',
 	};
 
 	/**
@@ -212,6 +214,9 @@ class WooPayDirectCheckout {
 		);
 		addElementBySelector(
 			this.redirectElements.BLOCKS_CART_PROCEED_BUTTON
+		);
+		addElementBySelector(
+			this.redirectElements.CLASSIC_MINI_CART_PROCEED_BUTTON
 		);
 
 		return elements;

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -77,7 +77,7 @@ class WC_Payments_WooPay_Direct_Checkout {
 		// Enqueue the WCPay common config script only if it hasn't been enqueued yet.
 		// This may happen when Direct Checkout is being enqueued on pages that are not the cart page,
 		// such as the home and shop pages.
-		if ( did_filter( 'wcpay_payment_fields_js_config' ) === 0 ) {
+		if ( function_exists( 'did_filter' ) && did_filter( 'wcpay_payment_fields_js_config' ) === 0 ) {
 			try {
 				// is_test() throws if the class 'Mode' has not been initialized.
 				$is_test_mode = WC_Payments::mode()->is_test();

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -6,6 +6,9 @@
  * @package WooCommerce\Payments
  */
 
+use WCPay\WooPay\WooPay_Session;
+use WCPay\WooPay\WooPay_Utilities;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -71,6 +74,36 @@ class WC_Payments_WooPay_Direct_Checkout {
 			return;
 		}
 
+		// Enqueue the WCPay common config script only if it hasn't been enqueued yet.
+		// This may happen when Direct Checkout is being enqueued on pages that are not the cart page,
+		// such as the home and shop pages.
+		if ( did_filter( 'wcpay_payment_fields_js_config' ) === 0 ) {
+			try {
+				// is_test() throws if the class 'Mode' has not been initialized.
+				$is_test_mode = WC_Payments::mode()->is_test();
+			} catch ( Exception $e ) {
+				// Default to false if the class 'Mode' has not been initialized.
+				$is_test_mode = false;
+			}
+
+			wp_register_script( 'WCPAY_WOOPAY_COMMON_CONFIG', '', [], WCPAY_VERSION_NUMBER, false );
+			wp_localize_script(
+				'WCPAY_WOOPAY_COMMON_CONFIG',
+				'wcpayConfig',
+				[
+					'woopayHost'                    => WooPay_Utilities::get_woopay_url(),
+					'testMode'                      => $is_test_mode,
+					'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+					'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
+					'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
+					'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
+					'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
+					'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
+				]
+			);
+			wp_enqueue_script( 'WCPAY_WOOPAY_COMMON_CONFIG' );
+		}
+
 		WC_Payments::register_script_with_dependencies( 'WCPAY_WOOPAY_DIRECT_CHECKOUT', 'dist/woopay-direct-checkout' );
 
 		$direct_checkout_settings = [
@@ -94,11 +127,14 @@ class WC_Payments_WooPay_Direct_Checkout {
 	 * - The current page is the cart page.
 	 * - The current page has a cart block.
 	 * - The current page has the blocks mini cart widget, i.e 'woocommerce_blocks_cart_enqueue_data' has been fired.
+	 * - The current page has the cart fragments script enqueued. which is enqueued by the shortcode mini cart widget.
 	 *
 	 * @return bool True if the scripts should be enqueued, false otherwise.
 	 */
 	private function should_enqueue_scripts(): bool {
-		return $this->is_cart_page() || did_action( 'woocommerce_blocks_cart_enqueue_data' ) > 0;
+		return $this->is_cart_page()
+			|| did_action( 'woocommerce_blocks_cart_enqueue_data' ) > 0
+			|| ( wp_script_is( 'wc-cart-fragments', 'enqueued' ) && ! $this->is_checkout_page() );
 	}
 
 	/**
@@ -108,6 +144,15 @@ class WC_Payments_WooPay_Direct_Checkout {
 	 */
 	private function is_cart_page(): bool {
 		return is_cart() || has_block( 'woocommerce/cart' );
+	}
+
+	/**
+	 * Check if the current page is the checkout page.
+	 *
+	 * @return bool True if the current page is the checkout page, false otherwise.
+	 */
+	private function is_checkout_page(): bool {
+		return is_checkout() || has_block( 'woocommerce/checkout' );
 	}
 
 	/**

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -78,30 +78,7 @@ class WC_Payments_WooPay_Direct_Checkout {
 		// This may happen when Direct Checkout is being enqueued on pages that are not the cart page,
 		// such as the home and shop pages.
 		if ( function_exists( 'did_filter' ) && did_filter( 'wcpay_payment_fields_js_config' ) === 0 ) {
-			try {
-				// is_test() throws if the class 'Mode' has not been initialized.
-				$is_test_mode = WC_Payments::mode()->is_test();
-			} catch ( Exception $e ) {
-				// Default to false if the class 'Mode' has not been initialized.
-				$is_test_mode = false;
-			}
-
-			wp_register_script( 'WCPAY_WOOPAY_COMMON_CONFIG', '', [], WCPAY_VERSION_NUMBER, false );
-			wp_localize_script(
-				'WCPAY_WOOPAY_COMMON_CONFIG',
-				'wcpayConfig',
-				[
-					'woopayHost'                    => WooPay_Utilities::get_woopay_url(),
-					'testMode'                      => $is_test_mode,
-					'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-					'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
-					'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
-					'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
-					'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
-					'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
-				]
-			);
-			wp_enqueue_script( 'WCPAY_WOOPAY_COMMON_CONFIG' );
+			WC_Payments::enqueue_woopay_common_config_script();
 		}
 
 		WC_Payments::register_script_with_dependencies( 'WCPAY_WOOPAY_DIRECT_CHECKOUT', 'dist/woopay-direct-checkout' );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1569,41 +1569,52 @@ class WC_Payments {
 	}
 
 	/**
-	 * Enqueues the common config script if the express checkout button is disabled on the cart page.
+	 * Validates whether the common config script should be enqueued and enqueues it.
+	 *
+	 * If the express checkout button is disabled on the cart page, the common config
+	 * script needs to be enqueued to ensure `wcpayConfig` is available on the cart page.
+	 *
+	 * @return void
+	 */
+	public static function validate_and_enqueue_woopay_common_config_script() {
+		$is_express_button_disabled_on_cart = self::get_express_checkout_helper()->is_cart()
+			&& ! self::get_express_checkout_helper()->is_available_at( 'cart', WC_Payments_WooPay_Button_Handler::BUTTON_LOCATIONS );
+
+		if ( $is_express_button_disabled_on_cart ) {
+			self::enqueue_woopay_common_config_script();
+		}
+	}
+
+	/**
+	 * Enqueues the common config script.
 	 *
 	 * @return void
 	 */
 	public static function enqueue_woopay_common_config_script() {
-		$is_express_button_disabled_on_cart = self::get_express_checkout_helper()->is_cart()
-			&& ! self::get_express_checkout_helper()->is_available_at( 'cart', WC_Payments_WooPay_Button_Handler::BUTTON_LOCATIONS );
-		// If the express checkout button is disabled on the cart page, the common config
-		// script needs to be enqueued to ensure wcpayConfig is available on the cart page.
-		if ( $is_express_button_disabled_on_cart ) {
-			try {
-				// is_test() throws if the class 'Mode' has not been initialized.
-				$is_test_mode = self::mode()->is_test();
-			} catch ( Exception $e ) {
-				// Default to false if the class 'Mode' has not been initialized.
-				$is_test_mode = false;
-			}
-
-			wp_register_script( 'WCPAY_WOOPAY_COMMON_CONFIG', '', [], WCPAY_VERSION_NUMBER, false );
-			wp_localize_script(
-				'WCPAY_WOOPAY_COMMON_CONFIG',
-				'wcpayConfig',
-				[
-					'woopayHost'                    => WooPay_Utilities::get_woopay_url(),
-					'testMode'                      => $is_test_mode,
-					'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-					'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
-					'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
-					'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
-					'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
-					'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
-				]
-			);
-			wp_enqueue_script( 'WCPAY_WOOPAY_COMMON_CONFIG' );
+		try {
+			// is_test() throws if the class 'Mode' has not been initialized.
+			$is_test_mode = self::mode()->is_test();
+		} catch ( Exception $e ) {
+			// Default to false if the class 'Mode' has not been initialized.
+			$is_test_mode = false;
 		}
+
+		wp_register_script( 'WCPAY_WOOPAY_COMMON_CONFIG', '', [], WCPAY_VERSION_NUMBER, false );
+		wp_localize_script(
+			'WCPAY_WOOPAY_COMMON_CONFIG',
+			'wcpayConfig',
+			[
+				'woopayHost'                    => WooPay_Utilities::get_woopay_url(),
+				'testMode'                      => $is_test_mode,
+				'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+				'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
+				'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
+				'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
+				'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
+				'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
+			]
+		);
+		wp_enqueue_script( 'WCPAY_WOOPAY_COMMON_CONFIG' );
 	}
 
 	/**
@@ -1619,7 +1630,7 @@ class WC_Payments {
 			return;
 		}
 
-		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_woopay_common_config_script' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'validate_and_enqueue_woopay_common_config_script' ] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2688

#### Changes proposed in this Pull Request

This PR adds the WooPay direct checkout flow to the classic mini cart widget.

<img width="248" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/10233985/bfe618a5-89c9-4f0b-82b8-fee6b2d12262">

It also enqueues the direct checkout scripts if the current page has the `wc-cart-fragments` script enqueued. I expand more on this in the comment below.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Setup**

1. Ensure the WooPay direct checkout feature flag `_wcpay_feature_woopay_direct_checkout` is set to `1`.
2. Switch to this branch and run `npm run build:client`.

**Regression test: Ensure the direct checkout flow works from classic and blocks carts**

1. As a shopper, add a product to the cart.
2. Ensure the direct checkout flow works from classic and blocks carts:
  - If the user is logged in on WooPay, the user is redirected to WooPay.
  - If the user is logged out from WooPay, the user is redirected to the merchant checkout.
  - Please test with third party cookies enabled and disabled.

**Test: Ensure the direct checkout scripts are enqueued in the right pages**

1. As a shopper, add a product to the cart.
2. Navigate to any page where the mini cart widget is available. The only exceptions here are likely the cart and checkout pages.
3. Ensure the `WCPAY_WOOPAY_DIRECT_CHECKOUT` script is enqueued in the page source.

**Test: Ensure the direct checkout flow works from the mini cart**

1. As a shopper, add a product to the cart.
2. Navigate to any page where the mini cart is visible (any page besides the cart or the checkout).
3. Click on the mini cart "Checkout" button.
4. Ensure the direct checkout flow works as expected:
  - If the user is logged in on WooPay, the user is redirected to WooPay.
  - If the user is logged out from WooPay, the user is redirected to the merchant checkout.
  - Please test with third party cookies enabled and disabled.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
