### PR TITLE
Payment activity card style fixes: remove left border and left-align header

### DIFF
--- a/client/components/payment-activity/style.scss
+++ b/client/components/payment-activity/style.scss
@@ -161,6 +161,11 @@
 		}
 	}
 
+	// The first, large tile in the payment activity widget should not have a left border.
+	> .wcpay-payment-data-highlights__item {
+		border-left: none;
+	}
+
 	&__total-payment-volume {
 		border-left: none;
 		align-self: stretch;

--- a/client/components/payment-activity/style.scss
+++ b/client/components/payment-activity/style.scss
@@ -167,13 +167,12 @@
 	}
 
 	&__total-payment-volume {
-		border-left: none;
-		align-self: stretch;
-
+		// @todo this selector is not used, verify and remove
 		&__label {
 			@include label-styles;
 		}
 
+		// @todo this selector is not used, verify and remove
 		&__amount {
 			@include amount-styles;
 		}


### PR DESCRIPTION
Partially fixes https://github.com/Automattic/woocommerce-payments-server/issues/5747

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fixes Payment Activity Card UI bugs reported in https://github.com/Automattic/woocommerce-payments-server/issues/5747 including:

- [x] 2) the double-border on the left side of the card
- [ ] 4) The Payment Activity Card heading should be text-align left

Other bugs reported in this issue are not specific to the Payment Activity Card and can be handled in other issues/PRs.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
