### PR TITLE
Remove bullet point from WooPay button on Safari

### DIFF
--- a/changelog/fix-9068-bullet-on-woopay
+++ b/changelog/fix-9068-bullet-on-woopay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove bullet from WooPay button on cart block in Safari

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -14,6 +14,7 @@
 	.StripeElement iframe {
 		max-width: unset;
 	}
+	list-style: none;
 }
 
 .woocommerce-checkout .wcpay-payment-request-wrapper {


### PR DESCRIPTION
Fixes #9068 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This change addresses an issue we noticed in which a bullet point was being displayed in the WooPay button in Safari on the Cart Block. As an added bonus this change also fixes some odd spacing issues we saw between buttons on Safari on the cart block when using the Stripe Express Checkout Element.

The change is a simple CSS change to apply a list-style: none to the parent container.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

**Before**
![Screenshot 2024-07-17 at 4 17 40 PM](https://github.com/user-attachments/assets/012c8b9b-4e9e-4798-8a5c-39e2c37a0640)

**After**
![Screenshot 2024-07-17 at 4 18 09 PM](https://github.com/user-attachments/assets/3a080e99-e6c6-44d3-bd8f-4b67edd3db7e)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable WooPay and the Cart Block page.
2. In Safari add an item to your cart and visit the Cart block page.
3. Confirm that there is no bullet point rendered in the button.
4. Enable ECE with `npm run wp option set _wcpay_feature_stripe_ece 1`
5. Enable Google Pay and Apple Pay if not already.
6. Revisit Cart block page and confirm that spacing between the buttons in standardized.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
