### PR TITLE
Fix credit card input errors and checkout errors E2E tests

### DIFF
--- a/changelog/fix-specific-field-checkout-failures-e2e-tests
+++ b/changelog/fix-specific-field-checkout-failures-e2e-tests
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix input specific credit card errors.
+Fix input-specific credit card errors.

--- a/changelog/fix-specific-field-checkout-failures-e2e-tests
+++ b/changelog/fix-specific-field-checkout-failures-e2e-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix input specific credit card errors.

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -49,6 +49,8 @@ const getFraudPreventionToken = () => {
 	return window.wcpayFraudPreventionToken ?? '';
 };
 
+const noop = () => null;
+
 const PaymentProcessor = ( {
 	api,
 	activePaymentMethod,
@@ -60,7 +62,7 @@ const PaymentProcessor = ( {
 	errorMessage,
 	shouldSavePayment,
 	fingerprint,
-	onLoadError,
+	onLoadError = noop,
 } ) => {
 	const stripe = useStripe();
 	const elements = useElements();

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -49,8 +49,6 @@ const getFraudPreventionToken = () => {
 	return window.wcpayFraudPreventionToken ?? '';
 };
 
-const noop = () => null;
-
 const PaymentProcessor = ( {
 	api,
 	activePaymentMethod,
@@ -62,11 +60,11 @@ const PaymentProcessor = ( {
 	errorMessage,
 	shouldSavePayment,
 	fingerprint,
-	onLoadError = noop,
+	onLoadError,
 } ) => {
 	const stripe = useStripe();
 	const elements = useElements();
-	const isPaymentInformationCompleteRef = useRef( false );
+	const hasLoadErrorRef = useRef( false );
 
 	const paymentMethodsConfig = getUPEConfig( 'paymentMethodsConfig' );
 	const isTestMode = getUPEConfig( 'testMode' );
@@ -140,11 +138,11 @@ const PaymentProcessor = ( {
 						return;
 					}
 
-					if ( ! isPaymentInformationCompleteRef.current ) {
+					if ( hasLoadErrorRef.current ) {
 						return {
 							type: 'error',
 							message: __(
-								'Your payment information is incomplete.',
+								'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.',
 								'woocommerce-payments'
 							),
 						};
@@ -237,8 +235,9 @@ const PaymentProcessor = ( {
 		shouldSavePayment
 	);
 
-	const setPaymentInformationCompletionStatus = ( event ) => {
-		isPaymentInformationCompleteRef.current = event.complete;
+	const setHasLoadError = ( event ) => {
+		hasLoadErrorRef.current = true;
+		onLoadError( event );
 	};
 
 	return (
@@ -256,8 +255,7 @@ const PaymentProcessor = ( {
 					shouldSavePayment,
 					paymentMethodsConfig
 				) }
-				onLoadError={ onLoadError }
-				onChange={ setPaymentInformationCompletionStatus }
+				onLoadError={ setHasLoadError }
 				className="wcpay-payment-element"
 			/>
 		</>

--- a/client/checkout/classic/test/payment-processing.test.js
+++ b/client/checkout/classic/test/payment-processing.test.js
@@ -76,14 +76,6 @@ const mockCreateFunction = jest.fn( () => ( {
 		eventHandlersFromElementsCreate[ event ].push( handler );
 	},
 } ) );
-const callAllCreateHandlersWith = ( event, ...args ) => {
-	eventHandlersFromElementsCreate[ event ]?.forEach( ( handler ) => {
-		handler.apply( null, args );
-	} );
-};
-const markAllPaymentElementsAsComplete = () => {
-	callAllCreateHandlersWith( 'change', { complete: true } );
-};
 
 const mockSubmit = jest.fn( () => ( {
 	then: jest.fn(),
@@ -396,7 +388,6 @@ describe( 'Payment processing', () => {
 		mockDomElement.dataset.paymentMethodType = 'card';
 
 		await mountStripePaymentElement( apiMock, mockDomElement );
-		markAllPaymentElementsAsComplete();
 
 		const mockJqueryForm = {
 			submit: jest.fn(),
@@ -443,7 +434,6 @@ describe( 'Payment processing', () => {
 		mockDomElement.dataset.paymentMethodType = 'card';
 
 		await mountStripePaymentElement( apiMock, mockDomElement );
-		markAllPaymentElementsAsComplete();
 
 		const checkoutForm = {
 			submit: jest.fn(),
@@ -487,7 +477,6 @@ describe( 'Payment processing', () => {
 		mockDomElement.dataset.paymentMethodType = 'card';
 
 		await mountStripePaymentElement( apiMock, mockDomElement );
-		markAllPaymentElementsAsComplete();
 
 		const checkoutForm = {
 			submit: jest.fn(),
@@ -527,7 +516,6 @@ describe( 'Payment processing', () => {
 		mockDomElement.dataset.paymentMethodType = 'card';
 
 		await mountStripePaymentElement( apiMock, mockDomElement );
-		markAllPaymentElementsAsComplete();
 
 		const checkoutForm = {
 			submit: jest.fn(),
@@ -564,7 +552,6 @@ describe( 'Payment processing', () => {
 		mockDomElement.dataset.paymentMethodType = 'card';
 
 		await mountStripePaymentElement( apiMock, mockDomElement );
-		markAllPaymentElementsAsComplete();
 
 		const checkoutForm = {
 			submit: jest.fn(),
@@ -599,7 +586,6 @@ describe( 'Payment processing', () => {
 		mockDomElement.dataset.paymentMethodType = 'card';
 
 		await mountStripePaymentElement( apiMock, mockDomElement );
-		markAllPaymentElementsAsComplete();
 
 		const addPaymentMethodForm = {
 			submit: jest.fn(),


### PR DESCRIPTION
### Description
The objective of this PR is two-fold:
1. Bring back input-specific credit card errors.
2. Fix `shopper-checkout-failures` E2E tests.

### Changes proposed in this Pull Request

- Only display an error message if Stripe Payment Element fails to load, instead of missing payment information.
- Use the previous copy for the error message ("Invalid or missing payment details"), since it is more in line with the current approach.
- Fix tests.

### Testing instructions

**Test 1: Ensure input-specific credit card errors are displayed again**

1. As a shopper, add a product to the cart.
4. Navigate to the checkout page.
5. Without filling out the credit card form, click "Place order".
6. Ensure you see input-specific errors as shown in the screenshot below.
7. Please test the same in classic, blocks checkout and ["Pay for order" flow](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#pay-for-order).

<img width="299" alt="input-specific-cc-errors" src="https://github.com/Automattic/woocommerce-payments/assets/5509901/54790624-ca84-4a0f-98b1-c5e67c5e6884">


**Test 2: Ensure there's no regression with +1M value error**

Please follow the instructions from #8793 and ensure the notice still appears for carts with over 1M in value.

**Test 3: Ensure shopper-checkout-failures E2E test spec passes**

No manual testing is required.

Ensure the [E2E Tests - All](https://github.com/Automattic/woocommerce-payments/actions/runs/9386098533/job/25845826685) workflow passes in this branch for the shopper checkout failures spec by looking for this log:

```
PASS tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
```

Note: Other test specs are still failing.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
