### PR TITLE
Remove duplicated CHANGELOG entry

### DIFF
--- a/changelog/add-8870-ece-for-shortcode-cart-and-checkout
+++ b/changelog/add-8870-ece-for-shortcode-cart-and-checkout
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add support for Express Checkout Element on shortcode Cart and Checkout pages.


### PR DESCRIPTION
This file was going to be deleted in #8987, but it seems it won't be merged today. Since the WooPayments code freeze is this Sunday, I would prefer to delete this duplicate file right away.