### PR TITLE
Disable ECE for non shipping products if Tax is calculated on billing address

### DIFF
--- a/changelog/as-disable-ece-non-shipping-products-tax-billing-address
+++ b/changelog/as-disable-ece-non-shipping-products-tax-billing-address
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Disable ECE for non shipping products if Tax is calculated on billing address
+Disable ECE for non shipping products if Tax is calculated on billing address.

--- a/changelog/as-disable-ece-non-shipping-products-tax-billing-address
+++ b/changelog/as-disable-ece-non-shipping-products-tax-billing-address
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable ECE for non shipping products if Tax is calculated on billing address

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -87,6 +87,7 @@ export const normalizePayForOrderData = ( event, paymentMethodId ) => {
 		payment_method: 'woocommerce_payments',
 		'wcpay-payment-method': paymentMethodId,
 		express_payment_type: event?.expressPaymentType,
+		'wcpay-fraud-prevention-token': window.wcpayFraudPreventionToken ?? '',
 	};
 };
 

--- a/client/express-checkout/utils/test/normalize.js
+++ b/client/express-checkout/utils/test/normalize.js
@@ -302,6 +302,7 @@ describe( 'Express checkout normalization', () => {
 			expect( normalizePayForOrderData( event, 'pm_123456' ) ).toEqual( {
 				payment_method: 'woocommerce_payments',
 				'wcpay-payment-method': 'pm_123456',
+				'wcpay-fraud-prevention-token': 'token123',
 				express_payment_type: 'express',
 			} );
 		} );
