### PR TITLE
Use WooPay direct checkout in alternative mini cart block

### DIFF
--- a/changelog/add-woopay-dc-in-footer-mini-cart
+++ b/changelog/add-woopay-dc-in-footer-mini-cart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Apply WooPay direct checkout flow to alternative mini cart checkout button.

--- a/client/checkout/woopay/direct-checkout/index.js
+++ b/client/checkout/woopay/direct-checkout/index.js
@@ -56,6 +56,14 @@ const addMiniCartEventListener = () => {
 };
 
 /**
+ * Add an event listener to the footer mini cart checkout button.
+ */
+const addFooterCartEventListener = () => {
+	const checkoutButton = WooPayDirectCheckout.getFooterMiniCartProceedToCheckoutButton();
+	handleWooPayDirectCheckout( [ checkoutButton ] );
+};
+
+/**
  * If the mini cart widget is available on the page, observe when the drawer element gets added to the DOM.
  *
  * As of today, no window events are triggered when the mini cart is opened or closed,
@@ -87,6 +95,11 @@ const maybeObserveMiniCart = () => {
 							WooPayDirectCheckout.redirectElements
 								.BLOCKS_MINI_CART_PROCEED_BUTTON,
 							addMiniCartEventListener
+						);
+						waitForSelector(
+							WooPayDirectCheckout.redirectElements
+								.BLOCKS_FOOTER_MINI_CART_PROCEED_BUTTON,
+							addFooterCartEventListener
 						);
 						return;
 					}

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -22,6 +22,8 @@ class WooPayDirectCheckout {
 			'.wp-block-woocommerce-proceed-to-checkout-block',
 		BLOCKS_MINI_CART_PROCEED_BUTTON:
 			'a.wp-block-woocommerce-mini-cart-checkout-button-block',
+		BLOCKS_FOOTER_MINI_CART_PROCEED_BUTTON:
+			'a.wc-block-mini-cart__footer-checkout',
 		CLASSIC_MINI_CART_PROCEED_BUTTON:
 			'.widget_shopping_cart a.button.checkout',
 	};
@@ -274,6 +276,17 @@ class WooPayDirectCheckout {
 	}
 
 	/**
+	 * Gets the footer mini cart 'Proceed to checkout' button.
+	 *
+	 * @return {Element} The footer mini cart 'Proceed to checkout' button.
+	 */
+	static getFooterMiniCartProceedToCheckoutButton() {
+		return document.querySelector(
+			this.redirectElements.BLOCKS_FOOTER_MINI_CART_PROCEED_BUTTON
+		);
+	}
+
+	/**
 	 * Adds a click-event listener to the given elements that redirects to the WooPay checkout page.
 	 *
 	 * @param {*[]} elements The elements to add a click-event listener to.
@@ -319,6 +332,9 @@ class WooPayDirectCheckout {
 			if (
 				element.classList.contains(
 					'wp-block-woocommerce-mini-cart-checkout-button-block'
+				) ||
+				element.classList.contains(
+					'wc-block-mini-cart__footer-checkout'
 				)
 			) {
 				return true;


### PR DESCRIPTION
## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Applies the WooPay direct checkout flow to the alternative checkout button in the block-based mini cart.

| Before | After |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/17b5e047-3556-430d-8de5-d5332b9b52f5"> | <video src="https://github.com/user-attachments/assets/eac2823e-8176-485c-ade6-07c81c586065"> |


## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!IMPORTANT]
> Testing requires the Tsubaki theme, or a different theme that uses the alternative checkout button in the mini cart.

1. Install and activate the Tsubaki theme on your test store.
2. Add an item to your cart.
3. Click on the cart icon at the top-right of the page to open the mini cart.
4. Right click on the Go to checkout button an select inspect.
5. Make sure the checkout button's CSS class is set to `wc-block-mini-cart__footer-checkout`.
6. Click on the **Go to checkout** button.
7. Make sure a loading spinner is shown on the button.
8. Make sure you are redirected to the WooPay checkout. 
9. Make sure you can complete a checkout successfully on WooPay.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
