### PR TITLE
Ensure Shopper Can Still Checkout Through Direct Checkout When WooPay Is Slow or Unavailable

### DIFF
--- a/changelog/add-8986-post-message-fail-safe-fallback
+++ b/changelog/add-8986-post-message-fail-safe-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Ensure shoppers can still checkout, even when WooPay is slow or unavailable.

--- a/client/checkout/woopay/connect/connect-utils.js
+++ b/client/checkout/woopay/connect/connect-utils.js
@@ -28,3 +28,26 @@ export function getConnectIframeInjectedState() {
 		INJECTED_STATE.NOT_INJECTED
 	);
 }
+
+/**
+ * Set the postMessage timeout for WooPayConnect.
+ * This is the amount of time to wait for a response from the WooPayConnectIframe.
+ *
+ * @param {int} milliseconds The postMessage timeout in milliseconds.
+ */
+export function setPostMessageTimeout( milliseconds ) {
+	if ( ! window.WooPayConnect ) {
+		window.WooPayConnect = {};
+	}
+
+	window.WooPayConnect.postMessageTimeout = milliseconds;
+}
+
+/**
+ * Get the postMessage timeout for WooPayConnect. If not set, the default is 5000 milliseconds.
+ *
+ * @return {int|number} The postMessage timeout in milliseconds.
+ */
+export function getPostMessageTimeout() {
+	return window?.WooPayConnect?.postMessageTimeout || 5000;
+}

--- a/client/checkout/woopay/connect/session-connect.js
+++ b/client/checkout/woopay/connect/session-connect.js
@@ -202,7 +202,7 @@ class WooPaySessionConnect extends WoopayConnect {
 					data.value
 				);
 				break;
-			case 'get_is_reachable_success':
+			case 'get_is_woopay_reachable_success':
 				this.listeners.getIsWooPayReachableCallback( data.value );
 				break;
 			case 'set_preemptive_session_data_success':

