### PR TITLE
POC: Introduce test-drive onboardings

### DIFF
--- a/client/components/account-status/account-tools/strings.tsx
+++ b/client/components/account-status/account-tools/strings.tsx
@@ -7,11 +7,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { isInDevMode } from 'utils';
+import { isInDevMode, isTestDriveAccount } from 'utils';
 
 export default {
 	title: __( 'Account Tools', 'woocommerce-payments' ),
-	description: isInDevMode()
+	// eslint-disable-next-line no-nested-ternary
+	description: isTestDriveAccount()
+		? __(
+				'Your account is a test-drive account. You can reset it and start from the beginning if you wish to test with a different country.',
+				'woocommerce-payments'
+		  )
+		: isInDevMode()
 		? __(
 				'Your account is in sandbox mode. If you are experiencing problems completing account setup, or wish to test with a different email/country associated with your account, you can reset your account and start from the beginning.',
 				'woocommerce-payments'

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -78,20 +78,22 @@ const AccountStatusDetails = ( props ) => {
 					}
 				/>
 			</FlexBlock>
-			<FlexItem className={ 'edit-details' }>
-				<Button
-					variant={ 'link' }
-					onClick={ () =>
-						recordEvent( 'wcpay_account_details_link_clicked', {
-							source: 'account-details',
-						} )
-					}
-					href={ accountLink }
-					target={ '_blank' }
-				>
-					{ __( 'Edit details', 'woocommerce-payments' ) }
-				</Button>
-			</FlexItem>
+			{ ! accountStatus.testDrive && (
+				<FlexItem className={ 'edit-details' }>
+					<Button
+						variant={ 'link' }
+						onClick={ () =>
+							recordEvent( 'wcpay_account_details_link_clicked', {
+								source: 'account-details',
+							} )
+						}
+						href={ accountLink }
+						target={ '_blank' }
+					>
+						{ __( 'Edit details', 'woocommerce-payments' ) }
+					</Button>
+				</FlexItem>
+			) }
 		</>
 	);
 

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -144,7 +144,7 @@ const ConnectAccountPage: React.FC = () => {
 
 		const url = addQueryArgs( connectUrl, {
 			test_mode: true,
-			create_builder_account: true,
+			test_drive: true,
 		} );
 		window.location.href = url;
 	};
@@ -215,7 +215,7 @@ const ConnectAccountPage: React.FC = () => {
 					{ incentive && <Incentive { ...incentive } /> }
 					<Panel className="connect-account-page__sandbox-mode-panel">
 						<PanelBody
-							title={ strings.sandboxMode.title }
+							title={ strings.testDriveMode.title }
 							initialOpen={ false }
 						>
 							<InlineNotice
@@ -223,7 +223,7 @@ const ConnectAccountPage: React.FC = () => {
 								status="info"
 								isDismissible={ false }
 							>
-								{ strings.sandboxMode.description }
+								{ strings.testDriveMode.description }
 							</InlineNotice>
 							<Button
 								variant="secondary"
@@ -231,7 +231,7 @@ const ConnectAccountPage: React.FC = () => {
 								disabled={ isSandboxModeClicked }
 								onClick={ handleEnableSandboxMode }
 							>
-								{ strings.button.sandbox }
+								{ strings.button.testDrive }
 							</Button>
 						</PanelBody>
 					</Panel>

--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -18,6 +18,7 @@ export default {
 			'woocommerce-payments'
 		),
 		sandbox: __( 'Enable sandbox mode', 'woocommerce-payments' ),
+		testDrive: __( 'Engage test-drive mode', 'woocommerce-payments' ),
 	},
 	heading: ( firstName?: string ): string =>
 		sprintf(
@@ -47,6 +48,20 @@ export default {
 			/* translators: %s: WooPayments */
 			__(
 				'This option will set up %s in sandbox mode. You can use our test data to set up. When you’re ready to launch your store, switching to live payments is easy.',
+				'woocommerce-payments'
+			),
+			'WooPayments'
+		),
+	},
+	testDriveMode: {
+		title: __(
+			'I want to set up my store first and worry about live payments later.',
+			'woocommerce-payments'
+		),
+		description: sprintf(
+			/* translators: %1$s: WooPayments */
+			__(
+				'This option will set up %1$s in test-drive mode. Everything %1$s has to offer is at your disposal. When you’re ready to launch your store, switching to live payments is easy.',
 				'woocommerce-payments'
 			),
 			'WooPayments'

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -37,6 +37,21 @@ export const isInDevMode = ( fallback = false ) => {
 	return wcpaySettings.devMode === '1' || fallback;
 };
 
+/**
+ * Returns true if the current account is a test-drive account, false otherwise.
+ *
+ * @param {boolean} fallback Fallback in case the account test-drive status can't be found (for example if the wcpaySettings are undefined).
+ *
+ * @return {boolean} True if the current account is a test-drive account, false otherwise.
+ * 					 Fallback value if the test-drive status can't be found.
+ */
+export const isTestDriveAccount = ( fallback = false ) => {
+	if ( typeof wcpaySettings.accountStatus.testDrive === 'undefined' ) {
+		return fallback;
+	}
+	return wcpaySettings.accountStatus.testDrive || fallback;
+};
+
 export const getAdminUrl = ( args ) => addQueryArgs( 'admin.php', args );
 
 /**


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-payments-server/issues/5418

#### Changes proposed in this Pull Request

For a proof-of-concept, we replace the builder flow with a test-drive flow.

See this spike post (paJDYF-dZe-p2) for more context.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.