### PR TITLE
Reporting: Preset date range selector for payment gateway widget

### DIFF
--- a/changelog/add-1-8482-preset-date-selector-for-payment-widget
+++ b/changelog/add-1-8482-preset-date-selector-for-payment-widget
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Behind feature flag - Add a preset date range selector with basic UI to the header of payment activity widget
+
+

--- a/client/components/payment-activity/date-range.tsx
+++ b/client/components/payment-activity/date-range.tsx
@@ -10,14 +10,30 @@ import * as React from 'react';
 import './style.scss';
 
 interface Props {
-	start: string;
-	end: string;
+	start: moment.Moment | undefined;
+	end: moment.Moment | undefined;
 }
 
 const DateRange: React.FC< Props > = ( { start, end } ) => {
+	//Today
+	if ( start?.isSame( end, 'day' ) ) {
+		return <>{ start.format( 'MMMM D, YYYY' ) }</>;
+	}
+
+	// different year
+	if ( ! start?.isSame( end, 'year' ) ) {
+		return (
+			<>
+				{ start?.format( 'MMMM D, YYYY' ) } -{ ' ' }
+				{ end?.format( 'MMMM D, YYYY' ) }
+			</>
+		);
+	}
+
+	// Different year
 	return (
 		<>
-			{ start } - { end }
+			{ start?.format( 'MMMM D' ) } - { end?.format( 'MMMM D, YYYY' ) }
 		</>
 	);
 };

--- a/client/components/payment-activity/date-range.tsx
+++ b/client/components/payment-activity/date-range.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+import './style.scss';
+
+interface Props {
+	start: string;
+	end: string;
+}
+
+const DateRange: React.FC< Props > = ( { start, end } ) => {
+	return (
+		<>
+			{ start } - { end }
+		</>
+	);
+};
+
+export default DateRange;

