### PR TITLE
fix: itemized totals & pending amount on tokenized cart

### DIFF
--- a/changelog/fix-pending-amount-missing-itemized-totals
+++ b/changelog/fix-pending-amount-missing-itemized-totals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: itemized totals & pending amount on tokenized cart

--- a/client/tokenized-payment-request/transformers/wc-to-stripe.js
+++ b/client/tokenized-payment-request/transformers/wc-to-stripe.js
@@ -13,26 +13,28 @@ import { __ } from '@wordpress/i18n';
 export const transformCartDataForDisplayItems = ( cartData ) => {
 	const displayItems = cartData.items.map( ( item ) => ( {
 		amount: parseInt( item.prices.price, 10 ),
-		// TODO: should we also add variation attributes?
+		// TODO: should we also add variation attributes to the description?
 		label: [ item.name, item.quantity > 1 && ` (x${ item.quantity })` ]
 			.filter( Boolean )
 			.join( '' ),
-		pending: true,
 	} ) );
 
-	if ( cartData.totals.total_tax ) {
+	const taxAmount = parseInt( cartData.totals.total_tax || '0', 10 );
+	if ( taxAmount ) {
 		displayItems.push( {
-			amount: parseInt( cartData.totals.total_tax, 10 ),
+			amount: taxAmount,
 			label: __( 'Tax', 'woocommerce-payments' ),
-			pending: true,
 		} );
 	}
 
-	if ( cartData.totals.total_shipping ) {
+	const shippingAmount = parseInt(
+		cartData.totals.total_shipping || '0',
+		10
+	);
+	if ( shippingAmount ) {
 		displayItems.push( {
-			amount: parseInt( cartData.totals.total_shipping, 10 ),
+			amount: shippingAmount,
 			label: __( 'Shipping', 'woocommerce-payments' ),
-			pending: true,
 		} );
 	}
 

--- a/client/tokenized-payment-request/transformers/wc-to-stripe.js
+++ b/client/tokenized-payment-request/transformers/wc-to-stripe.js
@@ -13,10 +13,19 @@ import { __ } from '@wordpress/i18n';
 export const transformCartDataForDisplayItems = ( cartData ) => {
 	const displayItems = cartData.items.map( ( item ) => ( {
 		amount: parseInt( item.prices.price, 10 ),
-		// TODO: should we also add variation attributes to the description?
-		label: [ item.name, item.quantity > 1 && ` (x${ item.quantity })` ]
+		label: [
+			item.name,
+			item.quantity > 1 && `(x${ item.quantity })`,
+			item.variation &&
+				item.variation
+					.map(
+						( variation ) =>
+							`${ variation.attribute }: ${ variation.value }`
+					)
+					.join( ', ' ),
+		]
 			.filter( Boolean )
-			.join( '' ),
+			.join( ' ' ),
 	} ) );
 
 	const taxAmount = parseInt( cartData.totals.total_tax || '0', 10 );


### PR DESCRIPTION
Fixes part of https://github.com/Automattic/woocommerce-payments/issues/8841

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The itemized totals sometimes weren't displayed.
It turns out that the issue is with a combination of "pending" amount and wrong `parseInt`.

I was doing things like `if ( attribute ) {...parseInt(attribute, 10)}`.
The problem is that `if( '0' )` (`if` on string with `0`) returns `true`. Which makes sense.

So I moved the `parseInt` outside of the `if(...)` check.
Now the `if` check is checking for the parsed value. In case of `0`, it returns `false).

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the "Enable Cart-Token implementation for PRBs" flag in your dev tools (you'll need to update them)
- Ensure you have Google Pay/Apple Pay enabled in the merchant's settings
- Go to a **variable** product page on your site
- Change the selected attribute of the variable product
- Click on the PRB button
- The itemized amount should be displayed (click the info icon next to the price to see it on GPay - the info icon wasn't visible before)

<img width="330" alt="Screenshot 2024-06-06 at 11 32 28 AM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/cef77833-bfe3-4081-906a-5447585e9b52">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
