### PR TITLE
Fix Documents API regex to allow documents with dashes in name to be viewed

### DIFF
--- a/changelog/fix-9083-documents-api-regex
+++ b/changelog/fix-9083-documents-api-regex
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Documents API regex to allow documents with dashes in name to be viewed.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1795,7 +1795,7 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception - If not connected or request failed.
 	 */
 	public function get_document( $document_id ) {
-		if ( ! preg_match( '/^\w+$/', $document_id ) ) {
+		if ( ! preg_match( '/^[\w-]+$/', $document_id ) ) {
 			throw new API_Exception(
 				__( 'Route param validation failed.', 'woocommerce-payments' ),
 				'wcpay_route_validation_failure',


### PR DESCRIPTION
Fixes #9083

#### Changes proposed in this Pull Request

* Update the regex for documents to allow dashes in the document ID.

![Screenshot 2024-07-11 at 12 06 25 PM](https://github.com/Automattic/woocommerce-payments/assets/4634416/64e83cce-8401-4742-b635-a27e65855268)


#### Testing instructions

* 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
