### PR TITLE
Disable Stripe Link in the Express Checkout Element

### DIFF
--- a/changelog/fix-9035-disable-link-in-ece
+++ b/changelog/fix-9035-disable-link-in-ece
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable Stripe Link in ECE.

--- a/client/express-checkout/utils/index.ts
+++ b/client/express-checkout/utils/index.ts
@@ -161,7 +161,9 @@ export const getExpressCheckoutButtonStyleSettings = () => {
 		paymentMethods: {
 			applePay: 'always',
 			googlePay: 'always',
-			link: 'auto',
+			link: 'never',
+			paypal: 'never',
+			amazonPay: 'never',
 		},
 		layout: { overflow: 'never' },
 		buttonTheme: {


### PR DESCRIPTION
Fixes #9035 

#### Changes proposed in this Pull Request

Disable Stripe Link in the Express Checkout Element.

#### Testing instructions

Check the code changes against the [Stripe documentation](https://docs.stripe.com/js/elements_object/create_express_checkout_element#express_checkout_element_create-options-paymentMethods) to make sure it’s correct.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
