### PR TITLE
Updated WooPayments MultiCurrency integration with Product Add-Ons

### DIFF
--- a/changelog/fix-issue-8911
+++ b/changelog/fix-issue-8911
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updated the integration between WooPayments Multi-Currency and Product Add-Ons.

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -137,6 +137,10 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 		} elseif ( 'flat_fee' === $addon['price_type'] && $addon['price'] ) {
 			if ( class_exists( '\WC_Product_Addons_Helper' ) ) {
 				$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
+				if ( 'input_multiplier' === $addon['field_type'] ) {
+					// Quantity/multiplier add on needs to be split, calculated, then multiplied by input value.
+					$addon_price = $this->multi_currency->get_price( $addon['price'] / $addon['value'], 'product' ) * $addon['value'];
+				}
 				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
 				/* translators: %1$s flat fee addon price in order */
 				$value .= sprintf( _x( ' (+ %1$s)', 'flat fee addon price in cart', 'woocommerce-payments' ), $addon_price );

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -128,24 +128,30 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 		} elseif ( 'percentage_based' === $addon['price_type'] && 0.0 === (float) $price ) {
 			$value .= '';
 		} elseif ( 'custom_price' === $addon['field_type'] && $addon['price'] ) {
-			$addon_price = wc_price( WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon['price'], $cart_item['data'], true ) );
-			/* translators: %1$s custom addon price in cart */
-			$value           .= sprintf( _x( ' (%1$s)', 'custom price addon price in cart', 'woocommerce-payments' ), $addon_price );
-			$addon['display'] = $value;
-		} elseif ( 'flat_fee' === $addon['price_type'] && $addon['price'] ) {
-			$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
-			$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
-			/* translators: %1$s flat fee addon price in order */
-			$value .= sprintf( _x( ' (+ %1$s)', 'flat fee addon price in cart', 'woocommerce-payments' ), $addon_price );
-		} elseif ( 'quantity_based' === $addon['price_type'] && $addon['price'] && $add_price_to_value ) {
-			$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
-			if ( 'input_multiplier' === $addon['field_type'] ) {
-				// Quantity/multiplier add on needs to be split, calculated, then multiplied by input value.
-				$addon_price = $this->multi_currency->get_price( $addon['price'] / $addon['value'], 'product' ) * $addon['value'];
+			if ( class_exists( '\WC_Product_Addons_Helper' ) ) {
+				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon['price'], $cart_item['data'], true ) );
+				/* translators: %1$s custom addon price in cart */
+				$value           .= sprintf( _x( ' (%1$s)', 'custom price addon price in cart', 'woocommerce-payments' ), $addon_price );
+				$addon['display'] = $value;
 			}
-			$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
-			/* translators: %1$s addon price in order */
-			$value .= sprintf( _x( ' (%1$s)', 'quantity based addon price in cart', 'woocommerce-payments' ), $addon_price );
+		} elseif ( 'flat_fee' === $addon['price_type'] && $addon['price'] ) {
+			if ( class_exists( '\WC_Product_Addons_Helper' ) ) {
+				$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
+				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
+				/* translators: %1$s flat fee addon price in order */
+				$value .= sprintf( _x( ' (+ %1$s)', 'flat fee addon price in cart', 'woocommerce-payments' ), $addon_price );
+			}
+		} elseif ( 'quantity_based' === $addon['price_type'] && $addon['price'] && $add_price_to_value ) {
+			if ( class_exists( '\WC_Product_Addons_Helper' ) ) {
+				$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
+				if ( 'input_multiplier' === $addon['field_type'] ) {
+					// Quantity/multiplier add on needs to be split, calculated, then multiplied by input value.
+					$addon_price = $this->multi_currency->get_price( $addon['price'] / $addon['value'], 'product' ) * $addon['value'];
+				}
+				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
+				/* translators: %1$s addon price in order */
+				$value .= sprintf( _x( ' (%1$s)', 'quantity based addon price in cart', 'woocommerce-payments' ), $addon_price );
+			}
 		} else {
 			// Get the percentage cost in the currency in use, and set the meta data on the product that the value was converted.
 			$_product = wc_get_product( $cart_item['product_id'] );

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -310,6 +310,8 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 				/* translators: %1$s custom addon price in order */
 				$value = sprintf( _x( ' (%1$s)', 'custom addon price in order', 'woocommerce-payments' ), $price );
 			}
