### PR TITLE
Update deprecated checkout hook

### DIFF
--- a/changelog/fix-deprecate-notice
+++ b/changelog/fix-deprecate-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Avoid using deprecated hook for processed checkout order.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -71,7 +71,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', [ $this, 'blocks_checkout_start' ] );
 		add_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after', [ $this, 'blocks_cart_page_view' ] );
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
-		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
+		add_action( 'woocommerce_store_api_checkout_order_processed', [ $this, 'checkout_order_processed' ], 10, 2 );
 		add_action( 'woocommerce_payments_save_user_in_woopay', [ $this, 'must_save_payment_method_to_platform' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'pay_for_order_page_view' ] );
 		add_action( 'woocommerce_thankyou', [ $this, 'thank_you_page_view' ] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5776

#### Changes proposed in this Pull Request
This PR replaced the deprecated hook for processed checkout order. The rest of the notices/errors mentioned in https://github.com/Automattic/woocommerce-payments/issues/5776 were debugged/checked and they are not relevant anymore (see for more details). Below is the deprecated notice which also suggests the new action name to use instead:

> woocommerce_blocks_checkout_order_processed is deprecated since version 7.2.0! Use woocommerce_store_api_checkout_order_processed instead. This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_order_processed instead

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* being on `develop`, after processing the Blocks checkout, confirm that `woocommerce_blocks_checkout_order_processed is deprecated since version 7.2.0` notice appears in `debug.log`
* check out this branch, perform the purchase and confirm no notice appears anymore
* set the debug point [here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-woopay-tracker.php#L509) and confirm this callback gets executed (after we changed the hook from the deprecated one to `woocommerce_store_api_checkout_order_processed`)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
