### PR TITLE
Ensure sh compatibility of the pre-push script

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
 # check if main stream (stdout and stderr) are attached to the terminal
@@ -7,12 +7,12 @@ if [ -t 1 ] && [ -t 2 ]; then
     exec < /dev/tty
 fi
 
-PROTECTED_BRANCH=("develop" "trunk")
+PROTECTED_BRANCH="develop trunk"
 CURRENT_BRANCH=$(git branch --show-current)
 
-if [[ " ${PROTECTED_BRANCH[@]} " =~ " ${CURRENT_BRANCH} " ]]; then
+if echo "$PROTECTED_BRANCH" | grep -q -w "$CURRENT_BRANCH"; then
     read -p "$CURRENT_BRANCH is a protected branch. Are you sure you want to push? (y/n): " confirmation
-        if [ "$confirmation" != "y" ]; then
+    if [ "$confirmation" != "y" ]; then
         echo "Push aborted"
         exit 1
     fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,10 +7,10 @@ if [ -t 1 ] && [ -t 2 ]; then
     exec < /dev/tty
 fi
 
-PROTECTED_BRANCH="develop trunk"
+PROTECTED_BRANCH_LIST="develop trunk"
 CURRENT_BRANCH=$(git branch --show-current)
 
-if echo "$PROTECTED_BRANCH" | grep -q -w "$CURRENT_BRANCH"; then
+if echo "$PROTECTED_BRANCH_LIST" | grep -q -w "$CURRENT_BRANCH"; then
     read -p "$CURRENT_BRANCH is a protected branch. Are you sure you want to push? (y/n): " confirmation
     if [ "$confirmation" != "y" ]; then
         echo "Push aborted"

--- a/changelog/misc-move-prepush-to-sh
+++ b/changelog/misc-move-prepush-to-sh
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add sh support in pre-push husky script.


### PR DESCRIPTION
#### Changes proposed in this Pull Request
p1718006172762859-slack-CGGCLBN58 mentions the error during `pre-push` execution due to the fact that the script is run within `sh`. This PR changes the way of defining arrays so that it's supported by `sh`.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* checking out `misc/move-prepush-to-sh` and right after trying to `git push origin misc/move-prepush-to-sh` will end up with `Everything up-to-date`, which means that the `pre-push` was executed successfully but haven't found this branch on the protected branches list
* add `misc/move-prepush-to-sh` to `PROTECTED_BRANCH_LIST` variable in the `pre-push`, try to `git push origin misc/move-prepush-to-sh` and confirm that you see the `misc/move-prepush-to-sh is a protected branch. Are you sure you want to push? (y/n)` message

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.