### PR TITLE
Use FILTER_SANITIZE_EMAIL filter to sanitize email input

### DIFF
--- a/changelog/update-use-filter-sanitize-email-to-sanitize-email-input
+++ b/changelog/update-use-filter-sanitize-email-to-sanitize-email-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use FILTER_SANITIZE_EMAIL to sanitize email input

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -202,9 +202,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 						$session_email = is_array( $customer ) && isset( $customer['email'] ) ? $customer['email'] : '';
 					}
 
-					// Silence the filter_input warning because we are sanitizing the input with sanitize_email().
-					// nosemgrep: audit.php.lang.misc.filter-input-no-filter.
-					$user_email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( filter_input( INPUT_POST, 'email' ) ) ) : $session_email;
+					$user_email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( filter_input( INPUT_POST, 'email', FILTER_SANITIZE_EMAIL ) ) ) : $session_email;
 
 					$js_config['order_id'] = $order->get_id();
 					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated


### PR DESCRIPTION
Fixes #8316 

#### Changes proposed in this Pull Request
Use `FILTER_SANITIZE_EMAIL` filter to sanitize email input
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Follow the QIT tests setup and run the tests
2. Check the `Result Url`
3. Should see `Security Test - Success`

|Before|After|
|--|--|
|<img width="875" alt="Screenshot 2024-06-13 at 10 51 29 PM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/ab907326-d565-4685-b3c5-a5effec31f3a">|<img width="1213" alt="Screenshot 2024-06-13 at 10 50 02 PM" src="https://github.com/Automattic/woocommerce-payments/assets/56378160/78f6620d-751a-4dc1-9f1a-4db2edde5dc3">|


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
