### PR TITLE
Payment Activity Widget: Select report currency when clicking "View report"

### DIFF
--- a/changelog/fix-8938-payment-activity-view-report-currency
+++ b/changelog/fix-8938-payment-activity-view-report-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Behind feature flag: Ensure currency is set in Payment Activity "View report" urls
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -112,6 +112,7 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 					page: 'wc-admin',
 					path: '/payments/transactions',
 					filter: 'advanced',
+					store_currency_is: currency,
 					'date_between[0]': moment(
 						paymentActivityData?.date_start
 					).format( 'YYYY-MM-DD' ),
@@ -154,6 +155,7 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						page: 'wc-admin',
 						path: '/payments/transactions',
 						filter: 'advanced',
+						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
 						).format( 'YYYY-MM-DD' ),
@@ -176,6 +178,7 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						page: 'wc-admin',
 						path: '/payments/transactions',
 						filter: 'advanced',
+						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
 						).format( 'YYYY-MM-DD' ),
@@ -198,6 +201,7 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						page: 'wc-admin',
 						path: '/payments/transactions',
 						filter: 'advanced',
+						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
 						).format( 'YYYY-MM-DD' ),

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`PaymentActivity component should render 1`] = `
               </p>
               <a
                 data-link-type="wc-admin"
-                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
+                href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&store_currency_is=eur&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=payment_failure_refund&search%5B3%5D=payment_refund&search%5B4%5D=refund&search%5B5%5D=refund_failure&search%5B6%5D=dispute&search%5B7%5D=dispute_reversal&search%5B8%5D=card_reader_fee"
               >
                 View report
               </a>
@@ -136,7 +136,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=adjustment"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&store_currency_is=eur&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=charge&search%5B1%5D=payment&search%5B2%5D=adjustment"
                 >
                   View report
                 </a>
@@ -165,7 +165,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=refund&search%5B1%5D=refund_failure&search%5B2%5D=payment_refund&search%5B3%5D=payment_failure_refund"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&store_currency_is=eur&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=refund&search%5B1%5D=refund_failure&search%5B2%5D=payment_refund&search%5B3%5D=payment_failure_refund"
                 >
                   View report
                 </a>
@@ -194,7 +194,7 @@ exports[`PaymentActivity component should render 1`] = `
                 </p>
                 <a
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=dispute&search%5B1%5D=dispute_reversal"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&store_currency_is=eur&date_between%5B0%5D=2024-01-01&date_between%5B1%5D=2024-01-31&search%5B0%5D=dispute&search%5B1%5D=dispute_reversal"
                 >
                   View report
                 </a>

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -122,7 +122,7 @@ describe( 'PaymentActivity component', () => {
 	} );
 
 	it( 'should render', () => {
-		const { container, getByText, getByLabelText } = render(
+		const { container, getByText, getByLabelText, getAllByText } = render(
 			<PaymentActivity />
 		);
 
@@ -132,6 +132,15 @@ describe( 'PaymentActivity component', () => {
 		// Check correct currency/value is displayed.
 		const tpvElement = getByLabelText( 'Total payment volume' );
 		expect( tpvElement ).toHaveTextContent( '€1.234,56' );
+
+		// Check the "View report" link is rendered with the correct currency query param.
+		const viewReportLinks = getAllByText( 'View report' );
+		viewReportLinks.forEach( ( link ) => {
+			expect( link ).toHaveAttribute(
+				'href',
+				expect.stringContaining( 'store_currency_is=eur' )
+			);
+		} );
 
 		expect( container ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
Fixes #8938

> [!TIP]
> This change is behind a feature flag `_wcpay_feature_payment_overview_widget`

#### Changes proposed in this Pull Request

This PR ensures the currency that is currently being viewing on the Payment Activity Card will also be selected on the subsequent report screen (e.g. Payments → Transactions) when clicking `View report` links.

> [!TIP]
> This is a small PR 🤏 – should be quick to test 

https://github.com/Automattic/woocommerce-payments/assets/3147296/103198af-0a6e-4fbe-8d93-05c6f3d678c2

_Screen recording of correct currency being selected in this PR – see #8938 for screen recording prior to this fix_



#### Testing instructions
- run `wp option update _wcpay_feature_payment_overview_widget 1` in CLI (`npm run cli` if docker)
* Use a multi deposit currency store
	* You can get a multi-deposit currency store by [onboarding with a country that supports multiple deposit currencies](https://woocommerce.com/document/woopayments/deposits/deposit-currencies/) and adding bank accounts during Stripe KYC
* Open Payments → Overview
* Select a currency using the currency-selector in the top-right of the screen
* Click "View report" under TPV
* Ensure that the correct currency is selected on this screen
* Observe the same behaviour for refunds, disputes and charges

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
