### PR TITLE
Fix WooPay opt-in blocks field

### DIFF
--- a/changelog/fix-woopay-opt-in-blocks-field
+++ b/changelog/fix-woopay-opt-in-blocks-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay opt-in blocks field on WooCommerce 9.1+.

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -86,13 +86,6 @@ button.wcpay-stripelink-modal-trigger:hover {
 	}
 }
 
-.is-mobile,
-.is-small {
-	#remember-me .wc-version-greater-than-91 h2 {
-		margin-top: 36px;
-	}
-}
-
 #payment-method {
 	label.wc-block-components-radio-control__option-checked {
 		.StripeElement {

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -86,6 +86,13 @@ button.wcpay-stripelink-modal-trigger:hover {
 	}
 }
 
+.is-mobile,
+.is-small {
+	#remember-me h2 {
+		margin-top: 36px;
+	}
+}
+
 #payment-method {
 	label.wc-block-components-radio-control__option-checked {
 		.StripeElement {

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -88,7 +88,7 @@ button.wcpay-stripelink-modal-trigger:hover {
 
 .is-mobile,
 .is-small {
-	#remember-me h2 {
+	#remember-me .wc-version-greater-than-91 h2 {
 		margin-top: 36px;
 	}
 }

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -39,6 +39,8 @@ const renderSaveUserSection = () => {
 				paymentOptions.nextSibling
 			);
 
+			paymentOptions.classList.add( 'is-woopay' );
+
 			ReactDOM.render(
 				<CheckoutPageSaveUser isBlocksCheckout={ true } />,
 				checkoutPageSaveUserContainer

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -184,7 +184,9 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		<Container isBlocksCheckout={ isBlocksCheckout }>
 			<div
 				className={ `save-details ${
-					wcVersionGreaterThan91 ? 'with-margin-bottom' : ''
+					wcVersionGreaterThan91 && isBlocksCheckout
+						? 'with-margin-bottom'
+						: ''
 				}` }
 			>
 				<div className="save-details-header">

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -181,14 +181,11 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	}
 
 	return (
-		<Container isBlocksCheckout={ isBlocksCheckout }>
-			<div
-				className={ `save-details ${
-					wcVersionGreaterThan91 && isBlocksCheckout
-						? 'with-margin-bottom'
-						: ''
-				}` }
-			>
+		<Container
+			isBlocksCheckout={ isBlocksCheckout }
+			wcVersionGreaterThan91={ wcVersionGreaterThan91 }
+		>
+			<div className="save-details">
 				<div className="save-details-header">
 					<div
 						className={

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -19,6 +19,8 @@ import useWooPayUser from '../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../hooks/use-selected-payment-method';
 import { recordUserEvent } from 'tracks';
 import './style.scss';
+import { getSetting } from '@woocommerce/settings';
+import { compare } from 'compare-versions';
 
 const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const [ isSaveDetailsChecked, setIsSaveDetailsChecked ] = useState(
@@ -34,6 +36,12 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	);
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
+	const wooCommerceVersionString = getSetting( 'wcVersion' );
+	const wcVersionGreaterThan91 = compare(
+		wooCommerceVersionString,
+		'9.1',
+		'>='
+	);
 
 	const getPhoneFieldValue = () => {
 		let phoneFieldValue = '';
@@ -175,7 +183,11 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 
 	return (
 		<Container isBlocksCheckout={ isBlocksCheckout }>
-			<div className="save-details">
+			<div
+				className={ `save-details ${
+					wcVersionGreaterThan91 ? 'with-margin-bottom' : ''
+				}` }
+			>
 				<div className="save-details-header">
 					<div
 						className={
@@ -193,6 +205,10 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 								id="save_user_in_woopay"
 								value="true"
 								className={ `save-details-checkbox ${
+									wcVersionGreaterThan91
+										? 'without-margin-right'
+										: ''
+								} ${
 									isBlocksCheckout
 										? 'wc-block-components-checkbox__input'
 										: ''

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -19,7 +19,6 @@ import useWooPayUser from '../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../hooks/use-selected-payment-method';
 import { recordUserEvent } from 'tracks';
 import './style.scss';
-import { getSetting } from '@woocommerce/settings';
 import { compare } from 'compare-versions';
 
 const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
@@ -36,7 +35,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	);
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
-	const wooCommerceVersionString = getSetting( 'wcVersion' );
+	const wooCommerceVersionString = window.wcSettings?.wcVersion;
 	const wcVersionGreaterThan91 = compare(
 		wooCommerceVersionString,
 		'9.1',

--- a/client/components/woopay/save-user/container.js
+++ b/client/components/woopay/save-user/container.js
@@ -3,11 +3,19 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const Container = ( { children, isBlocksCheckout } ) => {
+const Container = ( {
+	children,
+	isBlocksCheckout,
+	wcVersionGreaterThan91,
+} ) => {
 	if ( ! isBlocksCheckout ) return children;
 	return (
 		<>
-			<div className="woopay-save-new-user-container">
+			<div
+				className={ `woopay-save-new-user-container ${
+					wcVersionGreaterThan91 ? 'wc-version-greater-than-91' : ''
+				}` }
+			>
 				<h2>{ __( 'Save my info' ) }</h2>
 				{ children }
 			</div>

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -20,6 +20,24 @@
 	}
 }
 
+.is-medium,
+.is-large {
+	.woopay-save-new-user-container.wc-version-greater-than-91 {
+		border-bottom: 1px solid hsla( 0, 0%, 7%, 0.11 );
+		margin-bottom: 48px;
+	}
+}
+
+@media ( max-width: 600px ) {
+	.is-mobile,
+	.is-small {
+		.wc-block-components-form
+			.wc-block-components-checkout-step.is-woopay::after {
+			height: 0;
+		}
+	}
+}
+
 .woopay-save-new-user-container {
 	.save-details {
 		.wc-block-components-text-input input:-webkit-autofill {
@@ -31,7 +49,7 @@
 		@media ( min-width: 601px ),
 			( min-width: 566px ) and ( max-width: 568px ) {
 			.save-details {
-				margin-bottom: $gap-larger;
+				margin-bottom: 48px;
 			}
 		}
 	}

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -7,10 +7,26 @@
 	}
 }
 
+.is-mobile,
+.is-small {
+	.woopay-save-new-user-container::after {
+		background: currentColor;
+		box-shadow: -50vw 0 0 0 currentColor, 50vw 0 0 0 currentColor;
+		content: '';
+		height: 1px;
+		opacity: 0.11;
+		width: 100%;
+		margin-top: 22px;
+	}
+}
+
 .woopay-save-new-user-container {
 	.save-details {
-		&.with-margin-bottom {
-			margin-bottom: $gap-larger;
+		@media ( min-width: 601px ),
+			( min-width: 566px ) and ( max-width: 568px ) {
+			&.with-margin-bottom {
+				margin-bottom: $gap-larger;
+			}
 		}
 
 		.wc-block-components-text-input input:-webkit-autofill {

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -9,7 +9,7 @@
 
 .is-mobile,
 .is-small {
-	.woopay-save-new-user-container::after {
+	.woopay-save-new-user-container.wc-version-greater-than-91::after {
 		background: currentColor;
 		box-shadow: -50vw 0 0 0 currentColor, 50vw 0 0 0 currentColor;
 		content: '';
@@ -22,15 +22,17 @@
 
 .woopay-save-new-user-container {
 	.save-details {
-		@media ( min-width: 601px ),
-			( min-width: 566px ) and ( max-width: 568px ) {
-			&.with-margin-bottom {
-				margin-bottom: $gap-larger;
-			}
-		}
-
 		.wc-block-components-text-input input:-webkit-autofill {
 			padding: 1.5em 0.5em 1.5em 0.5em;
+		}
+	}
+
+	&.wc-version-greater-than-91 {
+		@media ( min-width: 601px ),
+			( min-width: 566px ) and ( max-width: 568px ) {
+			.save-details {
+				margin-bottom: $gap-larger;
+			}
 		}
 	}
 

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -8,6 +8,16 @@
 }
 
 .woopay-save-new-user-container {
+	.save-details {
+		&.with-margin-bottom {
+			margin-bottom: $gap-larger;
+		}
+
+		.wc-block-components-text-input input:-webkit-autofill {
+			padding: 1.5em 0.5em 1.5em 0.5em;
+		}
+	}
+
 	.save-details-header {
 		display: flex;
 		align-items: flex-start;
@@ -41,7 +51,7 @@
 				text-indent: 0;
 			}
 
-			input {
+			input:not( .without-margin-right ) {
 				margin-right: $gap-small;
 			}
 

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -83,6 +83,15 @@ describe( 'CheckoutPageSaveUser', () => {
 			( setting ) => setting === 'forceNetworkSavedCards'
 		);
 
+		window.wcSettings = {
+			wcVersion: '9.1.2',
+			storePages: {
+				checkout: {
+					permalink: 'http://localhost/',
+				},
+			},
+		};
+
 		window.wcpaySettings = {
 			accountStatus: {
 				country: 'US',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@woocommerce/explat": "2.3.0",
         "@woocommerce/number": "2.4.0",
         "canvas-confetti": "1.9.2",
+        "compare-versions": "6.1.1",
         "debug": "4.1.1",
         "intl-tel-input": "17.0.15",
         "lodash": "4.17.21"
@@ -19920,6 +19921,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
     },
     "node_modules/component-bind": {
       "version": "1.0.0",
@@ -58139,6 +58145,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
     },
     "component-bind": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@woocommerce/explat": "2.3.0",
     "@woocommerce/number": "2.4.0",
     "canvas-confetti": "1.9.2",
+    "compare-versions": "6.1.1",
     "debug": "4.1.1",
     "intl-tel-input": "17.0.15",
     "lodash": "4.17.21"


### PR DESCRIPTION
Fixes #9102

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Fix the WooPay opt-in blocks fields spacing issue when running on WooCommerce 9.1+.

Probably related to https://github.com/woocommerce/woocommerce/pull/47565.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install WooCommerce 9.1.2.
* Add products to your cart.
* Visit the blocks checkout page.
* Type an email that is not registered to WooPay.
* The spacing should work as expected.

<img width="672" alt="Screenshot 2024-07-18 at 2 48 37 PM" src="https://github.com/user-attachments/assets/d1e95a71-33e0-412b-bca1-c1442e68e261">

* Click the checkbox.
* Use the browser autofill to fill out the number.
* The text should be right positioned.

<img width="672" alt="Screenshot 2024-07-18 at 2 49 51 PM" src="https://github.com/user-attachments/assets/b94f7e19-8fd2-436d-a360-dc63f3f0d1a5">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
