### PR TITLE
Fix Express Checkout Element button width

### DIFF
--- a/changelog/fix-9005-fix-ece-button-width
+++ b/changelog/fix-9005-fix-ece-button-width
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix Express Checkout Element button width.

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -6,9 +6,12 @@
 	&:first-child {
 		margin-top: 0;
 	}
+}
 
-	#wcpay-express-checkout-element iframe {
-		// This fixes width calculation issues inside the iframe.
+// This fixes width calculation issues inside the iframe for blocks and shortcode pages.
+.wcpay-payment-request-wrapper,
+.wc-block-components-express-payment__event-buttons {
+	.StripeElement iframe {
 		max-width: unset;
 	}
 }

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -6,6 +6,11 @@
 	&:first-child {
 		margin-top: 0;
 	}
+
+	#wcpay-express-checkout-element iframe {
+		// This fixes width calculation issues inside the iframe.
+		max-width: unset;
+	}
 }
 
 .woocommerce-checkout .wcpay-payment-request-wrapper {


### PR DESCRIPTION
Fixes #9005 

#### Changes proposed in this Pull Request

- Reset ECE button iframe `max-width` property to its default value.

#### Testing instructions

1. Enable ECE by setting the `_wcpay_feature_stripe_ece` option to `1`.
2. As a merchant, set the store theme to Storefront via **Appearance > Themes**.
3. Enable the WooPay button for comparing widths.
4. As a shopper, navigate to a simple product page and ensure the ECE button's width is the same as the WooPay button.
5. Add a simple product to the cart.
6. Navigate to the cart and checkout pages, and ensure the ECE button's width is the same as the WooPay button.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
