### PR TITLE
Fix Payments Settings originated onboarding flow - for patch release 7.9.2

### DIFF
--- a/changelog/fix-payments-settings-originated-onboarding-flow
+++ b/changelog/fix-payments-settings-originated-onboarding-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix store connection loop for onboarding flows started from the Woo > Settings > Payments page.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -906,13 +906,19 @@ class WC_Payments_Account {
 			$progressive            = ! empty( $_GET['progressive'] ) && 'true' === $_GET['progressive'];
 			$create_builder_account = ! empty( $_GET['create_builder_account'] ) && 'true' === $_GET['create_builder_account'];
 
-			// Track connection start.
-			if ( ! isset( $_GET['wcpay-connect-jetpack-success'] ) ) {
+			// Determine the original source from where the merchant entered the onboarding flow.
+			$onboarding_source = WC_Payments_Onboarding_Service::get_source( (string) wp_get_referer(), $_GET );
 
+			// Track WooPayments onboarding (aka connection) start.
+			// We should not have a connected Stripe account. If we do, it means we are not at the very start,
+			// but somewhere in between.
+			// Exclude returns from the Jetpack/WPCOM connection screens.
+			if ( ! $this->is_stripe_connected() && ! isset( $_GET['wcpay-connect-jetpack-success'] ) ) {
 				$test_mode        = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
 				$event_properties = [
 					'incentive' => $incentive,
 					'mode'      => $test_mode || WC_Payments::mode()->is_test() ? 'test' : 'live',
+					'source'    => $onboarding_source,
 				];
 				$this->tracks_event(
 					self::TRACKS_EVENT_ACCOUNT_CONNECT_START,
@@ -920,11 +926,13 @@ class WC_Payments_Account {
 				);
 			}
 
-			$connect_page_source = WC_Payments_Onboarding_Service::get_source( (string) wp_get_referer(), $_GET );
-			// Redirect to the onboarding flow page if the account is not onboarded otherwise to the overview page.
-			// Builder accounts are handled below and redirected to Stripe KYC directly.
-			if ( ! $create_builder_account && in_array(
-				$connect_page_source,
+			// Main onboarding flow sources/entry-points are handled separately:
+			// - redirect to the Jetpack connection screens if there is no connection;
+			// - redirect to our onboarding wizard (MOX) if we have a connection but no Stripe account;
+			// - let other states be handled by the default business logic.
+			// We exclude builder flow onboardings from this special handling and let them use the fallback handling.
+			if ( in_array(
+				$onboarding_source,
 				[
 					WC_Payments_Onboarding_Service::SOURCE_WCADMIN_PAYMENT_TASK,
 					WC_Payments_Onboarding_Service::SOURCE_WCPAY_CONNECT_PAGE,
@@ -932,10 +940,12 @@ class WC_Payments_Account {
 					WC_Payments_Onboarding_Service::SOURCE_WCADMIN_INCENTIVE_PAGE,
 				],
 				true
-			) ) {
-				// Redirect non-onboarded account to the onboarding flow, otherwise to payments overview page.
+			) && ! $create_builder_account ) {
+				// Handle the state with no Stripe account.
+				// We either need to redirect to the onboarding wizard (MOX)
+				// or first set up the Jetpack connection and redirect to the onboarding wizard after a successful connection.
 				if ( ! $this->is_stripe_connected() ) {
-					$should_onboard_in_test_mode = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
+					$should_onboard_in_test_mode = isset( $_GET['test_mode'] ) && wc_clean( wp_unslash( $_GET['test_mode'] ) );
 					if ( ! $should_onboard_in_test_mode && WC_Payments_Onboarding_Service::is_test_mode_enabled() ) {
 						// If there is no test mode in the URL informing us to onboard in test mode,
 						// but the onboarding test mode is enabled in our DB, we should disable it.
@@ -943,12 +953,10 @@ class WC_Payments_Account {
 						WC_Payments_Onboarding_Service::set_test_mode( false );
 					}
 
-					if ( WC_Payments_Onboarding_Service::SOURCE_WCADMIN_SETTINGS_PAGE === $connect_page_source ) {
-						$this->redirect_service->redirect_to_connect_page( null, 'WCADMIN_PAYMENT_SETTINGS' );
-					} else {
-						$this->redirect_to_onboarding_page_or_start_server_connection( $connect_page_source );
-					}
-				} elseif ( WC_Payments_Onboarding_Service::SOURCE_WCADMIN_SETTINGS_PAGE === $connect_page_source && ! $this->is_details_submitted() ) {
+					$this->redirect_to_onboarding_page_or_start_server_connection( $onboarding_source );
+				} elseif ( ! $this->is_details_submitted() && $this->payments_api_client->is_server_connected() ) {
+					// Handle the state where we have a connected Stripe account, but it is not fully onboarded.
+					// We redirect to the Stripe KYC for the merchant to finish verifications.
 					try {
 						$this->init_stripe_onboarding(
 							$wcpay_connect_param,
@@ -963,34 +971,45 @@ class WC_Payments_Account {
 							__( 'There was a problem redirecting you to the account connection page. Please try again.', 'woocommerce-payments' )
 						);
 					}
+
+					// We should not reach this point as we either redirect to the Stripe KYC
+					// or to the Connect page with an error message.
 					return;
-				} else {
-					// Accounts with Stripe account connected will be redirected to the overview page.
-					$this->redirect_service->redirect_to_overview_page();
 				}
 			}
 
-			// Handle the flow for a builder moving from test to live.
-			if ( WC_Payments_Onboarding_Service::SOURCE_WCPAY_SETUP_LIVE_PAYMENTS === $connect_page_source ) {
+			// Handle the flow for [a builder] moving from test to live.
+			if ( ! empty( $_GET['wcpay-disable-onboarding-test-mode'] ) && 'true' === $_GET['wcpay-disable-onboarding-test-mode'] ) {
 				$test_mode = WC_Payments_Onboarding_Service::is_test_mode_enabled();
 
-				// Delete the account if the test mode is enabled otherwise it'll cause issues to onboard again.
+				// Delete the account if the test mode is enabled,
+				// otherwise it'll cause issues when trying to onboard again.
 				if ( $test_mode ) {
+					// Delete the account.
 					$this->payments_api_client->delete_account( $test_mode );
+					// Make sure we clear the cached account data as it may take a while
+					// for the account update webhook to come from our platform.
+					$this->clear_cache();
 				}
 
 				// Set the test mode to false now that we are handling a real onboarding.
 				WC_Payments_Onboarding_Service::set_test_mode( false );
-				$this->redirect_to_onboarding_page_or_start_server_connection( $connect_page_source );
+
+				$this->redirect_to_onboarding_page_or_start_server_connection( $onboarding_source );
 				return;
 			}
 
-			if ( WC_Payments_Onboarding_Service::SOURCE_WCPAY_RESET_ACCOUNT === $connect_page_source ) {
+			// Handle the flow for resetting an account (aka restarting onboarding).
+			if ( ! empty( $_GET['wcpay-reset-account'] ) && 'true' === $_GET['wcpay-reset-account'] ) {
 				$test_mode = WC_Payments_Onboarding_Service::is_test_mode_enabled() || WC_Payments::mode()->is_dev();
 
 				// Delete the account.
 				$this->payments_api_client->delete_account( $test_mode );
-				$this->redirect_to_onboarding_page_or_start_server_connection( $connect_page_source );
+				// Make sure we clear the cached account data as it may take a while
+				// for the account update webhook to come from our platform.
+				$this->clear_cache();
+
+				$this->redirect_to_onboarding_page_or_start_server_connection( $onboarding_source );
 				return;
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 6.5
+Tested up to: 6.6
 Requires PHP: 7.3
 Stable tag: 7.9.2
 License: GPLv2 or later


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We fix the issue described in #9103 for the WooPayments 7.9.1 release: when starting onboarding from the Woo Settings Payments page, when attempting to "Connect your store", you would get redirected back to the Connect page, in a loop.

Additional fix: We fixed a bug where sandbox mode onboarding without a Jetpack connection would end up with a live account.
Additional change: Bump the tested up to version for WP to 6.6 since we missed bumping it in 7.9.1.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a JN site with WooCommerce and WooPayments at this PR's live-branch ([short-lived JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&branches.woocommerce-payments=fix/payments-settings-originated-onboarding-flow))
1. When presented with the WooCommerce Profiler, skip the guided setup and set your store's country to `US`
1. Go to Plugins, and make sure that the WooPayments version starts with `8.0.0-dev_PR-9120` and that it is activated.
1. Go to WooCommerce > Settings > Payments and click on the "Finish setup" button for WooPayments
1. You should be redirected to the Jetpack connection screen.
1. Do not approve the connection, but click on "Return"
1. Go to your Payments Connect page and add `&from=WCADMIN_PAYMENTS_SETTINGS` to the URL (make sure there is no other value for the `from` URL parameter) and refresh the page (the `&from=WCADMIN_PAYMENTS_SETTINGS` should still be in the URL)
1. Click on "Connect your store" and you should be redirected to the Jetpack connection screen. Do not approve the connection, but click on "Return"
1. Click on the "Payments" menu item and refresh the page. There shouldn't be any `from` parameter in your URL.
1. Click on "Connect your store" and you should be redirected to the Jetpack connection screen. Do not approve the connection, but click on "Return"
1. Go to WooCommerce > Settings > Payments and click on the "Get started" button in the WooPayments banner
1. You should be redirected to the Jetpack connection screen.
1. Approve the connection and you should be redirected to the onboarding wizard
1. Complete the onboarding wizard and you should be redirected to the Stripe KYC

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