+
+			$meta_data['raw_price'] = $this->multi_currency->get_price( $addon['price'], 'product' );
 		}
 
 		$meta_data['value'] = $value;

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -182,11 +182,14 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 	 * @return array
 	 */
 	public function update_product_price( $updated_prices, $cart_item, $prices ): array {
-		$price         = $this->multi_currency->get_price( $prices['price'], 'product' );
-		$regular_price = $this->multi_currency->get_price( $prices['regular_price'], 'product' );
-		$sale_price    = $this->multi_currency->get_price( $prices['sale_price'], 'product' );
-		$flat_fees     = 0;
-		$quantity      = $cart_item['quantity'];
+		$price                       = $this->multi_currency->get_price( $prices['price'], 'product' );
+		$regular_price               = $this->multi_currency->get_price( $prices['regular_price'], 'product' );
+		$sale_price                  = $this->multi_currency->get_price( $prices['sale_price'], 'product' );
+		$flat_fees                   = 0;
+		$quantity                    = $cart_item['quantity'];
+		$price_before_addons         = $price;
+		$regular_price_before_addons = $regular_price;
+		$sale_price_before_addons    = $sale_price;
 
 		// TODO: Check compat with Smart Coupons.
 		// Compatibility with Smart Coupons self declared gift amount purchase.
@@ -219,9 +222,9 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 
 			switch ( $addon['price_type'] ) {
 				case 'percentage_based':
-					$price         += (float) ( $price * ( $addon_price / 100 ) );
-					$regular_price += (float) ( $regular_price * ( $addon_price / 100 ) );
-					$sale_price    += (float) ( $sale_price * ( $addon_price / 100 ) );
+					$price         += (float) ( $price_before_addons * ( $addon_price / 100 ) );
+					$regular_price += (float) ( $regular_price_before_addons * ( $addon_price / 100 ) );
+					$sale_price    += (float) ( $sale_price_before_addons * ( $addon_price / 100 ) );
 					break;
 				case 'flat_fee':
 					$flat_fee       = $quantity > 0 ? (float) ( $addon_price / $quantity ) : 0;

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -129,6 +129,10 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 			$value .= '';
 		} elseif ( 'custom_price' === $addon['field_type'] && $addon['price'] ) {
 			if ( class_exists( '\WC_Product_Addons_Helper' ) ) {
+				// phpcs:ignore
+				/**
+				 * @psalm-suppress UndefinedClass
+				 */
 				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon['price'], $cart_item['data'], true ) );
 				/* translators: %1$s custom addon price in cart */
 				$value           .= sprintf( _x( ' (%1$s)', 'custom price addon price in cart', 'woocommerce-payments' ), $addon_price );
@@ -141,6 +145,10 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 					// Quantity/multiplier add on needs to be split, calculated, then multiplied by input value.
 					$addon_price = $this->multi_currency->get_price( $addon['price'] / $addon['value'], 'product' ) * $addon['value'];
 				}
+				// phpcs:ignore
+				/**
+				 * @psalm-suppress UndefinedClass
+				 */
 				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
 				/* translators: %1$s flat fee addon price in order */
 				$value .= sprintf( _x( ' (+ %1$s)', 'flat fee addon price in cart', 'woocommerce-payments' ), $addon_price );
@@ -152,6 +160,10 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 					// Quantity/multiplier add on needs to be split, calculated, then multiplied by input value.
 					$addon_price = $this->multi_currency->get_price( $addon['price'] / $addon['value'], 'product' ) * $addon['value'];
 				}
+				// phpcs:ignore
+				/**
+				 * @psalm-suppress UndefinedClass
+				 */
 				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
 				/* translators: %1$s addon price in order */
 				$value .= sprintf( _x( ' (%1$s)', 'quantity based addon price in cart', 'woocommerce-payments' ), $addon_price );
