### PR TITLE
Allow the purchase of physical subscriptions using ECE if no shipping options are defined

### DIFF
--- a/changelog/9106-ece-checkout-fails-for-physical-subscription-product-if-no-shipping-methods-are-configured
+++ b/changelog/9106-ece-checkout-fails-for-physical-subscription-product-if-no-shipping-methods-are-configured
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Allow the purchase of physical subscriptions using ECE if no shipping options are defined.

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -408,7 +408,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 
 
 	/**
-	 * Determine wether to filter the cart needs shipping address.
+	 * Determine whether to filter the cart needs shipping address.
 	 *
 	 * @param boolean $needs_shipping_address Whether the cart needs a shipping address.
 	 */

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -92,6 +92,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 		add_action( 'template_redirect', [ $this, 'handle_express_checkout_redirect' ] );
 		add_filter( 'woocommerce_login_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
 		add_filter( 'woocommerce_registration_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
+		add_filter( 'woocommerce_cart_needs_shipping_address', [ $this, 'filter_cart_needs_shipping_address' ], 11, 1 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'display_pay_for_order_page_html' ], 1 );
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
@@ -403,6 +404,20 @@ class WC_Payments_Express_Checkout_Button_Handler {
 		wc_setcookie( 'wcpay_express_checkout_redirect_url', '' );
 
 		return $url;
+	}
+
+
+	/**
+	 * Determine wether to filter the cart needs shipping address.
+	 *
+	 * @param boolean $needs_shipping_address Whether the cart needs a shipping address.
+	 */
+	public function filter_cart_needs_shipping_address( $needs_shipping_address ) {
+		if ( $this->has_subscription_product() && wc_get_shipping_method_count( true, true ) === 0 ) {
+			return false;
+		}
+
+		return $needs_shipping_address;
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
@@ -101,13 +101,6 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 			)
 			->getMock();
 
-		$this->mock_express_checkout_ece_button_handler = new WC_Payments_Express_Checkout_Button_Handler(
-			$this->mock_wcpay_account,
-			$this->mock_wcpay_gateway,
-			$this->mock_express_checkout_helper,
-			$this->mock_express_checkout_ajax_handler
-		);
-
 		$this->mock_ece_button_helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
 			->setConstructorArgs(
 				[
@@ -272,6 +265,17 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 
 	public function test_filter_cart_needs_shipping_address_returns_true() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$this->mock_ece_button_helper
+			->method( 'is_product' )
+			->willReturn( true );
+
+		$this->mock_express_checkout_ece_button_handler = new WC_Payments_Express_Checkout_Button_Handler(
+			$this->mock_wcpay_account,
+			$this->mock_wcpay_gateway,
+			$this->mock_ece_button_helper,
+			$this->mock_express_checkout_ajax_handler
+		);
 
 		$this->assertTrue( $this->mock_express_checkout_ece_button_handler->filter_cart_needs_shipping_address( true ) );
 	}

--- a/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
@@ -36,6 +36,54 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	private $express_checkout_helper;
 
 	/**
+	 * Test shipping zone.
+	 *
+	 * @var WC_Shipping_Zone
+	 */
+	private $zone;
+
+	/**
+	 * Flat rate shipping method instance id
+	 *
+	 * @var int
+	 */
+	private $flat_rate_id;
+
+	/**
+	 * Flat rate shipping method instance id
+	 *
+	 * @var int
+	 */
+	private $local_pickup_id;
+
+	/**
+	 * Express Checkout Helper instance.
+	 *
+	 * @var WC_Payments_Express_Checkout_Button_Helper
+	 */
+	private $mock_express_checkout_helper;
+
+	/**
+	 * Express Checkout Ajax Handler instance.
+	 *
+	 * @var WC_Payments_Express_Checkout_Ajax_Handler
+	 */
+	private $mock_express_checkout_ajax_handler;
+
+	/**
+	 * Express Checkout ECE Button Handler instance.
+	 *
+	 * @var WC_Payments_Express_Checkout_Button_Handler
+	 */
+	private $mock_express_checkout_ece_button_handler;
+
+	/**
+	 * Test product to add to the cart
+	 * @var WC_Product_Simple
+	 */
+	private $simple_product;
+
+	/**
 	 * Sets up things all tests need.
 	 */
 	public function set_up() {
@@ -44,11 +92,59 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
 		$this->mock_wcpay_gateway = $this->make_wcpay_gateway();
 
-		$this->mock_express_checkout_helper = new WC_Payments_Express_Checkout_Button_Helper( $this->mock_wcpay_gateway, $this->mock_wcpay_account );
+		$this->mock_express_checkout_helper       = new WC_Payments_Express_Checkout_Button_Helper( $this->mock_wcpay_gateway, $this->mock_wcpay_account );
+		$this->mock_express_checkout_ajax_handler = $this->getMockBuilder( WC_Payments_Express_Checkout_Ajax_Handler::class )
+			->setConstructorArgs(
+				[
+					$this->mock_express_checkout_helper,
+				]
+			)
+			->getMock();
+
+		$this->mock_express_checkout_ece_button_handler = new WC_Payments_Express_Checkout_Button_Handler(
+			$this->mock_wcpay_account,
+			$this->mock_wcpay_gateway,
+			$this->mock_express_checkout_helper,
+			$this->mock_express_checkout_ajax_handler
+		);
+
+		$this->mock_ece_button_helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
+			->setConstructorArgs(
+				[
+					$this->mock_wcpay_gateway,
+					$this->mock_wcpay_account,
+				]
+			)
+			->getMock();
+
+		WC_Helper_Shipping::delete_simple_flat_rate();
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'Worldwide' );
+		$zone->set_zone_order( 1 );
+		$zone->save();
+
+		$this->flat_rate_id = $zone->add_shipping_method( 'flat_rate' );
+		self::set_shipping_method_cost( $this->flat_rate_id, '5' );
+
+		$this->local_pickup_id = $zone->add_shipping_method( 'local_pickup' );
+		self::set_shipping_method_cost( $this->local_pickup_id, '1' );
+
+		$this->zone = $zone;
+
+		$this->simple_product = WC_Helper_Product::create_simple_product();
+
+		WC()->session->init();
+		WC()->cart->add_to_cart( $this->simple_product->get_id(), 1 );
+		$this->mock_express_checkout_helper->update_shipping_method( [ self::get_shipping_option_rate_id( $this->flat_rate_id ) ] );
+		WC()->cart->calculate_totals();
 	}
 
 	public function tear_down() {
 		parent::tear_down();
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC()->cart->empty_cart();
+		WC()->session->cleanup_sessions();
+		$this->zone->delete();
 		remove_filter( 'wc_tax_enabled', '__return_true' );
 		remove_filter( 'wc_tax_enabled', '__return_false' );
 		remove_filter( 'pre_option_woocommerce_tax_display_cart', [ $this, '__return_excl' ] );
@@ -151,5 +247,59 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		$result = $this->mock_express_checkout_helper->get_total_label();
 
 		$this->assertEquals( 'Google Pay (via WooPayments)', $result );
+	}
+
+	public function test_filter_cart_needs_shipping_address_returns_false() {
+		sleep( 1 );
+		$this->zone->delete_shipping_method( $this->flat_rate_id );
+		$this->zone->delete_shipping_method( $this->local_pickup_id );
+
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$this->mock_ece_button_helper
+			->method( 'is_product' )
+			->willReturn( true );
+
+		$this->mock_express_checkout_ece_button_handler = new WC_Payments_Express_Checkout_Button_Handler(
+			$this->mock_wcpay_account,
+			$this->mock_wcpay_gateway,
+			$this->mock_ece_button_helper,
+			$this->mock_express_checkout_ajax_handler
+		);
+
+		$this->assertFalse( $this->mock_express_checkout_ece_button_handler->filter_cart_needs_shipping_address( true ) );
+	}
+
+	public function test_filter_cart_needs_shipping_address_returns_true() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$this->assertTrue( $this->mock_express_checkout_ece_button_handler->filter_cart_needs_shipping_address( true ) );
+	}
+
+	/**
+	 * Sets shipping method cost
+	 *
+	 * @param string $instance_id Shipping method instance id
+	 * @param string $cost Shipping method cost in USD
+	 */
+	private static function set_shipping_method_cost( $instance_id, $cost ) {
+		$method          = WC_Shipping_Zones::get_shipping_method( $instance_id );
+		$option_key      = $method->get_instance_option_key();
+		$options         = get_option( $option_key );
+		$options['cost'] = $cost;
+		update_option( $option_key, $options );
+	}
+
+	/**
+	 * Retrieves rate id by shipping method instance id.
+	 *
+	 * @param string $instance_id Shipping method instance id.
+	 *
+	 * @return string Shipping option instance rate id.
+	 */
+	private static function get_shipping_option_rate_id( $instance_id ) {
+		$method = WC_Shipping_Zones::get_shipping_method( $instance_id );
+
+		return $method->get_rate_id();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9106

#### Changes proposed in this Pull Request

Applies the same changes from #8024 to fix the issue preventing subscription purchases when the store has no defined shipping options.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch to the `develop` branch
- Enable the ECE flag.
- As a merchant, remove all shipping zones and shipping methods for "Rest of the world".
- Create a simple physical subscription product.
- As a shopper, navigate to the product page.
- Try to checkout using Google Pay or Apple Pay.
- Notice the error "The following problems were found: The payment request button is not - supported..." or something like that.
- switch to this branch `9106-ece-checkout-fails-for-physical-subscription-product-if-no-shipping-methods-are-configured`
- Refresh the subscription page and try again to checkout using Google Pay or Apple Pay.
- ✅ Checkout should proceed without issues.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
