### PR TITLE
Added Learn more link to Payment Activity Card Disputes tooltip

### DIFF
--- a/changelog/update-payment-activity-disputes-tooltip
+++ b/changelog/update-payment-activity-disputes-tooltip
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Payment Activity Card - minor improvement to tooltip.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -207,11 +207,19 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 							) }
 							content={ interpolateComponents( {
 								mixedString: __(
-									'{{strong}}Disputes{{/strong}} includes the amount of any disputed charges. Dispute fees are included in the Fees section.',
+									'{{strong}}Disputes{{/strong}} includes the amount of any disputed charges. Dispute fees are included in the Fees section. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 									'woocommerce-payments'
 								),
 								components: {
 									strong: <strong />,
+									learnMoreLink: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											target="_blank"
+											rel="noopener noreferrer"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+										/>
+									),
 								},
 							} ) }
 						/>


### PR DESCRIPTION
Addresses https://github.com/Automattic/woocommerce-payments/pull/8975#discussion_r1645386734

#### Changes proposed in this Pull Request
Added Learn More link to Disputes tooltip

#### Testing instructions
Verify the tooltip and the link

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

Not applicable

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
