### PR TITLE
Update compatibility data output

### DIFF
--- a/changelog/fix-5532-fix-compatibility-data
+++ b/changelog/fix-5532-fix-compatibility-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix output for compatibility data.

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -77,9 +77,9 @@ class Compatibility_Service {
 		$active_plugins        = get_option( 'active_plugins', [] );
 		$post_types_count      = $this->get_post_types_count();
 		$wc_permalinks         = get_option( 'woocommerce_permalinks', [] );
-		$wc_shop_permalink     = get_permalink( wc_get_page_id( 'shop' ) ) ? get_permalink( wc_get_page_id( 'shop' ) ) : 'Not set';
-		$wc_cart_permalink     = get_permalink( wc_get_page_id( 'cart' ) ) ? get_permalink( wc_get_page_id( 'cart' ) ) : 'Not set';
-		$wc_checkout_permalink = get_permalink( wc_get_page_id( 'checkout' ) ) ? get_permalink( wc_get_page_id( 'checkout' ) ) : 'Not set';
+		$wc_shop_permalink     = $this->get_permalink_for_page_id( 'shop' );
+		$wc_cart_permalink     = $this->get_permalink_for_page_id( 'cart' );
+		$wc_checkout_permalink = $this->get_permalink_for_page_id( 'checkout' );
 
 		return [
 			'woopayments_version'    => WCPAY_VERSION_NUMBER,
@@ -113,5 +113,18 @@ class Compatibility_Service {
 		}
 
 		return $post_types_count;
+	}
+
+	/**
+	 * Gets the permalink for a page ID.
+	 *
+	 * @param string $page_id The page ID to get the permalink for.
+	 *
+	 * @return string The permalink for the page ID, or 'Not set' if the permalink is not available.
+	 */
+	private function get_permalink_for_page_id( string $page_id ): string {
+		$permalink = get_permalink( wc_get_page_id( $page_id ) );
+
+		return $permalink ? $permalink : 'Not set';
 	}
 }

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -79,7 +79,7 @@ class Compatibility_Service {
 		$wc_permalinks         = get_option( 'woocommerce_permalinks', [] );
 		$wc_shop_permalink     = get_permalink( wc_get_page_id( 'shop' ) ) ? get_permalink( wc_get_page_id( 'shop' ) ) : 'Not set';
 		$wc_cart_permalink     = get_permalink( wc_get_page_id( 'cart' ) ) ? get_permalink( wc_get_page_id( 'cart' ) ) : 'Not set';
-		$wc_checkout_permalink = get_permalink( wc_get_page_id( 'checkout' ) ) ? get_permalink( wc_get_page_id( 'cart' ) ) : 'Not set';
+		$wc_checkout_permalink = get_permalink( wc_get_page_id( 'checkout' ) ) ? get_permalink( wc_get_page_id( 'checkout' ) ) : 'Not set';
 
 		return [
 			'woopayments_version'    => WCPAY_VERSION_NUMBER,

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -76,10 +76,10 @@ class Compatibility_Service {
 	private function get_compatibility_data(): array {
 		$active_plugins        = get_option( 'active_plugins', [] );
 		$post_types_count      = $this->get_post_types_count();
-		$wc_permalinks         = get_option( 'woocommerce_permalinks' );
-		$wc_shop_permalink     = get_permalink( wc_get_page_id( 'shop' ) );
-		$wc_cart_permalink     = get_permalink( wc_get_page_id( 'cart' ) );
-		$wc_checkout_permalink = get_permalink( wc_get_page_id( 'checkout' ) );
+		$wc_permalinks         = get_option( 'woocommerce_permalinks', [] );
+		$wc_shop_permalink     = get_permalink( wc_get_page_id( 'shop' ) ) ? get_permalink( wc_get_page_id( 'shop' ) ) : 'Not set';
+		$wc_cart_permalink     = get_permalink( wc_get_page_id( 'cart' ) ) ? get_permalink( wc_get_page_id( 'cart' ) ) : 'Not set';
+		$wc_checkout_permalink = get_permalink( wc_get_page_id( 'checkout' ) ) ? get_permalink( wc_get_page_id( 'cart' ) ) : 'Not set';
 
 		return [
 			'woopayments_version'    => WCPAY_VERSION_NUMBER,

--- a/tests/unit/test-class-compatibility-service.php
+++ b/tests/unit/test-class-compatibility-service.php
@@ -50,7 +50,7 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	private $post_types_count = [
 		'post'       => 1,
-		'page'       => 6,
+		'page'       => 4,
 		'attachment' => 0,
 		'product'    => 12,
 	];
@@ -158,6 +158,40 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 		$this->fix_active_plugins_option();
 	}
 
+	/**
+	 * Checks to make sure "Not set" is returned if a page id is not returned.
+	 *
+	 * @dataProvider provider_update_compatibility_data_permalinks_not_set
+	 */
+	public function test_update_compatibility_data_permalinks_not_set( $page_name ) {
+		// Arrange: Create the expected value to be passed to update_compatibility_data.
+		$expected = $this->get_mock_compatibility_data(
+			[
+				'woocommerce_' . $page_name => 'Not set',
+			]
+		);
+
+		// Arrange: Delete the page id reference from the database.
+		delete_option( 'woocommerce_' . $page_name . '_page_id' );
+
+		// Arrange/Assert: Set the expectations for update_compatibility_data.
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_compatibility_data' )
+			->with( $expected );
+
+		// Act: Call the method we're testing.
+		$this->compatibility_service->update_compatibility_data();
+	}
+
+	public function provider_update_compatibility_data_permalinks_not_set(): array {
+		return [
+			'shop'     => [ 'shop' ],
+			'cart'     => [ 'cart' ],
+			'checkout' => [ 'checkout' ],
+		];
+	}
+
 	public function test_add_compatibility_onboarding_data() {
 		// Arrange: Create the expected value.
 		$expected = [ 'compatibility_data' => $this->get_mock_compatibility_data() ];
@@ -178,7 +212,7 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 			[
 				'woopayments_version'    => WCPAY_VERSION_NUMBER,
 				'woocommerce_version'    => WC_VERSION,
-				'woocommerce_permalinks' => get_option( 'woocommerce_permalinks' ),
+				'woocommerce_permalinks' => get_option( 'woocommerce_permalinks', [] ),
 				'woocommerce_shop'       => get_permalink( wc_get_page_id( 'shop' ) ),
 				'woocommerce_cart'       => get_permalink( wc_get_page_id( 'cart' ) ),
 				'woocommerce_checkout'   => get_permalink( wc_get_page_id( 'checkout' ) ),
@@ -262,6 +296,11 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 		$post_types = ! empty( $post_types ) ? $post_types : $this->post_types_count;
 		$post_ids   = [];
 		foreach ( $post_types as $post_type => $count ) {
+			// Let's create the default WooCommerce pages for the test pages.
+			if ( 'page' === $post_type ) {
+				$post_ids = array_merge( $post_ids, $this->create_woocommerce_default_pages() );
+				continue;
+			}
 			$title_content = 'This is a ' . $post_type . ' test post';
 			for ( $i = 0; $i < $count; $i++ ) {
 				$post_ids[] = (int) wp_insert_post(
@@ -289,5 +328,57 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 		foreach ( $post_ids as $post_id ) {
 			wp_delete_post( (int) $post_id, true );
 		}
+	}
+
+	/**
+	 * Creates the default WooCommerce pages for test purposes.
+	 *
+	 * @return array Array of post IDs that were created.
+	 */
+	private function create_woocommerce_default_pages(): array {
+		// Note: Inspired by WC_Install::create_pages().
+
+		$pages = [
+			'shop'           => [
+				'name'    => 'shop',
+				'title'   => 'Shop',
+				'content' => '',
+			],
+			'cart'           => [
+				'name'    => 'cart',
+				'title'   => 'Cart',
+				'content' => '',
+			],
+			'checkout'       => [
+				'name'    => 'checkout',
+				'title'   => 'Checkout',
+				'content' => '',
+			],
+			'myaccount'      => [
+				'name'    => 'my-account',
+				'title'   => 'My account',
+				'content' => '',
+			],
+			'refund_returns' => [
+				'name'        => 'refund_returns',
+				'title'       => 'Refund and Returns Policy',
+				'content'     => '',
+				'post_status' => 'draft',
+			],
+		];
+
+		$page_ids = [];
+		foreach ( $pages as $key => $page ) {
+			$page_ids[] = wc_create_page(
+				esc_sql( $page['name'] ),
+				'woocommerce_' . $key . '_page_id',
+				$page['title'],
+				$page['content'],
+				'',
+				! empty( $page['post_status'] ) ? $page['post_status'] : 'publish'
+			);
+		}
+
+		return $page_ids;
 	}
 }

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -277,6 +277,8 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 			'f' => 6,
 		];
 
+		$default_wc_pages = $this->create_woocommerce_default_pages();
+
 		$this->mock_http_client
 			->expects( $this->once() )
 			->method( 'remote_request' )
@@ -326,6 +328,9 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 
 		// Assert the response is correct.
 		$this->assertEquals( [ 'url' => false ], $result );
+
+		// Remove test pages created.
+		$this->delete_test_posts( $default_wc_pages );
 	}
 
 	/**
@@ -1267,12 +1272,75 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 				'active_plugins'         => [],
 				'post_types_count'       => [
 					'post'       => 0,
-					'page'       => 0,
+					'page'       => 4,
 					'attachment' => 0,
 					'product'    => 0,
 				],
 			],
 			$args
 		);
+	}
+
+	/**
+	 * Creates the default WooCommerce pages for test purposes.
+	 *
+	 * @return array Array of post IDs that were created.
+	 */
+	private function create_woocommerce_default_pages(): array {
+		// Note: Inspired by WC_Install::create_pages().
+
+		$pages = [
+			'shop'           => [
+				'name'    => 'shop',
+				'title'   => 'Shop',
+				'content' => '',
+			],
+			'cart'           => [
+				'name'    => 'cart',
+				'title'   => 'Cart',
+				'content' => '',
+			],
+			'checkout'       => [
+				'name'    => 'checkout',
+				'title'   => 'Checkout',
+				'content' => '',
+			],
+			'myaccount'      => [
+				'name'    => 'my-account',
+				'title'   => 'My account',
+				'content' => '',
+			],
+			'refund_returns' => [
+				'name'        => 'refund_returns',
+				'title'       => 'Refund and Returns Policy',
+				'content'     => '',
+				'post_status' => 'draft',
+			],
+		];
+
+		$page_ids = [];
+		foreach ( $pages as $key => $page ) {
+			$page_ids[] = wc_create_page(
+				esc_sql( $page['name'] ),
+				'woocommerce_' . $key . '_page_id',
+				$page['title'],
+				$page['content'],
+				'',
+				! empty( $page['post_status'] ) ? $page['post_status'] : 'publish'
+			);
+		}
+
+		return $page_ids;
+	}
+
+	/**
+	 * Delete test posts that were created during a unit test.
+	 *
+	 * @param array $post_ids Array of post IDs to delete.
+	 */
+	private function delete_test_posts( array $post_ids = [] ) {
+		foreach ( $post_ids as $post_id ) {
+			wp_delete_post( (int) $post_id, true );
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments-server/issues/5532

#### Changes proposed in this Pull Request

* Update the `get_option` call for `woocommerce_permalinks` to have a default of an empty array so that an array is always sent.
  * This should never be an issue due to WooCommerce core itself updates the permalinks for WC, even if the admin never does.
* Update the calls for the `shop`, `cart`, and `checkout` permalinks to check for possible `false` values returned, and instead return `Not set`. 

#### Testing instructions

* Check out this branch.
* Navigate to WooCommerce > Settings > Products.
* Click the X to clear your _Shop page_ settings, and then save.
* Navigate to WooCommerce > Settings > Advanced.
* Click the X to clear your _Cart page_ and _Checkout page_ settings, and then save.
* Navigate to WCPay Dev Tools and clear your account cache.
* Check your `logstash` for your local server and look for the latest `compatibility` API request (it should be the last thing in the log`.
* The values for the permalinks should look like the example below.
* Don't forget to reset your permalinks you cleared above.

```
"woocommerce_shop": "Not set",
"woocommerce_cart": "Not set",
"woocommerce_checkout": "Not set",
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
