### PR TITLE
fix: tokenized cart PRB with no shipping options

### DIFF
--- a/changelog/fix-tokenized-cart-without-shipping-options
+++ b/changelog/fix-tokenized-cart-without-shipping-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: tokenized cart PRB w/ no shipping options
+
+

--- a/client/tokenized-payment-request/payment-request.js
+++ b/client/tokenized-payment-request/payment-request.js
@@ -263,12 +263,26 @@ export default class WooPaymentsPaymentRequest {
 					)
 				);
 
+				const shippingOptions = transformCartDataForShippingOptions(
+					cartData
+				);
+
+				// when no shipping options are returned, the API still returns a 200 status code.
+				// We need to ensure that shipping options are present - otherwise the PRB dialog won't update correctly.
+				if ( shippingOptions.length === 0 ) {
+					event.updateWith( {
+						// Possible statuses: https://docs.stripe.com/js/appendix/payment_response#payment_response_object-complete
+						status: 'invalid_shipping_address',
+					} );
+					_self.cachedCartData = cartData;
+
+					return;
+				}
+
 				event.updateWith( {
 					// Possible statuses: https://docs.stripe.com/js/appendix/payment_response#payment_response_object-complete
 					status: 'success',
-					shippingOptions: transformCartDataForShippingOptions(
-						cartData
-					),
+					shippingOptions,
 					total: {
 						label: getPaymentRequestData( 'total_label' ),
 						amount: transformPrice(


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When the Store API doesn't return shipping options for the PRB, the PRB UI hangs forever - eventually updating with "request timeout".
We need to update it with an error code, by checking if there are shipping options present.

Before:
<img width="633" alt="Screenshot 2024-07-17 at 6 37 40 PM" src="https://github.com/user-attachments/assets/8f711b4e-08ca-49e3-bc98-012769716ecf">
![2024-07-17 18 37 02](https://github.com/user-attachments/assets/766d523d-e4c4-48a3-b96e-8d56f3d09c2d)

After:
![2024-07-17 18 42 49](https://github.com/user-attachments/assets/c247fb96-be97-406f-b649-093afb1a4713)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the "Enable Cart-Token implementation for PRBs" flag in your dev tools (you'll need to update them)
- Ensure you have Google Pay/Apple Pay enabled in the merchant's settings
- Ensure you don't have options in the "rest of the world" shipping zone, in your WC settings
- Go to the product page for a physical product (this issue doesn't affect virtual products)
- Click on the ApplePay/GooglePay button
- Select an address that doesn't match with your configured shipping zones
- The "invalid shipping address" error should appear


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
