### PR TITLE
Stop WooPay opt-in from blocking the place order button

### DIFF
--- a/changelog/fix-9136-woopay-opt-in-blocking-place-order-button
+++ b/changelog/fix-9136-woopay-opt-in-blocking-place-order-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WooPay opt-in from blocking the place order button

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -156,7 +156,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			if ( isSaveDetailsChecked && ! isPhoneValid ) {
 				setValidationErrors( {
 					[ errorId ]: {
-						message: 'First name is required.',
+						message: '',
 						hidden: false,
 					},
 				} );
@@ -278,9 +278,8 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							} }
 							isBlocksCheckout={ isBlocksCheckout }
 						/>
-						{ ! isPhoneValid && (
+						{ isPhoneValid === false && (
 							<ValidationInputError
-								className="error-text"
 								errorMessage={ __(
 									'Please enter a valid mobile phone number.',
 									'woocommerce-payments'

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -26,11 +26,11 @@ import './style.scss';
 import { compare } from 'compare-versions';
 
 const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
+	const errorId = 'invalid-woopay-phone-number';
+
 	const { setValidationErrors, clearValidationError } = useDispatch(
 		VALIDATION_STORE_KEY
 	);
-
-	const errorId = 'invalid-woopay-phone-number';
 
 	const [ isSaveDetailsChecked, setIsSaveDetailsChecked ] = useState(
 		window.woopayCheckout?.PRE_CHECK_SAVE_MY_INFO || false
@@ -156,8 +156,12 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			if ( isSaveDetailsChecked && ! isPhoneValid ) {
 				setValidationErrors( {
 					[ errorId ]: {
-						message: '',
-						hidden: false,
+						message: __(
+							'Please enter a valid mobile phone number.',
+							'woocommerce-payments'
+						),
+						// Hides errors when the number has not been typed yet but shows when trying to place the order.
+						hidden: isPhoneValid === null,
 					},
 				} );
 			}
@@ -170,6 +174,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		};
 	}, [
 		setValidationErrors,
+		errorId,
 		clearValidationError,
 		isBlocksCheckout,
 		isPhoneValid,
@@ -278,15 +283,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							} }
 							isBlocksCheckout={ isBlocksCheckout }
 						/>
-						{ isPhoneValid === false && (
-							<ValidationInputError
-								errorMessage={ __(
-									'Please enter a valid mobile phone number.',
-									'woocommerce-payments'
-								) }
-								propertyName={ errorId }
-							/>
-						) }
+						<ValidationInputError propertyName={ errorId } />
 						<AdditionalInformation />
 						<Agreement />
 					</div>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -270,19 +270,25 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							name="woopay_viewport"
 							value={ `${ viewportWidth }x${ viewportHeight }` }
 						/>
-						<PhoneNumberInput
-							value={ phoneNumber }
-							onValueChange={ setPhoneNumber }
-							onValidationChange={ onPhoneValidationChange }
-							onCountryDropdownClick={
-								handleCountryDropdownClick
+						<div
+							className={
+								isPhoneValid === false ? 'has-error' : ''
 							}
-							inputProps={ {
-								name:
-									'woopay_user_phone_field[no-country-code]',
-							} }
-							isBlocksCheckout={ isBlocksCheckout }
-						/>
+						>
+							<PhoneNumberInput
+								value={ phoneNumber }
+								onValueChange={ setPhoneNumber }
+								onValidationChange={ onPhoneValidationChange }
+								onCountryDropdownClick={
+									handleCountryDropdownClick
+								}
+								inputProps={ {
+									name:
+										'woopay_user_phone_field[no-country-code]',
+								} }
+								isBlocksCheckout={ isBlocksCheckout }
+							/>
+						</div>
 						<ValidationInputError
 							elementId={ errorId }
 							propertyName={ errorId }

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -283,7 +283,10 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							} }
 							isBlocksCheckout={ isBlocksCheckout }
 						/>
-						<ValidationInputError propertyName={ errorId } />
+						<ValidationInputError
+							elementId={ errorId }
+							propertyName={ errorId }
+						/>
 						<AdditionalInformation />
 						<Agreement />
 					</div>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -95,7 +95,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			extensionCartUpdate( {
 				namespace: 'woopay',
 				data: data,
-			} ).then( () => {
+			} )?.then( () => {
 				setUserDataSent( ! shouldClearData );
 			} );
 		},

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -21,13 +21,18 @@ jest.mock( '../../hooks/use-selected-payment-method', () => jest.fn() );
 jest.mock( 'utils/checkout', () => ( {
 	getConfig: jest.fn(),
 } ) );
+
 jest.mock(
 	'@woocommerce/blocks-checkout',
 	() => ( {
 		extensionCartUpdate: jest.fn(),
+		ValidationInputError: () => {
+			return <div>Dummy error element</div>;
+		},
 	} ),
 	{ virtual: true }
 );
+
 jest.mock( '@wordpress/data' );
 
 jest.mock( 'tracks', () => ( {

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -14,6 +14,7 @@ import CheckoutPageSaveUser from '../checkout-page-save-user';
 import useWooPayUser from '../../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../../hooks/use-selected-payment-method';
 import { getConfig } from 'utils/checkout';
+import { useDispatch } from '@wordpress/data';
 
 jest.mock( '../../hooks/use-woopay-user', () => jest.fn() );
 jest.mock( '../../hooks/use-selected-payment-method', () => jest.fn() );
@@ -27,12 +28,7 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn().mockReturnValue( {
-		setBillingAddress: jest.fn(),
-		setShippingAddress: jest.fn(),
-	} ),
-} ) );
+jest.mock( '@wordpress/data' );
 
 jest.mock( 'tracks', () => ( {
 	recordUserEvent: jest.fn().mockReturnValue( true ),
@@ -57,6 +53,14 @@ jest.mock( 'tracks', () => ( {
 	},
 } ) );
 
+jest.mock(
+	'@woocommerce/block-data',
+	() => ( {
+		VALIDATION_STORE_KEY: 'wc/store/validation',
+	} ),
+	{ virtual: true }
+);
+
 const BlocksCheckoutEnvironmentMock = ( { children } ) => (
 	<div>
 		<button className="wc-block-components-checkout-place-order-button">
@@ -71,6 +75,15 @@ const BlocksCheckoutEnvironmentMock = ( { children } ) => (
 
 describe( 'CheckoutPageSaveUser', () => {
 	beforeEach( () => {
+		useDispatch.mockImplementation( () => {
+			return {
+				setValidationErrors: jest.fn(),
+				clearValidationError: jest.fn(),
+				setBillingAddress: jest.fn(),
+				setShippingAddress: jest.fn(),
+			};
+		} );
+
 		useWooPayUser.mockImplementation( () => false );
 		extensionCartUpdate.mockResolvedValue( {} );
 

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -21,7 +21,6 @@ jest.mock( '../../hooks/use-selected-payment-method', () => jest.fn() );
 jest.mock( 'utils/checkout', () => ( {
 	getConfig: jest.fn(),
 } ) );
-
 jest.mock(
 	'@woocommerce/blocks-checkout',
 	() => ( {
@@ -91,6 +90,7 @@ describe( 'CheckoutPageSaveUser', () => {
 
 		useWooPayUser.mockImplementation( () => false );
 		extensionCartUpdate.mockResolvedValue( {} );
+		extensionCartUpdate.mockClear();
 
 		useSelectedPaymentMethod.mockImplementation( () => ( {
 			isWCPayChosen: true,

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -37,7 +37,7 @@ const PhoneNumberInput = ( {
 	isBlocksCheckout,
 	...props
 }: PhoneNumberInputProps ): JSX.Element => {
-	const [ typedNumber, setTypedNumber ] = useState< boolean >( false );
+	const [ focusLost, setFocusLost ] = useState< boolean >( false );
 	const [
 		inputInstance,
 		setInputInstance,
@@ -67,7 +67,7 @@ const PhoneNumberInput = ( {
 		const currentRef = inputRef.current;
 
 		const handleCountryChange = () => {
-			if ( iti && typedNumber ) {
+			if ( iti && ( focusLost || iti.getNumber() ) ) {
 				onValueChange( iti.getNumber() );
 				onValidationChange( iti.isValidNumber() );
 			}
@@ -140,14 +140,18 @@ const PhoneNumberInput = ( {
 		onValueChange,
 		onValidationChange,
 		onCountryDropdownClick,
-		typedNumber,
+		focusLost,
 	] );
 
 	useEffect( () => {
-		if ( inputInstance && inputRef.current && typedNumber ) {
+		if (
+			inputInstance &&
+			inputRef.current &&
+			( focusLost || inputInstance.getNumber() )
+		) {
 			onValidationChange( inputInstance.isValidNumber() );
 		}
-	}, [ value, inputInstance, inputRef, onValidationChange, typedNumber ] );
+	}, [ value, inputInstance, inputRef, onValidationChange, focusLost ] );
 
 	// Wrapping this in a div instead of a fragment because the library we're using for the phone input
 	// alters the DOM and we'll get warnings about "removing content without using React."
@@ -162,7 +166,7 @@ const PhoneNumberInput = ( {
 				ref={ inputRef }
 				value={ removeInternationalPrefix( value ) }
 				onBlur={ () => {
-					setTypedNumber( true );
+					setFocusLost( true );
 				} }
 				onChange={ handlePhoneNumberInputChange }
 				placeholder={ __( 'Mobile number', 'woocommerce-payments' ) }

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -37,6 +37,7 @@ const PhoneNumberInput = ( {
 	isBlocksCheckout,
 	...props
 }: PhoneNumberInputProps ): JSX.Element => {
+	const [ typedNumber, setTypedNumber ] = useState< boolean >( false );
 	const [
 		inputInstance,
 		setInputInstance,
@@ -66,7 +67,7 @@ const PhoneNumberInput = ( {
 		const currentRef = inputRef.current;
 
 		const handleCountryChange = () => {
-			if ( iti ) {
+			if ( iti && typedNumber ) {
 				onValueChange( iti.getNumber() );
 				onValidationChange( iti.isValidNumber() );
 			}
@@ -135,13 +136,18 @@ const PhoneNumberInput = ( {
 				}
 			}
 		};
-	}, [ onValueChange, onValidationChange, onCountryDropdownClick ] );
+	}, [
+		onValueChange,
+		onValidationChange,
+		onCountryDropdownClick,
+		typedNumber,
+	] );
 
 	useEffect( () => {
-		if ( inputInstance && inputRef.current ) {
+		if ( inputInstance && inputRef.current && typedNumber ) {
 			onValidationChange( inputInstance.isValidNumber() );
 		}
-	}, [ value, inputInstance, inputRef, onValidationChange ] );
+	}, [ value, inputInstance, inputRef, onValidationChange, typedNumber ] );
 
 	// Wrapping this in a div instead of a fragment because the library we're using for the phone input
 	// alters the DOM and we'll get warnings about "removing content without using React."
@@ -155,6 +161,9 @@ const PhoneNumberInput = ( {
 				type="tel"
 				ref={ inputRef }
 				value={ removeInternationalPrefix( value ) }
+				onBlur={ () => {
+					setTypedNumber( true );
+				} }
 				onChange={ handlePhoneNumberInputChange }
 				placeholder={ __( 'Mobile number', 'woocommerce-payments' ) }
 				aria-label={

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -48,6 +48,7 @@
 		font-size: 1rem;
 		line-height: 1.25rem;
 		font-weight: 400;
+		gap: $gap;
 		transition: max-height 0.5s ease-in-out;
 		margin: 0 !important;
 		padding: 0 !important;
@@ -69,7 +70,6 @@
 			line-height: 21px;
 			text-align: left;
 			color: #000;
-			margin: $gap 0;
 		}
 
 		.tos {
@@ -78,6 +78,14 @@
 			:link {
 				color: #6d6d6d;
 			}
+		}
+
+		#validate-error-invalid-woopay-phone-number {
+			// Using rems to base this on the theme styles.
+			font-size: 0.875rem;
+			line-height: 1.5rem;
+			margin-bottom: 0;
+			color: $alert-red;
 		}
 
 		.line {

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -48,7 +48,6 @@
 		font-size: 1rem;
 		line-height: 1.25rem;
 		font-weight: 400;
-		gap: $gap;
 		transition: max-height 0.5s ease-in-out;
 		margin: 0 !important;
 		padding: 0 !important;
@@ -70,6 +69,7 @@
 			line-height: 21px;
 			text-align: left;
 			color: #000;
+			margin: $gap 0;
 		}
 
 		.tos {
@@ -78,17 +78,6 @@
 			:link {
 				color: #6d6d6d;
 			}
-		}
-
-		.error-text {
-			// Using rems to base this on the theme styles.
-			font-size: 0.875rem;
-			line-height: 1.5rem;
-		}
-
-		.error-text {
-			margin-bottom: 0;
-			color: $alert-red;
 		}
 
 		.line {


### PR DESCRIPTION
Fixes #9136

#### Changes proposed in this Pull Request
This PR prevents the WooPay opt-in from blocking the place order button while the phone number was not typed

#### Testing instructions
- Checkout to this branch
- As a guest shopper add a product to the cart
- Go to the checkout page (test both blocks and shortcode)
- Select the `Securely save my information for 1-click checkout` checkbox
- Make sure no error shows up below the input field and the place order button is not blocked
- Fill in all required fields but the WooPay phone number
- Click the place order button
- Make sure the phone input error shows up and the place order button is not blocked
- Type the phone number
- Make sure the error message is gone
- Click the place order button
- Make sure the success page shows up

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