@@ -297,6 +309,10 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 				$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
 			}
 			if ( class_exists( '\WC_Product_Addons_Helper' ) ) {
+				// phpcs:ignore
+				/**
+				 * @psalm-suppress UndefinedClass
+				 */
 				$price = html_entity_decode(
 					wp_strip_all_tags( wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $values['data'] ) ) ),
 					ENT_QUOTES,

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -136,6 +136,10 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 		} elseif ( 'flat_fee' === $addon['price_type'] && $addon['price'] ) {
 			if ( class_exists( 'WC_Product_Addons_Helper' ) ) {
 				$addon_price = $this->multi_currency->get_price( $addon['price'], 'product' );
+				if ( 'input_multiplier' === $addon['field_type'] ) {
+					// Quantity/multiplier add on needs to be split, calculated, then multiplied by input value.
+					$addon_price = $this->multi_currency->get_price( $addon['price'] / $addon['value'], 'product' ) * $addon['value'];
+				}
 				$addon_price = wc_price( \WC_Product_Addons_Helper::get_product_addon_price_for_display( $addon_price, $cart_item['data'] ) );
 				/* translators: %1$s flat fee addon price in order */
 				$value .= sprintf( _x( ' (+ %1$s)', 'flat fee addon price in cart', 'woocommerce-payments' ), $addon_price );

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -243,9 +243,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'sale_price'    => 0,
 		];
 		$expected  = [
-			'price'         => 78.0, // (10 * 1.5) + (42 * 1.5)
-			'regular_price' => 78.0,
-			'sale_price'    => 63.0, // (0 * 1.5) + (42 * 1.5)
+			'price'                => 78.0, // (10 * 1.5) + (42 * 1.5)
+			'regular_price'        => 78.0,
+			'sale_price'           => 63.0, // (0 * 1.5) + (42 * 1.5)
+			'addons_flat_fees_sum' => 63.0,
 		];
 
 		$this->mock_multi_currency
@@ -282,9 +283,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'sale_price'    => 0,
 		];
 		$expected  = [
-			'price'         => 22.5, // 10 * 1.5 * 1.5
-			'regular_price' => 22.5,
-			'sale_price'    => 0.0,
+			'price'                => 22.5, // 10 * 1.5 * 1.5
+			'regular_price'        => 22.5,
+			'sale_price'           => 0.0,
+			'addons_flat_fees_sum' => 0,
 		];
 
 		// Product is created with a price of 10, and update_product_price calls get_price, which is already converted.
@@ -322,9 +324,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'sale_price'    => 0,
 		];
 		$expected  = [
-			'price'         => 57.0, // (10 * 1.5) + 42
-			'regular_price' => 57.0,
-			'sale_price'    => 42.0,
+			'price'                => 57.0, // (10 * 1.5) + 42
+			'regular_price'        => 57.0,
+			'sale_price'           => 42.0,
+			'addons_flat_fees_sum' => 0,
 		];
 
 		$this->mock_multi_currency
@@ -359,9 +362,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'sale_price'    => 0,
 		];
 		$expected  = [
-			'price'         => 141.0, // (10 * 1.5) + ((42 * 1.5) * 2)
-			'regular_price' => 141.0,
-			'sale_price'    => 126.0, // (0 * 1.5) + ((42 * 1.5) * 2)
+			'price'                => 141.0, // (10 * 1.5) + ((42 * 1.5) * 2)
+			'regular_price'        => 141.0,
+			'sale_price'           => 126.0, // (0 * 1.5) + ((42 * 1.5) * 2)
+			'addons_flat_fees_sum' => 126.0,
 		];
 
 		$this->mock_multi_currency
