### PR TITLE
Reporting: Restore functioning of 'remove' button on last tag on transactions report search box

### DIFF
--- a/changelog/fix-9071-transaction-search-tag-close-button
+++ b/changelog/fix-9071-transaction-search-tag-close-button
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Restore the 'remove tag' function on the last search tag appearing on the transactions report search box.
+
+

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -125,6 +125,23 @@ $gap-small: 12px;
 				&.woocommerce-select-control__control {
 					min-height: 38px;
 					height: auto;
+
+					button.woocommerce-select-control__clear {
+						&::before {
+							content: '';
+							position: absolute;
+							left: -30px;
+							top: -2px;
+							bottom: 0;
+							width: 30px;
+							height: 100%;
+							background: linear-gradient(
+								to right,
+								rgba( 255, 255, 255, 0 ),
+								rgba( 255, 255, 255, 1 ) 90%
+							);
+						}
+					}
 				}
 			}
 		}
@@ -171,20 +188,6 @@ $gap-small: 12px;
 				white-space: nowrap;
 				scrollbar-width: none;
 				margin-right: 25px;
-
-				&::after {
-					content: '';
-					position: absolute;
-					top: 0;
-					right: 0;
-					width: 25px;
-					height: 100%;
-					background: linear-gradient(
-						to right,
-						rgba( 255, 255, 255, 0 ),
-						rgba( 255, 255, 255, 1 ) 90%
-					);
-				}
 			}
 
 			@include breakpoint( '<960px' ) {

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -125,9 +125,9 @@ $gap-small: 12px;
 				&.woocommerce-select-control__control {
 					min-height: 38px;
 					height: auto;
-
 					button.woocommerce-select-control__clear {
 						background-color: #fff;
+
 						&::before {
 							content: '';
 							position: absolute;
@@ -190,6 +190,12 @@ $gap-small: 12px;
 				white-space: nowrap;
 				scrollbar-width: none;
 				margin-right: 25px;
+			}
+
+			.woocommerce-select-control.is-focused
+				.components-base-control
+				.components-base-control__field {
+				flex-basis: 45%;
 			}
 
 			@include breakpoint( '<960px' ) {

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -127,6 +127,7 @@ $gap-small: 12px;
 					height: auto;
 
 					button.woocommerce-select-control__clear {
+						background-color: #fff;
 						&::before {
 							content: '';
 							position: absolute;

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -140,6 +140,7 @@ $gap-small: 12px;
 								rgba( 255, 255, 255, 0 ),
 								rgba( 255, 255, 255, 1 ) 90%
 							);
+							pointer-events: none;
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #9071 

#### Changes proposed in this Pull Request

There was a fading gradient added to the end of tags container within the transactions report search box. This was added to indicate there are more tags beyond what the box can hold. This gradient was tied to the tags container that fits tightly to the available containers, hence it ended up showing on the last tag, even if there were fewer tags. Further, the gradient prevented the last tag's close button from being clicked. 

##### How this is fixed in this PR
The gradient is now tied to `before` of the clear button that appears on the extreme right of the search box. This restores the `close` function within the tags.


#### Before
https://github.com/Automattic/woocommerce-payments/assets/41110392/5830f5b6-9a9e-424f-ad29-2f5bdb859263

#### After
https://github.com/Automattic/woocommerce-payments/assets/4162931/67e2e774-75fd-4ba1-b325-57984009024f


#### Testing instructions
* Browse to `Payments > Transactions` 
* Add a few search terms and make sure they appear as tags in the search bar
* The last tag in the list should not show a gradient, unless there are too many tags leading it to the right end of the search bar, close to the clear button. 
* Try closing the last tag 
* It should close without any errors

##### Additional test - check appearance of gradient
* Add several search tags till it reaches the right end of the search bar, or do the following steps
* Activate the feature flag - `_wcpay_feature_payment_overview_widget`
* Browse to `Payments > Overview`
* Click on the `View reports` link that appears below `Total payment volume`. This will open up the transaction page with several tags already within. The last tag should show a fading gradient, like the screenshot below:

![image](https://github.com/Automattic/woocommerce-payments/assets/4162931/8190db27-8b3e-48ef-9c48-4f49017d3236)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