--- a/client/components/payment-activity/date-range.tsx
+++ b/client/components/payment-activity/date-range.tsx
@@ -15,12 +15,12 @@ interface Props {
 }
 
 const DateRange: React.FC< Props > = ( { start, end } ) => {
-	//Today
+	// Today - show only today's date with no end date
 	if ( start?.isSame( end, 'day' ) ) {
 		return <>{ start.format( 'MMMM D, YYYY' ) }</>;
 	}
 
-	// different year
+	// Different year - show year for both start and end
 	if ( ! start?.isSame( end, 'year' ) ) {
 		return (
 			<>
@@ -30,7 +30,7 @@ const DateRange: React.FC< Props > = ( { start, end } ) => {
 		);
 	}
 
-	// Different year
+	// Same year - show year only once
 	return (
 		<>
 			{ start?.format( 'MMMM D' ) } - { end?.format( 'MMMM D, YYYY' ) }

--- a/client/components/payment-activity/index.tsx
+++ b/client/components/payment-activity/index.tsx
@@ -31,9 +31,6 @@ interface DateRangeProps {
 	end: moment.Moment | undefined;
 }
 
-const { lifetimeTPV } = wcpaySettings;
-const hasAtLeastOnePayment = lifetimeTPV > 0;
-
 const PaymentActivityEmptyState: React.FC = () => (
 	<Card>
 		<CardHeader>
@@ -66,6 +63,8 @@ const PaymentActivityEmptyState: React.FC = () => (
 const PaymentActivity: React.FC = () => {
 	const isOverviewSurveySubmitted =
 		wcpaySettings.isOverviewSurveySubmitted ?? false;
+
+	//const hasAtLeastOnePayment = wcpaySettings.lifetimeTPV > 0;
 
 	const yesterdayEndOfDay = moment()
 		.clone()
@@ -205,7 +204,11 @@ const PaymentActivity: React.FC = () => {
 				break;
 			}
 			case 'all_time':
-				// TODO
+				start = moment(
+					wcpaySettings.accountStatus.created,
+					'YYYY-MM-DD HH:mm:ss'
+				);
+				end = todayEndOfDay;
 				break;
 		}
 
@@ -233,10 +236,12 @@ const PaymentActivity: React.FC = () => {
 
 	return (
 		<Card>
-			<CardHeader>
-				{ __( 'Your payment activity', 'woocommerce-payments' ) }
+			<CardHeader className="wcpay-payment-activity__card__header">
+				<h1>
+					{ __( 'Your payment activity', 'woocommerce-payments' ) }
+				</h1>
 
-				{ hasAtLeastOnePayment && (
+				{ wcpaySettings.lifetimeTPV > 0 && (
 					<>
 						<Flex className="wcpay-payment-activity-filters">
 							<SelectControl
@@ -281,7 +286,8 @@ const PaymentActivity: React.FC = () => {
 };
 
 const PaymentActivityWrapper: React.FC = () => {
-	if ( ! hasAtLeastOnePayment ) {
+	//const hasAtLeastOnePayment = wcpaySettings.lifetimeTPV > 0;
+	if ( wcpaySettings.lifetimeTPV <= 0 ) {
 		return <PaymentActivityEmptyState />;
 	}
 

--- a/client/components/payment-activity/index.tsx
+++ b/client/components/payment-activity/index.tsx
@@ -64,8 +64,6 @@ const PaymentActivity: React.FC = () => {
 	const isOverviewSurveySubmitted =
 		wcpaySettings.isOverviewSurveySubmitted ?? false;
 
-	//const hasAtLeastOnePayment = wcpaySettings.lifetimeTPV > 0;
-
 	const yesterdayEndOfDay = moment()
 		.clone()
 		.subtract( 1, 'd' )
@@ -133,7 +131,7 @@ const PaymentActivity: React.FC = () => {
 				start = now
 					.clone()
 					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
-				end = yesterdayEndOfDay;
+				end = todayEndOfDay;
 				break;
 			}
 			case 'last_7_days': {
@@ -240,34 +238,17 @@ const PaymentActivity: React.FC = () => {
 				<h1>
 					{ __( 'Your payment activity', 'woocommerce-payments' ) }
 				</h1>
-
-				{ wcpaySettings.lifetimeTPV > 0 && (
-					<>
-						<Flex className="wcpay-payment-activity-filters">
-							<SelectControl
-								value={ dateRangePresetState }
-								onChange={ dateRangePresetOnChangeHandler }
-								options={ dateRangePresets }
-							/>
-							<DateRange
-								start={
-									dateRangeState.start
-										? dateRangeState.start.format(
-												'MMMM D'
-										  )
-										: ''
-								}
-								end={
-									dateRangeState.end
-										? dateRangeState.end.format(
-												'MMMM D, YYYY'
-										  )
-										: ''
-								}
-							/>
-						</Flex>
-					</>
-				) }
+				<Flex className="wcpay-payment-activity-filters">
+					<SelectControl
+						value={ dateRangePresetState }
+						onChange={ dateRangePresetOnChangeHandler }
+						options={ dateRangePresets }
+					/>
+					<DateRange
+						start={ dateRangeState.start }
+						end={ dateRangeState.end }
+					/>
+				</Flex>
 			</CardHeader>
 			<CardBody className="wcpay-payment-activity__card__body">
 				<PaymentActivityDataComponent
@@ -286,7 +267,6 @@ const PaymentActivity: React.FC = () => {
 };
 
 const PaymentActivityWrapper: React.FC = () => {
-	//const hasAtLeastOnePayment = wcpaySettings.lifetimeTPV > 0;
 	if ( wcpaySettings.lifetimeTPV <= 0 ) {
 		return <PaymentActivityEmptyState />;
 	}

--- a/client/components/payment-activity/index.tsx
+++ b/client/components/payment-activity/index.tsx
@@ -2,7 +2,14 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from 'react';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	Flex,
+	SelectControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import moment from 'moment';
@@ -11,26 +18,21 @@ import moment from 'moment';
  * Internal dependencies
  */
 
+import DateRange from './date-range';
 import EmptyStateAsset from 'assets/images/payment-activity-empty-state.svg?asset';
 import PaymentActivityDataComponent from './payment-activity-data';
 import Survey from './survey';
 import { WcPayOverviewSurveyContextProvider } from './survey/context';
 import { usePaymentActivityData } from 'wcpay/data';
-import type { DateRange } from './types';
 import './style.scss';
 
-/**
- * This will be replaces in the future with a dynamic date range picker.
- */
-const getDateRange = (): DateRange => {
-	return {
-		// Subtract 7 days from the current date.
-		date_start: moment()
-			.subtract( 7, 'd' )
-			.format( 'YYYY-MM-DD\\THH:mm:ss' ),
-		date_end: moment().format( 'YYYY-MM-DD\\THH:mm:ss' ),
-	};
-};
+interface DateRangeProps {
+	start: moment.Moment | undefined;
+	end: moment.Moment | undefined;
+}
+
+const { lifetimeTPV } = wcpaySettings;
+const hasAtLeastOnePayment = lifetimeTPV > 0;
 
 const PaymentActivityEmptyState: React.FC = () => (
 	<Card>
@@ -65,8 +67,158 @@ const PaymentActivity: React.FC = () => {
 	const isOverviewSurveySubmitted =
 		wcpaySettings.isOverviewSurveySubmitted ?? false;
 
+	const yesterdayEndOfDay = moment()
+		.clone()
+		.subtract( 1, 'd' )
+		.set( { hour: 23, minute: 59, second: 59, millisecond: 0 } );
+
+	const todayEndOfDay = moment()
+		.clone()
+		.set( { hour: 23, minute: 59, second: 59, millisecond: 0 } );
+
+	const [ dateRangeState, setDateRangeState ] = useState( {
+		start: moment().clone().subtract( 7, 'd' ),
+		end: yesterdayEndOfDay,
+	} as DateRangeProps );
+
+	const [ dateRangePresetState, setDateRangePresetState ] = useState(
+		'last_7_days'
+	);
+
+	const dateRangePresets = [
+		{
+			value: 'today',
+			label: 'Today',
+		},
+		{
+			value: 'last_7_days',
+			label: 'Last 7 days',
+		},
+		{
+			value: 'last_4_weeks',
+			label: 'Last 4 weeks',
+		},
+		{
+			value: 'last_3_months',
+			label: 'Last 3 months',
+		},
+		{
+			value: 'last_12_months',
+			label: 'Last 12 months',
+		},
+		{
+			value: 'month_to_date',
+			label: 'Month to date',
+		},
+		{
+			value: 'quarter_to_date',
+			label: 'Quarter to date',
+		},
+		{
+			value: 'year_to_date',
+			label: 'Year to date',
+		},
+		{
+			value: 'all_time',
+			label: 'All time',
+		},
+	];
+
+	const dateRangePresetOnChangeHandler = ( newDateRangePreset: string ) => {
+		let start, end;
+		const now = moment();
+		setDateRangePresetState( newDateRangePreset );
+
+		switch ( newDateRangePreset ) {
+			case 'today': {
+				start = now
+					.clone()
+					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
+				end = yesterdayEndOfDay;
+				break;
+			}
+			case 'last_7_days': {
+				start = now
+					.clone()
+					.subtract( 7, 'd' )
+					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
+				end = yesterdayEndOfDay;
+				break;
+			}
+			case 'last_4_weeks': {
+				start = now
+					.clone()
+					.subtract( 4, 'w' )
+					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
+				end = yesterdayEndOfDay;
+				break;
+			}
+			case 'last_3_months': {
+				start = now
+					.clone()
+					.subtract( 3, 'm' )
+					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
+				end = yesterdayEndOfDay;
+				break;
+			}
+			case 'last_12_months': {
+				start = now
+					.clone()
+					.subtract( 12, 'm' )
+					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
+				end = yesterdayEndOfDay;
+				break;
+			}
+			case 'month_to_date': {
+				start = now.clone().set( {
+					date: 1,
+					hour: 0,
+					minute: 0,
+					second: 0,
+					millisecond: 0,
+				} );
+				end = todayEndOfDay;
+				break;
+			}
+			case 'quarter_to_date': {
+				start = now.clone().set( {
+					month: Math.floor( now.month() / 3 ) * 3,
+					date: 1,
+					hour: 0,
+					minute: 0,
+					second: 0,
+					millisecond: 0,
+				} );
+				end = todayEndOfDay;
+				break;
+			}
+			case 'year_to_date': {
+				start = now.clone().set( {
+					month: 0,
+					date: 1,
+					hour: 0,
+					minute: 0,
+					second: 0,
+					millisecond: 0,
+				} );
+				end = todayEndOfDay;
+				break;
+			}
+			case 'all_time':
+				// TODO
+				break;
+		}
+
+		setDateRangeState( { start, end } );
+	};
+
 	const { paymentActivityData, isLoading } = usePaymentActivityData( {
-		...getDateRange(),
+		date_start: dateRangeState.start
+			? dateRangeState.start.format( 'YYYY-MM-DDTHH:mm:ss' )
+			: '',
+		date_end: dateRangeState.end
+			? dateRangeState.end.format( 'YYYY-MM-DDTHH:mm:ss' )
+			: '',
 		timezone: moment( new Date() ).format( 'Z' ),
 	} );
 
@@ -83,7 +235,34 @@ const PaymentActivity: React.FC = () => {
 		<Card>
 			<CardHeader>
 				{ __( 'Your payment activity', 'woocommerce-payments' ) }
-				{ /* Filters go here */ }
+
+				{ hasAtLeastOnePayment && (
+					<>
+						<Flex className="wcpay-payment-activity-filters">
+							<SelectControl
+								value={ dateRangePresetState }
+								onChange={ dateRangePresetOnChangeHandler }
+								options={ dateRangePresets }
+							/>
+							<DateRange
+								start={
+									dateRangeState.start
+										? dateRangeState.start.format(
+												'MMMM D'
+										  )
+										: ''
+								}
+								end={
+									dateRangeState.end
+										? dateRangeState.end.format(
+												'MMMM D, YYYY'
+										  )
+										: ''
+								}
+							/>
+						</Flex>
+					</>
+				) }
 			</CardHeader>
 			<CardBody className="wcpay-payment-activity__card__body">
 				<PaymentActivityDataComponent
@@ -102,9 +281,6 @@ const PaymentActivity: React.FC = () => {
 };
 
 const PaymentActivityWrapper: React.FC = () => {
-	const { lifetimeTPV } = wcpaySettings;
-	const hasAtLeastOnePayment = lifetimeTPV > 0;
-
 	if ( ! hasAtLeastOnePayment ) {
 		return <PaymentActivityEmptyState />;
 	}

--- a/client/components/payment-activity/index.tsx
+++ b/client/components/payment-activity/index.tsx
@@ -137,7 +137,7 @@ const PaymentActivity: React.FC = () => {
 			case 'last_7_days': {
 				start = now
 					.clone()
-					.subtract( 7, 'd' )
+					.subtract( 7, 'days' )
 					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
 				end = yesterdayEndOfDay;
 				break;
@@ -145,7 +145,7 @@ const PaymentActivity: React.FC = () => {
 			case 'last_4_weeks': {
 				start = now
 					.clone()
-					.subtract( 4, 'w' )
+					.subtract( 4, 'weeks' )
 					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
 				end = yesterdayEndOfDay;
 				break;
@@ -153,7 +153,7 @@ const PaymentActivity: React.FC = () => {
 			case 'last_3_months': {
 				start = now
 					.clone()
-					.subtract( 3, 'm' )
+					.subtract( 3, 'months' )
 					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
 				end = yesterdayEndOfDay;
 				break;
@@ -161,7 +161,7 @@ const PaymentActivity: React.FC = () => {
 			case 'last_12_months': {
 				start = now
 					.clone()
-					.subtract( 12, 'm' )
+					.subtract( 12, 'months' )
 					.set( { hour: 0, minute: 0, second: 0, millisecond: 0 } );
 				end = yesterdayEndOfDay;
 				break;

--- a/client/components/payment-activity/style.scss
+++ b/client/components/payment-activity/style.scss
@@ -15,6 +15,24 @@
 
 .wcpay-payment-activity {
 	&__card {
+		&__header {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			gap: 5px;
+
+			h1 {
+				flex-basis: 100%;
+				font-size: 20px;
+			}
+
+			.components-flex {
+				justify-content: flex-end;
+				font-size: 13px;
+				gap: 5px;
+			}
+		}
+
 		&__body {
 			padding: 0 !important;
 			&__empty-state-wrapper {

--- a/client/components/payment-activity/style.scss
+++ b/client/components/payment-activity/style.scss
@@ -27,9 +27,7 @@
 			}
 
 			.components-flex {
-				justify-content: flex-end;
 				font-size: 13px;
-				gap: 5px;
 			}
 		}
 

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -11,11 +11,119 @@ exports[`PaymentActivity component should render 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-flex components-card__header components-card-header css-1g5oj2q-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium em57xhy0"
+        class="components-flex components-card__header components-card-header wcpay-payment-activity__card__header css-1g5oj2q-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardHeader"
       >
-        Your payment activity
+        <h1>
+          Your payment activity
+        </h1>
+        <div
+          class="components-flex wcpay-payment-activity-filters css-1giw1wa-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="Flex"
+        >
+          <div
+            class="components-base-control css-wdf2ti-Wrapper ej5x27r4"
+          >
+            <div
+              class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+            >
+              <div
+                class="components-flex components-select-control em5sgkm7 css-c0mqng-View-Flex-sx-Base-sx-Items-ItemsColumn-Root-rootLabelPositionStyles em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Flex"
+              >
+                <div
+                  class="components-flex-item em5sgkm3 css-1fmchc6-View-Item-sx-Base-LabelWrapper em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="FlexItem"
+                />
+                <div
+                  class="components-input-control__container css-1sy20aj-Container-containerDisabledStyles-containerMarginStyles-containerWidthStyles em5sgkm6"
+                >
+                  <select
+                    class="components-select-control__input css-t4qksx-Select-fontSizeStyles-sizeStyles e1mv6sxx1"
+                    id="inspector-select-control-0"
+                  >
+                    <option
+                      value="today"
+                    >
+                      Today
+                    </option>
+                    <option
+                      value="last_7_days"
+                    >
+                      Last 7 days
+                    </option>
+                    <option
+                      value="last_4_weeks"
+                    >
+                      Last 4 weeks
+                    </option>
+                    <option
+                      value="last_3_months"
+                    >
+                      Last 3 months
+                    </option>
+                    <option
+                      value="last_12_months"
+                    >
+                      Last 12 months
+                    </option>
+                    <option
+                      value="month_to_date"
+                    >
+                      Month to date
+                    </option>
+                    <option
+                      value="quarter_to_date"
+                    >
+                      Quarter to date
+                    </option>
+                    <option
+                      value="year_to_date"
+                    >
+                      Year to date
+                    </option>
+                    <option
+                      value="all_time"
+                    >
+                      All time
+                    </option>
+                  </select>
+                  <span
+                    class="components-input-control__suffix css-oobb1x-Suffix em5sgkm0"
+                  >
+                    <div
+                      class="css-1einvap-DownArrowWrapper e1mv6sxx0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        focusable="false"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        width="18"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                        />
+                      </svg>
+                    </div>
+                  </span>
+                  <div
+                    aria-hidden="true"
+                    class="components-input-control__backdrop css-1gb9p1j-BackdropUI-backdropFocusedStyles em5sgkm2"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          April 1
+           - 
+          April 7, 2024
+        </div>
       </div>
       <div
         class="components-card__body components-card-body wcpay-payment-activity__card__body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -8,7 +8,7 @@ import { render } from '@testing-library/react';
  * Internal dependencies
  */
 import { usePaymentActivityData } from 'wcpay/data';
-import PaymentActivity from '..';
+import PaymentActivityWrapper from '..';
 
 jest.mock( '@wordpress/data', () => ( {
 	createRegistryControl: jest.fn(),
@@ -123,7 +123,7 @@ describe( 'PaymentActivity component', () => {
 
 	it( 'should render', () => {
 		const { container, getByText, getByLabelText } = render(
-			<PaymentActivity />
+			<PaymentActivityWrapper />
 		);
 
 		// Check survey is rendered.
@@ -139,7 +139,7 @@ describe( 'PaymentActivity component', () => {
 	it( 'should render an empty state', () => {
 		global.wcpaySettings.lifetimeTPV = 0;
 
-		const { container, getByText } = render( <PaymentActivity /> );
+		const { container, getByText } = render( <PaymentActivityWrapper /> );
 
 		expect( getByText( 'No payments…yet!' ) ).toBeInTheDocument();
 		expect( container ).toMatchSnapshot();
@@ -148,7 +148,7 @@ describe( 'PaymentActivity component', () => {
 	it( 'should not render survey if survey is already submitted', () => {
 		global.wcpaySettings.isOverviewSurveySubmitted = true;
 
-		const { queryByText } = render( <PaymentActivity /> );
+		const { queryByText } = render( <PaymentActivityWrapper /> );
 
 		expect(
 			queryByText( 'Are these metrics helpful?' )

--- a/client/components/payment-activity/types.ts
+++ b/client/components/payment-activity/types.ts
@@ -1,4 +1,0 @@
-export interface DateRange {
-	date_start: string; // Start date
-	date_end: string; // End date
-}


### PR DESCRIPTION
Fixes part of  #8734

#### Changes proposed in this Pull Request

* Add a basic date preset dropdown 
* Selecting the options should render a label with exact date ranges 

#### What is not covered
* Updation of the payment activity data shown below in reference to the dropdown change
* The final UI that resembles the design is being [developed separately](https://github.com/Automattic/woocommerce-payments/pull/8896). It will be integrated once it is reviewed and merged in a separate PR. 

#### Testing instructions
* Make sure the feature flag - `_wcpay_feature_payment_overview_widget`  is enabled
* Checkout this branch
* Make sure you see the date range selection dropdown to the top right of the widget
  * Try out various options and make sure the dates
  * Selecting `Today` should show only today's date and no end date ( check screenshot )
  * Select `Last 12 months` - It should show the year on both start and end date, since the years are different
 

#### Screenshots

##### Today 
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/3663dee8-41c1-4d17-9900-1d9229bad8f4)

##### Different year for start and end
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/c1577961-03fc-400a-86d2-3c0710f8362a)

##### Same year for start and end
![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/216f317b-b654-4388-941d-1c8d0a4ed0ec)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
