### PR TITLE
Pass theme data to WooPay session

### DIFF
--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -462,6 +462,9 @@ class WooPay_Session {
 			$order_id = $checkout_data['order_id'] ?? null;
 		}
 
+		$theme_json = \WP_Theme_JSON_Resolver::get_merged_data();
+		$theme_data = $theme_json->get_data();
+
 		$request = [
 			'wcpay_version'        => WCPAY_VERSION_NUMBER,
 			'user_id'              => $user->ID,
@@ -487,6 +490,7 @@ class WooPay_Session {
 				'return_url'                     => ! $is_pay_for_order ? wc_get_cart_url() : $order->get_checkout_payment_url(),
 				'blocks_data'                    => $blocks_data_extractor->get_data(),
 				'checkout_schema_namespaces'     => $blocks_data_extractor->get_checkout_schema_namespaces(),
+				'theme_data'                     => $theme_data,
 			],
 			'user_session'         => null,
 			'preloaded_requests'   => ! $is_pay_for_order ? [


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR is a proof of concept of [global themes support](https://woopayp2.wordpress.com/2024/06/19/theme-ing-woopay-checkout/#the-shortlisted-and-eliminated-style-tokens).  We pass merchant global theme data to WooPay session for WooPay consumption.


<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Test with [WooPay](https://github.com/Automattic/woopay/pull/2782) PR
2. As a merchant, install and activate a [theme that supports the site editor](https://wordpress.com/themes/filter/full-site-editing) from admin -> appearance -> theme
3. Update colors, typography, and button styles by visiting Theme -> Editor -> Styles
4. As a shopper, initialize WooPay checkout
5. See background color, text color, font family, size, line height match

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
