### PR TITLE
Fix PM title for PRBs not displaying correctly due to ECE code

### DIFF
--- a/changelog/fix-ece-payment-method-title
+++ b/changelog/fix-ece-payment-method-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Payment method title for PRBs not displaying correctly because of ECE code.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1800,7 +1800,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_method_type    = $this->get_payment_method_type_for_setup_intent( $intent, $token );
 		}
 
-		if ( empty( $_POST['payment_request_type'] ) || empty( $_POST['express_payment_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( empty( $_POST['payment_request_type'] ) && empty( $_POST['express_payment_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the condition that caused payment method titles for PRB payments to display the card brand instead of the express checkout method used.

#### Testing instructions

- Ensure the feature flag `_wcpay_feature_stripe_ece` is set to 0.

On `develop`:
- Complete a test purchase using PRBs and note the payment method title, which is currently reported as the card brand (e.g., Visa, Mastercard).


On this branch:
- Repeat the steps above, but this time verify that the payment method title correctly reflects the express checkout method used (e.g., Apple Pay, Google Pay).

#### Before
![Screen Shot 2024-06-10 at 15 38 41 PM](https://github.com/Automattic/woocommerce-payments/assets/4153905/cca1731c-248a-4e0b-8a49-7d7562fc1dd6)

#### After

![Screen Shot 2024-06-10 at 15 43 20 PM](https://github.com/Automattic/woocommerce-payments/assets/4153905/0b45c118-90b7-422f-b85e-24794f43069b)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.