### PR TITLE
Add/pass blocks checkout appearance via get woopay session request

### DIFF
--- a/changelog/add-pass-blocks-checkout-appearance-on-init-woopay
+++ b/changelog/add-pass-blocks-checkout-appearance-on-init-woopay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Pass Blocks checkout appearance on init WooPay

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -11,6 +11,7 @@ import {
 	getExpressCheckoutAjaxURL,
 	getExpressCheckoutConfig,
 } from 'utils/express-checkout';
+import { getAppearance } from 'checkout/upe-styles';
 
 /**
  * Handles generic connections to the server and Stripe.
@@ -459,8 +460,11 @@ export default class WCPayAPI {
 			this.isWooPayRequesting = true;
 			const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
 			const nonce = getConfig( 'initWooPayNonce' );
+			const appearance = getAppearance( 'blocks_checkout' );
+
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 				_wpnonce: nonce,
+				appearance: appearance,
 				email: userEmail,
 				user_session: woopayUserSession,
 				order_id: getConfig( 'order_id' ),

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -22,6 +22,33 @@ jest.mock( 'wcpay/utils/checkout', () => ( {
 	getConfig: jest.fn(),
 } ) );
 
+const mockAppearance = {
+	rules: {
+		'.Block': {},
+		'.Input': {},
+		'.Input--invalid': {},
+		'.Label': {},
+		'.Tab': {},
+		'.Tab--selected': {},
+		'.Tab:hover': {},
+		'.TabIcon--selected': {
+			color: undefined,
+		},
+		'.TabIcon:hover': {
+			color: undefined,
+		},
+		'.Text': {},
+		'.Text--redirect': {},
+	},
+	theme: 'stripe',
+	variables: {
+		colorBackground: '#ffffff',
+		colorText: undefined,
+		fontFamily: undefined,
+		fontSizeBase: undefined,
+	},
+};
+
 describe( 'WCPayAPI', () => {
 	test( 'does not initialize woopay if already requesting', async () => {
 		buildAjaxURL.mockReturnValue( 'https://example.org/' );
@@ -48,6 +75,7 @@ describe( 'WCPayAPI', () => {
 		getConfig.mockImplementation( ( key ) => {
 			const mockProperties = {
 				initWooPayNonce: 'foo',
+				appearance: mockAppearance,
 				order_id: 1,
 				key: 'testkey',
 				billing_email: 'test@example.com',
@@ -60,6 +88,7 @@ describe( 'WCPayAPI', () => {
 
 		expect( request ).toHaveBeenLastCalledWith( 'https://example.org/', {
 			_wpnonce: 'foo',
+			appearance: mockAppearance,
 			email: 'foo@bar.com',
 			user_session: 'qwerty123',
 			order_id: 1,

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -16,6 +16,7 @@ import {
 	appendRedirectionParams,
 } from '../utils';
 import { getTracksIdentity } from 'tracks';
+import { getAppearance } from 'wcpay/checkout/upe-styles';
 
 export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 	const woopayEmailInput = await getTargetElement( emailSelector );
@@ -106,6 +107,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 					order_id: getConfig( 'order_id' ),
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
+					appearance: getAppearance( 'blocks_checkout' ),
 				}
 			).then( ( response ) => {
 				if ( response?.data?.session ) {

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -70,6 +70,32 @@ describe( 'WoopayExpressCheckoutButton', () => {
 	const mockRequest = jest.fn().mockResolvedValue( true );
 	const mockAddToCart = jest.fn().mockResolvedValue( true );
 	const api = new WCPayAPI( {}, mockRequest );
+	const mockAppearance = {
+		rules: {
+			'.Block': {},
+			'.Input': {},
+			'.Input--invalid': {},
+			'.Label': {},
+			'.Tab': {},
+			'.Tab--selected': {},
+			'.Tab:hover': {},
+			'.TabIcon--selected': {
+				color: undefined,
+			},
+			'.TabIcon:hover': {
+				color: undefined,
+			},
+			'.Text': {},
+			'.Text--redirect': {},
+		},
+		theme: 'stripe',
+		variables: {
+			colorBackground: '#ffffff',
+			colorText: undefined,
+			fontFamily: undefined,
+			fontSizeBase: undefined,
+		},
+	};
 
 	beforeEach( () => {
 		expressCheckoutIframe.mockImplementation( () => jest.fn() );
@@ -145,6 +171,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					return 'testkey';
 				case 'order_id':
 					return 1;
+				case 'appearance':
+					return mockAppearance;
 				default:
 					return 'foo';
 			}
@@ -170,6 +198,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 				order_id: 1,
 				key: 'testkey',
 				billing_email: 'test@test.com',
+				appearance: mockAppearance,
 			} );
 			expect( expressCheckoutIframe ).not.toHaveBeenCalled();
 		} );

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -21,6 +21,7 @@ import {
 	deleteSkipWooPayCookie,
 } from 'wcpay/checkout/woopay/utils';
 import WooPayFirstPartyAuth from 'wcpay/checkout/woopay/express-button/woopay-first-party-auth';
+import { getAppearance } from 'wcpay/checkout/upe-styles';
 
 const BUTTON_WIDTH_THRESHOLD = 140;
 
@@ -268,6 +269,7 @@ export const WoopayExpressCheckoutButton = ( {
 					order_id: getConfig( 'order_id' ),
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
+					appearance: getAppearance( 'blocks_checkout' ),
 				} )
 					.then( async ( response ) => {
 						if ( response?.blog_id && response?.data?.session ) {

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -526,6 +526,33 @@ class WooPay_Session {
 	}
 
 	/**
+	 * Recursively map an array.
+	 *
+	 * @param function $callback The sanitize_text_field function.
+	 * @param array    $array    The nested array.
+	 *
+	 * @return array A new appearance array.
+	 */
+	private static function array_map_recursive( $callback, $array ) {
+		$func = function ( $item ) use ( &$func, &$callback ) {
+			return is_array( $item ) ? array_map( $func, $item ) : call_user_func( $callback, $item );
+		};
+
+		return array_map( $func, $array );
+	}
+
+	/**
+	 * Sanitize a string.
+	 *
+	 * @param string $item A string.
+	 *
+	 * @return string The sanitized string.
+	 */
+	private static function sanitize_string( $item ) {
+		return sanitize_text_field( wp_unslash( $item ) );
+	}
+
+	/**
 	 * Used to initialize woopay session.
 	 *
 	 * @return void
@@ -546,6 +573,7 @@ class WooPay_Session {
 
 		$body                 = self::get_init_session_request( $order_id, $key, $billing_email );
 		$body['user_session'] = isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null;
+		$body['appearance']   = isset( $_REQUEST['appearance'] ) ? self::array_map_recursive( array( __CLASS__, 'sanitize_string' ), $_REQUEST['appearance'] ) : null; // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, Generic.Arrays.DisallowLongArraySyntax.Found
 
 		$args = [
 			'url'     => WooPay_Utilities::get_woopay_rest_url( 'init' ),

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -528,7 +528,7 @@ class WooPay_Session {
 	/**
 	 * Recursively map an array.
 	 *
-	 * @param function $callback The sanitize_text_field function.
+	 * @param callable $callback The sanitize_text_field function.
 	 * @param array    $array    The nested array.
 	 *
 	 * @return array A new appearance array.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