--- a/client/checkout/woopay/connect/session-connect.js
+++ b/client/checkout/woopay/connect/session-connect.js
@@ -126,26 +126,34 @@ class WooPaySessionConnect extends WoopayConnect {
 	 * Sends session data to WooPay.
 	 *
 	 * @param {Object} data The data to send to WooPay.
-	 * @return {Promise<*>} Resolves to the WooPay session response.
+	 * @return {Promise<Object|null>} Resolves to the WooPay session response.
 	 */
 	async sendRedirectSessionDataToWooPay( data ) {
-		return await super.sendMessageAndListenWith(
-			{ action: 'setRedirectSessionData', value: data },
-			'setRedirectSessionDataCallback'
-		);
+		try {
+			return await super.sendMessageAndListenWith(
+				{ action: 'setRedirectSessionData', value: data },
+				'setRedirectSessionDataCallback'
+			);
+		} catch ( error ) {
+			return null;
+		}
 	}
 
 	/**
 	 * Sends session data to WooPay, preemptively.
 	 *
 	 * @param {Object} data The data to send to WooPay.
-	 * @return {Promise<*>} Resolves to the WooPay session response.
+	 * @return {Promise<Object|null>} Resolves to the WooPay session response.
 	 */
 	async setPreemptiveSessionData( data ) {
-		return await super.sendMessageAndListenWith(
-			{ action: 'setPreemptiveSessionData', value: data },
-			'setPreemptiveSessionDataCallback'
-		);
+		try {
+			return await super.sendMessageAndListenWith(
+				{ action: 'setPreemptiveSessionData', value: data },
+				'setPreemptiveSessionDataCallback'
+			);
+		} catch ( error ) {
+			return null;
+		}
 	}
 
 	/**

--- a/client/checkout/woopay/connect/session-connect.js
+++ b/client/checkout/woopay/connect/session-connect.js
@@ -13,6 +13,7 @@ class WooPaySessionConnect extends WoopayConnect {
 			...this.listeners,
 			setRedirectSessionDataCallback: () => {},
 			setTempThirdPartyCookieCallback: () => {},
+			getIsWooPayReachableCallback: () => {},
 			getIsThirdPartyCookiesEnabledCallback: () => {},
 			setPreemptiveSessionDataCallback: () => {},
 		};
@@ -157,6 +158,22 @@ class WooPaySessionConnect extends WoopayConnect {
 	}
 
 	/**
+	 * Checks if WooPay is reachable.
+	 *
+	 * @return {Promise<bool>} Resolves to true if WooPay is reachable.
+	 */
+	async isWooPayReachable() {
+		try {
+			return await this.sendMessageAndListenWith(
+				{ action: 'isWooPayReachable' },
+				'getIsWooPayReachableCallback'
+			);
+		} catch ( error ) {
+			return false;
+		}
+	}
+
+	/**
 	 * The callback function that is called when a message is received from the WooPayConnectIframe.
 	 *
 	 * @param {Object} data The data received from the WooPayConnectIframe.
@@ -180,6 +197,9 @@ class WooPaySessionConnect extends WoopayConnect {
 				this.listeners.getIsThirdPartyCookiesEnabledCallback(
 					data.value
 				);
+				break;
+			case 'get_is_reachable_success':
+				this.listeners.getIsWooPayReachableCallback( data.value );
 				break;
 			case 'set_preemptive_session_data_success':
 				this.listeners.setPreemptiveSessionDataCallback( data.value );

--- a/client/checkout/woopay/connect/session-connect.js
+++ b/client/checkout/woopay/connect/session-connect.js
@@ -63,6 +63,10 @@ class WooPaySessionConnect extends WoopayConnect {
 			}
 		);
 
+		if ( typeof resolvePostMessagePromise?.then !== 'function' ) {
+			return false;
+		}
+
 		// This request causes a page reload after the cookie has been set.
 		const tempPostMessage = await resolvePostMessagePromise;
 		tempPostMessage( { action: 'setTempThirdPartyCookie' } );

--- a/client/checkout/woopay/connect/user-connect.js
+++ b/client/checkout/woopay/connect/user-connect.js
@@ -21,22 +21,30 @@ class WooPayUserConnect extends WoopayConnect {
 	 * @return {Promise<bool>} Resolves to true if the user is logged in.
 	 */
 	async isUserLoggedIn() {
-		return await this.sendMessageAndListenWith(
-			{ action: 'getIsUserLoggedIn' },
-			'getIsUserLoggedInCallback'
-		);
+		try {
+			return await this.sendMessageAndListenWith(
+				{ action: 'getIsUserLoggedIn' },
+				'getIsUserLoggedInCallback'
+			);
+		} catch ( error ) {
+			return false;
+		}
 	}
 
 	/**
 	 * Retrieves encrypted data from WooPay.
 	 *
-	 * @return {Promise<Object>} Resolves to an object with encrypted data.
+	 * @return {Promise<Object|null>} Resolves to an object with encrypted data.
 	 */
 	async getEncryptedData() {
-		return await this.sendMessageAndListenWith(
-			{ action: 'getEncryptedData' },
-			'getEncryptedDataCallback'
-		);
+		try {
+			return await this.sendMessageAndListenWith(
+				{ action: 'getEncryptedData' },
+				'getEncryptedDataCallback'
+			);
+		} catch ( error ) {
+			return null;
+		}
 	}
 
 	/**

--- a/client/checkout/woopay/connect/woopay-connect.js
+++ b/client/checkout/woopay/connect/woopay-connect.js
@@ -18,6 +18,7 @@ class WoopayConnect {
 		// The initial state of these listeners serve as a placeholder.
 		this.listeners = {
 			getIframePostMessageCallback: () => {},
+			getPostMessageTimeoutCallback: () => {},
 		};
 		this.removeMessageListener = this.attachMessageListener();
 		this.injectWooPayConnectIframe();
@@ -176,6 +177,22 @@ class WoopayConnect {
 	}
 
 	/**
+	 * Retrieves the configured postMessageTimeout from WooPay.
+	 *
+	 * @return {int|null} The postMessage timeout in milliseconds.
+	 */
+	async getPostMessageTimeout() {
+		try {
+			return await this.sendMessageAndListenWith(
+				{ action: 'getPostMessageTimeout' },
+				'getPostMessageTimeoutCallback'
+			);
+		} catch ( error ) {
+			return null;
+		}
+	}
+
+	/**
 	 * The callback function that is called when a message is received from the WooPayConnectIframe.
 	 *
 	 * @param {Object} data The data received from the WooPayConnectIframe.
@@ -184,6 +201,9 @@ class WoopayConnect {
 		switch ( data.action ) {
 			case 'get_iframe_post_message_success':
 				this.listeners.getIframePostMessageCallback( data.value );
+				break;
+			case 'get_post_message_timeout_success':
+				this.listeners.getPostMessageTimeoutCallback( data.value );
 				break;
 		}
 	}

--- a/client/checkout/woopay/direct-checkout/index.js
+++ b/client/checkout/woopay/direct-checkout/index.js
@@ -215,6 +215,8 @@ window.addEventListener( 'load', async () => {
 
 	isThirdPartyCookieEnabled = await WooPayDirectCheckout.isWooPayThirdPartyCookiesEnabled();
 
+	await WooPayDirectCheckout.initPostMessageTimeout();
+
 	// Note, although the following hooks are prefixed with 'experimental__', they will be
 	// graduated to stable in the near future (it'll include the 'experimental__' prefix).
 	addAction(

--- a/client/checkout/woopay/direct-checkout/test/index.test.js
+++ b/client/checkout/woopay/direct-checkout/test/index.test.js
@@ -22,6 +22,7 @@ jest.mock(
 	() => ( {
 		init: jest.fn(),
 		isWooPayThirdPartyCookiesEnabled: jest.fn(),
+		initPostMessageTimeout: jest.fn(),
 		getCheckoutButtonElements: jest.fn(),
 		isUserLoggedIn: jest.fn(),
 		maybePrefetchEncryptedSessionData: jest.fn(),

--- a/client/checkout/woopay/direct-checkout/test/woopay-direct-checkout.test.js
+++ b/client/checkout/woopay/direct-checkout/test/woopay-direct-checkout.test.js
@@ -3,6 +3,10 @@
  */
 import WooPayDirectCheckout from '../woopay-direct-checkout';
 
+jest.spyOn( WooPayDirectCheckout, 'isWooPayReachable' ).mockResolvedValue(
+	true
+);
+
 describe( 'WooPayDirectCheckout', () => {
 	describe( 'addRedirectToWooPayEventListener', () => {
 		const originalLocation = window.location;

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -80,6 +80,15 @@ class WooPayDirectCheckout {
 	}
 
 	/**
+	 * Checks if WooPay is reachable.
+	 *
+	 * @return {Promise<bool>} Resolves to true if WooPay is reachable.
+	 */
+	static async isWooPayReachable() {
+		return this.getSessionConnect().isWooPayReachable();
+	}
+
+	/**
 	 * Checks if the user is logged in.
 	 *
 	 * @return {Promise<bool>} Resolves to true if the user is logged in.
@@ -365,6 +374,13 @@ class WooPayDirectCheckout {
 					if ( userIsLoggedIn ) {
 						woopayRedirectUrl = await this.getWooPayCheckoutUrl();
 					} else {
+						// Ensure WooPay is reachable before redirecting.
+						if ( ! ( await this.isWooPayReachable() ) ) {
+							throw new Error(
+								'WooPay is currently not available.'
+							);
+						}
+
 						woopayRedirectUrl = await this.getWooPayMinimumSessionUrl();
 					}
 

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -6,6 +6,7 @@ import request from 'wcpay/checkout/utils/request';
 import { buildAjaxURL } from 'wcpay/utils/express-checkout';
 import UserConnect from 'wcpay/checkout/woopay/connect/user-connect';
 import SessionConnect from 'wcpay/checkout/woopay/connect/session-connect';
+import { setPostMessageTimeout } from 'wcpay/checkout/woopay/connect/connect-utils';
 
 /**
  * The WooPayDirectCheckout class is responsible for injecting the WooPayConnectIframe into the
@@ -103,6 +104,16 @@ class WooPayDirectCheckout {
 	 */
 	static async isWooPayThirdPartyCookiesEnabled() {
 		return this.getSessionConnect().isWooPayThirdPartyCookiesEnabled();
+	}
+
+	/**
+	 * Sets the length of time to wait for when a message is sent to WooPay through the iframe.
+	 */
+	static async initPostMessageTimeout() {
+		const postMessageTimeout = await this.getSessionConnect().getPostMessageTimeout();
+		if ( postMessageTimeout ) {
+			setPostMessageTimeout( postMessageTimeout );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8986

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that the WooPay Direct Checkout flow does not hang when a message is posted to WooPay and WooPay does not respond. Additionally, it ensures that WooPay is available before redirecting shoppers to WooPay Checkout.

#### Testing instructions

> [!note]
> The changes in this PR should be tested with the changes in 2794-gh-Automattic/woopay.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure test instructions from 2794-gh-Automattic/woopay successfully pass.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
