### PR TITLE
Revert "Disable WooPay if WooPayments is not enabled as payment gateway"

### DIFF
--- a/changelog/as-disable-dc-if-woopayments-disabled
+++ b/changelog/as-disable-dc-if-woopayments-disabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Disable WooPay if WooPayments is not enabled as payment gateway.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -62,12 +62,6 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_woopay_enabled() {
-		// If WooPayments is not enabled then disable WooPay.
-		$enabled_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) ) {
-			return false;
-		}
-
 		$is_woopay_eligible               = self::is_woopay_eligible(); // Feature flag.
 		$is_woopay_enabled                = 'yes' === WC_Payments::get_gateway()->get_option( 'platform_checkout' );
 		$is_woopay_express_button_enabled = self::is_woopay_express_checkout_enabled();

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -48,16 +48,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			->willReturn( false );
 
 		WC_Payments::set_account_service( $this->mock_wcpay_account );
-
-		add_filter(
-			'woocommerce_available_payment_gateways',
-			function () {
-				return [
-					'woocommerce_payments' => new class() extends WC_Payment_Gateway {
-					},
-				];
-			}
-		);
 	}
 
 	public function tear_down() {
@@ -76,9 +66,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
-
-		remove_all_filters( 'woocommerce_available_payment_gateways' );
-
 		parent::tear_down();
 	}
 
@@ -221,12 +208,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
 	}
 
-	public function test_is_woopay_enabled_returns_false_when_woopayments_is_disabled() {
-		remove_all_filters( 'woocommerce_available_payment_gateways' );
-
-		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
-	}
-
 	public function test_is_woopay_express_checkout_enabled_returns_true() {
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
@@ -255,12 +236,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			]
 		);
 		$this->assertTrue( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
-	}
-
-	public function test_is_woopay_direct_checkout_enabled_returns_false_when_woopayments_is_disabled() {
-		remove_all_filters( 'woocommerce_available_payment_gateways' );
-
-		$this->assertFalse( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_false_when_flag_is_false() {


### PR DESCRIPTION
Reverts Automattic/woocommerce-payments#9147 since it seems to have introduced a regresion with Subscriptions.

More details.  https://github.com/Automattic/woocommerce-payments/pull/9147#issuecomment-2245796901

I'll investigate this and submit the fix again.

@ricardo I think it's better to just disable ECE for now instead of disabling WooPay entirely. I'll take a look to see which option we have.

