### PR TITLE
Revert route validation

### DIFF
--- a/changelog/revert-8901-update-route-param-validation
+++ b/changelog/revert-8901-update-route-param-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Dispute not loaded" error that was affecting responding to disputes.

--- a/includes/admin/class-wc-rest-payments-authorizations-controller.php
+++ b/includes/admin/class-wc-rest-payments-authorizations-controller.php
@@ -46,7 +46,7 @@ class WC_REST_Payments_Authorizations_Controller extends WC_Payments_REST_Contro
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<payment_intent_id>(ch|pi|py)_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/(?P<payment_intent_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_authorization' ],

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -28,7 +28,7 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<charge_id>ch_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/(?P<charge_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_charge' ],
@@ -37,7 +37,7 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/order/(?P<order_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/order/(?P<order_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'generate_charge_from_order' ],

--- a/includes/admin/class-wc-rest-payments-customer-controller.php
+++ b/includes/admin/class-wc-rest-payments-customer-controller.php
@@ -49,7 +49,7 @@ class WC_REST_Payments_Customer_Controller extends WC_Payments_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<customer_id>[A-Za-z0-9_\-]+)/payment_methods',
+			'/' . $this->rest_base . '/(?P<customer_id>\w+)/payment_methods',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,

--- a/includes/admin/class-wc-rest-payments-deposits-controller.php
+++ b/includes/admin/class-wc-rest-payments-deposits-controller.php
@@ -55,7 +55,7 @@ class WC_REST_Payments_Deposits_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<deposit_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<deposit_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_deposit' ],

--- a/includes/admin/class-wc-rest-payments-disputes-controller.php
+++ b/includes/admin/class-wc-rest-payments-disputes-controller.php
@@ -54,7 +54,7 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<dispute_id>(dp|dispute)_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/(?P<dispute_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_dispute' ],
@@ -63,7 +63,7 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<dispute_id>(dp|dispute)_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/(?P<dispute_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'update_dispute' ],
@@ -72,7 +72,7 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<dispute_id>(dp|dispute)_[A-Za-z0-9]+)/close',
+			'/' . $this->rest_base . '/(?P<dispute_id>\w+)/close',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'close_dispute' ],

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -35,7 +35,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<file_id>[A-Za-z0-9_\-]+)/details',
+			'/' . $this->rest_base . '/(?P<file_id>\w+)/details',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_file_detail' ],
@@ -45,7 +45,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<file_id>[A-Za-z0-9_\-]+)/content',
+			'/' . $this->rest_base . '/(?P<file_id>\w+)/content',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_file_content' ],
@@ -55,7 +55,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<file_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<file_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_file' ],

--- a/includes/admin/class-wc-rest-payments-fraud-outcomes-controller.php
+++ b/includes/admin/class-wc-rest-payments-fraud-outcomes-controller.php
@@ -25,7 +25,7 @@ class WC_REST_Payments_Fraud_Outcomes_Controller extends WC_Payments_REST_Contro
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[A-Za-z0-9_\-]+)/latest',
+			'/' . $this->rest_base . '/(?P<id>\w+)/latest',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_latest_fraud_outcome' ],

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -68,7 +68,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<order_id>[A-Za-z0-9_\-]+)/capture_terminal_payment',
+			$this->rest_base . '/(?P<order_id>\w+)/capture_terminal_payment',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'capture_terminal_payment' ],
@@ -82,7 +82,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<order_id>[A-Za-z0-9_\-]+)/capture_authorization',
+			$this->rest_base . '/(?P<order_id>\w+)/capture_authorization',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'capture_authorization' ],
@@ -96,7 +96,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<order_id>[A-Za-z0-9_\-]+)/cancel_authorization',
+			$this->rest_base . '/(?P<order_id>\w+)/cancel_authorization',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'cancel_authorization' ],
@@ -110,7 +110,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<order_id>[A-Za-z0-9_\-]+)/create_terminal_intent',
+			$this->rest_base . '/(?P<order_id>\w+)/create_terminal_intent',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'create_terminal_intent' ],

