### PR TITLE
Disable Direct Checkout if WooPayments is disabled

### DIFF
--- a/changelog/as-disable-dc-if-woopayments-disabled
+++ b/changelog/as-disable-dc-if-woopayments-disabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable WooPay’s Direct Checkout feature if WooPayments is not enabled as payment gateway.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -825,6 +825,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
+		if ( ! $this->payment_method ) {
+			return false;
+		}
+
 		$processing_payment_method = $this->payment_methods[ $this->payment_method->get_id() ];
 		if ( ! $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) ) {
 			return false;
@@ -904,7 +908,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$supported_currencies = $this->account->get_account_customer_supported_currencies();
 		$current_currency     = strtolower( get_woocommerce_currency() );
 
-		if ( count( $supported_currencies ) === 0 ) {
+		if ( is_null( $supported_currencies ) || ( is_array( $supported_currencies ) && count( $supported_currencies ) === 0 ) ) {
 			// If we don't have info related to the supported currencies
 			// of the country, we won't disable the gateway.
 			return true;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -62,6 +62,12 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_woopay_enabled() {
+		// If WooPayments is not enabled then disable Direct checkout.
+		$enabled_gateways = WC()->payment_gateways->get_available_payment_gateways();
+		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) ) {
+			return false;
+		}
+
 		$is_woopay_eligible               = self::is_woopay_eligible(); // Feature flag.
 		$is_woopay_enabled                = 'yes' === WC_Payments::get_gateway()->get_option( 'platform_checkout' );
 		$is_woopay_express_button_enabled = self::is_woopay_express_checkout_enabled();
@@ -266,12 +272,6 @@ class WC_Payments_Features {
 	 * @return bool True if Direct Checkout is enabled, false otherwise.
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
-		// If WooPayments is not enabled then disable Direct checkout.
-		$enabled_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) ) {
-			return false;
-		}
-
 		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -266,6 +266,12 @@ class WC_Payments_Features {
 	 * @return bool True if Direct Checkout is enabled, false otherwise.
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
+		// If WooPayments is not enabled then disable Direct checkout.
+		$enabled_gateways = WC()->payment_gateways->get_available_payment_gateways();
+		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) ) {
+			return false;
+		}
+
 		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -62,19 +62,6 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_woopay_enabled() {
-		// If WooPayments is not enabled then disable Direct checkout.
-		// TODO: Change to WC()->payment_gateways->get_available_payment_gateways() once issue with WC Subscriptions is sorted out.
-		$wc_payment_gateways = WC_Payment_Gateways::instance();
-		$wc_payment_gateways->init();
-		$enabled_gateways = $wc_payment_gateways->payment_gateways();
-
-		// Only used for tests.
-		$enabled_gateways = apply_filters( 'woocommerce_payments_enabled_gateways_for_woopay', $enabled_gateways );
-
-		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) || ! $enabled_gateways['woocommerce_payments']->is_available() ) {
-			return false;
-		}
-
 		$is_woopay_eligible               = self::is_woopay_eligible(); // Feature flag.
 		$is_woopay_enabled                = 'yes' === WC_Payments::get_gateway()->get_option( 'platform_checkout' );
 		$is_woopay_express_button_enabled = self::is_woopay_express_checkout_enabled();
@@ -279,6 +266,19 @@ class WC_Payments_Features {
 	 * @return bool True if Direct Checkout is enabled, false otherwise.
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
+		// If WooPayments is not enabled then disable Direct checkout.
+		// TODO: Change to WC()->payment_gateways->get_available_payment_gateways() once issue with WC Subscriptions is sorted out.
+		$wc_payment_gateways = WC_Payment_Gateways::instance();
+		$wc_payment_gateways->init();
+		$enabled_gateways = $wc_payment_gateways->payment_gateways();
+
+		// Only used for tests.
+		$enabled_gateways = apply_filters( 'woocommerce_payments_enabled_gateways_for_woopay', $enabled_gateways );
+
+		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) || ! $enabled_gateways['woocommerce_payments']->is_available() ) {
+			return false;
+		}
+
 		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -63,8 +63,15 @@ class WC_Payments_Features {
 	 */
 	public static function is_woopay_enabled() {
 		// If WooPayments is not enabled then disable Direct checkout.
-		$enabled_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) ) {
+		// TODO: Change to WC()->payment_gateways->get_available_payment_gateways() once issue with WC Subscriptions is sorted out.
+		$wc_payment_gateways = WC_Payment_Gateways::instance();
+		$wc_payment_gateways->init();
+		$enabled_gateways = $wc_payment_gateways->payment_gateways();
+
+		// Only used for tests.
+		$enabled_gateways = apply_filters( 'woocommerce_payments_enabled_gateways_for_woopay', $enabled_gateways );
+
+		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) || ! $enabled_gateways['woocommerce_payments']->is_available() ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -300,7 +300,7 @@ class WC_Payments_Incentives_Service {
 				)
 			),
 			// Whether the store has at least one payment gateway enabled.
-			'has_payments' => ! empty( WC()->payment_gateways()->get_available_payment_gateways() ),
+			'has_payments' => @ ! empty( WC()->payment_gateways()->get_available_payment_gateways() ), // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			'has_wcpay'    => $this->has_wcpay(),
 		];
 	}

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -300,7 +300,7 @@ class WC_Payments_Incentives_Service {
 				)
 			),
 			// Whether the store has at least one payment gateway enabled.
-			'has_payments' => ! empty( WC()->payment_gateways()->get_available_payment_gateways() ), // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			'has_payments' => ! empty( WC()->payment_gateways()->get_available_payment_gateways() ),
 			'has_wcpay'    => $this->has_wcpay(),
 		];
 	}

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -300,7 +300,7 @@ class WC_Payments_Incentives_Service {
 				)
 			),
 			// Whether the store has at least one payment gateway enabled.
