### PR TITLE
Fix Klarna E2E tests

### DIFF
--- a/changelog/fix-klarna-e2e-tests
+++ b/changelog/fix-klarna-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix Klarna E2E Tests.
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -102,77 +102,63 @@ describe( 'Klarna checkout', () => {
 
 		await shopper.placeOrder();
 
-		// Klarna is rendered in an iframe, so we need to get its reference.
-		// Sometimes the iframe is updated (or removed from the page),
-		// this function has been created so that we always get the most updated reference.
-		const getNewKlarnaIframe = async () => {
-			const klarnaFrameHandle = await page.waitForSelector(
-				'#klarna-apf-iframe'
-			);
+		await page.waitForSelector( '#phone' );
 
-			return await klarnaFrameHandle.contentFrame();
-		};
+		await page.waitFor( 2000 );
+		console.log( '1' );
 
-		let klarnaIframe = await getNewKlarnaIframe();
-
-		const frameNavigationHandler = async ( frame ) => {
-			if ( frame.url().includes( 'klarna.com' ) ) {
-				const newKlarnaIframe = await getNewKlarnaIframe();
-
-				if ( frame === newKlarnaIframe ) {
-					klarnaIframe = newKlarnaIframe;
-				}
-			}
-		};
-
-		// Add frame navigation event listener.
-		page.on( 'framenavigated', frameNavigationHandler );
-
-		// Waiting for the redirect & the Klarna iframe to load within the Stripe test page.
-		// this is the "confirm phone number" page - we just click "continue".
-		await klarnaIframe.waitForSelector( '#phone' );
-		await klarnaIframe
+		await page
 			.waitForSelector( '#onContinue' )
 			.then( ( button ) => button.click() );
 
+		await page.waitFor( 2000 );
+
 		// This is where the OTP code is entered.
-		await klarnaIframe.waitForSelector( '#phoneOtp' );
-		await expect( klarnaIframe ).toFill( 'input#otp_field', '123456' );
+		await page.waitForSelector( '#phoneOtp' );
+
+		await page.waitFor( 2000 );
+		console.log( '2' );
+
+		await expect( page ).toFill( 'input#otp_field', '123456' );
 
 		// Select Payment Plan - 4 weeks & click continue.
-		await klarnaIframe
+		await page
 			.waitForSelector( 'button#pay_over_time__label' )
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );
+		console.log( '3' );
 
-		await klarnaIframe
+		await page
 			.waitForSelector( 'button[data-testid="select-payment-category"' )
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );
+		console.log( '4' );
 
 		// Payment summary page. Click continue.
-		await klarnaIframe
+		await page
 			.waitForSelector( 'button[data-testid="pick-plan"]' )
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );
-
-		// At this point, the event listener is not needed anymore.
-		page.removeListener( 'framenavigated', frameNavigationHandler );
+		console.log( '5' );
 
 		await page.waitFor( 2000 );
 
 		// Confirm payment.
-		await klarnaIframe
+		await page
 			.waitForSelector( 'button#buy_button' )
 			.then( ( button ) => button.click() );
+
+		console.log( '6' );
 
 		// Wait for the order confirmation page to load.
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );
+
+		await page.waitForSelector( 'h1.entry-title' );
 
 		await expect( page ).toMatch( 'Order received' );
 	} );

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -105,7 +105,6 @@ describe( 'Klarna checkout', () => {
 		await page.waitForSelector( '#phone' );
 
 		await page.waitFor( 2000 );
-		console.log( '1' );
 
 		await page
 			.waitForSelector( '#onContinue' )
@@ -117,7 +116,6 @@ describe( 'Klarna checkout', () => {
 		await page.waitForSelector( '#phoneOtp' );
 
 		await page.waitFor( 2000 );
-		console.log( '2' );
 
 		await expect( page ).toFill( 'input#otp_field', '123456' );
 
@@ -127,14 +125,12 @@ describe( 'Klarna checkout', () => {
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );
-		console.log( '3' );
 
 		await page
 			.waitForSelector( 'button[data-testid="select-payment-category"' )
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );
-		console.log( '4' );
 
 		// Payment summary page. Click continue.
 		await page
@@ -142,16 +138,11 @@ describe( 'Klarna checkout', () => {
 			.then( ( button ) => button.click() );
 
 		await page.waitFor( 2000 );
-		console.log( '5' );
-
-		await page.waitFor( 2000 );
 
 		// Confirm payment.
 		await page
 			.waitForSelector( 'button#buy_button' )
 			.then( ( button ) => button.click() );
-
-		console.log( '6' );
 
 		// Wait for the order confirmation page to load.
 		await page.waitForNavigation( {


### PR DESCRIPTION
**Context:** This is a follow-up of https://github.com/Automattic/woocommerce-payments/pull/8858#issuecomment-2127767063 after Klarna tests started failing again due to changes in their test checkout flow.

### Changes proposed in this Pull Request

The Klarna test environment has been updated with new redirects after authentication.

This PR removes the `getNewKlarnaIframe` logic so redirects don't break the E2E test flow.

### Testing instructions

No testing is required, but ensure [the workflow run for this branch](https://github.com/Automattic/woocommerce-payments/actions/runs/9382238520/job/25833247511) passes for `wcpay - shopper` Klarna checkout spec by searching for the following log:

```
PASS tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
```

Notes:
- E2E Tests for `wcpay - shopper` are still failing in `shopper-checkout-failures.spec.js`.
- For some reason, the WC beta workflow is more flaky, but the test should pass in a second attempt.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
