### PR TITLE
fix: display refund amount w/ tokenized cart PRBs

### DIFF
--- a/changelog/fix-tokenized-cart-prbs-refund-amount-display
+++ b/changelog/fix-tokenized-cart-prbs-refund-amount-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: display refund amount w/ tokenized cart PRBs

--- a/client/tokenized-payment-request/frontend-utils.js
+++ b/client/tokenized-payment-request/frontend-utils.js
@@ -61,7 +61,9 @@ export const getPaymentRequest = ( { stripe, cartData, productData } ) => {
 					currency: cartData.totals.currency_code.toLowerCase(),
 					total: {
 						label: getPaymentRequestData( 'total_label' ),
-						amount: parseInt( cartData.totals.total_price, 10 ),
+						amount:
+							parseInt( cartData.totals.total_price, 10 ) -
+							parseInt( cartData.totals.total_refund || 0, 10 ),
 					},
 					requestShipping:
 						getPaymentRequestData( 'button_context' ) ===

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -173,10 +173,15 @@ export default class WooPaymentsPaymentRequest {
 						paymentRequest.update( {
 							total: {
 								label: getPaymentRequestData( 'total_label' ),
-								amount: parseInt(
-									newCartData.totals.total_price,
-									10
-								),
+								amount:
+									parseInt(
+										newCartData.totals.total_price,
+										10
+									) -
+									parseInt(
+										newCartData.totals.total_refund || 0,
+										10
+									),
 							},
 							displayItems: transformCartDataForDisplayItems(
 								newCartData
@@ -257,7 +262,9 @@ export default class WooPaymentsPaymentRequest {
 					),
 					total: {
 						label: getPaymentRequestData( 'total_label' ),
-						amount: parseInt( cartData.totals.total_price, 10 ),
+						amount:
+							parseInt( cartData.totals.total_price, 10 ) -
+							parseInt( cartData.totals.total_refund || 0, 10 ),
 					},
 					displayItems: transformCartDataForDisplayItems( cartData ),
 				} );
@@ -281,7 +288,9 @@ export default class WooPaymentsPaymentRequest {
 					status: 'success',
 					total: {
 						label: getPaymentRequestData( 'total_label' ),
-						amount: parseInt( cartData.totals.total_price, 10 ),
+						amount:
+							parseInt( cartData.totals.total_price, 10 ) -
+							parseInt( cartData.totals.total_refund || 0, 10 ),
 					},
 					displayItems: transformCartDataForDisplayItems( cartData ),
 				} );

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -178,10 +178,7 @@ export default class WooPaymentsPaymentRequest {
 						total: {
 							label: getPaymentRequestData( 'total_label' ),
 							amount:
-								parseInt(
-									newCartData.totals.total_price,
-									10
-								) -
+								parseInt( newCartData.totals.total_price, 10 ) -
 								parseInt(
 									newCartData.totals.total_refund || 0,
 									10

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -178,14 +178,14 @@ export default class WooPaymentsPaymentRequest {
 						total: {
 							label: getPaymentRequestData( 'total_label' ),
 							amount:
-									parseInt(
-										newCartData.totals.total_price,
-										10
-									) -
-									parseInt(
-										newCartData.totals.total_refund || 0,
-										10
-									),
+								parseInt(
+									newCartData.totals.total_price,
+									10
+								) -
+								parseInt(
+									newCartData.totals.total_refund || 0,
+									10
+								),
 						},
 						displayItems: transformCartDataForDisplayItems(
 							newCartData


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The amount displayed in the tokenized cart PRBs doesn't reflect the refund amount in the pay-for-order flow.
The Store API returns a `totals.total_price`, but the refund amount isn't subtracted from that attribute. We instead need to subtract it manually: p1718207386500249-slack-C02TS23QJ1X

This PR fixes the _displayed_ amount in the tokenized cart PRBs. It doesn't fix the amount being charged.
For that fix, we'll need to work on this issue affecting WooPayments as a whole: https://github.com/Automattic/woocommerce-payments/issues/8933

Before:
<img width="625" alt="Screenshot 2024-06-18 at 6 18 32 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/feb23306-6cf8-4887-a9bc-00c2d29ff6c5">
<img width="332" alt="Screenshot 2024-06-18 at 6 18 36 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/ecee492b-0c20-400a-90ac-4849d4af90e6">

After:
<img width="632" alt="Screenshot 2024-06-18 at 6 18 04 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/eec7f47b-c040-4868-b94c-755ce5c53126">
<img width="624" alt="Screenshot 2024-06-18 at 6 18 08 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/09edb900-cf35-484e-abb3-63b3eac0878b">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the "Enable Cart-Token implementation for PRBs" flag in your dev tools (you'll need to update them)
- Ensure you have Google Pay/Apple Pay enabled in the merchant's settings
- As a merchant, create a draft order in the backend (include billing/shipping details and some products - more than one). Save the order
	- PLEASE NOTE: the order data needs to have an email address associated to it for the Store API to work properly, investigating here: p1718365667412379-slack-C02TS23QJ1X
- After saving, edit the order by refunding one of the items
- Once the order is updated, click on the "Customer payment page" link (you can use this link both in incognito or as an anonymous customer - but you'll need to be logged into your Google Account to use Google Pay)
- Click on the Google Pay/Apple Pay button displayed on the page
- The total amount should be accurately reflecting the amount that should be paid
- Place the order
- Unfortunately, the charge for the order will still not match the total with the refund subtracted, but the order's total amount
<img width="633" alt="Screenshot 2024-06-18 at 6 21 14 PM" src="https://github.com/Automattic/woocommerce-payments/assets/273592/cdfff1c5-6ee6-469a-aa7a-8b0f84f4c10a">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.