### PR TITLE
Fix WooPay Direct Checkout feature check

### DIFF
--- a/changelog/fix-woopay-direct-checkout-feature-check
+++ b/changelog/fix-woopay-direct-checkout-feature-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay Direct Checkout feature check.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -270,7 +270,7 @@ class WC_Payments_Features {
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
 
-		return $is_direct_checkout_eligible && $is_direct_checkout_flag_enabled && self::is_woopay_eligible();
+		return $is_direct_checkout_eligible && $is_direct_checkout_flag_enabled && self::is_woopay_enabled();
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're changing the Direct Checkout feature check so that it evaluates to `true` when WooPay is enabled instead of eligible. That will prevent unnecessary HTTP requests that would be made even when the merchant explicitly disabled WooPay.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Regression test: Ensure direct checkout no longer depends on enabling first party auth**

1. Run `npm run wp option update _wcpay_feature_woopay_first_party_auth 0` to disable first party auth.
3. Run the following regression test. If it works as expected, it means direct checkout no longer depends on the first party auth being enabled.

**Regression test: direct checkout feature**

1. Go through #2390's test instructions.
2. Ensure you can complete the checkout on each instruction.

**Test: Direct Checkout scripts are not enqueued if WooPay is disabled**

1. As a merchant, ensure WooPay is eligible in the store.
2. Disable WooPay.
3. As a customer, add a product to the cart and go to the cart.
4. Ensure the `WCPAY_WOOPAY_DIRECT_CHECKOUT` script is **NOT** enqueued in the page source.

**Test: Direct Checkout scripts are enqueued if WooPay is enabled**

1. As a merchant, enable WooPay.
3. As a customer, add a product to the cart and go to the cart.
4. Ensure the `WCPAY_WOOPAY_DIRECT_CHECKOUT` script is enqueued in the page source.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
