### PR TITLE
Prevent account creation during WooPay preflight request

### DIFF
--- a/changelog/fix-woopay-preflight-create-account
+++ b/changelog/fix-woopay-preflight-create-account
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent account creation during WooPay preflight request.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -676,6 +676,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			remove_all_actions( 'woocommerce_store_api_checkout_order_processed' );
 			// Avoid increasing coupon usage count during preflight check.
 			remove_all_actions( 'woocommerce_order_status_pending' );
+
+			// Avoid creating new accounts during preflight check.
+			remove_all_filters( 'woocommerce_checkout_registration_enabled' );
+			remove_all_filters( 'woocommerce_checkout_registration_required' );
 		}
 
 		return $response;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -678,7 +678,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			remove_all_actions( 'woocommerce_order_status_pending' );
 
 			// Avoid creating new accounts during preflight check.
-			remove_all_filters( 'woocommerce_checkout_registration_enabled' );
 			remove_all_filters( 'woocommerce_checkout_registration_required' );
 		}
 

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Duplicate_Payment_Prevention_Service;
+use Automattic\WooCommerce\Internal\Utilities\Users;
 
 /**
  * Class handling order success page.
@@ -16,6 +17,7 @@ class WC_Payments_Order_Success_Page {
 	 * Constructor.
 	 */
 	public function __construct() {
+		add_filter( 'woocommerce_order_received_verify_known_shoppers', [ $this, 'determine_woopay_order_received_verify_known_shoppers' ], 11 );
 		add_action( 'woocommerce_before_thankyou', [ $this, 'register_payment_method_override' ] );
 		add_action( 'woocommerce_order_details_before_order_table', [ $this, 'unregister_payment_method_override' ] );
 		add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'add_notice_previous_paid_order' ], 11 );
@@ -226,5 +228,34 @@ class WC_Payments_Order_Success_Page {
 			WC_Payments::get_file_version( 'assets/css/success.css' ),
 			'all',
 		);
+	}
+
+	/**
+	 * Make sure we show the TYP page for orders paid with WooPay
+	 * that create new user accounts, code mainly copied from
+	 * WooCommerce WC_Shortcode_Checkout::order_received and
+	 * WC_Shortcode_Checkout::guest_should_verify_email.
+	 *
+	 * @param bool $value The current value for this filter.
+	 */
+	public function determine_woopay_order_received_verify_known_shoppers( $value ) {
+		global $wp;
+
+		$order_id  = $wp->query_vars['order-received'];
+		$order_key = apply_filters( 'woocommerce_thankyou_order_key', empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) ) );
+		$order     = wc_get_order( $order_id );
+
+		if ( ( ! $order instanceof WC_Order ) || ! $order->get_meta( 'is_woopay' ) || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			return $value;
+		}
+
+		$verification_grace_period = (int) apply_filters( 'woocommerce_order_email_verification_grace_period', 10 * MINUTE_IN_SECONDS, $order );
+		$date_created              = $order->get_date_created();
+
+		// We do not need to verify the email address if we are within the grace period immediately following order creation.
+		$is_within_grace_period = is_a( $date_created, \WC_DateTime::class, true )
+			&& time() - $date_created->getTimestamp() <= $verification_grace_period;
+
+		return ! $is_within_grace_period;
 	}
 }

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -6,7 +6,6 @@
  */
 
 use WCPay\Duplicate_Payment_Prevention_Service;
-use Automattic\WooCommerce\Internal\Utilities\Users;
 
 /**
  * Class handling order success page.


### PR DESCRIPTION
Fixes 2713-gh-Automattic/woopay

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
While some plugins create new user accounts during checkout, WooPay makes two requests to the `/checkout` endpoint, resulting in the error "An account is already registered with your email address" on the WooPay checkout page.

This PR addresses this issue by:

* Preventing the creation of new merchant site accounts during the WooPay preflight request.
* Allowing the TYP page to be displayed for 10 minutes for WooPay orders, as these orders require user authentication to view the page due to the associated billing email address of a now existing user.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow 2713-gh-Automattic/woopay steps to reproduce.
* No error should be thrown and the TYP page should be displayed as expected. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
