### PR TITLE
Improve the tooltip texts on Payment Activity Card data tiles.

### DIFF
--- a/changelog/update-8973-payment-activity-tooltips
+++ b/changelog/update-8973-payment-activity-tooltips
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Part of Payment Activity Card. Improved tooltips.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -88,7 +88,7 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 							<>
 								{ interpolateComponents( {
 									mixedString: __(
-										'{{strong}}Total payment volume{{/strong}} is gross value of payments successfully processed over a given timeframe.',
+										'{{strong}}Total payment volume{{/strong}} is the sum of all transactions in a given time period, minus refunds and disputes.',
 										'woocommerce-payments'
 									),
 									components: {
@@ -197,6 +197,25 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 					id="wcpay-payment-data-highlights__disputes"
 					label={ __( 'Disputes', 'woocommerce-payments' ) }
 					currencyCode={ currency }
+					tooltip={
+						<ClickTooltip
+							className="payment-data-highlights__disputes__tooltip"
+							buttonIcon={ <HelpOutlineIcon /> }
+							buttonLabel={ __(
+								'Disputes tooltip',
+								'woocommerce-payments'
+							) }
+							content={ interpolateComponents( {
+								mixedString: __(
+									'{{strong}}Disputes{{/strong}} includes the amount of any disputed charges. Dispute fees are included in the Fees section.',
+									'woocommerce-payments'
+								),
+								components: {
+									strong: <strong />,
+								},
+							} ) }
+						/>
+					}
 					amount={ disputes }
 					reportLink={ getAdminUrl( {
 						page: 'wc-admin',
@@ -230,11 +249,19 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 							) }
 							content={ interpolateComponents( {
 								mixedString: __(
-									'{{strong}}Fees{{/strong}} includes fees on payments as well as disputes.',
+									'{{strong}}Fees{{/strong}} includes all types of fees charged by WooPayments. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 									'woocommerce-payments'
 								),
 								components: {
 									strong: <strong />,
+									learnMoreLink: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											target="_blank"
+											rel="noopener noreferrer"
+											href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/"
+										/>
+									),
 								},
 							} ) }
 						/>

--- a/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/payment-activity/test/__snapshots__/index.test.tsx.snap
@@ -229,6 +229,34 @@ exports[`PaymentActivity component should render 1`] = `
                 >
                   Disputes
                 </span>
+                <button
+                  class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
+                  type="button"
+                >
+                  <div
+                    class="wcpay-tooltip__content-wrapper"
+                  >
+                    <div
+                      aria-label="Disputes tooltip"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <svg
+                        class="gridicon gridicons-help-outline"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <g>
+                          <path
+                            d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2v-1.141A3.991 3.991 0 0016 10zm-3 6h-2v2h2v-2z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </p>
               <div
                 class="wcpay-payment-data-highlights__item__wrapper"


### PR DESCRIPTION
Fixes #8973 

#### Changes proposed in this Pull Request

Updates the tooltip texts as mentioned in #8973 

**Screenshots**
<img width="343" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/32092402/b6f3d9d5-99d7-4f93-9c04-f352b901a2f4">
<hr/>
<img width="370" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/32092402/8d2362cb-072a-4eea-b66f-e4b66a698ab4">
<hr/>
<img width="668" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/32092402/8a4ce57b-99b9-4023-8918-650efada0314">


#### Testing instructions
- check the tooltips on the data tiles in Payment Activity card
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**
Not Applicable - Part of Payment Activity Card.
- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
