### PR TITLE
Fix unused parameter phpcs sniffs in checkout classes

### DIFF
--- a/changelog/fix-unused-param-phpcs-sniffs
+++ b/changelog/fix-unused-param-phpcs-sniffs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix unused parameter phpcs sniffs in checkout classes.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -1179,12 +1179,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 			$packages = WC()->shipping->get_packages();
 
 			if ( ! empty( $packages ) && WC()->customer->has_calculated_shipping() ) {
-				foreach ( $packages as $package_key => $package ) {
+				foreach ( $packages as $package ) {
 					if ( empty( $package['rates'] ) ) {
 						throw new Exception( __( 'Unable to find shipping method for address.', 'woocommerce-payments' ) );
 					}
 
-					foreach ( $package['rates'] as $key => $rate ) {
+					foreach ( $package['rates'] as $rate ) {
 						$data['shipping_options'][] = [
 							'id'     => $rate->id,
 							'label'  => $rate->label,

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -69,15 +69,13 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		}
 
 		$items     = [];
-		$subtotal  = 0;
 		$discounts = 0;
 		$currency  = get_woocommerce_currency();
 
 		// Default show only subtotal instead of itemization.
 		if ( ! apply_filters( 'wcpay_payment_request_hide_itemization', ! $itemized_display_items ) ) {
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+			foreach ( WC()->cart->get_cart() as $cart_item ) {
 				$amount         = $cart_item['line_subtotal'];
-				$subtotal      += $cart_item['line_subtotal'];
 				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
 
 				$product_name = $cart_item['data']->get_name();
@@ -138,7 +136,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		}
 
 		// Include fees and taxes as display items.
-		foreach ( $cart_fees as $key => $fee ) {
+		foreach ( $cart_fees as $fee ) {
 			$items[] = [
 				'label'  => $fee->name,
 				'amount' => WC_Payments_Utils::prepare_amount( $fee->amount, $currency ),
@@ -507,12 +505,12 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			$packages = WC()->shipping->get_packages();
 
 			if ( ! empty( $packages ) && WC()->customer->has_calculated_shipping() ) {
-				foreach ( $packages as $package_key => $package ) {
+				foreach ( $packages as $package ) {
 					if ( empty( $package['rates'] ) ) {
 						throw new Exception( __( 'Unable to find shipping method for address.', 'woocommerce-payments' ) );
 					}
 
-					foreach ( $package['rates'] as $key => $rate ) {
+					foreach ( $package['rates'] as $rate ) {
 						$data['shipping_options'][] = [
 							'id'          => $rate->id,
 							'displayName' => $rate->label,

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -72,10 +72,12 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 	 * Returns payment method title.
 	 *
 	 * @param string|null $account_country Country of merchants account.
-	 * @param array|false $_unused_payment_details Payment details from charge object. Not used by this class.
+	 * @param array|false $payment_details Payment details from charge object. Not used by this class.
 	 * @return string|null
+	 *
+	 * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
-	public function get_title( string $account_country = null, $_unused_payment_details = false ) {
+	public function get_title( string $account_country = null, $payment_details = false ) {
 		if ( 'GB' === $account_country ) {
 			return __( 'Clearpay', 'woocommerce-payments' );
 		}

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -72,10 +72,10 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 	 * Returns payment method title.
 	 *
 	 * @param string|null $account_country Country of merchants account.
-	 * @param array|false $payment_details Optional payment details from charge object.
+	 * @param array|false $_unused_payment_details Payment details from charge object. Not used by this class.
 	 * @return string|null
 	 */
-	public function get_title( string $account_country = null, $payment_details = false ) {
+	public function get_title( string $account_country = null, $_unused_payment_details = false ) {
 		if ( 'GB' === $account_country ) {
 			return __( 'Clearpay', 'woocommerce-payments' );
 		}

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -130,6 +130,8 @@ abstract class UPE_Payment_Method {
 	 * @param array|false $payment_details Optional payment details from charge object.
 	 *
 	 * @return string
+	 *
+	 * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
 	public function get_title( string $account_country = null, $payment_details = false ) {
 		return $this->title;
@@ -260,6 +262,8 @@ abstract class UPE_Payment_Method {
 	 *
 	 * @param string|null $account_country Optional account country.
 	 * @return string
+	 *
+	 * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
 	public function get_icon( string $account_country = null ) {
 		return isset( $this->icon_url ) ? $this->icon_url : '';

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,7 +40,7 @@
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated" />
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8436 is closed. -->
-		<!-- <exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" /> -->
+		<exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" />
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8437 is clsoed. -->
 		<exclude name="WooCommerce.Commenting.CommentHooks.MissingHookComment" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,7 +40,7 @@
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated" />
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8436 is closed. -->
-		<exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" />
+		<!-- <exclude name="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" /> -->
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8437 is clsoed. -->
 		<exclude name="WooCommerce.Commenting.CommentHooks.MissingHookComment" />


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8657

#### Changes proposed in this Pull Request
This PR fixes the unused parameter sniffs from PHPCS, occurring in the checkout classes.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
* run `npm run lint:php` and confirm that none of the below files are listed in the error report

```php
includes/payment-methods/class-afterpay-payment-method.php
includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
includes/payment-methods/class-upe-payment-method.php
includes/class-wc-payments-payment-request-button-handler.php
```

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
