### PR TITLE
Ensure Shoppers Are Able to Use Google Pay When WooPay Is Enabled

### DIFF
--- a/changelog/fix-9113-ece-google-pay-fails-with-woopay-enabled
+++ b/changelog/fix-9113-ece-google-pay-fails-with-woopay-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make Google Pay ECE compatible with WooPay.

--- a/client/express-checkout/blocks/components/express-checkout-container.js
+++ b/client/express-checkout/blocks/components/express-checkout-container.js
@@ -14,7 +14,7 @@ const ExpressCheckoutContainer = ( props ) => {
 	const { api, billing } = props;
 
 	const stripePromise = useMemo( () => {
-		return api.loadStripe();
+		return api.loadStripe( true );
 	}, [ api ] );
 
 	const options = {


### PR DESCRIPTION
Fixes #9113

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

These PR changes ensure shoppers can use Google Pay without issues at the Blocks checkout page. Before these changes, if WooPay was enabled, the shopper could not checkout through Google Pay.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Reproduce Bug: Google Pay Not Compatible With WooPay**
* Switch over to the `develop` branch.
* As a merchant, ensure Google Pay is enabled.
* Ensure WooPay is enabled.
* As a shopper, navigate to the merchant shop, add an item to the cart, and navigate to the checkout page.
* Click on the `Buy with Google Pay` button.
* Confirm bug can be reproduced as described in [WooPayments#9113](https://github.com/Automattic/woocommerce-payments/issues/9113).

**Confirm Fix: Google Pay Compatible With WooPay**
* Switch over to this branch (e.g. `fix/9113-ece-google-pay-fails-with-woopay-enabled`).
* As a merchant, ensure Google Pay is enabled.
* Ensure WooPay is enabled.
* As a shopper, navigate to the merchant shop, add an item to the cart, and navigate to the checkout page.
* Click on the `Buy with Google Pay` button.
* Confirm you can successfully checkout.

**Regression Test: Ensure WooPay Continues to Work as Intended**
* Switch over to this branch (e.g. `fix/9113-ece-google-pay-fails-with-woopay-enabled`).
* As a merchant, ensure Google Pay is enabled.
* Ensure WooPay is enabled.
* As a shopper, navigate to the merchant shop, add an item to the cart, and navigate to the checkout page.
* Click on the `Buy with WooPay` button.
* Login into WooPay if necessary, click `Place order` button.
* Confirm you can successfully checkout through WooPay.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
