### PR TITLE
Reporting: Add 'All Time' date preset option in the payment activity widget

### DIFF
--- a/changelog/add-8929-all-time-date-preset
+++ b/changelog/add-8929-all-time-date-preset
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Changes behind feature flag. Adds an `All time` option to the date preset dropdown in the payment activity widget.
+
+

--- a/client/components/payment-activity/date-range-picker.tsx
+++ b/client/components/payment-activity/date-range-picker.tsx
@@ -80,6 +80,14 @@ const timeOptions: {
 		end: todayEndOfDay,
 		displayKey: __( 'Year to date', 'woocommerce-payments' ),
 	},
+	all_time: {
+		start: moment(
+			wcpaySettings.accountStatus.created,
+			'YYYY-MM-DD\\THH:mm:ss'
+		),
+		end: todayEndOfDay,
+		displayKey: __( 'All time', 'woocommerce-payments' ),
+	},
 };
 
 const formatDateRange = (

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -64,6 +64,7 @@ declare const global: {
 					[ currencyCode: string ]: number;
 				};
 			};
+			created: string;
 		};
 		accountDefaultCurrency: string;
 		zeroDecimalCurrencies: string[];
@@ -87,6 +88,7 @@ describe( 'PaymentActivity component', () => {
 						usd: 500,
 					},
 				},
+				created: '2022-01-01 00:00:00',
 			},
 			accountDefaultCurrency: 'eur',
 			zeroDecimalCurrencies: [],

--- a/client/components/payment-activity/test/payment-data-tile.test.tsx
+++ b/client/components/payment-activity/test/payment-data-tile.test.tsx
@@ -17,6 +17,9 @@ declare const global: {
 		connect: {
 			country: string;
 		};
+		accountStatus: {
+			created: string;
+		};
 	};
 };
 
@@ -36,6 +39,9 @@ describe( 'PaymentDataTile', () => {
 				decimalSeparator: '.',
 				precision: 2,
 			},
+		},
+		accountStatus: {
+			created: '2022-01-01 00:00:00',
 		},
 	};
 

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -93,6 +93,7 @@ describe( 'Overview page', () => {
 					isComplete: false,
 					isEnabled: false,
 				},
+				created: '2022-01-01 00:00:00',
 			},
 			accountFees: {
 				base: {

--- a/tests/js/jest-test-file-setup.js
+++ b/tests/js/jest-test-file-setup.js
@@ -109,6 +109,9 @@ global.wcpaySettings = {
 	accountLoans: {
 		loans: [ 'flxln_123456|active' ],
 	},
+	accountStatus: {
+		created: '2022-01-01 00:00:00',
+	},
 };
 
 // const config = require( '../../config/development.json' );


### PR DESCRIPTION
Fixes #8929 

>[!IMPORTANT]
>The PR is branched from 8734-add-date-selector that adds the date selector to the widget. That PR is currently in review and yet to be merged with develop.

>[!CAUTION]
>This PR should be merged with `develop` only after #8927 is merged.

#### Changes proposed in this Pull Request
The PR adds an `All time` option to the date range within the Payment activity widget. 

#### Testing instructions

* Make sure you have feature flag - `_wcpay_feature_payment_overview_widget` enabled
* Checkout this branch on your local / test setup
* Browse to `Payments > Overview`
* On top right of the ` Your payment activity` widget, select `All time` on the date selector
* Check the summary numbers, click each link on the tile and test if the dates and the transactions match for your test account.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
