### PR TITLE
Allow Afterpay to process payments when the state field is optional (UK and NZ customers)

### DIFF
--- a/changelog/fix-9046-allow-empty-state-when-optional-afterpay-gateway
+++ b/changelog/fix-9046-allow-empty-state-when-optional-afterpay-gateway
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Allow Afterpay gateway to process payments when the state/county is optional for GB and NZ addresses.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4501,14 +4501,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			if ( $address['country'] ) {
 				$country_locale_data = $wc_locale_data[ $address['country'] ] ?? null;
 
-				$is_state_not_required = (
+				$is_state_optional = (
 					is_array( $country_locale_data ) &&
 					isset( $country_locale_data['state'] ) &&
 					isset( $country_locale_data['state']['required'] ) &&
 					false === $country_locale_data['state']['required']
 				);
 
-				if ( $is_state_not_required ) {
+				if ( $is_state_optional ) {
 					return $address['country'] && $address['city'] && $address['postal_code'] && $address['line1'];
 				}
 			}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4511,7 +4511,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$is_field_required = (
 						! isset( $country_locale_data[ $locale_field ] ) ||
 						! isset( $country_locale_data[ $locale_field ]['required'] ) ||
-						false !== $country_locale_data[ $locale_field ]['required']
+						$country_locale_data[ $locale_field ]['required']
 					);
 
 					if ( $is_field_required && ! $address[ $address_field ] ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4496,7 +4496,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	private function handle_afterpay_shipping_requirement( WC_Order $order, Create_And_Confirm_Intention $request ): void {
 		$check_if_usable = function ( array $address ): bool {
-			return $address['country'] && $address['state'] && $address['city'] && $address['postal_code'] && $address['line1'];
+			if ( in_array( $address['country'], [ 'GB', 'NZ' ], true ) ) {
+				$is_state_usable = true;
+			} else {
+				$is_state_usable = ! empty( $address['state'] );
+			}
+			return $address['country'] && $is_state_usable && $address['city'] && $address['postal_code'] && $address['line1'];
 		};
 
 		$shipping_data = $this->order_service->get_shipping_data_from_order( $order );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4496,7 +4496,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	private function handle_afterpay_shipping_requirement( WC_Order $order, Create_And_Confirm_Intention $request ): void {
 		$check_if_usable = function ( array $address ): bool {
-			if ( in_array( $address['country'], [ 'GB', 'NZ' ], true ) ) {
+			if ( in_array( $address['country'], [ Country_Code::UNITED_KINGDOM, Country_Code::NEW_ZEALAND ], true ) ) {
 				$is_state_usable = true;
 			} else {
 				$is_state_usable = ! empty( $address['state'] );

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -114,14 +114,15 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 * @param  mixed                  $response                     The expected response.
 	 * @param  WC_Payments_API_Client $api_client_mock              Specific API client mock if necessary.
 	 * @param  WC_Payments_Http       $http_mock                    Specific HTTP mock if necessary.
+	 * @param  bool                   $force_request_mock           When true, a request will be mocked even if $total_api_calls is 0.
 	 *
 	 * @return Request|MockObject                                   The mocked request.
 	 */
-	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $request_class_constructor_id = null, $response = null, $api_client_mock = null, $http_mock = null ) {
+	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $request_class_constructor_id = null, $response = null, $api_client_mock = null, $http_mock = null, $force_request_mock = false ) {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
 		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
 
-		if ( 1 > $total_api_calls ) {
+		if ( 1 > $total_api_calls && ! $force_request_mock ) {
 			$api_client_mock->expects( $this->never() )->method( 'send_request' );
 
 			// No expectation for calls, return here.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2905,7 +2905,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 				],
 				'locale_data'        => [
 					// A missing `required` attribute means that the field will be required.
-					'US' => [ 'state' => [ 'label' => 'State' ] ],
+					Country_Code::UNITED_STATES => [ 'state' => [ 'label' => 'State' ] ],
 				],
 				'expected_exception' => Invalid_Address_Exception::class,
 			],
@@ -2917,10 +2917,9 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'country'  => Country_Code::UNITED_KINGDOM,
 				],
 				'locale_data'        => [
-					'GB' => [ 'state' => [ 'required' => false ] ],
+					Country_Code::UNITED_KINGDOM => [ 'state' => [ 'required' => false ] ],
 				],
 				'expected_exception' => null,
-
 			],
 			'without city, GB'        => [
 				'address'            => [
@@ -2930,10 +2929,9 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'country'  => Country_Code::UNITED_KINGDOM,
 				],
 				'locale_data'        => [
-					'GB' => [ 'state' => [ 'required' => false ] ],
+					Country_Code::UNITED_KINGDOM => [ 'state' => [ 'required' => false ] ],
 				],
 				'expected_exception' => Invalid_Address_Exception::class,
-
 			],
 		];
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2885,7 +2885,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 	public function process_payment_for_order_afterpay_clearpay_provider() {
 		return [
-			'with valid full address' => [
+			'with valid full address'         => [
 				'address'            => [
 					'city'     => 'WooCity',
 					'state'    => 'NY',
@@ -2896,7 +2896,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 				'locale_data'        => [],
 				'expected_exception' => null,
 			],
-			'with incomplete address' => [
+			'with incomplete address'         => [
 				'address'            => [
 					'city'     => 'WooCity',
 					'state'    => '',
@@ -2909,7 +2909,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 				],
 				'expected_exception' => Invalid_Address_Exception::class,
 			],
-			'without state, GB'       => [
+			'optional state'                  => [
 				'address'            => [
 					'city'     => 'London',
 					'state'    => '',
@@ -2921,7 +2921,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 				],
 				'expected_exception' => null,
 			],
-			'without city, GB'        => [
+			'optional state and postcode'     => [
+				'address'            => [
+					'city'     => 'London',
+					'state'    => '',
+					'postcode' => '',
+					'country'  => Country_Code::UNITED_KINGDOM,
+				],
+				'locale_data'        => [
+					Country_Code::UNITED_KINGDOM => [
+						'state'    => [ 'required' => false ],
+						'postcode' => [ 'required' => false ],
+					],
+				],
+				'expected_exception' => null,
+			],
+			'optional state, invalid address' => [
 				'address'            => [
 					'city'     => '',
 					'state'    => 'London',


### PR DESCRIPTION
Fixes #9046

#### Changes proposed in this Pull Request

From #9046 

> In WooCommerce Core, customers using a UK or NZ address have optional fields: County and Region respectively. Both of these fields are passed as billing_state.
> However, Afterpay via WooPayments requires that a state value be passed for physical products.
> If it is not, an exception will be thrown
> As a result, customers attempting to make a purchase via Afterpay who leave these optional fields empty will experience an error on checkout — even though the address they are using is correct.

This PR addresses this issue by checking the locale configuration from WooCommerce and applying the same rules in the Afterpay/Clearpay address validation.

#### Testing instructions

1. Onboard with a UK account.
2. Go to WooPayments Settings. 
3. Enable Clearpay and Add a support email (otherwise Clearpay may be rejected). Then Save your changes.
4. Add a physical product to the cart that is between £1–£1,200 GBP.
5. Go to the checkout page.
6. Add a UK address.
7. Leave the optional County field blank.
8. Place the order.

##### Before

An error appears and the order is not placed.
![image](https://github.com/Automattic/woocommerce-payments/assets/15204776/8dfb61dc-4f72-450d-adc1-b721c83d617e)


##### After

You will be redirected to the Stripe test page to authorize or fail the payment. If you authorize the payment the order will succeed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