-			'has_payments' => @ ! empty( WC()->payment_gateways()->get_available_payment_gateways() ), // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			'has_payments' => ! empty( WC()->payment_gateways()->get_available_payment_gateways() ), // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			'has_wcpay'    => $this->has_wcpay(),
 		];
 	}

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -196,7 +196,9 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
 	}
 
-	public function test_is_woopay_enabled_returns_false_if_woopayments_is_disabled_and_woopay_is_enabled() {
+	// We are disabling only DC for now. We should disable WooPay if WooPayments is disabled though.
+	// Leaving this test case so we can catch that later.
+	public function test_is_woopay_enabled_returns_true_if_woopayments_is_disabled_and_woopay_is_enabled() {
 		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'disable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -48,6 +48,16 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			->willReturn( false );
 
 		WC_Payments::set_account_service( $this->mock_wcpay_account );
+
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			function () {
+				return [
+					'woocommerce_payments' => new class() extends WC_Payment_Gateway {
+					},
+				];
+			}
+		);
 	}
 
 	public function tear_down() {
@@ -66,6 +76,9 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
+
+		remove_all_filters( 'woocommerce_available_payment_gateways' );
+
 		parent::tear_down();
 	}
 
@@ -236,6 +249,12 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			]
 		);
 		$this->assertTrue( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
+	}
+
+	public function test_is_woopay_direct_checkout_enabled_returns_false_when_woopayments_is_disabled() {
+		add_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
+
+		$this->assertFalse( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_false_when_flag_is_false() {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -258,7 +258,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_false_when_woopayments_is_disabled() {
-		add_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
+		remove_all_filters( 'woocommerce_available_payment_gateways' );
 
 		$this->assertFalse( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
 	}

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -327,7 +327,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		return array_map(
 			function ( $gateway ) {
 				if ( is_a( $gateway, 'WC_Payment_Gateway' ) && 'woocommerce_payments' === $gateway->id ) {
-					// Simple class to replace the WooPayments instance. With this the `is_available` method will return `true` enabling WooPayments.
+					// Simple class to replace the WC_Payment_Gateway_WCPay instance. With this the `is_available` method will return `true` enabling the payment gateway.
 					return new class() extends WC_Payment_Gateway_WCPay {
 						public function __construct() {
 						}

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -67,8 +67,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
 
-		remove_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
-		remove_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'disable_woopayments' ] );
+		remove_all_filters( 'woocommerce_payments_enabled_gateways_for_woopay' );
 
 		parent::tear_down();
 	}
@@ -202,7 +201,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
-		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
+		$this->assertTrue( WC_Payments_Features::is_woopay_enabled() );
 	}
 
 	public function test_is_woopay_enabled_returns_false_when_express_checkout_flag_is_false() {
@@ -327,13 +326,13 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			function ( $gateway ) {
 				if ( is_a( $gateway, 'WC_Payment_Gateway' ) && 'woocommerce_payments' === $gateway->id ) {
 					// Simple class to replace the WooPayments instance. With this the `is_available` method will return `true` enabling WooPayments.
-					return new class() extends WC_Payment_Gateway {
-						/**
-						 * Payment Gateway ID.
-						 *
-						 * @var string
-						 */
-						public $id = 'woocommerce_payments';
+					return new class() extends WC_Payment_Gateway_WCPay {
+						public function __construct() {
+						}
+
+						public function is_available() {
+							return true;
+						}
 					};
 				}
 				return $gateway;

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -221,6 +221,12 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
 	}
 
+	public function test_is_woopay_enabled_returns_false_when_woopayments_is_disabled() {
+		remove_all_filters( 'woocommerce_available_payment_gateways' );
+
+		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
+	}
+
 	public function test_is_woopay_express_checkout_enabled_returns_true() {
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2829

> [!NOTE]  
> The [original PR](https://github.com/Automattic/woocommerce-payments/pull/9147) was [reverted](https://github.com/Automattic/woocommerce-payments/pull/9154) due to a [bug](https://github.com/Automattic/woocommerce-payments/pull/9147#issuecomment-2245796901) that was found on the WC Subscriptions plugin. Please test that case as well.


#### Changes proposed in this Pull Request

This PR fixes the bug where the shopper is redirected to WooPay if logged in to WooPay, and Direct Checkout is enabled while WooPayment is not set as a payment option.

In this PR, we are disabling the Direct Checkout feature only. We are not disabling WooPay, given that doing so introduces some bugs. Due to WooPayment's code freeze, we want to fix the issue as soon as possible without compromising the stability of the plugin.

#### Testing instructions

**Reproduce bug**
* Login to WooPay.
* Enable Direct Checkout feature if not already enabled on your store.
  ```
  wp option update _wcpay_feature_woopay_direct_checkout 1
  ```
* Go to the store and add a product to the cart.
* Go to the cart page click "Proceed to checkout".
* Shopper should be redirected to WooPay.
* On the merchant store, go to Payments > Settings
* Uncheck "Enable WooPayments" then click "disable", save changes.
* Get back to the cart page and refresh the page.
* Click "Proceed to checkout" 
* ❌ Shopper is redirected to WooPay <-- This is the bug.
* Switch to this branch `as-disable-dc-if-woopayments-disabled`
* Go to the cart page and refresh the page.
* Click "Proceed to checkout"
* ✅ Shopper is redirected to the checkout page.
* Disable Direct Checkout `wp option update _wcpay_feature_woopay_direct_checkout 0`
* Enable WooPayments
* then go to the cart page and refresh the page.
* Click "Proceed to checkout"
* ✅ Shopper should be redirected to the checkout page.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
