### PR TITLE
Dev: Improve test coverage of upe.js

### DIFF
--- a/changelog/dev-7387-add-tests-to-upe-js
+++ b/changelog/dev-7387-add-tests-to-upe-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Improve test coverage of upe.js and rename isPaymentMethodRestrictedToLocation to hasPaymentMethodCountryRestrictions

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -9,7 +9,7 @@ import {
 	generateCheckoutEventNames,
 	getSelectedUPEGatewayPaymentMethod,
 	isLinkEnabled,
-	isPaymentMethodRestrictedToLocation,
+	hasPaymentMethodCountryRestrictions,
 	isUsingSavedPaymentMethod,
 	togglePaymentMethodForCountry,
 } from '../utils/upe';
@@ -228,7 +228,7 @@ jQuery( function ( $ ) {
 	}
 
 	function restrictPaymentMethodToLocation( upeElement ) {
-		if ( isPaymentMethodRestrictedToLocation( upeElement ) ) {
+		if ( hasPaymentMethodCountryRestrictions( upeElement ) ) {
 			togglePaymentMethodForCountry( upeElement );
 
 			// this event only applies to the checkout form, but not "place order" or "add payment method" pages.

--- a/client/checkout/utils/test/upe.test.js
+++ b/client/checkout/utils/test/upe.test.js
@@ -8,6 +8,7 @@ import {
 	getStripeElementOptions,
 	blocksShowLinkButtonHandler,
 	getSelectedUPEGatewayPaymentMethod,
+	hasPaymentMethodCountryRestrictions,
 	isUsingSavedPaymentMethod,
 	dispatchChangeEventFor,
 	togglePaymentMethodForCountry,
@@ -126,6 +127,66 @@ describe( 'UPE checkout utils', () => {
 		} );
 	} );
 
+	describe( 'hasPaymentMethodCountryRestrictions', () => {
+		let container;
+
+		beforeAll( () => {
+			container = document.createElement( 'div' );
+			container.innerHTML = `
+				<ul class="wc_payment_methods payment_methods methods">
+					<li class="wc_payment_method payment_method_woocommerce_payments_card" data-payment-method-type="card">
+						<input id="payment_method_woocommerce_payments" type="radio" class="input-radio">
+					</li>
+					<li class="wc_payment_method payment_method_woocommerce_payments_bancontact" data-payment-method-type="bancontact">
+						<input id="payment_method_woocommerce_payments_bancontact" type="radio" class="input-radio">
+					</li>
+				</ul>
+			`;
+			document.body.appendChild( container );
+		} );
+
+		afterAll( () => {
+			document.body.removeChild( container );
+			container = null;
+		} );
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+			getUPEConfig.mockImplementation( ( argument ) => {
+				if ( argument === 'paymentMethodsConfig' ) {
+					return {
+						card: { countries: [] },
+						bancontact: { countries: [ 'BE' ] },
+					};
+				}
+
+				if ( argument === 'gatewayId' ) {
+					return 'woocommerce_payments';
+				}
+			} );
+		} );
+
+		it( 'should be true when the payment method is restricted to the location', () => {
+			const bancontactUpeElement = document.querySelector(
+				'.payment_method_woocommerce_payments_bancontact'
+			);
+
+			expect(
+				hasPaymentMethodCountryRestrictions( bancontactUpeElement )
+			).toBe( true );
+		} );
+
+		it( 'should be false when the payment method is not restricted to the location', () => {
+			const cardUpeElement = document.querySelector(
+				'.payment_method_woocommerce_payments_card'
+			);
+
+			expect(
+				hasPaymentMethodCountryRestrictions( cardUpeElement )
+			).toBe( false );
+		} );
+	} );
+
 	describe( 'togglePaymentMethodForCountry', () => {
 		let container;
 
@@ -171,7 +232,6 @@ describe( 'UPE checkout utils', () => {
 		} );
 
 		afterEach( () => {
-			// document.getElementById('billing_country').value = '';
 			window.wcpayCustomerData = null;
 		} );
 

--- a/client/checkout/utils/test/upe.test.js
+++ b/client/checkout/utils/test/upe.test.js
@@ -159,10 +159,6 @@ describe( 'UPE checkout utils', () => {
 						bancontact: { countries: [ 'BE' ] },
 					};
 				}
-
-				if ( argument === 'gatewayId' ) {
-					return 'woocommerce_payments';
-				}
 			} );
 		} );
 

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -292,19 +292,21 @@ export const blocksShowLinkButtonHandler = ( linkAutofill ) => {
 };
 
 /**
- * Hides payment method if it has set specific countries in the PHP class.
+ * Returns true if the payment method has configured with any country restrictions.
  *
- * @param {Object} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
+ * @param {HTMLElement} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
  * @return {boolean} Whether the payment method is restricted to selected billing country.
  **/
-export const isPaymentMethodRestrictedToLocation = ( upeElement ) => {
+export const hasPaymentMethodCountryRestrictions = ( upeElement ) => {
 	const paymentMethodsConfig = getUPEConfig( 'paymentMethodsConfig' );
 	const paymentMethodType = upeElement.dataset.paymentMethodType;
 	return !! paymentMethodsConfig[ paymentMethodType ].countries.length;
 };
 
 /**
- * @param {Object} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
+ * Hides payment method if it has set specific countries in the PHP class.
+ *
+ * @param {HTMLElement} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
  **/
 export const togglePaymentMethodForCountry = ( upeElement ) => {
 	const paymentMethodsConfig = getUPEConfig( 'paymentMethodsConfig' );


### PR DESCRIPTION
Fixes #7387

#### Changes proposed in this Pull Request

Add missing tests to upe.js and rename `isPaymentMethodRestrictedToLocation` method to `hasPaymentMethodCountryRestrictions`


#### Testing instructions

* Enable Bancontact, ensure the store currency is EUR
* Navigate to shortcode checkout
* Select Belgium in the billing country field, choose Bancontact payment method
* Change country to e.g. United States
* Bancontact now disappears

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
