### PR TITLE
Fix ECE not working without WooPay

### DIFF
--- a/changelog/as-fix-ece-with-woopay
+++ b/changelog/as-fix-ece-with-woopay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Fix ECE not working without WooPay.

--- a/client/express-checkout/blocks/components/express-checkout-container.js
+++ b/client/express-checkout/blocks/components/express-checkout-container.js
@@ -19,9 +19,11 @@ const ExpressCheckoutContainer = ( props ) => {
 	};
 
 	return (
-		<Elements stripe={ stripe } options={ options }>
-			<ExpressCheckoutComponent { ...props } />
-		</Elements>
+		<div style={ { minHeight: '50px' } }>
+			<Elements stripe={ stripe } options={ options }>
+				<ExpressCheckoutComponent { ...props } />
+			</Elements>
+		</div>
 	);
 };
 

--- a/client/express-checkout/blocks/index.js
+++ b/client/express-checkout/blocks/index.js
@@ -1,5 +1,3 @@
-/* global wcpayConfig, wcpayExpressCheckoutParams */
-
 /**
  * Internal dependencies
  */
@@ -26,11 +24,7 @@ const expressCheckoutElementPaymentMethod = ( api ) => ( {
 			return false;
 		}
 
-		if ( typeof wcpayConfig !== 'undefined' ) {
-			return wcpayConfig.isExpressCheckoutElementEnabled;
-		}
-
-		return false;
+		return true;
 	},
 } );
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -168,18 +168,6 @@ class WC_Payments_Express_Checkout_Button_Handler {
 
 		wp_set_script_translations( 'WCPAY_EXPRESS_CHECKOUT_ECE', 'woocommerce-payments' );
 
-		$wcpay_config = rawurlencode( wp_json_encode( WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() ) );
-
-		if ( ! wp_script_is( 'WCPAY_WOOPAY_EXPRESS_BUTTON', 'enqueued' ) ) {
-			wp_add_inline_script(
-				'WCPAY_EXPRESS_CHECKOUT_ECE',
-				"
-				var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
-				",
-				'before'
-			);
-		}
-
 		wp_enqueue_script( 'WCPAY_EXPRESS_CHECKOUT_ECE' );
 
 		Fraud_Prevention_Service::maybe_append_fraud_prevention_token();

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -170,13 +170,15 @@ class WC_Payments_Express_Checkout_Button_Handler {
 
 		$wcpay_config = rawurlencode( wp_json_encode( WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() ) );
 
-		wp_add_inline_script(
-			'WCPAY_EXPRESS_CHECKOUT_ECE',
-			"
-			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
-			",
-			'before'
-		);
+		if ( ! wp_script_is( 'WCPAY_WOOPAY_EXPRESS_BUTTON', 'enqueued' ) ) {
+			wp_add_inline_script(
+				'WCPAY_EXPRESS_CHECKOUT_ECE',
+				"
+				var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
+				",
+				'before'
+			);
+		}
 
 		wp_enqueue_script( 'WCPAY_EXPRESS_CHECKOUT_ECE' );
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -168,6 +168,16 @@ class WC_Payments_Express_Checkout_Button_Handler {
 
 		wp_set_script_translations( 'WCPAY_EXPRESS_CHECKOUT_ECE', 'woocommerce-payments' );
 
+		$wcpay_config = rawurlencode( wp_json_encode( WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() ) );
+
+		wp_add_inline_script(
+			'WCPAY_EXPRESS_CHECKOUT_ECE',
+			"
+			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
+			",
+			'before'
+		);
+
 		wp_enqueue_script( 'WCPAY_EXPRESS_CHECKOUT_ECE' );
 
 		Fraud_Prevention_Service::maybe_append_fraud_prevention_token();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the Express Checkout element not working without WooPay.

#### Testing instructions

Follow testing instructions from https://github.com/Automattic/woocommerce-payments/pull/8884

- [x] Unselect WooPay from WooPayments. ECE is displayed as expected.
- [x] Select WooPay from WooPayments. ECE is displayed as expected.
- [x] Disabled ECE feature. (`wp option update _wcpay_feature_stripe_ece 0`). Payment Request buttons should work as expected.
- [x] Test previous items in both Chrome and Safari. ECE and PRBs must work as usual.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