@@ -315,6 +316,7 @@ describe( 'Express checkout normalization', () => {
 			).toEqual( {
 				payment_method: 'woocommerce_payments',
 				'wcpay-payment-method': '',
+				'wcpay-fraud-prevention-token': 'token123',
 				express_payment_type: undefined,
 			} );
 		} );

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -367,7 +367,10 @@ class WC_Payments_Express_Checkout_Button_Helper {
 
 		// Non-shipping product and billing is calculated based on shopper billing addres.
 		if (
-			// If product doesn't needs shipping.
+			// Except for the Pay for order page.
+			! $this->is_pay_for_order_page() &&
+
+			// If the product doesn't needs shipping.
 			(
 				// on the product page.
 				( $this->is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
@@ -379,7 +382,6 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			// ...and billing is calculated based on billing address.
 			&& 'billing' === get_option( 'woocommerce_tax_based_on' )
 		) {
-
 			return false;
 		}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -365,6 +365,11 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			return false;
 		}
 
+		// Non-shipping product and billing is calculated based on shopper billing addres.
+		if ( $this->is_product() && ! $this->product_needs_shipping( $this->get_product() ) && 'billing' === get_option( 'woocommerce_tax_based_on' ) ) {
+			return false;
+		}
+
 		// Product page, but not available in settings.
 		if ( $this->is_product() && ! $this->is_available_at( 'product', WC_Payments_Express_Checkout_Button_Handler::BUTTON_LOCATIONS ) ) {
 			return false;
@@ -409,6 +414,21 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check if the passed product needs to be shipped.
+	 *
+	 * @param WC_Product $product The product to check.
+	 *
+	 * @return bool Returns true if the product requires shipping; otherwise, returns false.
+	 */
+	public function product_needs_shipping( WC_Product $product ) {
+		if ( ! $product ) {
+			return false;
+		}
+
+		return wc_shipping_enabled() && 0 !== wc_get_shipping_method_count( true ) && $product->needs_shipping();
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -365,26 +365,6 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			return false;
 		}
 
-		// Non-shipping product and billing is calculated based on shopper billing addres.
-		if (
-			// Except for the Pay for order page.
-			! $this->is_pay_for_order_page() &&
-
-			// If the product doesn't needs shipping.
-			(
-				// on the product page.
-				( $this->is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
-
-				// on the cart or checkout page.
-				( ( $this->is_cart() || $this->is_checkout() ) && ! WC()->cart->needs_shipping() )
-			)
-
-			// ...and billing is calculated based on billing address.
-			&& 'billing' === get_option( 'woocommerce_tax_based_on' )
-		) {
-			return false;
-		}
-
 		// Product page, but not available in settings.
 		if ( $this->is_product() && ! $this->is_available_at( 'product', WC_Payments_Express_Checkout_Button_Handler::BUTTON_LOCATIONS ) ) {
 			return false;
@@ -415,6 +395,23 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		// Order total doesn't matter for Pay for Order page. Thus, this page should always display payment buttons.
 		if ( $this->is_pay_for_order_page() ) {
 			return true;
+		}
+
+		// Non-shipping product and billing is calculated based on shopper billing addres. Excludes Pay for Order page.
+		if (
+			// If the product doesn't needs shipping.
+			(
+				// on the product page.
+				( $this->is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
+
+				// on the cart or checkout page.
+				( ( $this->is_cart() || $this->is_checkout() ) && ! WC()->cart->needs_shipping() )
+			)
+
+			// ...and billing is calculated based on billing address.
+			&& 'billing' === get_option( 'woocommerce_tax_based_on' )
+		) {
+			return false;
 		}
 
 		// Cart total is 0 or is on product page and product price is 0.

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -366,7 +366,20 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		}
 
 		// Non-shipping product and billing is calculated based on shopper billing addres.
-		if ( $this->is_product() && ! $this->product_needs_shipping( $this->get_product() ) && 'billing' === get_option( 'woocommerce_tax_based_on' ) ) {
+		if (
+			// If product doesn't needs shipping.
+			(
+				// on the product page.
+				( $this->is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
+
+				// on the cart or checkout page.
+				( ( $this->is_cart() || $this->is_checkout() ) && ! WC()->cart->needs_shipping() )
+			)
+
+			// ...and billing is calculated based on billing address.
+			&& 'billing' === get_option( 'woocommerce_tax_based_on' )
+		) {
+
 			return false;
 		}
 

--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -104,15 +104,12 @@ class Fraud_Prevention_Service {
 	}
 
 	/**
-	 * Checks if current page is the Pay for order page.
+	 * Checks if this is the Pay for Order page.
 	 *
 	 * @return bool
 	 */
 	public function is_pay_for_order_page() {
-		global $wp;
-		$order_id = $wp->query_vars['order-pay'] ?? null;
-		// phpcs:disable WordPress.Security.NonceVerification
-		return isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) && current_user_can( 'pay_for_order', $order_id );
+		return is_checkout() && isset( $_GET['pay_for_order'] ); // phpcs:ignore WordPress.Security.NonceVerification
 	}
 
 	/**

--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -87,7 +87,7 @@ class Fraud_Prevention_Service {
 			return;
 		}
 
-		// Don't add the token if the user isn't on the cart, checkout or product page.
+		// Don't add the token if the user isn't on the cart, checkout, product or pay for order page.
 		// Checking the product and cart page too because the user can pay quickly via the payment buttons on that page.
 		if ( ! is_checkout() && ! is_cart() && ! is_product() && ! $instance->is_pay_for_order_page() ) {
 			return;

--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -89,7 +89,7 @@ class Fraud_Prevention_Service {
 
 		// Don't add the token if the user isn't on the cart, checkout or product page.
 		// Checking the product and cart page too because the user can pay quickly via the payment buttons on that page.
-		if ( ! is_checkout() && ! is_cart() && ! is_product() ) {
+		if ( ! is_checkout() && ! is_cart() && ! is_product() && ! $instance->is_pay_for_order_page() ) {
 			return;
 		}
 
@@ -101,6 +101,18 @@ class Fraud_Prevention_Service {
 			"window.wcpayFraudPreventionToken = '" . esc_js( $instance->get_token() ) . "';",
 			'after'
 		);
+	}
+
+	/**
+	 * Checks if current page is the Pay for order page.
+	 *
+	 * @return bool
+	 */
+	public function is_pay_for_order_page() {
+		global $wp;
+		$order_id = $wp->query_vars['order-pay'] ?? null;
+		// phpcs:disable WordPress.Security.NonceVerification
+		return isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) && current_user_can( 'pay_for_order', $order_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9080

#### Changes proposed in this Pull Request

Disables the ECE element on the following scenarios:

- Pages: Product, Cart and Checkout pages. **Except Pay for order**.
- Conditions:
  - If the product (or cart according to the page) doesn't require shipping
  - and tax amount is calculated based on the shopper's billing address.

This is to avoid charging the shopper a different amount than what was presented on the payment sheet. More on that [here](https://github.com/Automattic/woocommerce-payments/issues/8373).

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test product, cart and checkout pages**

- Go to WooCommerce > Settings > General.
  - Then Enable taxes and save changes.
- Go to WooCommerce > Settings > Tax.
  - Set "Calculate tax based on": "Customer billing address" and save changes.
- Make sure ECE is enabled. 
  - You can enable with following command: `wp option update _wcpay_feature_stripe_ece 1`
- Create a simple **virtual** product.
- Visit the product page you just created.
- ✅ Notice there's no ECE button rendered.
- Add the product to the cart then go to the cart page.
- ✅ Notice there's no ECE button rendered.
- Go to the checkout page.
- ✅ Notice there's no ECE button rendered.
- Set "Calculate tax based on": "Customer shipping address" and save changes.
- Visit the product page you created on previous steps.
- ✅ Notice the ECE button is rendered.
- Add the product to the cart and go to the cart page.
- ✅ Notice the ECE button is rendered.
- Go to the checkout page
- ✅ Notice the ECE button is rendered.

**Test Pay for order page is unaffected**
- Go to WooCommerce > Settings > General.
  - Then Enable taxes and save changes.
- Go to WooCommerce > Settings > Tax.
  - Set "Calculate tax based on": "Customer billing address" and save changes.
- Go to WooCommerce > Orders
  - Click "Add order" to create a new order.
  - Click "Add items" the "Add product(s)" to add the virtual product create steps above.
  - Click "Create"
  - Copy the link "Customer payment page →" and open it in another browser instance.
  - ✅ Notice the ECE button is rendered.
- Pay using ECE.
- ✅ Order should be processed and amount should be correct.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
