### PR TITLE
Enable WP_DEBUG to be able to get previous Exception class

### DIFF
--- a/changelog/add-add-wc-return-previous-exceptions-filter
+++ b/changelog/add-add-wc-return-previous-exceptions-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add woocommerce-return-previous-exceptions filter

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1289,6 +1289,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->add_order_note( $note );
 			}
 
+			// This allows WC to check if WP_DEBUG mode is enabled before returning previous Exception and expose Exception class name to frontend.
 			add_filter( 'woocommerce_return_previous_exceptions', '__return_true' );
 			// Re-throw the exception after setting everything up.
 			// This makes the error notice show up both in the regular and block checkout.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1289,6 +1289,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->add_order_note( $note );
 			}
 
+			add_filter( 'woocommerce_return_previous_exceptions', '__return_true' );
 			// Re-throw the exception after setting everything up.
 			// This makes the error notice show up both in the regular and block checkout.
 			throw new Exception( WC_Payments_Utils::get_filtered_error_message( $e, $blocked_by_fraud_rules ), 0, $e );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
We only get the `previous Exception` class when `WP_DEBUG` is enabled; otherwise, the `Exception` class name will be exposed at frontend.

Slack discussion: https://a8c.slack.com/archives/C8X6Q7XQU/p1717505760671199?thread_ts=1717144904.072499&cid=C8X6Q7XQU
WC changes: https://github.com/woocommerce/woocommerce/pull/47489/commits/a96d5d72934d642e8c5ccc654c13aace8949c473 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Test with [WC PR](https://github.com/woocommerce/woocommerce/pull/47489)
2. Throw an error using the snippet below:
```
use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;

add_action( 
	'woocommerce_rest_checkout_process_payment_with_context', 
	function() {
		throw new \Exception( 
			'woocommerce_test_exception',
			0,
			new RouteException(
				'woocommerce_test_previous',
				'exception message',
				0
			)
		);
	}
);

add_action( 'woocommerce_store_api_disable_nonce_check', '__return_true' ); // Make sure to remove this after you are done with testing.
```

3. Update `WP_DEBUG` mode to `true`

4. Add an item to your cart by POSTing to `{YOUR_DOMAIN}/wp-json/wc/store/v1/cart/add-item`
```
Body - Raw - JSON
{
  "id": 2040,
  "quantity": 1
}
```
5. Checkout with the cart by POSTing to `{YOUR_DOMAIN}/wp-json/wc/store/v1/checkout`
```
{
  "billing_address": {
        "first_name": "Test",
        "last_name": "Billing",
        "company": "",
        "address_1": "123 test",
        "address_2": "",
        "city": "San Diego",
        "state": "CA",
        "postcode": "92103",
        "country": "US",
        "email": "test@test.com",
        "phone": "+14708274627"
    },
    "shipping_address": {
        "first_name": "Test",
        "last_name": "Shipping",
        "company": "",
        "address_1": "123 test",
        "address_2": "",
        "city": "San Diego",
        "state": "CA",
        "postcode": "92103",
        "country": "US",
        "phone": "+14708274627"
    },
  "payment_method": "woocommerce_payments"
}
```

6. Should see 
```
{
    "code": "woocommerce_rest_checkout_process_payment_error",
    "message": "woocommerce_test_exception",
    "data": {
        "previous": "Automattic\\WooCommerce\\StoreApi\\Exceptions\\RouteException",
        "status": 400
    }
}
```

7. Update `WP_DEBUG` mode to `false`
8. You should see:
```
{
    "code": "woocommerce_rest_checkout_process_payment_error",
    "message": "woocommerce_test_exception",
    "data": {
        "status": 400
    }
}
```


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
