### PR TITLE
Fix UI state when processing ECE payment on Cart Block

### DIFF
--- a/changelog/fix-9100-unblocked-ui-on-cart-block
+++ b/changelog/fix-9100-unblocked-ui-on-cart-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix UI state when processing ECE payment on Cart Block.

--- a/client/express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/express-checkout/blocks/hooks/use-express-checkout.js
@@ -13,7 +13,10 @@ import {
 	normalizeLineItems,
 } from 'wcpay/express-checkout/utils';
 import {
+	onAbortPaymentHandler,
+	onCancelHandler,
 	onClickHandler,
+	onCompletePaymentHandler,
 	onConfirmHandler,
 	onReadyHandler,
 } from 'wcpay/express-checkout/event-handlers';
@@ -32,16 +35,19 @@ export const useExpressCheckout = ( {
 	const buttonOptions = getExpressCheckoutButtonStyleSettings();
 
 	const onCancel = () => {
+		onCancelHandler();
 		onClose();
 	};
 
 	const completePayment = ( redirectUrl ) => {
+		onCompletePaymentHandler( redirectUrl );
 		window.location = redirectUrl;
 	};
 
 	const abortPayment = ( onConfirmEvent, message ) => {
 		onConfirmEvent.paymentFailed( { reason: 'fail' } );
 		setExpressPaymentError( message );
+		onAbortPaymentHandler( onConfirmEvent, message );
 	};
 
 	const onButtonClick = useCallback(
@@ -68,7 +74,6 @@ export const useExpressCheckout = ( {
 			onClick();
 			// Global click event handler from WooPayments to ECE.
 			onClickHandler( event );
-
 			event.resolve( options );
 		},
 		[

--- a/client/express-checkout/event-handlers.js
+++ b/client/express-checkout/event-handlers.js
@@ -1,3 +1,8 @@
+/* global jQuery */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -13,7 +18,6 @@ import {
 	trackExpressCheckoutButtonClick,
 	trackExpressCheckoutButtonLoad,
 } from './tracking';
-import { __ } from '@wordpress/i18n';
 
 export const shippingAddressChangeHandler = async ( api, event, elements ) => {
 	try {
@@ -136,9 +140,36 @@ export const onReadyHandler = async function ( { availablePaymentMethods } ) {
 	}
 };
 
+const blockUI = () => {
+	jQuery.blockUI( {
+		message: null,
+		overlayCSS: {
+			background: '#fff',
+			opacity: 0.6,
+		},
+	} );
+};
+
+const unblockUI = () => {
+	jQuery.unblockUI();
+};
+
 export const onClickHandler = async function ( { expressPaymentType } ) {
+	blockUI();
 	trackExpressCheckoutButtonClick(
 		expressPaymentType,
 		getExpressCheckoutData( 'button_context' )
 	);
+};
+
+export const onAbortPaymentHandler = () => {
+	unblockUI();
+};
+
+export const onCompletePaymentHandler = () => {
+	blockUI();
+};
+
+export const onCancelHandler = () => {
+	unblockUI();
 };

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -14,7 +14,10 @@ import {
 	normalizeLineItems,
 } from './utils/index';
 import {
+	onAbortPaymentHandler,
+	onCancelHandler,
 	onClickHandler,
+	onCompletePaymentHandler,
 	onConfirmHandler,
 	onReadyHandler,
 	shippingAddressChangeHandler,
@@ -98,7 +101,7 @@ jQuery( ( $ ) => {
 		 */
 		abortPayment: ( payment, message ) => {
 			payment.paymentFailed( { reason: 'fail' } );
-			wcpayECE.unblock();
+			onAbortPaymentHandler( payment, message );
 
 			$( '.woocommerce-error' ).remove();
 
@@ -126,22 +129,8 @@ jQuery( ( $ ) => {
 		 * @param {string} url Order thank you page URL.
 		 */
 		completePayment: ( url ) => {
-			wcpayECE.block();
+			onCompletePaymentHandler( url );
 			window.location = url;
-		},
-
-		block: () => {
-			$.blockUI( {
-				message: null,
-				overlayCSS: {
-					background: '#fff',
-					opacity: 0.6,
-				},
-			} );
-		},
-
-		unblock: () => {
-			$.unblockUI();
 		},
 
 		/**
@@ -308,7 +297,7 @@ jQuery( ( $ ) => {
 					phoneNumberRequired: options.requestPhone,
 					shippingRates,
 				};
-				wcpayECE.block();
+
 				onClickHandler( event );
 				event.resolve( clickOptions );
 			} );
@@ -337,7 +326,7 @@ jQuery( ( $ ) => {
 
 			eceButton.on( 'cancel', async () => {
 				wcpayECE.paymentAborted = true;
-				wcpayECE.unblock();
+				onCancelHandler();
 			} );
 
 			eceButton.on( 'ready', onReadyHandler );


### PR DESCRIPTION
Fixes #9100.

#### Changes proposed in this Pull Request

This PR fixes the UI state when processing an ECE payment on Cart Block. I fixed that by moving the block/unblock UI logic to the event handlers since that's not something the ECE logic should be concerned about. With that move, I had to add a couple new event handlers and make sure they're called both in the classic and Blocks cart.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Setup**

- Ensure ECE is enabled by setting the `_wcpay_feature_stripe_ece` option to `1`.
- Set up a public facing URL using HTTPS for your environment. Use something like Jurassic Tube or ngrok to create a tunnel.

**Test: Ensure ECE works as expected in the cart**

- Test this in the classic and Blocks cart.
- By testing this you're already ensuring there are no regressions.

1. As a shopper, add a product to the cart and navigate to the cart.
2. Click on the Google Pay or Apple Pay button.
3. Try to interact with elements outside of the payment sheet that can interfere in the payment flow, such as the **Proceed to checkout** button.
4. Click on **Pay** and while the payment is being processed, try to interact with elements outside of the payment sheet.
5. Ensure the order is sucessfully processed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
