### PR TITLE
Implement error logging in ECE

### DIFF
--- a/changelog/add-9049-error-logging-in-ece
+++ b/changelog/add-9049-error-logging-in-ece
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add error logging to ECE critical endpoints.

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -48,26 +48,38 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 
 	/**
 	 * Create order. Security is handled by WC.
+	 *
+	 * @throws Exception If cart is empty.
 	 */
 	public function ajax_create_order() {
-		if ( WC()->cart->is_empty() ) {
-			wp_send_json_error( __( 'Empty cart', 'woocommerce-payments' ), 400 );
+		try {
+			if ( WC()->cart->is_empty() ) {
+				throw new Exception( __( 'Empty cart', 'woocommerce-payments' ) );
+			}
+
+			if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+				define( 'WOOCOMMERCE_CHECKOUT', true );
+			}
+
+			if ( ! defined( 'WCPAY_ECE_CHECKOUT' ) ) {
+				define( 'WCPAY_ECE_CHECKOUT', true );
+			}
+
+			// In case the state is required, but is missing, add a more descriptive error notice.
+			$this->express_checkout_button_helper->validate_state();
+
+			$this->express_checkout_button_helper->normalize_state();
+
+			WC()->checkout()->process_checkout();
+		} catch ( Exception $e ) {
+			Logger::error( 'Failed to process express checkout payment: ' . $e );
+
+			$response = [
+				'result'   => 'error',
+				'messages' => $e->getMessage(),
+			];
+			wp_send_json( $response, 400 );
 		}
-
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
-		if ( ! defined( 'WCPAY_ECE_CHECKOUT' ) ) {
-			define( 'WCPAY_ECE_CHECKOUT', true );
-		}
-
-		// In case the state is required, but is missing, add a more descriptive error notice.
-		$this->express_checkout_button_helper->validate_state();
-
-		$this->express_checkout_button_helper->normalize_state();
-
-		WC()->checkout()->process_checkout();
 
 		die( 0 );
 	}
@@ -80,22 +92,16 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 	public function ajax_pay_for_order() {
 		check_ajax_referer( 'pay_for_order' );
 
-		if (
-			! isset( $_POST['payment_method'] ) || 'woocommerce_payments' !== $_POST['payment_method']
-			|| ! isset( $_POST['order'] ) || ! intval( $_POST['order'] )
-			|| ! isset( $_POST['wcpay-payment-method'] ) || empty( $_POST['wcpay-payment-method'] )
-		) {
-			// Incomplete request.
-			$response = [
-				'result'   => 'error',
-				'messages' => __( 'Invalid request', 'woocommerce-payments' ),
-			];
-			wp_send_json( $response, 400 );
-
-			return;
-		}
-
 		try {
+			if (
+				! isset( $_POST['payment_method'] ) || 'woocommerce_payments' !== $_POST['payment_method']
+				|| ! isset( $_POST['order'] ) || ! intval( $_POST['order'] )
+				|| ! isset( $_POST['wcpay-payment-method'] ) || empty( $_POST['wcpay-payment-method'] )
+			) {
+				// Incomplete request.
+				throw new Exception( __( 'Invalid request', 'woocommerce-payments' ) );
+			}
+
 			// Set up an environment, similar to core checkout.
 			wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
 			wc_set_time_limit( 0 );
@@ -128,14 +134,18 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 			$result['order_id'] = $order_id;
 
 			$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
+
+			wp_send_json( $result );
 		} catch ( Exception $e ) {
+			$order_message = isset( $order_id ) ? "order #$order_id" : 'invalid order';
+			Logger::error( 'Failed to process express checkout payment for ' . $order_message . ': ' . $e );
+
 			$result = [
 				'result'   => 'error',
 				'messages' => $e->getMessage(),
 			];
+			wp_send_json( $result, 400 );
 		}
-
-		wp_send_json( $result );
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -49,7 +49,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 	/**
 	 * Create order. Security is handled by WC.
 	 *
-	 * @throws Exception If cart is empty.
+	 * @throws Exception If cart is empty. That is handled within the method.
 	 */
 	public function ajax_create_order() {
 		try {


### PR DESCRIPTION
Resolves #9049.

#### Changes proposed in this Pull Request

I've looked into all PHP and JS files concerning ECE and spotted only two opportunities where we can log errors, that are in the backend. In the frontend, we're already displaying errors to the customer and that is being tracked in the checkout conversion. Since the most critical errors come from the backend, that should suffice.

I didn't implement any testing here as we're going to look into unit tests for ECE as a whole in #9026.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Setup**

- Ensure ECE is enabled by setting the `_wcpay_feature_stripe_ece` option to `1`.
- Set up a public facing URL using HTTPS for your environment. Use something like Jurassic Tube or ngrok to create a tunnel.

**Regression test: Ensure you can pay with ECE**

1. As a customer, navigate to the store and click on any product.
2. Pay using Google Pay or Apple Pay and make sure the payment is processed successfully.

**Regression test: Ensure you can pay with ECE in the pay for order flow**

1. As a merchant, navigate to **WooCommerce > Orders > Add order**.
2. Click on **Add item(s)**, then on **Add product(s)**.
3. Type in some product name, such as "Beanie" and select it.
4. Click on the **Add** button, and finally, on the **Create** button.
5. Copy the **Customer payment page** link.
6. As a customer, navigate to the link you copied.
7. Pay using Google Pay or Apple Pay and make sure the payment is processed successfully.

**Test: Ensure error is displayed and logged when trying to pay with ECE**

1. To emulate an error, modify [this if condition](https://github.com/Automattic/woocommerce-payments/blob/4ddc6cfa368241cc5c5a34ccc14e58dfa3810db2/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php#L56) to `true`.
2. As a customer, navigate to the store and click on any product.
3. Try to pay using Google Pay or Apple Pay.
4. Ensure you can see an error alert "There was a problem processing the order.".
5. As a merchant, navigate to **WooCommerce > Status > Logs**.
6. Select the `woopayments` log of the current day and ensure you can find a log "Failed to process express checkout payment: Exception: Empty cart..." matching the time you tried to checkout.
7. Undo the modification you did in step 1.

**Test: Ensure error is displayed and logged when trying to pay with ECE in the pay for order flow**

1. To emulate an error, modify [this if condition](https://github.com/Automattic/woocommerce-payments/blob/4ddc6cfa368241cc5c5a34ccc14e58dfa3810db2/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php#L97-L99) to `true`.
2. As a merchant, navigate to **WooCommerce > Orders > Add order**.
3. Click on **Add item(s)**, then on **Add product(s)**.
4. Type in some product name, such as "Beanie" and select it.
5. Click on the **Add** button, and finally, on the **Create** button.
6. Copy the **Customer payment page** link.
7. As a customer, navigate to the link you copied.
8. Try to pay using Google Pay or Apple Pay.
9. Ensure you can see an error alert "There was a problem processing the order.".
10. As a merchant, navigate to **WooCommerce > Status > Logs**.
11. Select the `woopayments` log of the current day and ensure you can find a log "Failed to process express checkout payment for invalid order: Exception: Invalid request..." matching the time you tried to checkout.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
