### PR TITLE
Reporting: Add test for date preset drowpdown in PaymentActivity component

### DIFF
--- a/changelog/add-8943-test-for-date-selector-hook
+++ b/changelog/add-8943-test-for-date-selector-hook
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Add test for date selector in PaymentActivity component
+Comment: Add tests for the date preset dropdown in the PaymentActivity component
 
 

--- a/changelog/add-8943-test-for-date-selector-hook
+++ b/changelog/add-8943-test-for-date-selector-hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add test for date selector in PaymentActivity component
+
+

--- a/client/components/payment-activity/hooks.ts
+++ b/client/components/payment-activity/hooks.ts
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 
-export interface DateRange {
+interface DateRange {
 	/** The name of the date range preset. e.g. last_7_days */
 	preset_name: string;
 	/** The date range start datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */

--- a/client/components/payment-activity/hooks.ts
+++ b/client/components/payment-activity/hooks.ts
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 
-interface DateRange {
+export interface DateRange {
 	/** The name of the date range preset. e.g. last_7_days */
 	preset_name: string;
 	/** The date range start datetime used to calculate transaction data, e.g. 2024-04-29T16:19:29 */

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -230,44 +230,56 @@ describe( 'PaymentActivity component', () => {
 			( { dateNow, expected } ) => {
 				mockDateNowTo( dateNow );
 
-				const { getAllByRole, getByRole } = render(
-					<PaymentActivity />
-				);
+				const { getByRole } = render( <PaymentActivity /> );
 
 				const dateSelectorButton = getByRole( 'button', {
 					name: 'Period',
 				} );
 				fireEvent.click( dateSelectorButton );
-				const datePresetOptions = getAllByRole( 'option' );
 
-				expect( datePresetOptions ).toHaveLength( 9 );
-				expect( datePresetOptions[ 0 ] ).toHaveTextContent(
-					`Today${ expected.today }`
-				);
-				expect( datePresetOptions[ 1 ] ).toHaveTextContent(
-					`Last 7 days${ expected.last7Days }`
-				);
-				expect( datePresetOptions[ 2 ] ).toHaveTextContent(
-					`Last 4 weeks${ expected.last4Weeks }`
-				);
-				expect( datePresetOptions[ 3 ] ).toHaveTextContent(
-					`Last 3 months${ expected.last3Months }`
-				);
-				expect( datePresetOptions[ 4 ] ).toHaveTextContent(
-					`Last 12 months${ expected.last12Months }`
-				);
-				expect( datePresetOptions[ 5 ] ).toHaveTextContent(
-					`Month to date${ expected.monthToDate }`
-				);
-				expect( datePresetOptions[ 6 ] ).toHaveTextContent(
-					`Quarter to date${ expected.quarterToDate }`
-				);
-				expect( datePresetOptions[ 7 ] ).toHaveTextContent(
-					`Year to date${ expected.yearToDate }`
-				);
-				expect( datePresetOptions[ 8 ] ).toHaveTextContent(
-					`All time${ expected.allTime }`
-				);
+				expect(
+					getByRole( 'option', { name: `Today ${ expected.today }` } )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Last 7 days ${ expected.last7Days }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Last 4 weeks ${ expected.last4Weeks }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Last 3 months ${ expected.last3Months }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Last 12 months ${ expected.last12Months }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Month to date ${ expected.monthToDate }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Quarter to date ${ expected.quarterToDate }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `Year to date ${ expected.yearToDate }`,
+					} )
+				).toBeInTheDocument();
+				expect(
+					getByRole( 'option', {
+						name: `All time ${ expected.allTime }`,
+					} )
+				).toBeInTheDocument();
 			}
 		);
 	} );

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -175,6 +175,7 @@ describe( 'PaymentActivity component', () => {
 		};
 		const dataSet = [
 			{
+				// Ordinary case or Happy Path
 				dateNow: '2024-06-10T16:19:29',
 				expected: {
 					today: 'June 10, 2024',
@@ -188,6 +189,7 @@ describe( 'PaymentActivity component', () => {
 				},
 			},
 			{
+				// Start of the year
 				dateNow: '2024-01-01T00:00:01',
 				expected: {
 					today: 'January 1, 2024',
@@ -201,6 +203,7 @@ describe( 'PaymentActivity component', () => {
 				},
 			},
 			{
+				// Leap year
 				dateNow: '2024-02-29T00:00:00',
 				expected: {
 					today: 'February 29, 2024',

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -168,55 +168,95 @@ describe( 'PaymentActivity component', () => {
 	} );
 
 	describe( 'Date selector renders correct ranges', () => {
-		/* const dataSet = [
-			{
-				rightNow: '2024-06-10T16:19:29',
-				preset: 'today',
-				start: '2024-06-12T00:00:00',
-				end: '2024-06-12T23:59:59',
-			},
-		]; */
-		it( 'should render the correct date ranges', () => {
+		const mockDateNowTo = ( date: string ) => {
 			Date.now = jest.fn( () =>
-				moment
-					.tz( new Date( '2024-06-10T16:19:29' ).getTime(), 'UTC' )
-					.valueOf()
+				moment.tz( new Date( date ).getTime(), 'UTC' ).valueOf()
 			);
+		};
+		const dataSet = [
+			{
+				dateNow: '2024-06-10T16:19:29',
+				expected: {
+					today: 'June 10, 2024',
+					last7Days: 'June 3 - June 9, 2024',
+					last4Weeks: 'May 13 - June 9, 2024',
+					last3Months: 'March 10 - June 9, 2024',
+					last12Months: 'June 10, 2023 - June 9, 2024',
+					monthToDate: 'June 1 - June 10, 2024',
+					quarterToDate: 'April 1 - June 10, 2024',
+					yearToDate: 'January 1 - June 10, 2024',
+				},
+			},
+			{
+				dateNow: '2024-01-01T00:00:01',
+				expected: {
+					today: 'January 1, 2024',
+					last7Days: 'December 25 - December 31, 2023',
+					last4Weeks: 'December 4 - December 31, 2023',
+					last3Months: 'October 1 - December 31, 2023',
+					last12Months: 'January 1 - December 31, 2023',
+					monthToDate: 'January 1, 2024',
+					quarterToDate: 'January 1, 2024',
+					yearToDate: 'January 1, 2024',
+				},
+			},
+			{
+				dateNow: '2024-02-29T00:00:00',
+				expected: {
+					today: 'February 29, 2024',
+					last7Days: 'February 22 - February 28, 2024',
+					last4Weeks: 'February 1 - February 28, 2024',
+					last3Months: 'November 29, 2023 - February 28, 2024',
+					last12Months: 'February 28, 2023 - February 28, 2024',
+					monthToDate: 'February 1 - February 29, 2024',
+					quarterToDate: 'January 1 - February 29, 2024',
+					yearToDate: 'January 1 - February 29, 2024',
+				},
+			},
+		];
 
-			const { container, getAllByRole } = render( <PaymentActivity /> );
+		it.each( dataSet )(
+			'should render the correct date ranges',
+			( { dateNow, expected } ) => {
+				mockDateNowTo( dateNow );
 
-			const dateSelectorButton = getAllByRole( 'button' )[ 0 ];
-			fireEvent.click( dateSelectorButton );
-			const datePresetOptions = getAllByRole( 'option' );
+				const { getAllByRole } = render( <PaymentActivity /> );
 
-			expect( datePresetOptions ).toHaveLength( 9 );
-			expect( datePresetOptions[ 0 ] ).toHaveTextContent(
-				'TodayJune 10, 2024'
-			);
-			expect( datePresetOptions[ 1 ] ).toHaveTextContent(
-				'Last 7 daysJune 3 - June 9, 2024'
-			);
-			expect( datePresetOptions[ 2 ] ).toHaveTextContent(
-				'Last 4 weeksMay 13 - June 9, 2024'
-			);
-			expect( datePresetOptions[ 3 ] ).toHaveTextContent(
-				'Last 3 monthsMarch 10 - June 9, 2024'
-			);
-			expect( datePresetOptions[ 4 ] ).toHaveTextContent(
-				'Last 12 monthsJune 10, 2023 - June 9, 2024'
-			);
-			expect( datePresetOptions[ 5 ] ).toHaveTextContent(
-				'Month to dateJune 1 - June 10, 2024'
-			);
-			expect( datePresetOptions[ 6 ] ).toHaveTextContent(
-				'Quarter to dateApril 1 - June 10, 2024'
-			);
-			expect( datePresetOptions[ 7 ] ).toHaveTextContent(
-				'Year to dateJanuary 1 - June 10, 2024'
-			);
-			expect( datePresetOptions[ 8 ] ).toHaveTextContent( 'All time' );
+				const dateSelectorButton = getAllByRole( 'button' )[ 0 ];
+				fireEvent.click( dateSelectorButton );
+				const datePresetOptions = getAllByRole( 'option' );
 
-			Date.now = () => new Date().getTime();
-		} );
+				expect( datePresetOptions ).toHaveLength( 9 );
+				expect( datePresetOptions[ 0 ] ).toHaveTextContent(
+					`Today${ expected.today }`
+				);
+				expect( datePresetOptions[ 1 ] ).toHaveTextContent(
+					`Last 7 days${ expected.last7Days }`
+				);
+				expect( datePresetOptions[ 2 ] ).toHaveTextContent(
+					`Last 4 weeks${ expected.last4Weeks }`
+				);
+				expect( datePresetOptions[ 3 ] ).toHaveTextContent(
+					`Last 3 months${ expected.last3Months }`
+				);
+				expect( datePresetOptions[ 4 ] ).toHaveTextContent(
+					`Last 12 months${ expected.last12Months }`
+				);
+				expect( datePresetOptions[ 5 ] ).toHaveTextContent(
+					`Month to date${ expected.monthToDate }`
+				);
+				expect( datePresetOptions[ 6 ] ).toHaveTextContent(
+					`Quarter to date${ expected.quarterToDate }`
+				);
+				expect( datePresetOptions[ 7 ] ).toHaveTextContent(
+					`Year to date${ expected.yearToDate }`
+				);
+				expect( datePresetOptions[ 8 ] ).toHaveTextContent(
+					'All time'
+				);
+
+				Date.now = () => new Date().getTime();
+			}
+		);
 	} );
 } );

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -191,7 +191,7 @@ describe( 'PaymentActivity component', () => {
 			},
 			{
 				// Start of the year
-				dateNow: '2024-01-01T00:00:01',
+				dateNow: '2024-01-01T00:00:00',
 				expected: {
 					today: 'January 1, 2024',
 					last7Days: 'December 25 - December 31, 2023',

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -64,6 +65,7 @@ declare const global: {
 					[ currencyCode: string ]: number;
 				};
 			};
+			created: string;
 		};
 		accountDefaultCurrency: string;
 		zeroDecimalCurrencies: string[];
@@ -87,6 +89,7 @@ describe( 'PaymentActivity component', () => {
 						usd: 500,
 					},
 				},
+				created: '2022-01-01T00:00:00Z',
 			},
 			accountDefaultCurrency: 'eur',
 			zeroDecimalCurrencies: [],
@@ -162,5 +165,58 @@ describe( 'PaymentActivity component', () => {
 		expect(
 			queryByText( 'Are these metrics helpful?' )
 		).not.toBeInTheDocument();
+	} );
+
+	describe( 'Date selector renders correct ranges', () => {
+		/* const dataSet = [
+			{
+				rightNow: '2024-06-10T16:19:29',
+				preset: 'today',
+				start: '2024-06-12T00:00:00',
+				end: '2024-06-12T23:59:59',
+			},
+		]; */
+		it( 'should render the correct date ranges', () => {
+			Date.now = jest.fn( () =>
+				moment
+					.tz( new Date( '2024-06-10T16:19:29' ).getTime(), 'UTC' )
+					.valueOf()
+			);
+
+			const { container, getAllByRole } = render( <PaymentActivity /> );
+
+			const dateSelectorButton = getAllByRole( 'button' )[ 0 ];
+			fireEvent.click( dateSelectorButton );
+			const datePresetOptions = getAllByRole( 'option' );
+
+			expect( datePresetOptions ).toHaveLength( 9 );
+			expect( datePresetOptions[ 0 ] ).toHaveTextContent(
+				'TodayJune 10, 2024'
+			);
+			expect( datePresetOptions[ 1 ] ).toHaveTextContent(
+				'Last 7 daysJune 3 - June 9, 2024'
+			);
+			expect( datePresetOptions[ 2 ] ).toHaveTextContent(
+				'Last 4 weeksMay 13 - June 9, 2024'
+			);
+			expect( datePresetOptions[ 3 ] ).toHaveTextContent(
+				'Last 3 monthsMarch 10 - June 9, 2024'
+			);
+			expect( datePresetOptions[ 4 ] ).toHaveTextContent(
+				'Last 12 monthsJune 10, 2023 - June 9, 2024'
+			);
+			expect( datePresetOptions[ 5 ] ).toHaveTextContent(
+				'Month to dateJune 1 - June 10, 2024'
+			);
+			expect( datePresetOptions[ 6 ] ).toHaveTextContent(
+				'Quarter to dateApril 1 - June 10, 2024'
+			);
+			expect( datePresetOptions[ 7 ] ).toHaveTextContent(
+				'Year to dateJanuary 1 - June 10, 2024'
+			);
+			expect( datePresetOptions[ 8 ] ).toHaveTextContent( 'All time' );
+
+			Date.now = () => new Date().getTime();
+		} );
 	} );
 } );

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -10,7 +10,6 @@ import moment from 'moment';
  */
 import { usePaymentActivityData } from 'wcpay/data';
 import PaymentActivity from '..';
-import { after } from 'lodash';
 
 jest.mock( '@wordpress/data', () => ( {
 	createRegistryControl: jest.fn(),
@@ -231,9 +230,13 @@ describe( 'PaymentActivity component', () => {
 			( { dateNow, expected } ) => {
 				mockDateNowTo( dateNow );
 
-				const { getAllByRole } = render( <PaymentActivity /> );
+				const { getAllByRole, getByRole } = render(
+					<PaymentActivity />
+				);
 
-				const dateSelectorButton = getAllByRole( 'button' )[ 0 ];
+				const dateSelectorButton = getByRole( 'button', {
+					name: 'Period',
+				} );
 				fireEvent.click( dateSelectorButton );
 				const datePresetOptions = getAllByRole( 'option' );
 

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -186,6 +186,7 @@ describe( 'PaymentActivity component', () => {
 					monthToDate: 'June 1 - June 10, 2024',
 					quarterToDate: 'April 1 - June 10, 2024',
 					yearToDate: 'January 1 - June 10, 2024',
+					allTime: 'January 1, 2022 - June 10, 2024',
 				},
 			},
 			{
@@ -200,6 +201,7 @@ describe( 'PaymentActivity component', () => {
 					monthToDate: 'January 1, 2024',
 					quarterToDate: 'January 1, 2024',
 					yearToDate: 'January 1, 2024',
+					allTime: 'January 1, 2022 - January 1, 2024',
 				},
 			},
 			{
@@ -214,6 +216,7 @@ describe( 'PaymentActivity component', () => {
 					monthToDate: 'February 1 - February 29, 2024',
 					quarterToDate: 'January 1 - February 29, 2024',
 					yearToDate: 'January 1 - February 29, 2024',
+					allTime: 'January 1, 2022 - February 29, 2024',
 				},
 			},
 		];
@@ -255,7 +258,7 @@ describe( 'PaymentActivity component', () => {
 					`Year to date${ expected.yearToDate }`
 				);
 				expect( datePresetOptions[ 8 ] ).toHaveTextContent(
-					'All time'
+					`All time${ expected.allTime }`
 				);
 
 				Date.now = () => new Date().getTime();

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -10,6 +10,7 @@ import moment from 'moment';
  */
 import { usePaymentActivityData } from 'wcpay/data';
 import PaymentActivity from '..';
+import { after } from 'lodash';
 
 jest.mock( '@wordpress/data', () => ( {
 	createRegistryControl: jest.fn(),
@@ -168,6 +169,10 @@ describe( 'PaymentActivity component', () => {
 	} );
 
 	describe( 'Date selector renders correct ranges', () => {
+		afterEach( () => {
+			Date.now = () => new Date().getTime();
+		} );
+
 		const mockDateNowTo = ( date: string ) => {
 			Date.now = jest.fn( () =>
 				moment.tz( new Date( date ).getTime(), 'UTC' ).valueOf()
@@ -260,8 +265,6 @@ describe( 'PaymentActivity component', () => {
 				expect( datePresetOptions[ 8 ] ).toHaveTextContent(
 					`All time${ expected.allTime }`
 				);
-
-				Date.now = () => new Date().getTime();
 			}
 		);
 	} );


### PR DESCRIPTION
Fixes #8943 

Adds a test that checks if the correct date ranges are rendered for three different date cases - Ordinary, Start of year, Leap year. 

#### Testing instructions
* All tests should pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - Not applicable

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
