### PR TITLE
Send optional fields data to WooPay

### DIFF
--- a/changelog/fix-send-optional-fields-data-to-woopay
+++ b/changelog/fix-send-optional-fields-data-to-woopay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Send optional fields data to WooPay.

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -783,11 +783,20 @@ class WooPay_Session {
 
 		// Blocks checkout options. To get the blocks checkout options, we need
 		// to parse the checkout page content because the options are stored
-		// in the block attributes as a JSON.
-		$checkout_page_id      = get_option( 'woocommerce_checkout_page_id' );
-		$checkout_page_content = get_post( $checkout_page_id )->post_content;
-		$checkout_page_blocks  = parse_blocks( $checkout_page_content );
-		$checkout_block_index  = array_search( 'woocommerce/checkout', array_column( $checkout_page_blocks, 'blockName' ), true );
+		// in the blocks HTML as a JSON.
+		$checkout_page_id = get_option( 'woocommerce_checkout_page_id' );
+		$checkout_page    = get_post( $checkout_page_id );
+
+		if ( empty( $checkout_page ) ) {
+			return [
+				'company'   => $company,
+				'address_2' => $address_2,
+				'phone'     => $phone,
+			];
+		}
+
+		$checkout_page_blocks = parse_blocks( $checkout_page->post_content );
+		$checkout_block_index = array_search( 'woocommerce/checkout', array_column( $checkout_page_blocks, 'blockName' ), true );
 
 		// If we can find the index, it means the merchant checkout page is using blocks checkout.
 		if ( false !== $checkout_block_index ) {

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -799,7 +799,7 @@ class WooPay_Session {
 		$checkout_block_index = array_search( 'woocommerce/checkout', array_column( $checkout_page_blocks, 'blockName' ), true );
 
 		// If we can find the index, it means the merchant checkout page is using blocks checkout.
-		if ( false !== $checkout_block_index ) {
+		if ( false !== $checkout_block_index && ! empty( $checkout_page_blocks[ $checkout_block_index ]['attrs'] ) ) {
 			$checkout_block_attrs = $checkout_page_blocks[ $checkout_block_index ]['attrs'];
 
 			$company   = 'optional';

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -487,6 +487,7 @@ class WooPay_Session {
 				'return_url'                     => ! $is_pay_for_order ? wc_get_cart_url() : $order->get_checkout_payment_url(),
 				'blocks_data'                    => $blocks_data_extractor->get_data(),
 				'checkout_schema_namespaces'     => $blocks_data_extractor->get_checkout_schema_namespaces(),
+				'optional_fields_status'         => self::get_option_fields_status(),
 			],
 			'user_session'         => null,
 			'preloaded_requests'   => ! $is_pay_for_order ? [
@@ -767,5 +768,61 @@ class WooPay_Session {
 		];
 
 		return str_replace( array_keys( $replacement_map ), array_values( $replacement_map ), $custom_message );
+	}
+
+	/**
+	 * Returns the status of checkout optional/required address fields.
+	 *
+	 * @return array The status of the checkout fields.
+	 */
+	private static function get_option_fields_status() {
+		// Shortcode checkout options.
+		$company   = get_option( 'woocommerce_checkout_company_field', 'optional' );
+		$address_2 = get_option( 'woocommerce_checkout_address_2_field', 'optional' );
+		$phone     = get_option( 'woocommerce_checkout_phone_field', 'required' );
+
+		// Blocks checkout options. To get the blocks checkout options, we need
+		// to parse the checkout page content because the options are stored
+		// in the block attributes as a JSON.
+		$checkout_page_id      = get_option( 'woocommerce_checkout_page_id' );
+		$checkout_page_content = get_post( $checkout_page_id )->post_content;
+		$checkout_page_blocks  = parse_blocks( $checkout_page_content );
+		$checkout_block_index  = array_search( 'woocommerce/checkout', array_column( $checkout_page_blocks, 'blockName' ), true );
+
+		// If we can find the index, it means the merchant checkout page is using blocks checkout.
+		if ( false !== $checkout_block_index ) {
+			$checkout_block_attrs = $checkout_page_blocks[ $checkout_block_index ]['attrs'];
+
+			$company   = 'optional';
+			$address_2 = 'optional';
+			$phone     = 'optional';
+
+			if ( ! empty( $checkout_block_attrs['requireCompanyField'] ) ) {
+				$company = 'required';
+			}
+
+			if ( ! empty( $checkout_block_attrs['requirePhoneField'] ) ) {
+				$phone = 'required';
+			}
+
+			// showCompanyField is undefined by default.
+			if ( empty( $checkout_block_attrs['showCompanyField'] ) ) {
+				$company = 'hidden';
+			}
+
+			if ( isset( $checkout_block_attrs['showApartmentField'] ) && false === $checkout_block_attrs['showApartmentField'] ) {
+				$address_2 = 'hidden';
+			}
+
+			if ( isset( $checkout_block_attrs['showPhoneField'] ) && false === $checkout_block_attrs['showPhoneField'] ) {
+				$phone = 'hidden';
+			}
+		}
+
+		return [
+			'company'   => $company,
+			'address_2' => $address_2,
+			'phone'     => $phone,
+		];
 	}
 }


### PR DESCRIPTION
Fixes 2145-gh-Automattic/woopay

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Currently the merchant can choose to require the company and phone fields, plus hide these fields and the address 2 field, this PR sends this information to WooPay so we can handle this the same way there.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow 2813-gh-Automattic/woopay testing instructions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
