### PR TITLE
[Afterpay] Fix wrong error message displayed in the checkout form with an invalid address

### DIFF
--- a/changelog/fix-9042-afterpay-wrong-error-message-displayed-in-the-checkout-form-with-an-invalid-address
+++ b/changelog/fix-9042-afterpay-wrong-error-message-displayed-in-the-checkout-form-with-an-invalid-address
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Display an invalid address error instead of generic one in the checkout form when Afterpay is selected as payment method

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -441,6 +441,7 @@ class WC_Payments {
 		include_once __DIR__ . '/exceptions/class-order-not-found-exception.php';
 		include_once __DIR__ . '/exceptions/class-order-id-mismatch-exception.php';
 		include_once __DIR__ . '/exceptions/class-rate-limiter-enabled-exception.php';
+		include_once __DIR__ . '/exceptions/class-invalid-address-exception.php';
 		include_once __DIR__ . '/constants/class-base-constant.php';
 		include_once __DIR__ . '/constants/class-country-code.php';
 		include_once __DIR__ . '/constants/class-currency-code.php';


### PR DESCRIPTION
Fixes #9042 

#### Changes proposed in this Pull Request
* Include the file that contains the `Invalid_Address_Exception` error, that was previously missing.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You need to customize the address fields of the checkout form so that the resulting address is invalid for Afterpay. This can be achieved in several ways, here's one:

* Navigate to WooCommerce > Settings > General > Shipping location(s). Set 'Disable shipping & shipping calculations'.
* Disable the following fields in the Billing Address form: billing_country, billing_city, _billing_state. Hint: you can use the [Flexible Checkout Fields](https://wordpress.org/plugins/flexible-checkout-fields/) plugin
* As a shopper, add a product to your cart and proceed to checkout
* Select Afterpay as your payment method and place the order
* Check that the invalid address error is displayed

<img width="932" alt="Screenshot 2024-07-03 at 13 13 34" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/6160450d-1cf8-4e95-83d9-ff8a0e07230a">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