@@ -527,7 +531,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 		$expected  = [
 			'name'    => 'Checkbox',
-			'value'   => 'Percentage (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span>)',
+			'value'   => 'Percentage',
 			'display' => '',
 		];
 

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -149,8 +149,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$item->save();
 
 		$expected = [
-			'key'   => 'checkboxes ($84.00)',
-			'value' => 'flat fee',
+			'key'   => 'checkboxes',
+			'value' => 'flat fee (+ $84.00)',
 		];
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
 	}

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -137,7 +137,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price * 2 );
 		$addon = [
 			'name'       => 'checkboxes',
-			'value'      => 'flat fee',
+			'value'      => 'flat fee (+ $84.00)',
 			'price'      => (float) $price,
 			'field_type' => 'checkbox',
 			'price_type' => 'flat_fee',

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -137,7 +137,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price * 2 );
 		$addon = [
 			'name'       => 'checkboxes',
-			'value'      => 'flat fee (+ $84.00)',
+			'value'      => 'flat fee',
 			'price'      => (float) $price,
 			'field_type' => 'checkbox',
 			'price_type' => 'flat_fee',
@@ -152,7 +152,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'key'   => 'checkboxes',
 			'value' => 'flat fee (+ $84.00)',
 		];
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
+		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [ 'key' => 'checkboxes' ], $addon, $item, [ 'data' => '' ] ) );
 	}
 
 	public function test_order_line_item_meta_returns_percentage_data_correctly() {
@@ -174,7 +174,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'key'   => 'checkboxes',
 			'value' => 'percentage based',
 		];
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
+		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [ 'key' => 'checkboxes' ], $addon, $item, [ 'data' => '' ] ) );
 	}
 
 	public function test_order_line_item_meta_returns_input_multiplier_data_correctly() {
@@ -198,15 +198,15 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'key'   => 'quantity',
 			'value' => 2,
 		];
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
+		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [ 'key' => 'quantity' ], $addon, $item, [ 'data' => '' ] ) );
 	}
 
 	public function test_order_line_item_meta_returns_custom_price_data_correctly() {
 		$price = 42;
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price * 2 );
 		$addon = [
-			'name'       => 'checkboxes',
-			'value'      => 'custom price',
+			'name'       => 'custom price',
+			'value'      => (float) $price,
 			'price'      => (float) $price,
 			'field_type' => 'custom_price',
 			'price_type' => '',
@@ -221,7 +221,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'key'   => 'checkboxes',
 			'value' => 42.0,
 		];
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
+		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [ 'key' => 'checkboxes' ], $addon, $item, [ 'data' => '' ] ) );
 	}
 
 	public function test_update_product_price_returns_flat_fee_data_correctly() {
@@ -440,9 +440,9 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'addons_price_before_calc' => 10,
 		];
 		$expected  = [
-			'name'    => 'Customer defined price (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'value'   => '',
-			'display' => '',
+			'name'    => 'Customer defined price',
+			'value'   => '(<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			'display' => '(<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
 		];
 
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -137,7 +137,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price * 2 );
 		$addon = [
 			'name'       => 'checkboxes',
-			'value'      => 'flat fee',
+			'value'      => 'flat fee (+ $84.00)',
 			'price'      => (float) $price,
 			'field_type' => 'checkbox',
 			'price_type' => 'flat_fee',
@@ -441,8 +441,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 		$expected  = [
 			'name'    => 'Customer defined price',
-			'value'   => '(<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'display' => '(<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			'value'   => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			'display' => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
 		];
 
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -171,7 +171,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$item->save();
 
 		$expected = [
-			'key'   => 'checkboxes ($5.00)',
+			'key'   => 'checkboxes',
 			'value' => 'percentage based',
 		];
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
@@ -195,7 +195,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$item->save();
 
 		$expected = [
-			'key'   => 'quantity ($42.00)',
+			'key'   => 'quantity',
 			'value' => 2,
 		];
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
@@ -218,7 +218,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		$item->save();
 
 		$expected = [
-			'key'   => 'checkboxes ($42.00)',
+			'key'   => 'checkboxes',
 			'value' => 42.0,
 		];
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [], $addon, $item, [ 'data' => '' ] ) );
@@ -464,8 +464,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'quantity' => 1,
 		];
 		$expected  = [
-			'name'    => 'Multiplier (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'value'   => 2,
+			'name'    => 'Multiplier',
+			'value'   => '2 (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
 			'display' => '',
 		];
 
