### PR TITLE
[ECE] Add ECE support for WooCommerce Deposits.

### DIFF
--- a/changelog/as-ece-wc-deposits-support
+++ b/changelog/as-ece-wc-deposits-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add ECE support for WooCommerce Deposits.

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -407,6 +407,21 @@ jQuery( ( $ ) => {
 		},
 
 		attachProductPageEventListeners: ( elements ) => {
+			// WooCommerce Deposits support.
+			// Trigger the "woocommerce_variation_has_changed" event when the deposit option is changed.
+			// Needs to be defined before the `woocommerce_variation_has_changed` event handler is set.
+			$(
+				'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
+			)
+				.off( 'change' )
+				.on( 'change', () => {
+					$( 'form' )
+						.has(
+							'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
+						)
+						.trigger( 'woocommerce_variation_has_changed' );
+				} );
+
 			$( document.body )
 				.off( 'woocommerce_variation_has_changed' )
 				.on( 'woocommerce_variation_has_changed', () => {
@@ -487,20 +502,6 @@ jQuery( ( $ ) => {
 							} );
 					}, 250 )
 				);
-
-			// WooCommerce Deposits support.
-			// Trigger the "woocommerce_variation_has_changed" event when the deposit option is changed.
-			$(
-				'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
-			)
-				.off( 'change' )
-				.on( 'change', () => {
-					$( 'form' )
-						.has(
-							'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
-						)
-						.trigger( 'woocommerce_variation_has_changed' );
-				} );
 		},
 
 		reInitExpressCheckoutElement: ( response ) => {

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -429,6 +429,7 @@ jQuery( ( $ ) => {
 
 					$.when( wcpayECE.getSelectedProductData() )
 						.then( ( response ) => {
+							const isDeposits = wcpayECE.productHasDepositOption();
 							/**
 							 * If the customer aborted the express checkout,
 							 * we need to re init the express checkout button to ensure the shipping
@@ -436,11 +437,12 @@ jQuery( ( $ ) => {
 							 * and the product's shipping status is consistent,
 							 * we can simply update the express checkout button with the new total and display items.
 							 */
-							if (
+							const needsShipping =
 								! wcpayECE.paymentAborted &&
 								getExpressCheckoutData( 'product' )
-									.needs_shipping === response.needs_shipping
-							) {
+									.needs_shipping === response.needs_shipping;
+
+							if ( ! isDeposits && needsShipping ) {
 								elements.update( {
 									amount: response.total.amount,
 								} );
@@ -546,6 +548,12 @@ jQuery( ( $ ) => {
 				wcpayECE.show();
 				eceButton.mount( '#wcpay-express-checkout-element' );
 			}
+		},
+
+		productHasDepositOption() {
+			return !! $( 'form' ).has(
+				'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
+			).length;
 		},
 
 		/**

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -443,7 +443,6 @@ jQuery( ( $ ) => {
 							) {
 								elements.update( {
 									amount: response.total.amount,
-									displayItems: response.displayItems,
 								} );
 							} else {
 								wcpayECE.reInitExpressCheckoutElement(

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -487,6 +487,20 @@ jQuery( ( $ ) => {
 							} );
 					}, 250 )
 				);
+
+			// WooCommerce Deposits support.
+			// Trigger the "woocommerce_variation_has_changed" event when the deposit option is changed.
+			$(
+				'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
+			)
+				.off( 'change' )
+				.on( 'change', () => {
+					$( 'form' )
+						.has(
+							'input[name=wc_deposit_option],input[name=wc_deposit_payment_plan]'
+						)
+						.trigger( 'woocommerce_variation_has_changed' );
+				} );
 		},
 
 		reInitExpressCheckoutElement: ( response ) => {

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -306,7 +306,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 				'pending' => true,
 			];
 
-			$data['needs_shipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
+			$data['needs_shipping'] = wc_shipping_enabled() && 0 !== wc_get_shipping_method_count( true ) && $product->needs_shipping();
 			$data['currency']       = strtolower( get_woocommerce_currency() );
 			$data['country_code']   = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -394,13 +394,6 @@ class WC_Payments_Express_Checkout_Button_Helper {
 
 		// Order total doesn't matter for Pay for Order page. Thus, this page should always display payment buttons.
 		if ( $this->is_pay_for_order_page() ) {
-
-			// ECE doesn't work on the Pay For Order Page.
-			$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
-			if ( $order && class_exists( 'WC_Deposits_Order_Manager' ) && WC_Deposits_Order_Manager::is_follow_up_order( $order ) ) {
-				return false;
-			}
-
 			return true;
 		}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -394,6 +394,13 @@ class WC_Payments_Express_Checkout_Button_Helper {
 
 		// Order total doesn't matter for Pay for Order page. Thus, this page should always display payment buttons.
 		if ( $this->is_pay_for_order_page() ) {
+
+			// ECE doesn't work on the Pay For Order Page.
+			$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
+			if ( $order && class_exists( 'WC_Deposits_Order_Manager' ) && WC_Deposits_Order_Manager::is_follow_up_order( $order ) ) {
+				return false;
+			}
+
 			return true;
 		}
 
@@ -755,20 +762,11 @@ class WC_Payments_Express_Checkout_Button_Helper {
 
 		// If WooCommerce Deposits is active, we need to get the correct price for the product.
 		if ( class_exists( 'WC_Deposits_Product_Manager' ) && class_exists( 'WC_Deposits_Plans_Manager' ) && WC_Deposits_Product_Manager::deposits_enabled( $product->get_id() ) ) {
+			// If is_deposit is null, we use the default deposit type for the product.
 			if ( is_null( $is_deposit ) ) {
-				/**
-				 * If is_deposit is null, we use the default deposit type for the product.
-				 *
-				 * @psalm-suppress UndefinedClass
-				 */
 				$is_deposit = 'deposit' === WC_Deposits_Product_Manager::get_deposit_selected_type( $product->get_id() );
 			}
 			if ( $is_deposit ) {
-				/**
-				 * Ignore undefined classes from 3rd party plugins.
-				 *
-				 * @psalm-suppress UndefinedClass
-				 */
 				$deposit_type       = WC_Deposits_Product_Manager::get_deposit_type( $product->get_id() );
 				$available_plan_ids = WC_Deposits_Plans_Manager::get_plan_ids_for_product( $product->get_id() );
 				// Default to first (default) plan if no plan is specified.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,6 +36,11 @@
       <code>WC_Subscriptions_Cart</code>
     </UndefinedClass>
   </file>
+  <file src="includes/express-checkout/class-wc-payments-express-checkout-button-helper.php">
+    <UndefinedClass occurrences="1">
+      <code>WC_Deposits_Order_Manager</code>
+    </UndefinedClass>
+  </file>
   <file src="includes/class-wc-payments.php">
     <UndefinedClass occurrences="1">
       <code>WC_Subscriptions_Product</code>


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/9067

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

_Based on testing instructions of https://github.com/Automattic/woocommerce-payments/pull/7910 which added support for WooCommerce Deposits with PRBs. The functionality should be identical with ECE._


- Enable Express Checkouts (Google and Apple Pay) to be displayed on product pages.
- Install and enable WooCommerce Deposits. You can download it from [here](https://woocommerce.com/my-account/downloads/)

**Virtual Product**
- Create a virtual simple product with an optional deposit of 50%
- <img width="375.5" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/1025173/34a7be76-f574-43fe-adec-446151b69475">
- Visit virtual simple product with optional deposit of 50%
- Select "Pay Deposit" (if not already selected)
- Click Apple/Google Pay button.
- The price in the payment sheet should reflect the deposit amount (Only the 50% of the total amount in this case).
- Proceed with purchase.
- The deposit amount should be recorded as paid against the order.
- The remaining amount should be recorded against the order.

**Physical Product**
- Create a simple product with optional deposit of 30%
- <img width="378" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/1025173/f476b00c-298d-4d43-8d91-9e72a675f632">
- Visit the product page then click the express checkout button.
- Check the paid amount is only the 30% of the total `(product price + shipping) * 0.3`


**Virtual product with payment plan**
- Go to Products > Payment Plans and create a 30%/70% payment plan.
- <img width="303" alt="Screenshot 2024-07-10 at 8 53 18 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1025173/445e44f0-245b-478e-9fcc-d9b922ffcaab">
- Create a virtual product with optional plan
- <img width="827" alt="Screenshot 2024-07-10 at 8 52 17 PM" src="https://github.com/Automattic/woocommerce-payments/assets/1025173/755b1e6c-2333-4280-95b3-81bd8c18524f">
- Go to the product page.
- Select "Pay Deposit".
- Select payment plan.
- Click Apple/Google Pay button.
- Proceed with purchase.
- The first payment amount should be recorded as paid against the order.
- The remaining amount should be recorded against the order.

**Note**
If you want to test to pay the remaining balance you have to go to the order page in the admin area then click "Invoice Remaining Balance"

<img width="525" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/1025173/a56df1f9-838d-40ae-a86e-1b235e7a5767">

It will create a new order, and you will be able to pay the remaining using the "Customer payment page" link. Note that the ECE button didn't work on the Pay for Order page, so code has been added to disable it on that page in this PR.

<img width="516" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/1025173/a722dd8f-ab56-4214-893e-d14078e24620">


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)


**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
