### PR TITLE
Revert "Disable WooPay for suspended and rejected accounts (#8857)"

### DIFF
--- a/changelog/as-disable-woopay-rejected-suspended-accounts
+++ b/changelog/as-disable-woopay-rejected-suspended-accounts
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Disable WooPay for suspended and rejected accounts.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -210,15 +210,7 @@ class WC_Payments_Features {
 
 		// read directly from cache, ignore cache expiration check.
 		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
-
-		$is_account_rejected = WC_Payments::get_account_service()->is_account_rejected();
-
-		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
-
-		return is_array( $account )
-			&& ( $account['platform_checkout_eligible'] ?? false )
-			&& ! $is_account_rejected
-			&& ! $is_account_under_review;
+		return is_array( $account ) && ( $account['platform_checkout_eligible'] ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -570,9 +570,7 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error every time the account cache is refreshed,
-		// given that $wp_rewrite is defined right after the `plugins_loaded` action is fired. See #8857.
-		add_action( 'setup_theme', [ __CLASS__, 'maybe_register_woopay_hooks' ] );
+		self::maybe_register_woopay_hooks();
 
 		self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
 		self::$apple_pay_registration->init_hooks();
@@ -1504,7 +1502,6 @@ class WC_Payments {
 
 	/**
 	 * Registers woopay hooks if the woopay feature flag is enabled.
-	 * Removes WooPay webhooks if the merchant is not eligible.
 	 *
 	 * @return void
 	 */
@@ -1554,8 +1551,6 @@ class WC_Payments {
 			}
 
 			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
-		} else {
-			WooPay_Order_Status_Sync::remove_webhook();
 		}
 	}
 

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -18,13 +18,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	 */
 	protected $mock_cache;
 
-	/**
-	 * Mock WC_Payments_Account.
-	 *
-	 * @var WC_Payments_Account|MockObject
-	 */
-	private $mock_wcpay_account;
-
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
 		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
 		'_wcpay_feature_documents'               => 'documents',
@@ -36,17 +29,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->_cache     = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
 		WC_Payments::set_database_cache( $this->mock_cache );
-
-		// Mock the WCPay Account class to make sure the account is not restricted by default.
-		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
-		$this->mock_wcpay_account
-			->method( 'is_account_rejected' )
-			->willReturn( false );
-		$this->mock_wcpay_account
-			->method( 'is_account_under_review' )
-			->willReturn( false );
-
-		WC_Payments::set_account_service( $this->mock_wcpay_account );
 	}
 
 	public function tear_down() {
@@ -106,32 +88,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_woopay_eligible_returns_false() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
-		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
-	}
-
-	public function test_is_woopay_eligible_when_account_is_suspended_returns_false() {
-		$mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
-		$mock_wcpay_account
-			->method( 'is_account_under_review' )
-			->willReturn( true );
-
-		WC_Payments::set_account_service( $mock_wcpay_account );
-
-		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
-
-		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
-	}
-
-	public function test_is_woopay_eligible_when_account_is_rejected_returns_false() {
-		$mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
-		$mock_wcpay_account
-			->method( 'is_account_rejected' )
-			->willReturn( true );
-
-		WC_Payments::set_account_service( $mock_wcpay_account );
-
-		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
-
 		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
 	}
 


### PR DESCRIPTION
This reverts commit 8aa455c724e3eeaa7a31bbe536b6266296b0592a.

Reverting the PR because is causing a fatal PHP error. It seems to happen when the Account cache expires. I'll work on a fix later.

Stack trace:

```
:  Uncaught Error: Call to a member function get_page_permastruct() on null in /Users/asumaran/valet/wcpay/wp-includes/link-template.php:434
Stack trace:
#0 /Users/asumaran/valet/wcpay/wp-includes/link-template.php(397): _get_page_link(Object(WP_Post), false, false)
#1 /Users/asumaran/valet/wcpay/wp-includes/link-template.php(197): get_page_link(Object(WP_Post), false, false)
#2 /Users/asumaran/Developer/woocommerce-payments/includes/class-compatibility-service.php(80): get_permalink(Object(WP_Post))
#3 /Users/asumaran/Developer/woocommerce-payments/includes/class-compatibility-service.php(53): WCPay\Compatibility_Service->get_compatibility_data()
#4 /Users/asumaran/valet/wcpay/wp-includes/class-wp-hook.php(324): WCPay\Compatibility_Service->update_compatibility_data(Array)
#5 /Users/asumaran/valet/wcpay/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#6 /Users/asumaran/valet/wcpay/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#7 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments-account.php(1666): do_action('woocommerce_pay...', Array)
#8 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments-account.php(185): WC_Payments_Account->get_cached_account_data()
#9 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments-account.php(172): WC_Payments_Account->try_is_stripe_connected()
#10 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments-account.php(224): WC_Payments_Account->is_stripe_connected()
#11 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments-features.php(214): WC_Payments_Account->is_account_rejected()
#12 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments-woopay-button-handler.php(112): WC_Payments_Features::is_woopay_eligible()
#13 /Users/asumaran/Developer/woocommerce-payments/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php(91): WC_Payments_WooPay_Button_Handler->init()
#14 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments.php(1646): WC_Payments_Express_Checkout_Button_Display_Handler->init()
#15 /Users/asumaran/Developer/woocommerce-payments/includes/class-wc-payments.php(583): WC_Payments::maybe_display_express_checkout_buttons()
#16 /Users/asumaran/Developer/woocommerce-payments/woocommerce-payments.php(165): WC_Payments::init()
#17 /Users/asumaran/valet/wcpay/wp-includes/class-wp-hook.php(324): wcpay_init('')
#18 /Users/asumaran/valet/wcpay/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#19 /Users/asumaran/valet/wcpay/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#20 /Users/asumaran/valet/wcpay/wp-settings.php(550): do_action('plugins_loaded')
#21 /Users/asumaran/valet/wcpay/wp-config.php(206): require_once('/Users/asumaran...')
#22 /Users/asumaran/valet/wcpay/wp-load.php(50): require_once('/Users/asumaran...')
#23 /Users/asumaran/valet/wcpay/wp-admin/admin.php(34): require_once('/Users/asumaran...')
#24 /Users/asumaran/valet/wcpay/wp-admin/index.php(10): require_once('/Users/asumaran...')
#25 /Users/asumaran/.composer/vendor/laravel/valet/server.php(138): require('/Users/asumaran...')
#26 {main}
  thrown in /Users/asumaran/valet/wcpay/wp-includes/link-template.php
```