### PR TITLE
Save UPE Appeareance for the Add Payment Method page in its own transient

### DIFF
--- a/changelog/add-8413-compute-styles-on-add-payment-method-page
+++ b/changelog/add-8413-compute-styles-on-add-payment-method-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a separate transient to save UPE appearance styles for the Add Payment Method standalone page. Correct regression that prevented proper styles calculation in the shortcode checkout.

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -69,7 +69,7 @@ jQuery( function ( $ ) {
 	} );
 
 	$( document.body ).on( 'updated_checkout', () => {
-		maybeMountStripePaymentElement();
+		maybeMountStripePaymentElement( 'shortcode_checkout' );
 		injectStripePMMEContainers();
 	} );
 
@@ -112,7 +112,11 @@ jQuery( function ( $ ) {
 	} );
 
 	if ( $addPaymentMethodForm.length || $payForOrderForm.length ) {
-		maybeMountStripePaymentElement();
+		maybeMountStripePaymentElement( 'add_payment_method' );
+	}
+
+	if ( $payForOrderForm.length ) {
+		maybeMountStripePaymentElement( 'shortcode_checkout' );
 	}
 
 	$addPaymentMethodForm.on( 'submit', function () {
@@ -214,13 +218,17 @@ jQuery( function ( $ ) {
 		}
 	}
 
-	async function maybeMountStripePaymentElement() {
+	async function maybeMountStripePaymentElement( elementsLocation ) {
 		if (
 			$( '.wcpay-upe-element' ).length &&
 			! $( '.wcpay-upe-element' ).children().length
 		) {
 			for ( const upeElement of $( '.wcpay-upe-element' ).toArray() ) {
-				await mountStripePaymentElement( api, upeElement );
+				await mountStripePaymentElement(
+					api,
+					upeElement,
+					elementsLocation
+				);
 				restrictPaymentMethodToLocation( upeElement );
 			}
 			maybeEnableStripeLink( api );

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -586,3 +586,15 @@ export const processPayment = (
 	// Prevent WC Core default form submission (see woocommerce/assets/js/frontend/checkout.js) from happening.
 	return false;
 };
+
+/**
+ * Used only for testing, resets the gatewayUPEComponents internal cache of elements for a given property.
+ *
+ * @param {string} paymentMethodType The paymentMethodType we want to remove the upeElement from.
+ * @return {void}
+ */
+export function __resetGatewayUPEComponentsElement( paymentMethodType ) {
+	if ( gatewayUPEComponents[ paymentMethodType ]?.upeElement ) {
+		delete gatewayUPEComponents[ paymentMethodType ].upeElement;
+	}
+}

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -49,17 +49,24 @@ for ( const paymentMethodType in getUPEConfig( 'paymentMethodsConfig' ) ) {
  * it is simply returned.
  *
  * @param {Object} api The API object used to save the UPE configuration.
+ * @param {string} elementsLocation The location of the UPE elements.
  * @return {Promise<Object>} The appearance object for the UPE.
  */
-async function initializeAppearance( api ) {
-	const appearance = getUPEConfig( 'upeAppearance' );
+async function initializeAppearance( api, elementsLocation ) {
+	const upeConfigMap = {
+		shortcode_checkout: 'upeAppearance',
+		add_payment_method: 'upeAddPaymentMethodAppearance',
+	};
+	const upeConfigProperty =
+		upeConfigMap[ elementsLocation ] ?? 'upeAppearance';
+	const appearance = getUPEConfig( upeConfigProperty );
 	if ( appearance ) {
 		return Promise.resolve( appearance );
 	}
 
 	return await api.saveUPEAppearance(
-		getAppearance( 'shortcode_checkout' ),
-		'shortcode_checkout'
+		getAppearance( elementsLocation ),
+		elementsLocation
 	);
 }
 
@@ -202,9 +209,14 @@ function createStripePaymentMethod(
  *
  * @param {Object} api The API object used to create the Stripe payment element.
  * @param {string} paymentMethodType The type of Stripe payment method to create.
+ * @param {string} elementsLocation The location of the UPE elements.
  * @return {Object} A promise that resolves with the created Stripe payment element.
  */
-async function createStripePaymentElement( api, paymentMethodType ) {
+async function createStripePaymentElement(
+	api,
+	paymentMethodType,
+	elementsLocation
+) {
 	const amount = Number( getUPEConfig( 'cartTotal' ) );
 	const paymentMethodTypes = getPaymentMethodTypes( paymentMethodType );
 	const options = {
@@ -213,7 +225,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		amount: amount,
 		paymentMethodCreation: 'manual',
 		paymentMethodTypes: paymentMethodTypes,
-		appearance: await initializeAppearance( api ),
+		appearance: await initializeAppearance( api, elementsLocation ),
 		fonts: getFontRulesFromPage(),
 	};
 
@@ -373,8 +385,13 @@ export function maybeEnableStripeLink( api ) {
  *
  * @param {Object} api The API object.
  * @param {string} domElement The selector of the DOM element of particular payment method to mount the UPE element to.
+ * @param {string} elementsLocation Thhe location of the UPE element.
  **/
-export async function mountStripePaymentElement( api, domElement ) {
+export async function mountStripePaymentElement(
+	api,
+	domElement,
+	elementsLocation
+) {
 	try {
 		if ( ! fingerprint ) {
 			const { visitorId } = await getFingerprint();
@@ -404,7 +421,11 @@ export async function mountStripePaymentElement( api, domElement ) {
 
 	const upeElement =
 		gatewayUPEComponents[ paymentMethodType ].upeElement ||
-		( await createStripePaymentElement( api, paymentMethodType ) );
+		( await createStripePaymentElement(
+			api,
+			paymentMethodType,
+			elementsLocation
+		) );
 	upeElement.mount( domElement );
 	upeElement.on( 'loaderror', ( e ) => {
 		// setting the flag to true to prevent the form from being submitted.

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -148,7 +148,7 @@ const appearanceSelectors = {
 			case 'blocks_checkout':
 				appearanceSelector = this.blocksCheckout;
 				break;
-			case 'classic_checkout':
+			case 'shortcode_checkout':
 				appearanceSelector = this.classicCheckout;
 				break;
 			case 'bnpl_product_page':

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -11,7 +11,7 @@ import {
 	getBackgroundColor,
 } from './utils.js';
 
-const appearanceSelectors = {
+export const appearanceSelectors = {
 	default: {
 		hiddenContainer: '#wcpay-hidden-div',
 		hiddenInput: '#wcpay-hidden-input',

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -199,4 +199,57 @@ describe( 'Getting styles for automated theming', () => {
 			},
 		} );
 	} );
+
+	[
+		{
+			elementsLocation: 'shortcode_checkout',
+			expectedSelectors: [
+				upeStyles.appearanceSelectors.classicCheckout
+					.upeThemeInputSelector,
+				upeStyles.appearanceSelectors.classicCheckout
+					.upeThemeLabelSelector,
+			],
+		},
+		{
+			elementsLocation: 'blocks_checkout',
+			expectedSelectors: [
+				upeStyles.appearanceSelectors.blocksCheckout
+					.upeThemeInputSelector,
+				upeStyles.appearanceSelectors.blocksCheckout
+					.upeThemeLabelSelector,
+			],
+		},
+		{
+			elementsLocation: 'other',
+			expectedSelectors: [
+				upeStyles.appearanceSelectors.blocksCheckout
+					.upeThemeInputSelector,
+				upeStyles.appearanceSelectors.blocksCheckout
+					.upeThemeLabelSelector,
+			],
+		},
+	].forEach( ( { elementsLocation, expectedSelectors } ) => {
+		afterEach( () => {
+			document.querySelector.mockClear();
+		} );
+
+		describe( `when elementsLocation is ${ elementsLocation }`, () => {
+			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', () => {
+				jest.spyOn( document, 'querySelector' ).mockImplementation(
+					() => mockElement
+				);
+				jest.spyOn( window, 'getComputedStyle' ).mockImplementation(
+					() => mockCSStyleDeclaration
+				);
+
+				upeStyles.getAppearance( elementsLocation );
+
+				expectedSelectors.forEach( ( selector ) => {
+					expect( document.querySelector ).toHaveBeenCalledWith(
+						selector
+					);
+				} );
+			} );
+		} );
+	} );
 } );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -115,17 +115,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	const USER_FORMATTED_TOKENS_LIMIT = 100;
 
-	const PROCESS_REDIRECT_ORDER_MISMATCH_ERROR_CODE       = 'upe_process_redirect_order_id_mismatched';
-	const UPE_APPEARANCE_TRANSIENT                         = 'wcpay_upe_appearance';
-	const WC_BLOCKS_UPE_APPEARANCE_TRANSIENT               = 'wcpay_wc_blocks_upe_appearance';
-	const UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT       = 'wcpay_upe_bnpl_product_page_appearance';
-	const UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT       = 'wcpay_upe_bnpl_classic_cart_appearance';
-	const UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT         = 'wcpay_upe_bnpl_cart_block_appearance';
-	const UPE_APPEARANCE_THEME_TRANSIENT                   = 'wcpay_upe_appearance_theme';
-	const WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT         = 'wcpay_wc_blocks_upe_appearance_theme';
-	const UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT = 'wcpay_upe_bnpl_product_page_appearance_theme';
-	const UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT = 'wcpay_upe_bnpl_classic_cart_appearance_theme';
-	const UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT   = 'wcpay_upe_bnpl_cart_block_appearance_theme';
+	const PROCESS_REDIRECT_ORDER_MISMATCH_ERROR_CODE        = 'upe_process_redirect_order_id_mismatched';
+	const UPE_APPEARANCE_TRANSIENT                          = 'wcpay_upe_appearance';
+	const UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT       = 'wcpay_upe_add_payment_method_appearance';
+	const WC_BLOCKS_UPE_APPEARANCE_TRANSIENT                = 'wcpay_wc_blocks_upe_appearance';
+	const UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT        = 'wcpay_upe_bnpl_product_page_appearance';
+	const UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT        = 'wcpay_upe_bnpl_classic_cart_appearance';
+	const UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT          = 'wcpay_upe_bnpl_cart_block_appearance';
+	const UPE_APPEARANCE_THEME_TRANSIENT                    = 'wcpay_upe_appearance_theme';
+	const UPE_ADD_PAYMENT_METHOD_APPEARANCE_THEME_TRANSIENT = 'wcpay_upe_add_payment_method_appearance_theme';
+	const WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT          = 'wcpay_wc_blocks_upe_appearance_theme';
+	const UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT  = 'wcpay_upe_bnpl_product_page_appearance_theme';
+	const UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT  = 'wcpay_upe_bnpl_classic_cart_appearance_theme';
+	const UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT    = 'wcpay_upe_bnpl_cart_block_appearance_theme';
 
 	/**
 	 * The locations of appearance transients.
@@ -4037,7 +4039,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$elements_location = isset( $_POST['elements_location'] ) ? wc_clean( wp_unslash( $_POST['elements_location'] ) ) : null;
 			$appearance        = isset( $_POST['appearance'] ) ? json_decode( wc_clean( wp_unslash( $_POST['appearance'] ) ) ) : null;
 
-			$valid_locations = [ 'blocks_checkout', 'shortcode_checkout', 'bnpl_product_page', 'bnpl_classic_cart', 'bnpl_cart_block' ];
+			$valid_locations = [ 'blocks_checkout', 'shortcode_checkout', 'bnpl_product_page', 'bnpl_classic_cart', 'bnpl_cart_block', 'add_payment_method' ];
 			if ( ! $elements_location || ! in_array( $elements_location, $valid_locations, true ) ) {
 				throw new Exception(
 					__( 'Unable to update UPE appearance values at this time.', 'woocommerce-payments' )
@@ -4067,6 +4069,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$appearance_transient       = [
 				'shortcode_checkout' => self::UPE_APPEARANCE_TRANSIENT,
+				'add_payment_method' => self::UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT,
 				'blocks_checkout'    => self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT,
 				'bnpl_product_page'  => self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT,
 				'bnpl_classic_cart'  => self::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT,
@@ -4074,6 +4077,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			][ $elements_location ];
 			$appearance_theme_transient = [
 				'shortcode_checkout' => self::UPE_APPEARANCE_THEME_TRANSIENT,
+				'add_payment_method' => self::UPE_ADD_PAYMENT_METHOD_APPEARANCE_THEME_TRANSIENT,
 				'blocks_checkout'    => self::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT,
 				'bnpl_product_page'  => self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT,
 				'bnpl_classic_cart'  => self::UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT,

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4061,7 +4061,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			/**
 			 * This filter is only called on "save" of the appearance, to avoid calling it on every page load.
 			 * If you apply changes through this filter, you'll need to clear the transient data to see them at checkout.
-			 * $elements_location can be 'blocks_checkout', 'shortcode_checkout', 'bnpl_product_page', 'bnpl_classic_cart', 'bnpl_cart_block'.
+			 * $elements_location can be 'blocks_checkout', 'shortcode_checkout', 'bnpl_product_page', 'bnpl_classic_cart', 'bnpl_cart_block', 'add_payment_method'.
 			 *
 			 * @since 7.4.0
 			 */

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -217,23 +217,25 @@ class WC_Payments_Checkout {
 		 */
 		$payment_fields = apply_filters( 'wcpay_payment_fields_js_config', $js_config );
 
-		$payment_fields['accountDescriptor']                 = $this->gateway->get_account_statement_descriptor();
-		$payment_fields['addPaymentReturnURL']               = wc_get_account_endpoint_url( 'payment-methods' );
-		$payment_fields['gatewayId']                         = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$payment_fields['isCheckout']                        = is_checkout();
-		$payment_fields['paymentMethodsConfig']              = $this->get_enabled_payment_method_config();
-		$payment_fields['testMode']                          = WC_Payments::mode()->is_test();
-		$payment_fields['upeAppearance']                     = get_transient( WC_Payment_Gateway_WCPay::UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplProductPageAppearance']      = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplProductPageAppearanceTheme'] = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT );
-		$payment_fields['upeBnplClassicCartAppearance']      = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplClassicCartAppearanceTheme'] = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT );
-		$payment_fields['upeBnplCartBlockAppearance']        = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplCartBlockAppearanceTheme']   = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearance']             = get_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearanceTheme']        = get_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT );
-		$payment_fields['cartContainsSubscription']          = $this->gateway->is_subscription_item_in_cart();
-		$payment_fields['currency']                          = get_woocommerce_currency();
+		$payment_fields['accountDescriptor']                  = $this->gateway->get_account_statement_descriptor();
+		$payment_fields['addPaymentReturnURL']                = wc_get_account_endpoint_url( 'payment-methods' );
+		$payment_fields['gatewayId']                          = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$payment_fields['isCheckout']                         = is_checkout();
+		$payment_fields['paymentMethodsConfig']               = $this->get_enabled_payment_method_config();
+		$payment_fields['testMode']                           = WC_Payments::mode()->is_test();
+		$payment_fields['upeAppearance']                      = get_transient( WC_Payment_Gateway_WCPay::UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['upeAddPaymentMethodAppearance']      = get_transient( WC_Payment_Gateway_WCPay::UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT );
+		$payment_fields['upeAddPaymentMethodAppearanceTheme'] = get_transient( WC_Payment_Gateway_WCPay::UPE_ADD_PAYMENT_METHOD_APPEARANCE_THEME_TRANSIENT );
+		$payment_fields['upeBnplProductPageAppearance']       = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT );
+		$payment_fields['upeBnplProductPageAppearanceTheme']  = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT );
+		$payment_fields['upeBnplClassicCartAppearance']       = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT );
+		$payment_fields['upeBnplClassicCartAppearanceTheme']  = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT );
+		$payment_fields['upeBnplCartBlockAppearance']         = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT );
+		$payment_fields['upeBnplCartBlockAppearanceTheme']    = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT );
+		$payment_fields['wcBlocksUPEAppearance']              = get_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['wcBlocksUPEAppearanceTheme']         = get_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT );
+		$payment_fields['cartContainsSubscription']           = $this->gateway->is_subscription_item_in_cart();
+		$payment_fields['currency']                           = get_woocommerce_currency();
 		$cart_total                  = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$payment_fields['cartTotal'] = WC_Payments_Utils::prepare_amount( $cart_total, get_woocommerce_currency() );
 

--- a/tests/unit/test-class-wc-payments-checkout.php
+++ b/tests/unit/test-class-wc-payments-checkout.php
@@ -510,4 +510,30 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 			);
 			$this->assertSame( true, $this->system_under_test->get_payment_fields_js_config()['paymentMethodsConfig'][ Payment_Method::CARD ]['showSaveOption'] );
 	}
+
+	public function test_upe_appearance_transients() {
+		$this->mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn(
+				[
+					Payment_Method::CARD,
+				]
+			);
+		$this->mock_wcpay_gateway
+			->method( 'wc_payments_get_payment_method_by_id' )
+			->willReturn(
+				new CC_Payment_Method( $this->mock_token_service )
+			);
+
+		set_transient( WC_Payment_Gateway_WCPay::UPE_APPEARANCE_TRANSIENT, '{}', DAY_IN_SECONDS );
+		set_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT, 'night', DAY_IN_SECONDS );
+		delete_transient( WC_Payment_Gateway_WCPay::UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT );
+
+		$js_config = $this->system_under_test->get_payment_fields_js_config();
+
+		$this->assertSame( '{}', $js_config['upeAppearance'] );
+		$this->assertSame( 'night', $js_config['wcBlocksUPEAppearanceTheme'] );
+		$this->assertFalse( $js_config['upeAddPaymentMethodAppearance'] );
+	}
 }


### PR DESCRIPTION
Fixes #8413

#### Changes proposed in this Pull Request

This PR addresses two important aspects:

1. Saves the UPE appearance object for the "Add Payment Method" in a new transient, instead of sharing the Classic Checkout transient.
2. Fixes a regression introduced by https://github.com/Automattic/woocommerce-payments/pull/8421 that prevents the styles from Classic Checkout from being generated more accurately.


| Page | Before | After |
|--------|--------|--------|
| Add Payment Method | ![image](https://github.com/Automattic/woocommerce-payments/assets/15204776/357e0e03-ce86-4cfa-8623-79d712ac77b5) | ![image](https://github.com/Automattic/woocommerce-payments/assets/15204776/fcae535f-627b-4514-a376-61560f63d347) (no change, classic checkout styles do not collide) |
| Classic Checkout | ![image](https://github.com/Automattic/woocommerce-payments/assets/15204776/3c000c68-765c-4b20-a3c4-d3cdf83ef1a0) (Styles do not match) | ![image](https://github.com/Automattic/woocommerce-payments/assets/15204776/b0364bd4-b41b-43bb-8284-d66d7cc46a5f) (Styles match the checkout form) | 


#### Testing instructions

* Change the theme of your store to a dark theme (Or use the customizer to use a dark background with a white font)
* Execute the following SQL query to remove all the transients related to the UPE appearance: 
```sql
SELECT option_name, option_value FROM `wp_options` WHERE `option_name` LIKE '_transient_wcpay_upe_%';
```
* Go to My Account > Payment methods > Add payment method
* Validate that the credit card form is rendering appropriately based on the background and font colors.
* Validate that no errors appear in the Developer Tools (javascript) console.
* Add a product to your cart and then go to the Classic (shortcode) Checkout page.
* Validate that the styles used by the credit card form mimic the styles of the rest of the checkout form.

##### Regression Testing
* Add a product to your cart and then go to the Blocks Checkout page.
* Validate that the styles used by the credit card form mimic the styles of the rest of the checkout form.
* Execute the query to clean up all the styles, then repeat the process in inverse order (Go to Blocks checkout first, then Classic Checkout, and finally the Add Payment Method page). Validate that each form has unique styles depending on the context where it's being rendered.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
