### PR TITLE
Fix duplicated enqueued scripts in shortcode checkout

### DIFF
--- a/changelog/fix-8863-duplicated-enqueued-scripts
+++ b/changelog/fix-8863-duplicated-enqueued-scripts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix WooPay OTP modal not rendering on the shortcode checkout if BNPL methods are available.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -150,7 +150,8 @@ class WC_Payments_Checkout {
 			! WC()->cart->is_empty() &&
 			! WC()->cart->needs_payment() &&
 			is_checkout() &&
-			! has_block( 'woocommerce/checkout' )
+			! has_block( 'woocommerce/checkout' ) &&
+			! wp_script_is( 'wcpay-upe-checkout', 'enqueued' )
 		) {
 			WC_Payments::get_gateway()->tokenization_script();
 			$script_handle = 'wcpay-upe-checkout';

--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -70,6 +70,10 @@ class Fraud_Prevention_Service {
 	 * @return  void
 	 */
 	public static function maybe_append_fraud_prevention_token() {
+		if ( wp_script_is( self::TOKEN_NAME, 'enqueued' ) ) {
+			return;
+		}
+
 		// Check session first before trying to append the token.
 		if ( ! WC()->session ) {
 			return;


### PR DESCRIPTION
Fixes #8863

### Changes proposed in this Pull Request

Currently, when multiple WooPayments payment methods are available, certain scripts are being enqueued more than once in the shortcode checkout:

```html
<script id="woocommerce-tokenization-form-js-extra">
var wc_tokenization_form_params = ...
var wc_tokenization_form_params = ...
var wc_tokenization_form_params = ...
</script>
...
<script id="wcpay-upe-checkout-js-extra">
var wcpay_upe_config = ...
var wcpay_upe_config = ...
var wcpay_upe_config = ...
</script>
```

This is because `WC_Payments_Checkout` gets instantiated for every WC payment gateway, and therefore almost the same `wp_enqueue_scripts` hook gets called multiple times.

This is a long standing issue that was introduced when the UPE payment methods were separated into different WooCommerce payment gateways.

This PR adds a simple check so `wcpay-upe-checkout` and `wcpay-fraud-prevention-token` scripts are not enqueued and localized twice.

**This results in:**
1. The same `wc_tokenization_form_params` variable is not repeated.
2. The same `wcpay_upe_config` variable is not repeated.
   - The only difference in this variable when enqueued for different payment methods is in `wcpay_upe_config.icon`, `wcpay_upe_config.woopayMinimumSessionData` and `wcpay_upe_config.isWooPayEnabled` – The latter causing the issue seen in #8863.
3. [`WooPay_Session::get_woopay_minimum_session_data`](https://github.com/Automattic/woocommerce-payments/blob/1b642ef01cecdef3ff514b88e72f59ae675d23bd/includes/class-wc-payments-checkout.php#L208) is not called multiple times unnecessarily. 💪

### Testing instructions

**Reproducing the issue**

1. Switch to the `develop` branch.
2. As a merchant, enable multiple payment methods. You can set the store currency to EUR to enable most of the PMs.
3. As a shopper, add a product to the cart and navigate to the shortcode checkout.
4. Ensure multiple WooPayments payment methods are available. (You might need to set the billing address to a different country e.g Germany to see methods like Giropay).
5. Navigate to the page source code and ensure you see multiple instances of `var wcpay_upe_config`.
6. Switch to this branch.
7. Ensure you see only one instance of `var wcpay_upe_config`.

**Fixing WooPay OTP modal does not render on the shortcode checkout if BNPL methods are available #8863**

Follow the steps to reproduce from #8863 and ensure the issue can no longer be reproduced in this branch.

**Regression tests**

Perform smoke tests in the following, both in blocks and shortcode checkout:

- Checkout with CC.
- Checkout with saved CC.
- Checkout with other payment methods.
- Checkout with simple subscription product and free trial subscription.
- Checkout with WooPay.
- Adding a new credit card via "My account".

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
