### PR TITLE
Disable WooPay for suspended and rejected accounts - Take 2

### DIFF
--- a/changelog/as-disable-woopay-rejected-suspended-accounts
+++ b/changelog/as-disable-woopay-rejected-suspended-accounts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable WooPay for suspended and rejected accounts.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -215,7 +215,7 @@ class WC_Payments_Features {
 
 		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
 
-		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
+		return is_array( $account ) && isset( $account['platform_checkout_eligible'] ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -213,7 +213,9 @@ class WC_Payments_Features {
 
 		$is_account_rejected = WC_Payments::get_account_service()->is_account_rejected();
 
-		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected ?? false );
+		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
+
+		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -210,7 +210,10 @@ class WC_Payments_Features {
 
 		// read directly from cache, ignore cache expiration check.
 		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
-		return is_array( $account ) && ( $account['platform_checkout_eligible'] ?? false );
+
+		$is_account_rejected = WC_Payments::get_account_service()->is_account_rejected();
+
+		return is_array( $account ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected ?? false );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -215,7 +215,10 @@ class WC_Payments_Features {
 
 		$is_account_under_review = WC_Payments::get_account_service()->is_account_under_review();
 
-		return is_array( $account ) && isset( $account['platform_checkout_eligible'] ) && ( $account['platform_checkout_eligible'] && ! $is_account_rejected && ! $is_account_under_review ?? false );
+		return is_array( $account )
+			&& ( $account['platform_checkout_eligible'] ?? false )
+			&& ! $is_account_rejected
+			&& ! $is_account_under_review;
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1509,12 +1509,10 @@ class WC_Payments {
 	 * @return void
 	 */
 	public static function maybe_register_woopay_hooks() {
-		$is_woopay_eligible      = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
-		$is_woopay_enabled       = 'yes' === self::get_gateway()->get_option( 'platform_checkout', 'no' );
-		$is_account_rejected     = self::get_account_service()->is_account_rejected();
-		$is_account_under_review = self::get_account_service()->is_account_under_review();
+		$is_woopay_eligible = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
+		$is_woopay_enabled  = 'yes' === self::get_gateway()->get_option( 'platform_checkout', 'no' );
 
-		if ( $is_woopay_eligible && $is_woopay_enabled && ! $is_account_rejected && ! $is_account_under_review ) {
+		if ( $is_woopay_eligible && $is_woopay_enabled ) {
 			add_action( 'wc_ajax_wcpay_init_woopay', [ WooPay_Session::class, 'ajax_init_woopay' ] );
 			add_action( 'wc_ajax_wcpay_get_woopay_session', [ WooPay_Session::class, 'ajax_get_woopay_session' ] );
 			add_action( 'wc_ajax_wcpay_get_woopay_signature', [ __CLASS__, 'ajax_get_woopay_signature' ] );
@@ -1556,9 +1554,7 @@ class WC_Payments {
 			}
 
 			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
-		}
-
-		if ( $is_account_rejected || $is_account_under_review ) {
+		} else {
 			WooPay_Order_Status_Sync::remove_webhook();
 		}
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -570,21 +570,24 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error every time the account cache is refreshed,
-		// given that $wp_rewrite is defined right after the `plugins_loaded` action is fired. See #8857.
-		add_action( 'setup_theme', [ __CLASS__, 'maybe_register_woopay_hooks' ] );
-
 		self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
 		self::$apple_pay_registration->init_hooks();
 
 		$express_checkout_helper = new WC_Payments_Express_Checkout_Button_Helper( self::get_gateway(), self::$account );
 		self::set_express_checkout_helper( $express_checkout_helper );
 
-		self::maybe_display_express_checkout_buttons();
-
-		self::maybe_init_woopay_direct_checkout();
-
-		self::maybe_enqueue_woopay_common_config_script( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
+		// Delay registering hooks that could end up in a fatal error due to expired account cache.
+		// The `woocommerce_payments_account_refreshed` action will result in a fatal error if it's fired before the `$wp_rewrite` is defined.
+		// See #8942 for more details.
+		add_action(
+			'setup_theme',
+			function () {
+				self::maybe_register_woopay_hooks();
+				self::maybe_display_express_checkout_buttons();
+				self::maybe_init_woopay_direct_checkout();
+				self::maybe_enqueue_woopay_common_config_script( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
+			}
+		);
 
 		// Insert the Stripe Payment Messaging Element only if there is at least one BNPL method enabled.
 		$enabled_bnpl_payment_methods = array_intersect(

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -582,6 +582,8 @@ class WC_Payments {
 		add_action(
 			'setup_theme',
 			function () {
+				add_action( 'woocommerce_payments_account_refreshed', [ WooPay_Order_Status_Sync::class, 'remove_webhook' ] );
+
 				self::maybe_register_woopay_hooks();
 				self::maybe_display_express_checkout_buttons();
 				self::maybe_init_woopay_direct_checkout();
@@ -1557,8 +1559,6 @@ class WC_Payments {
 			}
 
 			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
-		} else {
-			WooPay_Order_Status_Sync::remove_webhook();
 		}
 	}
 
@@ -1616,6 +1616,7 @@ class WC_Payments {
 				'testMode'                      => $is_test_mode,
 				'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 				'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
+				'woopayMerchantId'              => Jetpack_Options::get_option( 'id' ),
 				'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
 				'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
 				'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -570,7 +570,7 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error on the WooPayment Dev Tools,
+		// Defer registering the WooPay hooks. Later on, $wp_rewrite is used and causes a fatal error every time the account cache is refreshed,
 		// given that $wp_rewrite is defined right after the `plugins_loaded` action is fired. See #8857.
 		add_action( 'setup_theme', [ __CLASS__, 'maybe_register_woopay_hooks' ] );
 

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -18,6 +18,13 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	 */
 	protected $mock_cache;
 
+	/**
+	 * Mock WC_Payments_Account.
+	 *
+	 * @var WC_Payments_Account|MockObject
+	 */
+	private $mock_wcpay_account;
+
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
 		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
 		'_wcpay_feature_documents'               => 'documents',
@@ -29,6 +36,17 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->_cache     = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
 		WC_Payments::set_database_cache( $this->mock_cache );
+
+		// Mock the WCPay Account class to make sure the account is not restricted by default.
+		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+		$this->mock_wcpay_account
+			->method( 'is_account_rejected' )
+			->willReturn( false );
+		$this->mock_wcpay_account
+			->method( 'is_account_under_review' )
+			->willReturn( false );
+
+		WC_Payments::set_account_service( $this->mock_wcpay_account );
 	}
 
 	public function tear_down() {
@@ -88,6 +106,32 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_woopay_eligible_returns_false() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
+		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
+	}
+
+	public function test_is_woopay_eligible_when_account_is_suspended_returns_false() {
+		$mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+		$mock_wcpay_account
+			->method( 'is_account_under_review' )
+			->willReturn( true );
+
+		WC_Payments::set_account_service( $mock_wcpay_account );
+
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
+
+		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
+	}
+
+	public function test_is_woopay_eligible_when_account_is_rejected_returns_false() {
+		$mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+		$mock_wcpay_account
+			->method( 'is_account_rejected' )
+			->willReturn( true );
+
+		WC_Payments::set_account_service( $mock_wcpay_account );
+
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
+
 		$this->assertFalse( WC_Payments_Features::is_woopay_eligible() );
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/woopay/issues/2641

Original PR (#8857) introduced some fatal PHP errors that others also saw it (p1717672645619179-slack-CGGCLBN58).

I decided to revert the PR in #8912 to find and fix the error.

Changes in this PR are the same as #8857 except for the last commit which contains the fix to the fatal errors.

Given that the changes were already reviewed in #8857 I'll focus on explaining the fix.

- The error happens when the account cache expires and it's refreshed.
- If the cache is refreshed the `woocommerce_payments_account_refreshed` is fired ([ref](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-account.php#L1685))
- The `Compatibility_Service` class already registered a callback for that hook. ([ref](https://github.com/Automattic/woocommerce-payments/blob/f4804ab3dc2b145c66ed646758fdd9d88075949b/includes/class-compatibility-service.php#L41))
- During the `update_compatibility_data()` method call, `get_permalink()` will be called. ([ref](https://github.com/Automattic/woocommerce-payments/blob/f4804ab3dc2b145c66ed646758fdd9d88075949b/includes/class-compatibility-service.php#L80C28-L80C41))
- `get_permalink()` calls `get_page_link()` which calls `_get_page_link()` which uses the `$wp_rewrite` global variable ([ref](https://github.com/WordPress/wordpress-develop/blob/459d99618c4dd6d412d7ad5a5d96e79e87602dc6/src/wp-includes/link-template.php#L429)).
- Given that our code [started running](https://github.com/Automattic/woocommerce-payments/blob/4b59f3b1c0bb98ed4272bf355d5e4e7cb9335a45/woocommerce-payments.php#L175) with the `plugins_loaded` action there's no `$wp_rewrite` global defined. Since `plugins_loaded` is fired [before](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-settings.php#L555) `$wp_rewrite` [is defined](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-settings.php#L596). That explains the error:
  ```
  Fatal error:  Uncaught Error: Call to a member function get_page_permastruct() on null in /Users/asumaran/valet/wcpay/wp-includes/link-template.php:434
  ```
- So, in this PR, I'm proposing delaying registering actions that could refresh the account cache [to the next immediate](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-settings.php#L630) action, `setup_theme`.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Visit the Woopayments page in the admin area.
* Modify [this line](https://github.com/Automattic/woocommerce-payments/blob/4b59f3b1c0bb98ed4272bf355d5e4e7cb9335a45/includes/class-database-cache.php#L338) to the following to decrease the "time to live" of the account cache to 10 seconds.
  ```diff
  diff --git a/includes/class-database-cache.php b/includes/class-database-cache.php
  index 68b4c7d4d..0dafaae24 100644
  --- a/includes/class-database-cache.php
  +++ b/includes/class-database-cache.php
  @@ -335,14 +335,7 @@ class Database_Cache {
 		  switch ( $key ) {
 			  case self::ACCOUNT_KEY:
 				  if ( is_admin() ) {
  -					// Fetches triggered from the admin panel should be more frequent.
  -					if ( $cache_contents['errored'] ) {
  -						// Attempt to refresh the data quickly if the last fetch was an error.
  -						$ttl = 2 * MINUTE_IN_SECONDS;
  -					} else {
  -						// If the data was fetched successfully, fetch it every 2h.
  -						$ttl = 2 * HOUR_IN_SECONDS;
  -					}
  +					$ttl = 10;
 				  } else {
 					  // Non-admin requests should always refresh only after 24h since the last fetch.
 					  $ttl = DAY_IN_SECONDS;
  ```
- Refresh the page after 10 seconds and there shouldn't be any fatal error.
- Confirm the fix by moving outside of the `setup_theme` hook each individual line and refreshing the page after 10 seconds. You should see a different fatal error for each line.
  - `self::maybe_register_woopay_hooks();`
  - `self::maybe_display_express_checkout_buttons();`
  - `self::maybe_init_woopay_direct_checkout();`
  - `self::maybe_enqueue_woopay_common_config_script( WC_Payments_Features::is_woopay_direct_checkout_enabled() );` <-- here `WC_Payments_Features::is_woopay_direct_checkout_enabled()` is what triggers the error.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.