### PR TITLE
Adding adjustments to TPV Report

### DIFF
--- a/changelog/add-adjustments-tpv-report
+++ b/changelog/add-adjustments-tpv-report
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Modified TPV report on Payment Activity Card. Behind Payment Activity Card Feature Flag.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -28,6 +28,7 @@ const searchTermsForViewReportLink = {
 		'dispute',
 		'dispute_reversal',
 		'card_reader_fee',
+		'adjustment',
 	],
 
 	charge: [ 'charge', 'payment', 'adjustment' ],

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`PaymentActivity component should render 1`] = `
               </p>
               <a
                 data-link-type="wc-admin"
-                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&store_currency_is=eur&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
+                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&store_currency_is=eur&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee&search%5B9%5D=adjustment"
               >
                 View report
               </a>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
On server, `adjustments` are included in the `Charges` [calculation](https://github.com/Automattic/woocommerce-payments-server/blob/5e3dc372ea0f10cab740439ff0ca1ebc7fa7715b/server/wp-content/rest-api-plugins/endpoints/wcpay/repository/class-transaction-repository.php#L51) and hence, in the TPV [calculation](https://github.com/Automattic/woocommerce-payments-server/blob/5e3dc372ea0f10cab740439ff0ca1ebc7fa7715b/server/wp-content/rest-api-plugins/endpoints/wcpay/service/class-reporting-service.php#L90).
So the TPV report should include adjustments.

Note: `adjustments` are not common, we are including them to keep the totals and transaction listing accurate.

#### Additional Context
p1718085878746209/1717986232.682179-slack-C06BBFTF6EM

#### Testing instructions
- Compare the TPV total and transaction rows when `adjustment` is present in `transactions_cache` for the merchant
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.