### PR TITLE
Updates to Tracks onboarding events props - Take 2

### DIFF
--- a/changelog/update-tracks-onboarding-events-props-take2
+++ b/changelog/update-tracks-onboarding-events-props-take2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: It is just about improving Tracks events data consistency.
+
+

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -56,12 +56,31 @@ const ConnectAccountPage: React.FC = () => {
 
 	const isCountrySupported = !! availableCountries[ country ];
 
+	const determineTrackingSource = () => {
+		const urlParams = new URLSearchParams( window.location.search );
+		const from = urlParams.get( 'from' ) || '';
+
+		// Determine where the user came from.
+		let source = 'wcadmin';
+		switch ( from ) {
+			case 'WCADMIN_PAYMENT_TASK':
+				source = 'wcadmin-payment-task';
+				break;
+			case 'WCADMIN_PAYMENT_SETTINGS':
+				source = 'wcadmin-payment-settings';
+				break;
+		}
+
+		return source;
+	};
+
 	useEffect( () => {
 		recordEvent( 'page_view', {
 			path: 'payments_connect_v2',
 			...( incentive && {
 				incentive_id: incentive.id,
 			} ),
+			source: determineTrackingSource(),
 		} );
 		// We only want to run this once.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -106,6 +125,7 @@ const ConnectAccountPage: React.FC = () => {
 			} ),
 			sandbox_mode: sandboxMode,
 			path: 'payments_connect_v2',
+			source: determineTrackingSource(),
 		} );
 	};
 

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -67,7 +67,7 @@ const ConnectAccountPage: React.FC = () => {
 				source = 'wcadmin-payment-task';
 				break;
 			case 'WCADMIN_PAYMENT_SETTINGS':
-				source = 'wcadmin-payment-settings';
+				source = 'wcadmin-settings-page';
 				break;
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1081,15 +1081,26 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Get Stripe connect url
+	 * Get connect url.
 	 *
 	 * @see WC_Payments_Account::get_onboarding_return_url(). The $wcpay_connect_from param relies on this function returning the corresponding URL.
-	 * @param string $wcpay_connect_from Optional. A page ID representing where the user should be returned to after connecting. Default is '1' - redirects back to the WC Payments overview page.
 	 *
-	 * @return string Stripe account login url.
+	 * @param string $wcpay_connect_from Optional. A page ID representing where the user should be returned to after connecting.
+	 *                                   Default is '1' - redirects back to the WooPayments overview page.
+	 *
+	 * @return string Connect URL.
 	 */
 	public static function get_connect_url( $wcpay_connect_from = '1' ) {
-		return wp_nonce_url( add_query_arg( [ 'wcpay-connect' => $wcpay_connect_from ], admin_url( 'admin.php' ) ), 'wcpay-connect' );
+		$url_params = [
+			'wcpay-connect' => $wcpay_connect_from,
+		];
+
+		// Maintain the `from` param from the request URL, if present.
+		if ( isset( $_GET['from'] ) ) {
+			$url_params['from'] = sanitize_text_field( wp_unslash( $_GET['from'] ) );
+		}
+
+		return wp_nonce_url( add_query_arg( $url_params, admin_url( 'admin.php' ) ), 'wcpay-connect' );
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -803,13 +803,18 @@ class WC_Payments_Account {
 
 		// Prevent access to onboarding flow if the server is not connected. Redirect back to the connect page with an error message.
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			$referer = sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '' ) );
+			$referer = sanitize_text_field( wp_get_raw_referer() );
 
 			// Track unsuccessful Jetpack connection.
 			if ( strpos( $referer, 'wordpress.com' ) ) {
 				$this->tracks_event(
 					self::TRACKS_EVENT_ACCOUNT_CONNECT_WPCOM_CONNECTION_FAILURE,
-					[ 'mode' => WC_Payments::mode()->is_test() ? 'test' : 'live' ]
+					[
+						'mode'   => WC_Payments::mode()->is_test() ? 'test' : 'live',
+						// Capture the user source of the connection attempt originating page.
+						// This is the same source that is used to track the onboarding flow origin.
+						'source' => isset( $_GET['source'] ) ? sanitize_text_field( wp_unslash( $_GET['source'] ) ) : '',
+					]
 				);
 			}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -818,7 +818,8 @@ class WC_Payments_Account {
 				/* translators: %s: WooPayments */
 					__( 'Please connect to WordPress.com to start using %s.', 'woocommerce-payments' ),
 					'WooPayments'
-				)
+				),
+				'WCPAY_ONBOARDING_FLOW'
 			);
 			return true;
 		}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -938,7 +938,7 @@ class WC_Payments_Account {
 					}
 
 					if ( WC_Payments_Onboarding_Service::SOURCE_WCADMIN_SETTINGS_PAGE === $connect_page_source ) {
-						$this->redirect_service->redirect_to_connect_page();
+						$this->redirect_service->redirect_to_connect_page( null, 'WCADMIN_PAYMENT_SETTINGS' );
 					} else {
 						$this->redirect_to_onboarding_page_or_start_server_connection( $connect_page_source );
 					}
