### PR TITLE
Workaround for mismatch between Transaction Listing Report and Payment Activity Overview screens due to timezone.

### DIFF
--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -159,10 +159,14 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
-						).format( 'YYYY-MM-DD' ),
+						)
+							.utc()
+							.format( 'YYYY-MM-DD HH:mm:ss' ),
 						'date_between[1]': moment(
 							paymentActivityData?.date_end
-						).format( 'YYYY-MM-DD' ),
+						)
+							.utc()
+							.format( 'YYYY-MM-DD HH:mm:ss' ),
 						...getSearchParams(
 							searchTermsForViewReportLink.charge
 						),


### PR DESCRIPTION
Workaround for #9064

The Payment Activity widget uses the dates from the date filtering input as merchant timezone. But when these dates are passed to the existing Transaction Listing screens (navigated from the View Report links), they are assumed to be in UTC.
This causes mismatch between the widget and the linked reports, pdjTHR-3N2-p2#comment-5417

The permanent fix could be to fix all Report screens to use the merchant timezone #9064, but we might workaround this by converting and passing the dates on the `View Report' link, as done in this PR.

#### Changes proposed in this Pull Request

In the Payment Activity widget, convert the merchant timezone dates into UTC before passing them to the Transaction Reporting screen.

#### Testing instructions
- Test Setup:  pdjTHR-3N2-p2#comment-5417 (Transactions that fall into a selected time range in the merchant timezone, but not in UTC, so that there is mismatch between Report and Overview screens)
- On applying this diff, the totals on both screens should match.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.