### PR TITLE
Payment Activity data refreshes with currency selection

### DIFF
--- a/changelog/add-8490-payment-activity-currency-selector
+++ b/changelog/add-8490-payment-activity-currency-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Behind a feature flag. Payment Activity Card updates according to currency selection.
+
+

--- a/client/components/payment-activity/index.tsx
+++ b/client/components/payment-activity/index.tsx
@@ -69,8 +69,6 @@ const PaymentActivity: React.FC = () => {
 	const { selectedCurrency } = useSelectedCurrency();
 
 	const { paymentActivityData, isLoading } = usePaymentActivityData( {
-		// In future this will be bound to currency picker via useSelectedCurrency().
-		// Can hard-code other store settings to test.
 		currency: selectedCurrency ?? wcpaySettings.accountDefaultCurrency,
 		...getDateRange(),
 		timezone: moment( new Date() ).format( 'Z' ),

--- a/client/components/payment-activity/index.tsx
+++ b/client/components/payment-activity/index.tsx
@@ -16,6 +16,7 @@ import PaymentActivityDataComponent from './payment-activity-data';
 import Survey from './survey';
 import { WcPayOverviewSurveyContextProvider } from './survey/context';
 import { usePaymentActivityData } from 'wcpay/data';
+import { useSelectedCurrency } from 'wcpay/overview/hooks';
 import type { DateRange } from './types';
 import './style.scss';
 
@@ -65,10 +66,12 @@ const PaymentActivity: React.FC = () => {
 	const isOverviewSurveySubmitted =
 		wcpaySettings.isOverviewSurveySubmitted ?? false;
 
+	const { selectedCurrency } = useSelectedCurrency();
+
 	const { paymentActivityData, isLoading } = usePaymentActivityData( {
 		// In future this will be bound to currency picker via useSelectedCurrency().
 		// Can hard-code other store settings to test.
-		currency: wcpaySettings.accountDefaultCurrency,
+		currency: selectedCurrency ?? wcpaySettings.accountDefaultCurrency,
 		...getDateRange(),
 		timezone: moment( new Date() ).format( 'Z' ),
 	} );

--- a/client/data/payment-activity/hooks.ts
+++ b/client/data/payment-activity/hooks.ts
@@ -14,11 +14,16 @@ import { PaymentActivityState, PaymentActivityQuery } from './types';
 export const usePaymentActivityData = (
 	query: PaymentActivityQuery
 ): PaymentActivityState =>
-	useSelect( ( select ) => {
-		const { getPaymentActivityData, isResolving } = select( STORE_NAME );
+	useSelect(
+		( select ) => {
+			const { getPaymentActivityData, isResolving } = select(
+				STORE_NAME
+			);
 
-		return {
-			paymentActivityData: getPaymentActivityData( query ),
-			isLoading: isResolving( 'getPaymentActivityData', [ query ] ),
-		};
-	}, [] );
+			return {
+				paymentActivityData: getPaymentActivityData( query ),
+				isLoading: isResolving( 'getPaymentActivityData', [ query ] ),
+			};
+		},
+		[ query.currency ]
+	);


### PR DESCRIPTION
Fixes #8490 

#### Changes proposed in this Pull Request
- PaymentActivityData component is refreshed when currency is selected
- works with both Balance Tabs design and [new currency switcher design](https://github.com/Automattic/woocommerce-payments/pull/8791)

#### Testing instructions
Test that payment activity card updates with the correct data when  currency switcher.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
