### PR TITLE
fix: tokenized PRBs payment type

### DIFF
--- a/changelog/fix-tokenized-payment-request-payment-fix
+++ b/changelog/fix-tokenized-payment-request-payment-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: tokenized PRBs payment type

--- a/client/tokenized-payment-request/transformers/stripe-to-wc.js
+++ b/client/tokenized-payment-request/transformers/stripe-to-wc.js
@@ -83,6 +83,10 @@ export const transformStripePaymentMethodForStoreApi = ( paymentData ) => {
 		payment_method: 'woocommerce_payments',
 		payment_data: [
 			{
+				key: 'payment_method',
+				value: 'card',
+			},
+			{
 				key: 'payment_request_type',
 				value: paymentRequestType,
 			},


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Placing an order with the tokenized pay-for-order flow would fail if the USD amount was less than $50.

This is happening because this line isn't detecting the correct payment method being used:
https://github.com/Automattic/woocommerce-payments/blob/13ea0cffabe45301b6f2850036784e389142559b/includes/class-wc-payment-gateway-wcpay.php#L2059-L2059

Since the payment method is `card` for PRBs, let's fix it by passing the `card` method.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the "Enable Cart-Token implementation for PRBs" flag in your dev tools (you'll need to update them)
- Ensure you have Google Pay/Apple Pay enabled in the merchant's settings
- Ensure you have Affirm enabled in your settings
- As a merchant, create an order in the backend with some items to pay for, ensure the amount is less than $50
	- PLEASE NOTE: the order data needs to have an email address associated to it for the Store API to work properly, investigating here: p1718365667412379-slack-C02TS23QJ1X
- Once the order is saved, click on the "Customer payment page" link (you can use this link both in incognito or as an anonymous customer)
- Click on the Google Pay/Apple Pay button displayed on the page
- Placing the order should be successful, even if the amount is less than $50
- Using PRBs on a product page should also still be working fine (i.e.: PRBs functionality on product pages shouldn't be affected)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