@@ -500,8 +500,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'quantity' => 1,
 		];
 		$expected  = [
-			'name'    => 'Checkbox (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'value'   => 'Flat fee',
+			'name'    => 'Checkbox',
+			'value'   => 'Flat fee (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
 			'display' => '',
 		];
 
@@ -526,8 +526,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'addons_price_before_calc' => 10,
 		];
 		$expected  = [
-			'name'    => 'Checkbox (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span>)',
-			'value'   => 'Percentage',
+			'name'    => 'Checkbox',
+			'value'   => 'Percentage (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>5.00</bdi></span>)',
 			'display' => '',
 		];
 


### PR DESCRIPTION
Fixes #8911 

#### Changes proposed in this Pull Request

This PR updates the integration between WooPayments MultiCurrency and Product Add-Ons which hasn't been reviewed after the Product Add-Ons v6.x.x releases.

One of the major changes in the newer Product Add-Ons versions is that the way add-on prices show up in the cart has changed. Add-on prices are no longer added after the add-on name, but are added after the add-on's value. Moreover, Product Add-Ons has simplified how flat fee prices show up in the cart to make it more evident to shoppers how the cart total is calculated.

Therefore, this PR: 
- updates the WooPayments MultiCurrency/Product Add-Ons integration, so MultiCurrency converts and displays add-on prices in the right location and;
- resolves an issue that made the product price in the cart change when the cart item quantity was increased. 

#### Testing instructions

First, set up a MultiCurrency environment: 
- Use WooPayments `trunk` or the latest stable version. 
- Set up WooPayments for your store. 
- Under **Payments > Settings, enable MultiCurrency** functionality. 
- Under **WooCommerce > Settings > Multi-Currency** add a couple of currencies that do not have a 1:1 conversion rate, like USD and GBP. 
- In the same screen, enable "Add a currency switcher to the Storefront theme on breadcrumb section.".

Now, let's see some bugs: 
- Install Product Add-Ons v6.9.0. 
- Create a Simple Product. 
- Go to Product Data > Add-Ons. 
- Create a 'Checkboxes' add-on. 
- Add 4 options, A, B, C, D. 
- A should have a $0 Flat Fee. 
- B should have a non-$0 Flat Fee. 
- C should have a non-$0 Quantity Based Price. 
- D should have a non-$0 Percentage Based Price. 
- View the product and select A. Add it to the cart. 
- In the cart, notice that the Flat Fee is added to the name of the add-on and is displayed as $0.00. 
- Back to the single product page, select either B or D. Add the product to the cart. 
- In the cart, change the currency. 
- Then, increase the quantity -- notice that the product price, which represents the price of the single unit, changes (this doesn't happen for products without add-ons).

Finally, let's see some fixes: 
- Grab: https://github.com/woocommerce/woocommerce-product-addons/pull/1048.
- For WooPayments, check out this branch. 
- Clear your cart and revisit the product you created. 
- Select A and add it to the cart. 
- In the cart, the $0.00 should not be visible. 
- Back to the single product page, select B. Add the product to the cart. 
- In the cart, notice that B's price shows up after the add-on value, like so (+$xx).
- Change the currency and notice that B's price is converted. 
- Increase the product quantity and ensure that the product price doesn't change. 
- Complete the order. 
- In **WooCommerce > Orders** find the order you submitted -- ensure that B's price shows up correctly there. 
- By default, quantity and percentage based prices do not show up in the cart. To make them show up to confirm that they are correct use these [snippets](https://woocommerce.com/document/product-add-ons/#display-addon-prices-cart-order).
- Back to the product page, add the product to the cart once with C and once with D selected. 
- Ensure that the prices in the cart are correct, even when changing the currency. 
- Ensure that both the product price and the add-on prices are correct when increasing the product quantity. 
- Complete the order. 
- In **WooCommerce > Orders** find the order you submitted -- ensure that C's and D's price show up correctly there. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