--- a/includes/admin/class-wc-rest-payments-payment-intents-controller.php
+++ b/includes/admin/class-wc-rest-payments-payment-intents-controller.php
@@ -32,7 +32,7 @@ class WC_REST_Payments_Payment_Intents_Controller extends WC_Payments_REST_Contr
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<payment_intent_id>(ch|pi|py)_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/(?P<payment_intent_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_payment_intent' ],

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -114,7 +114,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/charges/(?P<transaction_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/charges/(?P<transaction_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_summary' ],
@@ -132,7 +132,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/receipts/(?P<payment_intent_id>(ch|pi|py)_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/receipts/(?P<payment_intent_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'generate_print_receipt' ],

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -38,7 +38,7 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<location_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<location_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'delete_location' ],
@@ -47,7 +47,7 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<location_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<location_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'update_location' ],
@@ -66,7 +66,7 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<location_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<location_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_location' ],

--- a/includes/admin/class-wc-rest-payments-timeline-controller.php
+++ b/includes/admin/class-wc-rest-payments-timeline-controller.php
@@ -24,7 +24,7 @@ class WC_REST_Payments_Timeline_Controller extends WC_Payments_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<intention_id>(ch|pi|py)_[A-Za-z0-9]+)',
+			'/' . $this->rest_base . '/(?P<intention_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_timeline' ],

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -100,7 +100,7 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<transaction_id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<transaction_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_transaction' ],

--- a/includes/reports/class-wc-rest-payments-reports-authorizations-controller.php
+++ b/includes/reports/class-wc-rest-payments-reports-authorizations-controller.php
@@ -40,7 +40,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller extends WC_Payments_RES
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<id>\w+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,

--- a/includes/reports/class-wc-rest-payments-reports-transactions-controller.php
+++ b/includes/reports/class-wc-rest-payments-reports-transactions-controller.php
@@ -39,7 +39,7 @@ class WC_REST_Payments_Reports_Transactions_Controller extends WC_Payments_REST_
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[A-Za-z0-9_\-]+)',
+			'/' . $this->rest_base . '/(?P<id>\w+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -518,17 +518,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $dispute_id id of requested dispute.
 	 * @return array dispute object.
-	 * @throws API_Exception - Exception thrown in case route validation fails.
 	 */
 	public function get_dispute( $dispute_id ) {
-		if ( ! preg_match( '/(dp|dispute)_[A-Za-z0-9]+/', $dispute_id ) ) {
-			throw new API_Exception(
-				__( 'Route param validation failed.', 'woocommerce-payments' ),
-				'wcpay_route_validation_failure',
-				400
-			);
-		}
-
 		$dispute = $this->request( [], self::DISPUTES_API . '/' . $dispute_id, self::GET );
 
 		if ( is_wp_error( $dispute ) ) {
@@ -735,17 +726,8 @@ class WC_Payments_API_Client {
 	 * @return array
 	 *
 	 * @throws Exception - Exception thrown on request failure.
-	 * @throws API_Exception - Exception thrown in case route validation fails.
 	 */
 	public function get_timeline( $id ) {
-		if ( ! preg_match( '/(ch|pi|py)_[A-Za-z0-9]+/', $id ) ) {
-			throw new API_Exception(
-				__( 'Route param validation failed.', 'woocommerce-payments' ),
-				'wcpay_route_validation_failure',
-				400
-			);
-		}
-
 		$timeline = $this->request( [], self::TIMELINE_API . '/' . $id, self::GET );
 
 		$has_fraud_outcome_event = false;
@@ -1187,14 +1169,6 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception
 	 */
 	public function get_charge( string $charge_id ) {
-		if ( ! preg_match( '/(ch|pi|py)_[A-Za-z0-9]+/', $charge_id ) ) {
-			throw new API_Exception(
-				__( 'Route param validation failed.', 'woocommerce-payments' ),
-				'wcpay_route_validation_failure',
-				400
-			);
-		}
-
 		return $this->request(
 			[],
 			self::CHARGES_API . '/' . $charge_id,


### PR DESCRIPTION
Fixes #9008

#### Changes proposed in this Pull Request

This PR reverts #8901 which introduced stricter REST route validation of unique object IDs. Restoring the validation of these URLs to the state in WooPayments 7.7.0.

The original PR increased validation with stricter object ID's checking moving from `\w+` to `[A-Za-z0-9]+` regex.

Charges and disputes also had specific prefixes required `(ch|py|pi)_` and `(dispute|dp)_`. 

After the release of WooPayments 7.8.0 reports came in that confirmed dispute objects can also have a prefix of `du_`. Due to the original PR, these disputes were unable to viewed or responded to.

As per [Stripe docs](https://docs.stripe.com/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible), changing ID prefixes is considered backwards compatible:
> Stripe considers the following changes to be backwards-compatible:
> Changing the length or format of opaque strings, such as object IDs, error messages, and other human-readable strings.
> This includes adding or removing fixed prefixes (such as ch_ on charge IDs). :warning:

#### Testing instructions

Test the various routes that are affected by this PR.

* [ ] Charge authorization
* [ ] View charge
* [ ] View, update and close dispute
* [ ] Get file, content, and detail
* [ ] View fraud detail
* [ ] In person payments
* [ ] Charge timeline

NB: As the validation state is reverting to a known working state in WooPayments 7.7, not all of these scenarios need to be tested.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
