### PR TITLE
feat: pay-for-order support w/ tokenized cart PRBs

### DIFF
--- a/changelog/feat-tokenized-cart-pay-for-order-flow
+++ b/changelog/feat-tokenized-cart-pay-for-order-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+feat: add pay-for-order support w/ tokenized cart PRBs

--- a/client/tokenized-payment-request/index.js
+++ b/client/tokenized-payment-request/index.js
@@ -7,8 +7,10 @@ import { doAction } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import { getUPEConfig } from 'wcpay/utils/checkout';
 import WCPayAPI from '../checkout/api';
 import PaymentRequestCartApi from './cart-api';
+import PaymentRequestOrderApi from './order-api';
 import WooPaymentsPaymentRequest from './payment-request';
 import paymentRequestButtonUi from './button-ui';
 import { getPaymentRequestData } from './frontend-utils';
@@ -52,7 +54,14 @@ jQuery( ( $ ) => {
 			} );
 		}
 	);
-	const paymentRequestCartApi = new PaymentRequestCartApi();
+	let paymentRequestCartApi = new PaymentRequestCartApi();
+	if ( getPaymentRequestData( 'button_context' ) === 'pay_for_order' ) {
+		paymentRequestCartApi = new PaymentRequestOrderApi(
+			getUPEConfig( 'order_id' ),
+			getUPEConfig( 'key' ),
+			getUPEConfig( 'billing_email' )
+		);
+	}
 
 	const wooPaymentsPaymentRequest = new WooPaymentsPaymentRequest( {
 		wcpayApi: api,

--- a/client/tokenized-payment-request/index.js
+++ b/client/tokenized-payment-request/index.js
@@ -56,11 +56,11 @@ jQuery( ( $ ) => {
 	);
 	let paymentRequestCartApi = new PaymentRequestCartApi();
 	if ( getPaymentRequestData( 'button_context' ) === 'pay_for_order' ) {
-		paymentRequestCartApi = new PaymentRequestOrderApi(
-			getUPEConfig( 'order_id' ),
-			getUPEConfig( 'key' ),
-			getUPEConfig( 'billing_email' )
-		);
+		paymentRequestCartApi = new PaymentRequestOrderApi( {
+			orderId: getUPEConfig( 'order_id' ),
+			key: getUPEConfig( 'key' ),
+			billingEmail: getUPEConfig( 'billing_email' ),
+		} );
 	}
 
 	const wooPaymentsPaymentRequest = new WooPaymentsPaymentRequest( {

--- a/client/tokenized-payment-request/order-api.js
+++ b/client/tokenized-payment-request/order-api.js
@@ -11,6 +11,9 @@ export default class PaymentRequestOrderApi {
 	key;
 	billingEmail = '';
 
+	// needed to replay the cart data to the `placeOrder` endpoint when placing the order.
+	cachedCartData = {};
+
 	/**
 	 * Creates an instance of class to query for order data.
 	 *
@@ -48,8 +51,8 @@ export default class PaymentRequestOrderApi {
 				key: this.key,
 				billing_email: this.billingEmail,
 				// preventing billing and shipping address from being overwritten in the request to the store - we don't want to update them
-				billing_address: undefined,
-				shipping_address: undefined,
+				billing_address: this.cachedCartData.billing_address,
+				shipping_address: this.cachedCartData.shipping_address,
 			},
 		} );
 	}
@@ -61,12 +64,12 @@ export default class PaymentRequestOrderApi {
 	 * @return {Promise} Cart response object.
 	 */
 	async getCart() {
-		return await apiFetch( {
+		return ( this.cachedCartData = await apiFetch( {
 			method: 'GET',
 			path: addQueryArgs( `/wc/store/v1/order/${ this.orderId }`, {
 				key: this.key,
 				billing_email: this.billingEmail,
 			} ),
-		} );
+		} ) );
 	}
 }

--- a/client/tokenized-payment-request/order-api.js
+++ b/client/tokenized-payment-request/order-api.js
@@ -18,7 +18,7 @@ export default class PaymentRequestOrderApi {
 	 * @param {string} key The order key, used to verify the order ID.
 	 * @param {string?} billingEmail The billing email address, used for guest orders.
 	 */
-	constructor( orderId, key, billingEmail = '' ) {
+	constructor( { orderId, key, billingEmail = '' } ) {
 		this.orderId = orderId;
 		this.key = key;
 		this.billingEmail = billingEmail;

--- a/client/tokenized-payment-request/order-api.js
+++ b/client/tokenized-payment-request/order-api.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { getPaymentRequestData } from './frontend-utils';
+
+export default class PaymentRequestOrderApi {
+	// parameters used in every request, just in different ways.
+	orderId;
+	key;
+	billingEmail = '';
+
+	/**
+	 * Creates an instance of class to query for order data.
+	 *
+	 * @param {string} orderId The order ID,
+	 * @param {string} key The order key, used to verify the order ID.
+	 * @param {string?} billingEmail The billing email address, used for guest orders.
+	 */
+	constructor( orderId, key, billingEmail = '' ) {
+		this.orderId = orderId;
+		this.key = key;
+		this.billingEmail = billingEmail;
+	}
+
+	/**
+	 * Creates an order from the cart object.
+	 * See https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/docs/checkout-order.md
+	 *
+	 * @param {{
+	 *          billing_address: Object,
+	 *          shipping_address: Object,
+	 *          payment_method: string,
+	 *          payment_data: Array,
+	 *        }} paymentData Additional payment data to place the order.
+	 * @return {Promise} Result of the order creation request.
+	 */
+	async placeOrder( paymentData ) {
+		return await apiFetch( {
+			method: 'POST',
+			path: `/wc/store/v1/checkout/${ this.orderId }`,
+			headers: {
+				Nonce: getPaymentRequestData( 'nonce' ).tokenized_order_nonce,
+			},
+			data: {
+				...paymentData,
+				key: this.key,
+				billing_email: this.billingEmail,
+				// preventing billing and shipping address from being overwritten in the request to the store - we don't want to update them
+				billing_address: undefined,
+				shipping_address: undefined,
+			},
+		} );
+	}
+
+	/**
+	 * Returns the customer's order object.
+	 * See https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/docs/cart.md#get-cart
+	 *
+	 * @return {Promise} Cart response object.
+	 */
+	async getOrder() {
+		return await apiFetch( {
+			method: 'GET',
+			path: addQueryArgs( `/wc/store/v1/order/${ this.orderId }`, {
+				key: this.key,
+				billing_email: this.billingEmail,
+			} ),
+		} );
+	}
+}

--- a/client/tokenized-payment-request/order-api.js
+++ b/client/tokenized-payment-request/order-api.js
@@ -60,7 +60,7 @@ export default class PaymentRequestOrderApi {
 	 *
 	 * @return {Promise} Cart response object.
 	 */
-	async getOrder() {
+	async getCart() {
 		return await apiFetch( {
 			method: 'GET',
 			path: addQueryArgs( `/wc/store/v1/order/${ this.orderId }`, {

--- a/client/tokenized-payment-request/order-api.js
+++ b/client/tokenized-payment-request/order-api.js
@@ -56,7 +56,7 @@ export default class PaymentRequestOrderApi {
 
 	/**
 	 * Returns the customer's order object.
-	 * See https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/docs/cart.md#get-cart
+	 * See https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/docs/order.md
 	 *
 	 * @return {Promise} Cart response object.
 	 */

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -143,7 +143,7 @@ export default class WooPaymentsPaymentRequest {
 			paymentRequestButton.on( 'click', () => {
 				trackPaymentRequestButtonClick( 'pay_for_order' );
 			} );
-		} else if ( getPaymentRequestData( 'button_context' ) === 'product' ) {
+		} else {
 			this.attachPaymentRequestButtonEventListeners();
 			removeAction(
 				'wcpay.payment-request.update-button-data',

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -384,10 +384,6 @@ export default class WooPaymentsPaymentRequest {
 	}
 
 	async getCartData() {
-		if ( getPaymentRequestData( 'button_context' ) === 'pay_for_order' ) {
-			return await this.paymentRequestCartApi.getOrder();
-		}
-
 		if ( getPaymentRequestData( 'button_context' ) !== 'product' ) {
 			return await this.paymentRequestCartApi.getCart();
 		}

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -139,93 +139,104 @@ export default class WooPaymentsPaymentRequest {
 			} );
 		paymentRequestButtonUi.showButton( paymentRequestButton );
 
-		this.attachPaymentRequestButtonEventListeners();
-		removeAction(
-			'wcpay.payment-request.update-button-data',
-			'automattic/wcpay/payment-request'
-		);
-		addAction(
-			'wcpay.payment-request.update-button-data',
-			'automattic/wcpay/payment-request',
-			async () => {
-				const newCartData = await _self.getCartData();
-				// checking if items needed shipping, before assigning new cart data.
-				const didItemsNeedShipping =
-					_self.initialProductData?.needs_shipping ||
-					_self.cachedCartData?.needs_shipping;
+		if ( getPaymentRequestData( 'button_context' ) === 'pay_for_order' ) {
+			paymentRequestButton.on( 'click', () => {
+				trackPaymentRequestButtonClick( 'pay_for_order' );
+			} );
+		} else if ( getPaymentRequestData( 'button_context' ) === 'product' ) {
+			this.attachPaymentRequestButtonEventListeners();
+			removeAction(
+				'wcpay.payment-request.update-button-data',
+				'automattic/wcpay/payment-request'
+			);
+			addAction(
+				'wcpay.payment-request.update-button-data',
+				'automattic/wcpay/payment-request',
+				async () => {
+					const newCartData = await _self.getCartData();
+					// checking if items needed shipping, before assigning new cart data.
+					const didItemsNeedShipping =
+						_self.initialProductData?.needs_shipping ||
+						_self.cachedCartData?.needs_shipping;
 
-				_self.cachedCartData = newCartData;
+					_self.cachedCartData = newCartData;
 
-				/**
-				 * If the customer aborted the payment request, we need to re init the payment request button to ensure the shipping
-				 * options are re-fetched. If the customer didn't abort the payment request, and the product's shipping status is
-				 * consistent, we can simply update the payment request button with the new total and display items.
-				 */
-				if (
-					! _self.isPaymentAborted &&
-					didItemsNeedShipping === newCartData.needs_shipping
-				) {
-					paymentRequest.update( {
-						total: {
-							label: getPaymentRequestData( 'total_label' ),
-							amount: parseInt(
-								newCartData.totals.total_price,
-								10
+					/**
+					 * If the customer aborted the payment request, we need to re init the payment request button to ensure the shipping
+					 * options are re-fetched. If the customer didn't abort the payment request, and the product's shipping status is
+					 * consistent, we can simply update the payment request button with the new total and display items.
+					 */
+					if (
+						! _self.isPaymentAborted &&
+						didItemsNeedShipping === newCartData.needs_shipping
+					) {
+						paymentRequest.update( {
+							total: {
+								label: getPaymentRequestData( 'total_label' ),
+								amount: parseInt(
+									newCartData.totals.total_price,
+									10
+								),
+							},
+							displayItems: transformCartDataForDisplayItems(
+								newCartData
 							),
-						},
-						displayItems: transformCartDataForDisplayItems(
-							newCartData
-						),
-					} );
-				} else {
-					_self.init().then( noop );
+						} );
+					} else {
+						_self.init().then( noop );
+					}
 				}
-			}
-		);
+			);
 
-		const $addToCartButton = jQuery( '.single_add_to_cart_button' );
+			const $addToCartButton = jQuery( '.single_add_to_cart_button' );
 
-		paymentRequestButton.on( 'click', ( event ) => {
-			trackPaymentRequestButtonClick( 'product' );
+			paymentRequestButton.on( 'click', ( event ) => {
+				trackPaymentRequestButtonClick( 'product' );
 
-			// If login is required for checkout, display redirect confirmation dialog.
-			if ( getPaymentRequestData( 'login_confirmation' ) ) {
-				event.preventDefault();
-				displayLoginConfirmationDialog( buttonBranding );
-				return;
-			}
+				// If login is required for checkout, display redirect confirmation dialog.
+				if ( getPaymentRequestData( 'login_confirmation' ) ) {
+					event.preventDefault();
+					displayLoginConfirmationDialog( buttonBranding );
+					return;
+				}
 
-			// First check if product can be added to cart.
-			if ( $addToCartButton.is( '.disabled' ) ) {
-				event.preventDefault(); // Prevent showing payment request modal.
-				if ( $addToCartButton.is( '.wc-variation-is-unavailable' ) ) {
-					window.alert(
-						window.wc_add_to_cart_variation_params
-							?.i18n_unavailable_text ||
+				// First check if product can be added to cart.
+				if ( $addToCartButton.is( '.disabled' ) ) {
+					event.preventDefault(); // Prevent showing payment request modal.
+					if (
+						$addToCartButton.is( '.wc-variation-is-unavailable' )
+					) {
+						window.alert(
+							window.wc_add_to_cart_variation_params
+								?.i18n_unavailable_text ||
+								__(
+									'Sorry, this product is unavailable. Please choose a different combination.',
+									'woocommerce-payments'
+								)
+						);
+					} else {
+						window.alert(
 							__(
-								'Sorry, this product is unavailable. Please choose a different combination.',
+								'Please select your product options before proceeding.',
 								'woocommerce-payments'
 							)
-					);
-				} else {
-					window.alert(
-						__(
-							'Please select your product options before proceeding.',
-							'woocommerce-payments'
-						)
-					);
+						);
+					}
+					return;
 				}
-				return;
-			}
 
-			_self.paymentRequestCartApi.addProductToCart();
-		} );
+				_self.paymentRequestCartApi.addProductToCart();
+			} );
+		}
 
 		paymentRequest.on( 'cancel', () => {
 			_self.isPaymentAborted = true;
-			// clearing the cart to avoid issues with products with low or limited availability
-			// being held hostage by customers cancelling the PRB.
-			_self.paymentRequestCartApi.emptyCart();
+
+			if ( getPaymentRequestData( 'button_context' ) === 'product' ) {
+				// clearing the cart to avoid issues with products with low or limited availability
+				// being held hostage by customers cancelling the PRB.
+				_self.paymentRequestCartApi.emptyCart();
+			}
 		} );
 
 		paymentRequest.on( 'shippingaddresschange', async ( event ) => {
@@ -281,7 +292,7 @@ export default class WooPaymentsPaymentRequest {
 		} );
 
 		paymentRequest.on( 'paymentmethod', async ( event ) => {
-			// TODO: this works for PDPs - need to handle checkout scenarios for pay-for-order, cart, checkout.
+			// TODO: this works for PDPs - need to handle checkout scenarios for cart, checkout.
 			try {
 				const response = await _self.paymentRequestCartApi.placeOrder( {
 					// adding extension data as a separate action,
@@ -373,6 +384,10 @@ export default class WooPaymentsPaymentRequest {
 	}
 
 	async getCartData() {
+		if ( getPaymentRequestData( 'button_context' ) === 'pay_for_order' ) {
+			return await this.paymentRequestCartApi.getOrder();
+		}
+
 		if ( getPaymentRequestData( 'button_context' ) !== 'product' ) {
 			return await this.paymentRequestCartApi.getCart();
 		}

--- a/client/tokenized-payment-request/test/order-api.js
+++ b/client/tokenized-payment-request/test/order-api.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import PaymentRequestOrderApi from '../order-api';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+global.wcpayPaymentRequestParams = {};
+global.wcpayPaymentRequestParams.nonce = {};
+global.wcpayPaymentRequestParams.nonce.tokenized_order_nonce =
+	'global_tokenized_order_nonce';
+
+describe( 'PaymentRequestOrderApi', () => {
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'gets order data with the provided arguments', async () => {
+		const api = new PaymentRequestOrderApi( {
+			orderId: '1',
+			key: 'key_123',
+			billingEmail: 'cheese@toast.com',
+		} );
+
+		await api.getOrder();
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'GET',
+				path: expect.stringMatching(
+					// I am using a regex to ensure the order of the parameters doesn't matter.
+					/(?=.*\/wc\/store\/v1\/order\/1)(?=.*billing_email=cheese%40toast.com)(?=.*key=key_123)/
+				),
+			} )
+		);
+	} );
+
+	it( 'places an order', async () => {
+		const api = new PaymentRequestOrderApi( {
+			orderId: '1',
+			key: 'key_123',
+			billingEmail: 'cheese@toast.com',
+		} );
+
+		await api.placeOrder( {
+			billing_address: {
+				first_name: 'Fake',
+			},
+			shipping_address: {
+				first_name: 'Test',
+			},
+			anythingElse: 'passedThrough',
+		} );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'POST',
+				path: '/wc/store/v1/checkout/1',
+				headers: expect.objectContaining( {
+					Nonce: 'global_tokenized_order_nonce',
+				} ),
+				data: expect.objectContaining( {
+					key: 'key_123',
+					billing_email: 'cheese@toast.com',
+					billing_address: undefined,
+					shipping_address: undefined,
+					anythingElse: 'passedThrough',
+				} ),
+			} )
+		);
+	} );
+} );

--- a/client/tokenized-payment-request/test/order-api.js
+++ b/client/tokenized-payment-request/test/order-api.js
@@ -72,4 +72,57 @@ describe( 'PaymentRequestOrderApi', () => {
 			} )
 		);
 	} );
+
+	it( 'places an order with the previous API request data', async () => {
+		const api = new PaymentRequestOrderApi( {
+			orderId: '1',
+			key: 'key_123',
+			billingEmail: 'cheese@toast.com',
+		} );
+
+		apiFetch.mockResolvedValueOnce( {
+			billing_address: {
+				first_name: 'Fake',
+				last_name: 'Test',
+			},
+			shipping_address: {
+				first_name: 'Test',
+				last_name: 'Fake',
+			},
+		} );
+		await api.getCart();
+
+		await api.placeOrder( {
+			billing_address: {
+				first_name: 'Fake',
+			},
+			shipping_address: {
+				first_name: 'Test',
+			},
+			anythingElse: 'passedThrough',
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'POST',
+				path: '/wc/store/v1/checkout/1',
+				headers: expect.objectContaining( {
+					Nonce: 'global_tokenized_order_nonce',
+				} ),
+				data: expect.objectContaining( {
+					key: 'key_123',
+					billing_email: 'cheese@toast.com',
+					billing_address: expect.objectContaining( {
+						first_name: 'Fake',
+						last_name: 'Test',
+					} ),
+					shipping_address: expect.objectContaining( {
+						first_name: 'Test',
+						last_name: 'Fake',
+					} ),
+					anythingElse: 'passedThrough',
+				} ),
+			} )
+		);
+	} );
 } );

--- a/client/tokenized-payment-request/test/order-api.js
+++ b/client/tokenized-payment-request/test/order-api.js
@@ -27,7 +27,7 @@ describe( 'PaymentRequestOrderApi', () => {
 			billingEmail: 'cheese@toast.com',
 		} );
 
-		await api.getOrder();
+		await api.getCart();
 		expect( apiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				method: 'GET',

--- a/client/tokenized-payment-request/test/payment-request.test.js
+++ b/client/tokenized-payment-request/test/payment-request.test.js
@@ -133,6 +133,7 @@ describe( 'WooPaymentsPaymentRequest', () => {
 		expect( trackPaymentRequestButtonLoad ).toHaveBeenCalledWith( 'cart' );
 
 		doAction( 'wcpay.payment-request.update-button-data' );
+
 		await waitForAction( 'wcpay.payment-request.update-button-data' );
 		expect( paymentRequestAvailabilityCallback ).toHaveBeenCalledTimes( 1 );
 

--- a/client/tokenized-payment-request/transformers/wc-to-stripe.js
+++ b/client/tokenized-payment-request/transformers/wc-to-stripe.js
@@ -47,6 +47,14 @@ export const transformCartDataForDisplayItems = ( cartData ) => {
 		} );
 	}
 
+	const refundAmount = parseInt( cartData.totals.total_refund || '0', 10 );
+	if ( refundAmount ) {
+		displayItems.push( {
+			amount: -refundAmount,
+			label: __( 'Refund', 'woocommerce-payments' ),
+		} );
+	}
+
 	return displayItems;
 };
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -929,6 +929,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 				'platform_tracker'          => wp_create_nonce( 'platform_tracks_nonce' ),
 				'pay_for_order'             => wp_create_nonce( 'pay_for_order' ),
 				'tokenized_cart_nonce'      => wp_create_nonce( 'woopayments_tokenized_cart_nonce' ),
+				'tokenized_order_nonce'     => wp_create_nonce( 'wc_store_api' ),
 			],
 			'checkout'           => [
 				'currency_code'     => strtolower( get_woocommerce_currency() ),
@@ -948,7 +949,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			'is_checkout_page'   => $this->express_checkout_helper->is_checkout(),
 		];
 
-		if ( WC_Payments_Features::is_tokenized_cart_prb_enabled() && $this->express_checkout_helper->is_product() ) {
+		if ( WC_Payments_Features::is_tokenized_cart_prb_enabled() && ( $this->express_checkout_helper->is_product() || $this->express_checkout_helper->is_pay_for_order_page() ) ) {
 			WC_Payments::register_script_with_dependencies(
 				'WCPAY_PAYMENT_REQUEST',
 				'dist/tokenized-payment-request',


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8530

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding support of the pay-for-order page w/ the tokenized cart feature.
I created a separate `PaymentRequestOrderApi` class to interact with the store, because the API is different than the checkout API.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the "Enable Cart-Token implementation for PRBs" flag in your dev tools (you'll need to update them)
- Ensure you have Google Pay/Apple Pay enabled in the merchant's settings
- As a merchant, create an order in the backend with some items to pay for
	- PLEASE NOTE: the cart amount needs to be greater than $50 USD - investigating here: p1718364553103609-slack-CU6SYV31A
	- PLEASE NOTE: the order data needs to have an email address associated to it for the Store API to work properly, investigating here: p1718365667412379-slack-C02TS23QJ1X
- Once the order is saved, click on the "Customer payment page" link (you can use this link both in incognito or as an anonymous customer)
- Click on the Google Pay/Apple Pay button displayed on the page
- You should be able to select a payment method (but not shipping options)
- Place the order
- The charge for the order should match the order's total amount

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.