### PR TITLE
GH Actions - Update direct usage of GitHub context in workflows + Update Code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # Harmony owns any files in the .github directory at the root of the repository and any of its subdirectories.
-/.github/ @Automattic/harmony
+/.github/ @Automattic/transact-architecture-devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 
 # Each line is a file pattern followed by one or more owners.
 
-# Harmony owns any files in the .github directory at the root of the repository and any of its subdirectories.
+# Transact architecture - DevOps owns any files in the .github directory at the root of the repository and any of its subdirectories.
 /.github/ @Automattic/transact-architecture-devops

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -139,8 +139,8 @@ jobs:
           NEXT_RELEASE_VERSION: ${{ steps.next-version.outputs.NEXT_RELEASE_VERSION }}
         run: |
           cd wiki
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           
           HAS_CHANGES=false
           

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -116,7 +116,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "• Created a release branch `release/${{ env.RELEASE_VERSION }}` \n • Raised a <https://github.com/Automattic/woocommerce-payments/pull/${{ env.RELEASE_PR_ID }}|Pull Request> to `trunk`\n • Built a <https://github.com/Automattic/woocommerce-payments/actions/runs/${{ github.run_id }}|zip file and ran smoke tests> against it"
+                    "text": "• Created a release branch `release/${{ env.RELEASE_VERSION }}` \n • Raised a <https://github.com/Automattic/woocommerce-payments/pull/${{ env.RELEASE_PR_ID }}|Pull Request> to `trunk`\n • Built a <https://github.com/Automattic/woocommerce-payments/actions/runs/$GITHUB_RUN_ID|zip file and ran smoke tests> against it"
                   }
                 },
                 {

--- a/changelog/gh-actions-fix-script-injection-vulnerabilities
+++ b/changelog/gh-actions-fix-script-injection-vulnerabilities
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update direct usage of GitHub contexts on workflows
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments-server/issues/5442

#### Changes proposed in this Pull Request

* Update code owners for GitHub workflows to Transact Architecture DevOps
* Replaces direct usages of GitHub action contexts
  * Replaced `github.actor` with  `$GITHUB_ACTOR` environment variable provided by GitHub
  * Replaced `github.run_id` with `$GITHUB_RUN_ID` environment variable provided by GitHub

#### Testing instructions

NA

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
