### PR TITLE
Fix payment method title for Express Checkout Element orders

### DIFF
--- a/changelog/2024-07-11-21-06-01-653423
+++ b/changelog/2024-07-11-21-06-01-653423
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix payment method title for Express Checkout Element orders.

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -112,7 +112,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 				throw new Exception( __( 'This order does not require payment!', 'woocommerce-payments' ) );
 			}
 
-			$this->express_checkout_button_helper->add_order_meta( $order_id );
+			$this->express_checkout_button_helper->add_order_payment_method_title( $order_id );
 
 			// Load the gateway.
 			$all_gateways = WC()->payment_gateways->get_available_payment_gateways();

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -112,7 +112,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 				throw new Exception( __( 'This order does not require payment!', 'woocommerce-payments' ) );
 			}
 
-			$this->add_order_meta( $order_id );
+			$this->express_checkout_button_helper->add_order_meta( $order_id );
 
 			// Load the gateway.
 			$all_gateways = WC()->payment_gateways->get_available_payment_gateways();
@@ -430,36 +430,5 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 		}
 
 		wp_send_json( [ 'result' => 'success' ] );
-	}
-
-	/**
-	 * Add needed order meta
-	 *
-	 * @param integer $order_id The order ID.
-	 *
-	 * @return  void
-	 */
-	public function add_order_meta( $order_id ) {
-		if ( empty( $_POST['express_payment_type'] ) || ! isset( $_POST['payment_method'] ) || 'woocommerce_payments' !== $_POST['payment_method'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return;
-		}
-
-		$order = wc_get_order( $order_id );
-
-		$express_payment_type = wc_clean( wp_unslash( $_POST['express_payment_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-
-		$express_payment_titles = [
-			'apple_pay'  => 'Apple Pay',
-			'google_pay' => 'Google Pay',
-		];
-
-		$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
-		if ( ! empty( $suffix ) ) {
-			$suffix = " ($suffix)";
-		}
-
-		$payment_method_title = isset( $express_payment_titles[ $express_payment_type ] ) ? $express_payment_titles[ $express_payment_type ] : 'Express Payment';
-		$order->set_payment_method_title( $payment_method_title . $suffix );
-		$order->save();
 	}
 }

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -94,6 +94,8 @@ class WC_Payments_Express_Checkout_Button_Handler {
 		add_filter( 'woocommerce_registration_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'display_pay_for_order_page_html' ], 1 );
+		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
+		add_action( 'woocommerce_checkout_order_processed', [ $this->express_checkout_helper, 'add_order_meta' ], 10, 2 );
 
 		$this->express_checkout_ajax_handler->init();
 	}
@@ -401,5 +403,33 @@ class WC_Payments_Express_Checkout_Button_Handler {
 		wc_setcookie( 'wcpay_express_checkout_redirect_url', '' );
 
 		return $url;
+	}
+
+	/**
+	 * Filters the gateway title to reflect the button type used.
+	 *
+	 * @param string $title Gateway title.
+	 * @param string $id Gateway ID.
+	 */
+	public function filter_gateway_title( $title, $id ) {
+		if ( 'woocommerce_payments' !== $id || ! is_admin() ) {
+			return $title;
+		}
+
+		$order        = $this->express_checkout_helper->get_current_order();
+		$method_title = is_object( $order ) ? $order->get_payment_method_title() : '';
+
+		if ( ! empty( $method_title ) ) {
+			if (
+				strpos( $method_title, 'Apple Pay' ) === 0
+				|| strpos( $method_title, 'Google Pay' ) === 0
+				|| strpos( $method_title, 'Payment Request' ) === 0 // Legacy PRB title.
+				|| strpos( $method_title, 'Express Payment' ) === 0
+			) {
+				return $method_title;
+			}
+		}
+
+		return $title;
 	}
 }

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -424,7 +424,6 @@ class WC_Payments_Express_Checkout_Button_Handler {
 				strpos( $method_title, 'Apple Pay' ) === 0
 				|| strpos( $method_title, 'Google Pay' ) === 0
 				|| strpos( $method_title, 'Payment Request' ) === 0 // Legacy PRB title.
-				|| strpos( $method_title, 'Express Payment' ) === 0
 			) {
 				return $method_title;
 			}

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -95,7 +95,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'display_pay_for_order_page_html' ], 1 );
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
-		add_action( 'woocommerce_checkout_order_processed', [ $this->express_checkout_helper, 'add_order_meta' ], 10, 2 );
+		add_action( 'woocommerce_checkout_order_processed', [ $this->express_checkout_helper, 'add_order_payment_method_title' ], 10, 2 );
 
 		$this->express_checkout_ajax_handler->init();
 	}

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -330,6 +330,26 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
+	 * Used to get the order in admin edit page.
+	 *
+	 * @return WC_Order|WC_Order_Refund|bool
+	 */
+	public function get_current_order() {
+		global $theorder;
+		global $post;
+
+		if ( is_object( $theorder ) ) {
+			return $theorder;
+		}
+
+		if ( is_object( $post ) ) {
+			return wc_get_order( $post->ID );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns true if the provided WC_Product is a subscription, false otherwise.
 	 *
 	 * @param WC_Product $product The product to check.
@@ -1031,6 +1051,37 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		}
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
+	}
+
+	/**
+	 * Add needed order meta
+	 *
+	 * @param integer $order_id The order ID.
+	 *
+	 * @return  void
+	 */
+	public function add_order_meta( $order_id ) {
+		if ( empty( $_POST['express_payment_type'] ) || ! isset( $_POST['payment_method'] ) || 'woocommerce_payments' !== $_POST['payment_method'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+
+		$express_payment_type = wc_clean( wp_unslash( $_POST['express_payment_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		$express_payment_titles = [
+			'apple_pay'  => 'Apple Pay',
+			'google_pay' => 'Google Pay',
+		];
+
+		$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
+		if ( ! empty( $suffix ) ) {
+			$suffix = " ($suffix)";
+		}
+
+		$payment_method_title = isset( $express_payment_titles[ $express_payment_type ] ) ? $express_payment_titles[ $express_payment_type ] : 'Express Payment';
+		$order->set_payment_method_title( $payment_method_title . $suffix );
+		$order->save();
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -1054,37 +1054,36 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
-	 * Add needed order meta
+	 * Add express checkout payment method title to the order.
 	 *
 	 * @param integer $order_id The order ID.
 	 *
 	 * @return  void
 	 */
-	public function add_order_meta( $order_id ) {
+	public function add_order_payment_method_title( $order_id ) {
 		if ( empty( $_POST['express_payment_type'] ) || ! isset( $_POST['payment_method'] ) || 'woocommerce_payments' !== $_POST['payment_method'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
-		$order = wc_get_order( $order_id );
-
-		$express_payment_type = wc_clean( wp_unslash( $_POST['express_payment_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-
+		$express_payment_type   = wc_clean( wp_unslash( $_POST['express_payment_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		$express_payment_titles = [
 			'apple_pay'  => 'Apple Pay',
 			'google_pay' => 'Google Pay',
 		];
+		$payment_method_title   = $express_payment_titles[ $express_payment_type ] ?? false;
 
-		$payment_method_title = $express_payment_titles[ $express_payment_type ] ?? false;
-
-		if ( $payment_method_title ) {
-			$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
-			if ( ! empty( $suffix ) ) {
-				$suffix = " ($suffix)";
-			}
-
-			$order->set_payment_method_title( $payment_method_title . $suffix );
-			$order->save();
+		if ( ! $payment_method_title ) {
+			return;
 		}
+
+		$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
+		if ( ! empty( $suffix ) ) {
+			$suffix = " ($suffix)";
+		}
+
+		$order = wc_get_order( $order_id );
+		$order->set_payment_method_title( $payment_method_title . $suffix );
+		$order->save();
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -1074,14 +1074,17 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			'google_pay' => 'Google Pay',
 		];
 
-		$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
-		if ( ! empty( $suffix ) ) {
-			$suffix = " ($suffix)";
-		}
+		$payment_method_title = $express_payment_titles[ $express_payment_type ] ?? false;
 
-		$payment_method_title = isset( $express_payment_titles[ $express_payment_type ] ) ? $express_payment_titles[ $express_payment_type ] : 'Express Payment';
-		$order->set_payment_method_title( $payment_method_title . $suffix );
-		$order->save();
+		if ( $payment_method_title ) {
+			$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
+			if ( ! empty( $suffix ) ) {
+				$suffix = " ($suffix)";
+			}
+
+			$order->set_payment_method_title( $payment_method_title . $suffix );
+			$order->save();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9076

#### Changes proposed in this Pull Request

- Add filter `woocommerce_gateway_title` to ECE implementation.
- Set payment method title for new orders through `woocommerce_checkout_order_processed`.
- Move and rename `add_order_meta`.
- Remove "Express Payment" pm title fallback.

#### Testing instructions

**Setup**

- Enable ECE by setting the `_wcpay_feature_stripe_ece` option to `1`.

**User checkout test**

1. As a shopper, use Safari to navigate to a product page and checkout with Apple Pay.
2. As a merchant, navigate to **WooCommerce > Orders** and click the order you just created as a shopper.
3. Ensure the payment method title is "Payment via Apple Pay (WooPayments)".
4. Repeat step 2, but checkout with Google Pay.
5. Ensure the payment method title is "Payment via Google Pay (WooPayments)".
6. Repeat the test with cart and checkout blocks.

**Pay for order test**

> [!NOTE]
> There's an open issue (#9048) where the order data is not being populated for pay for order checkouts, so the payment method title is not being rendered in the same way, but we can still make sure the payment method title is being saved correctly in the order meta.

1. As a merchant, navigate to **WooCommerce > Orders > Add order**.
2. Add any simple product item to the order and click "Create".
3. Open the "Customer payment page →" link.
4. Checkout using Google Pay.
5. As a merchant, refresh/open the "Edit order" page for this order.
6. Make sure you see a text "via Google Pay (WooPayments)" right after the "Paid" amount from the "Edit order" page.

<img width="447" src="https://github.com/user-attachments/assets/5df94db6-a5d0-4e96-aad3-ed3601b50401">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
