### PR TITLE
Ensuring billing country is not empty when updating billing address

### DIFF
--- a/changelog/fix-empty-country-update
+++ b/changelog/fix-empty-country-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed an error when renewing subscriptions without a billing country

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -923,6 +923,11 @@ class WC_Payments_Order_Service {
 			$billing_details['name'] = trim( $order->get_formatted_billing_full_name() );
 		}
 
+		// The country field can't ever be empty, so we remove it if it is.
+		if ( empty( $billing_details['address']['country'] ) ) {
+			unset( $billing_details['address']['country'] );
+		}
+
 		return $billing_details;
 	}
 


### PR DESCRIPTION
Fixes #8352

#### Changes proposed in this Pull Request

Because custom hooks, it is possible that an order's billing country is not set sometimes. When we are renewing a subscription with no billing country, we might send an empty string as the value for the country. This makes Stripe respond with an error. This PR ensures we never send an empty string as country when updating the billing address.

#### Testing instructions

1. Add [this snippet](https://wpdavies.dev/remove-checkout-fields-for-downloadable-products-woocommerce/) to your test site.
1. Subscribe for a Virtual Subscription.
2. Go to the admin dashboard and try to renew this subscription.
3. It should proceed when using `fix-empty-country-update`, but fail when using `develop` (unless p1718288909785719-slack-CU6SYV31A is merged, in which case we need to revert it for testing purposes).


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.