### PR TITLE
Add heading rules to appearance

### DIFF
--- a/changelog/add-get-heading-color-by-selectors
+++ b/changelog/add-get-heading-color-by-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add heading rules to appearance

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -39,6 +39,7 @@ const mockAppearance = {
 		},
 		'.Text': {},
 		'.Text--redirect': {},
+		'.Heading': {},
 	},
 	theme: 'stripe',
 	variables: {

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -9,7 +9,6 @@ import {
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
-	getHeadingColor,
 } from './utils.js';
 
 export const appearanceSelectors = {
@@ -442,7 +441,7 @@ export const getAppearance = ( elementsLocation ) => {
 	};
 
 	const backgroundColor = getBackgroundColor( selectors.backgroundSelectors );
-	const headingColor = getHeadingColor( selectors.headingSelectors );
+	const headingRules = getFieldStyles( selectors.headingSelectors, '.Label' );
 	const blockRules = getFieldStyles(
 		selectors.upeThemeLabelSelector,
 		'.Block',
@@ -452,7 +451,6 @@ export const getAppearance = ( elementsLocation ) => {
 	const globalRules = {
 		colorBackground: backgroundColor,
 		colorText: labelRules.color,
-		colorHeading: headingColor,
 		fontFamily: labelRules.fontFamily,
 		fontSizeBase: labelRules.fontSize,
 	};
@@ -472,6 +470,7 @@ export const getAppearance = ( elementsLocation ) => {
 			'.TabIcon--selected': selectedTabIconRules,
 			'.Text': labelRules,
 			'.Text--redirect': labelRules,
+			'.Heading': headingRules,
 		},
 	};
 	// Remove hidden fields from DOM.

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -9,6 +9,7 @@ import {
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
+	getHeadingColor,
 } from './utils.js';
 
 export const appearanceSelectors = {
@@ -36,6 +37,7 @@ export const appearanceSelectors = {
 			'form.checkout',
 			'body',
 		],
+		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	},
 	blocksCheckout: {
 		appendTarget: '#billing.wc-block-components-address-form',
@@ -58,6 +60,7 @@ export const appearanceSelectors = {
 			'.wc-block-checkout',
 			'body',
 		],
+		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	},
 	bnplProductPage: {
 		appendTarget: '.product .cart .quantity',
@@ -73,6 +76,7 @@ export const appearanceSelectors = {
 			'#main',
 			'body',
 		],
+		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	},
 	bnplClassicCart: {
 		appendTarget: '.cart .quantity',
@@ -88,6 +92,7 @@ export const appearanceSelectors = {
 			'#main',
 			'body',
 		],
+		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	},
 	bnplCartBlock: {
 		appendTarget: '.wc-block-cart .wc-block-components-quantity-selector',
@@ -107,6 +112,7 @@ export const appearanceSelectors = {
 			'.wp-block-woocommerce-cart',
 			'body',
 		],
+		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 	},
 
 	/**
@@ -436,6 +442,7 @@ export const getAppearance = ( elementsLocation ) => {
 	};
 
 	const backgroundColor = getBackgroundColor( selectors.backgroundSelectors );
+	const headingColor = getHeadingColor( selectors.headingSelectors );
 	const blockRules = getFieldStyles(
 		selectors.upeThemeLabelSelector,
 		'.Block',
@@ -445,6 +452,7 @@ export const getAppearance = ( elementsLocation ) => {
 	const globalRules = {
 		colorBackground: backgroundColor,
 		colorText: labelRules.color,
+		colorHeading: headingColor,
 		fontFamily: labelRules.fontFamily,
 		fontSizeBase: labelRules.fontSize,
 	};

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -196,6 +196,13 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 					backgroundColor: '#ffffff',
 				},
+				'.Heading': {
+					color: 'rgb(109, 109, 109)',
+					fontFamily:
+						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
+					fontSize: '12px',
+					padding: '10px',
+				},
 			},
 		} );
 	} );

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -150,34 +150,6 @@ export const getBackgroundColor = ( selectors ) => {
 };
 
 /**
- * Searches through array of CSS selectors and returns first visible heading color.
- *
- * @param {Array} selectors List of CSS selectors to check.
- * @return {string} CSS color value.
- */
-export const getHeadingColor = ( selectors ) => {
-	const defaultColor = '#ffffff';
-	let color = null;
-	let i = 0;
-	while ( ! color && i < selectors.length ) {
-		const element = document.querySelector( selectors[ i ] );
-		if ( ! element ) {
-			i++;
-			continue;
-		}
-
-		const headingColor = window.getComputedStyle( element ).color;
-
-		// If headingColor property present and alpha > 0.
-		if ( headingColor && tinycolor( headingColor ).getAlpha() > 0 ) {
-			color = headingColor;
-		}
-		i++;
-	}
-	return color || defaultColor;
-};
-
-/**
  * Determines whether background color is light or dark.
  *
  * @param {string} color CSS color value.

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -150,6 +150,34 @@ export const getBackgroundColor = ( selectors ) => {
 };
 
 /**
+ * Searches through array of CSS selectors and returns first visible heading color.
+ *
+ * @param {Array} selectors List of CSS selectors to check.
+ * @return {string} CSS color value.
+ */
+export const getHeadingColor = ( selectors ) => {
+	const defaultColor = '#ffffff';
+	let color = null;
+	let i = 0;
+	while ( ! color && i < selectors.length ) {
+		const element = document.querySelector( selectors[ i ] );
+		if ( ! element ) {
+			i++;
+			continue;
+		}
+
+		const headingColor = window.getComputedStyle( element ).color;
+
+		// If headingColor property present and alpha > 0.
+		if ( headingColor && tinycolor( headingColor ).getAlpha() > 0 ) {
+			color = headingColor;
+		}
+		i++;
+	}
+	return color || defaultColor;
+};
+
+/**
  * Determines whether background color is light or dark.
  *
  * @param {string} color CSS color value.

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -87,6 +87,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			},
 			'.Text': {},
 			'.Text--redirect': {},
+			'.Heading': {},
 		},
 		theme: 'stripe',
 		variables: {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2830

#### Changes proposed in this Pull Request
This PR adds heading rules to appearance to allow us to get heading color by `h` tags.

EPIC https://github.com/Automattic/woopay/issues/2781
SPIKE [here](https://woopayp2.wordpress.com/2024/07/01/spike-global-themes-support/#proof-of-concept-for-option-3-preferred)
PT [here](https://woopayp2.wordpress.com/2024/07/11/project-thread-woopay-global-themes-support/)

<img width="533" alt="Screenshot 2024-07-24 at 12 04 12 AM" src="https://github.com/user-attachments/assets/8a330e4c-ac2e-47c8-a8a6-fc713dfcb9c6">

#### Testing instructions
* Test with [WooPay PR](https://github.com/Automattic/woopay/pull/2830) to see heading styling applied on WooPay checkout page
* Go to WooPay admin -> WCPay Dev and enable WooPay global theme support feature flag

Test 1 ( The latest WooPayments version ):
1. Test this PR with the latest WooPayments version that includes `getAppearance` on the merchant site
1. Open dev tools
2. Initialize WooPay on Blocks checkout page
3. Find `get_woopay_session` request and find `appearance[rules][.Heading]`


Test 2 ( An older WooPayments version ):
1. Test an older version of WooPayments like [7.6.0](https://github.com/Automattic/woocommerce-payments/releases/download/7.6.0/woocommerce-payments.zip) that doesn't have `getAppearance` on the merchant site for regression test
2. Repeat above testing instructions

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