@@ -992,6 +992,12 @@ class WC_Payments_Account {
 			update_option( 'wcpay_menu_badge_hidden', 'yes' );
 
 			if ( isset( $_GET['wcpay-connect-jetpack-success'] ) ) {
+				$test_mode        = isset( $_GET['test_mode'] ) && wc_clean( wp_unslash( $_GET['test_mode'] ) );
+				$event_properties = [
+					'incentive' => $incentive,
+					'mode'      => $test_mode || WC_Payments::mode()->is_test() ? 'test' : 'live',
+				];
+
 				if ( ! $this->payments_api_client->is_server_connected() ) {
 					// Track unsuccessful Jetpack connection.
 					$this->tracks_event(
@@ -1011,11 +1017,6 @@ class WC_Payments_Account {
 				}
 
 				// Track successful Jetpack connection.
-				$test_mode        = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
-				$event_properties = [
-					'incentive' => $incentive,
-					'mode'      => $test_mode || WC_Payments::mode()->is_test() ? 'test' : 'live',
-				];
 				$this->tracks_event(
 					self::TRACKS_EVENT_ACCOUNT_CONNECT_WPCOM_CONNECTION_SUCCESS,
 					$event_properties

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -254,11 +254,13 @@ class WC_Payments_Onboarding_Service {
 			return self::SOURCE_WCADMIN_PAYMENT_TASK;
 		}
 		// Payments tab in Woo Admin Settings page.
-		if ( false !== strpos( $referer, 'page=wc-settings&tab=checkout' ) ) {
+		if ( false !== strpos( $referer, 'page=wc-settings&tab=checkout' )
+			|| 'WCADMIN_PAYMENT_SETTINGS' === $from_param ) {
 			return self::SOURCE_WCADMIN_SETTINGS_PAGE;
 		}
-		// Payments tab in the sidebar.
-		if ( false !== strpos( $referer, 'path=%2Fwc-pay-welcome-page' ) ) {
+		// Payments incentive page.
+		if ( false !== strpos( $referer, 'path=%2Fwc-pay-welcome-page' )
+			|| 'WCADMIN_PAYMENT_INCENTIVE' === $from_param ) {
 			return self::SOURCE_WCADMIN_INCENTIVE_PAGE;
 		}
 		if ( false !== strpos( $referer, 'path=%2Fpayments%2Fconnect' ) ) {

--- a/includes/class-wc-payments-redirect-service.php
+++ b/includes/class-wc-payments-redirect-service.php
@@ -125,7 +125,7 @@ class WC_Payments_Redirect_Service {
 	 * @param string|null $from Optional source of the redirect.
 	 *                     Will fall back to keeping the `from` parameter in the current request URL, if present.
 	 */
-	public function redirect_to_connect_page( ?string $error_message = null, string $from = null ): void {
+	public function redirect_to_connect_page( ?string $error_message = null, ?string $from = null ): void {
 		if ( isset( $error_message ) ) {
 			set_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT, $error_message, 30 );
 		}

--- a/includes/class-wc-payments-redirect-service.php
+++ b/includes/class-wc-payments-redirect-service.php
@@ -122,9 +122,10 @@ class WC_Payments_Redirect_Service {
 	 * Note that this function immediately ends the execution.
 	 *
 	 * @param string|null $error_message Optional error message to show in a notice.
-	 * @param string      $from          Optional source of the redirect.
+	 * @param string|null $from Optional source of the redirect.
+	 *                     Will fall back to keeping the `from` parameter in the current request URL, if present.
 	 */
-	public function redirect_to_connect_page( ?string $error_message = null, string $from = '' ): void {
+	public function redirect_to_connect_page( ?string $error_message = null, string $from = null ): void {
 		if ( isset( $error_message ) ) {
 			set_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT, $error_message, 30 );
 		}
@@ -135,11 +136,16 @@ class WC_Payments_Redirect_Service {
 		];
 
 		if ( count( $params ) === count( array_intersect_assoc( $_GET, $params ) ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			// We are already in the onboarding page, do nothing.
+			// We are already on the Connect page. Do nothing.
 			return;
 		}
 
-		if ( '' !== $from ) {
+		// If we were not given a source, try to get it from the request URL.
+		if ( ! isset( $from ) && isset( $_GET['from'] ) ) {
+			$from = sanitize_text_field( wp_unslash( $_GET['from'] ) );
+		}
+
+		if ( ! empty( $from ) ) {
 			$params['from'] = $from;
 		}
 

--- a/tests/unit/test-class-wc-payments-redirect-service.php
+++ b/tests/unit/test-class-wc-payments-redirect-service.php
@@ -171,4 +171,108 @@ class WC_Payments_Redirect_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->redirect_service->redirect_to_login();
 	}
+
+	public function test_redirect_to_connect_page_no_redirect() {
+		// Arrange.
+		// Set the request as if the user is already on the Connect page.
+		$_GET = [
+			'page' => 'wc-admin',
+			'path' => '/payments/connect',
+		];
+
+		// Assert.
+		$this->redirect_service
+			->expects( $this->never() )
+			->method( 'redirect_to' );
+
+		// Act.
+		$this->redirect_service->redirect_to_connect_page();
+
+		// Cleanup.
+		unset( $_GET );
+	}
+
+	public function test_redirect_to_connect_page_sets_transient_on_error_message() {
+		// Arrange.
+		// Set the request as if the user is already on the Connect page.
+		$_GET = [
+			'page' => 'wc-admin',
+			'path' => '/payments/connect',
+		];
+
+		// Assert.
+		$this->redirect_service
+			->expects( $this->never() )
+			->method( 'redirect_to' );
+
+		// Act.
+		$this->redirect_service->redirect_to_connect_page( 'Error message' );
+
+		// Assert.
+		$this->assertEquals( 'Error message', get_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT ) );
+
+		// Cleanup.
+		unset( $_GET );
+	}
+
+	public function test_redirect_to_connect_page_redirects() {
+		// Arrange.
+		$_GET = [
+			'page' => 'wc-admin',
+			'path' => '/some-other-path',
+		];
+
+		// Assert.
+		$this->redirect_service
+			->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/connect' ) );
+
+		// Act.
+		$this->redirect_service->redirect_to_connect_page();
+
+		// Cleanup.
+		unset( $_GET );
+	}
+
+	public function test_redirect_to_connect_page_redirects_with_from() {
+		// Assert.
+		$this->redirect_service
+			->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/connect&from=FROM_SOMEWHERE' ) );
+
+		// Act.
+		$this->redirect_service->redirect_to_connect_page( null, 'FROM_SOMEWHERE' );
+	}
+
+	public function test_redirect_to_connect_page_redirects_with_from_param_from_get() {
+		// Arrange.
+		$_GET = [
+			'from' => 'FROM_SOMEWHERE',
+		];
+
+		// Assert.
+		$this->redirect_service
+			->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/connect&from=FROM_SOMEWHERE' ) );
+
+		// Act.
+		$this->redirect_service->redirect_to_connect_page();
+
+		// Cleanup.
+		unset( $_GET );
+	}
+
+	public function test_redirect_to_connect_page_redirects_without_from_when_empty() {
+		// Assert.
+		$this->redirect_service
+			->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/connect' ) );
+
+		// Act.
+		$this->redirect_service->redirect_to_connect_page( null, '' );
+	}
 }

--- a/tests/unit/test-class-wc-payments-redirect-service.php
+++ b/tests/unit/test-class-wc-payments-redirect-service.php
@@ -49,7 +49,7 @@ class WC_Payments_Redirect_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
 
 		$this->redirect_service = $this->getMockBuilder( WC_Payments_Redirect_Service::class )
-			->setMethods( [ 'redirect_to' ] )
+			->onlyMethods( [ 'redirect_to' ] )
 			->setConstructorArgs( [ $this->mock_api_client ] )
 			->getMock();
 	}

--- a/tests/unit/test-class-wc-payments-redirect-service.php
+++ b/tests/unit/test-class-wc-payments-redirect-service.php
@@ -71,12 +71,12 @@ class WC_Payments_Redirect_Service_Test extends WCPAY_UnitTestCase {
 		$request
 			->expects( $this->once() )
 			->method( 'set_return_url' )
-			->with( 'http://example.org/wp-admin/admin.php?page=wc-admin&path=/payments/overview' );
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/overview' ) );
 
 		$request
 			->expects( $this->once() )
 			->method( 'set_refresh_url' )
-			->with( 'http://example.org/wp-admin/admin.php?wcpay-loan-offer' );
+			->with( admin_url( 'admin.php?wcpay-loan-offer' ) );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -97,12 +97,12 @@ class WC_Payments_Redirect_Service_Test extends WCPAY_UnitTestCase {
 		$request
 			->expects( $this->once() )
 			->method( 'set_return_url' )
-			->with( 'http://example.org/wp-admin/admin.php?page=wc-admin&path=/payments/overview' );
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/overview' ) );
 
 		$request
 			->expects( $this->once() )
 			->method( 'set_refresh_url' )
-			->with( 'http://example.org/wp-admin/admin.php?wcpay-loan-offer' );
+			->with( admin_url( 'admin.php?wcpay-loan-offer' ) );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -142,7 +142,7 @@ class WC_Payments_Redirect_Service_Test extends WCPAY_UnitTestCase {
 		$this->redirect_service
 			->expects( $this->once() )
 			->method( 'redirect_to' )
-			->with( 'http://example.org/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview&wcpay-server-link-error=1' );
+			->with( admin_url( 'admin.php?page=wc-admin&path=%2Fpayments%2Foverview&wcpay-server-link-error=1' ) );
 
 		$this->redirect_service->redirect_to_account_link(
 			[
@@ -158,7 +158,7 @@ class WC_Payments_Redirect_Service_Test extends WCPAY_UnitTestCase {
 
 		$request->expects( $this->once() )
 			->method( 'set_redirect_url' )
-			->with( 'http://example.org/wp-admin/admin.php?page=wc-admin&path=/payments/overview' );
+			->with( admin_url( 'admin.php?page=wc-admin&path=/payments/overview' ) );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )


### PR DESCRIPTION
Follow up to #9015 

#### Changes proposed in this Pull Request

- We add the URL-based `source` prop to both Connect page view and Connect CTA click
- We ensure that the PHP-based redirects to Connect page keep the GET `from` param of the request
- We ensure that connect URLs keep the GET `from` param of the request
- Updates to source determination to account more for the `from` param value 

#### Testing instructions

* Checkout the PR branch on your local client install and build it by running `npm run build:client`
* Remove/reset any onboarded account you currently have so the Connect page is accessible
* Make sure you have the Tracks Vigilante (p7H4VZ-3cB-p2) Chrome extension installed and opened so you can monitor Tracks events
* Deactivate the WooPayments plugin
* Go to WooCommerce > Home and click on the "Get paid" task item.
* You should be redirected to the Connect page with `&from=WCADMIN_PAYMENT_TASK` in the URL
* In Tracks Vigilante, you should see a `wcadmin_page_view` event with the `source: wcadmin-payment-task` prop
* If you already have a working Jetpack connection:
  * install [the Jetpack Debug Helper plugin](https://github.com/Automattic/jetpack-debug-helper) (download the `trunk` zip files and install+activate on your local client installation)
  * activate the "Broken token Utilities" module and go to [its settings page](http://localhost:8082/wp-admin/admin.php?page=broken-token)
  * Store your current connection data by clicking on "Store these options"
  * Break your connection completely by clicking successively on: "Clear blog token", "Clear user token", "Clear the Primary user", "Clear the blog ID"
* Go to [the Connect page](http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&from=WCADMIN_PAYMENT_TASK), make sure you have `&from=WCADMIN_PAYMENT_TASK` in your URL, and that you see a "Connect your store" CTA button.
* Click on "Connect your store" and you should be redirected back to the Connect page but with an error about not being able to establish a connection on localhost
* The page URL should still include `&from=WCADMIN_PAYMENT_TASK`
* Fire up your Jurassic Tube by running `npm run tube:start` and access your local WP admin through it.
* Go to WooCommerce > Home, click on the "Get paid" (or "Get paid with WooCommerce") task item and your should see your Connect page with `&from=WCADMIN_PAYMENT_TASK` in the URL
* Connect your store to your WPCOM account and you should end up in the MOX flow with `&source=wcadmin-payment-task` in the URL
* Complete onboarding and make sure you can successfully onboard an account.
* Run `npm run tube:stop` to stop the tunneling
* Go to Jetpack Debug > Broken Token and click on "Restore from stored options" to get your Jetpack connection back as it was.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
