### PR TITLE
Reporting - Match Payment widget numbers to the totals seen in reports

### DIFF
--- a/changelog/fix-server-5934-payment-widget-data-mismatch
+++ b/changelog/fix-server-5934-payment-widget-data-mismatch
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Make the numbers on the payment activity widget match the totals on the clicked detailed reports screen.
+
+

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -68,6 +68,8 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 	const disputes = paymentActivityData?.disputes ?? 0;
 	const refunds = paymentActivityData?.refunds ?? 0;
 	const currency = paymentActivityData?.currency;
+	const siteTimeZone = wcSettings.admin.timeZone;
+	// We need to add a time offset to the date range to ensure the correct dates are passed on to the transactions report via the view report link.
 
 	return (
 		<div className="wcpay-payment-activity-data">
@@ -114,12 +116,12 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 					path: '/payments/transactions',
 					filter: 'advanced',
 					store_currency_is: currency,
-					'date_between[0]': moment(
-						paymentActivityData?.date_start
-					).format( 'YYYY-MM-DD' ),
-					'date_between[1]': moment(
-						paymentActivityData?.date_end
-					).format( 'YYYY-MM-DD' ),
+					'date_between[0]': moment( paymentActivityData?.date_start )
+						.add( siteTimeZone )
+						.format( 'YYYY-MM-DD' ),
+					'date_between[1]': moment( paymentActivityData?.date_end )
+						.add( siteTimeZone )
+						.format( 'YYYY-MM-DD' ),
 					...getSearchParams(
 						searchTermsForViewReportLink.totalPaymentVolume
 					),
@@ -159,10 +161,14 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
-						).format( 'YYYY-MM-DD' ),
+						)
+							.add( siteTimeZone )
+							.format( 'YYYY-MM-DD' ),
 						'date_between[1]': moment(
 							paymentActivityData?.date_end
-						).format( 'YYYY-MM-DD' ),
+						)
+							.add( siteTimeZone )
+							.format( 'YYYY-MM-DD' ),
 						...getSearchParams(
 							searchTermsForViewReportLink.charge
 						),
@@ -182,10 +188,14 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
-						).format( 'YYYY-MM-DD' ),
+						)
+							.add( siteTimeZone )
+							.format( 'YYYY-MM-DD' ),
 						'date_between[1]': moment(
 							paymentActivityData?.date_end
-						).format( 'YYYY-MM-DD' ),
+						)
+							.add( siteTimeZone )
+							.format( 'YYYY-MM-DD' ),
 						...getSearchParams(
 							searchTermsForViewReportLink.refunds
 						),
@@ -232,10 +242,14 @@ const PaymentActivityDataComponent: React.FC< Props > = ( {
 						store_currency_is: currency,
 						'date_between[0]': moment(
 							paymentActivityData?.date_start
-						).format( 'YYYY-MM-DD' ),
+						)
+							.add( siteTimeZone )
+							.format( 'YYYY-MM-DD' ),
 						'date_between[1]': moment(
 							paymentActivityData?.date_end
-						).format( 'YYYY-MM-DD' ),
+						)
+							.add( siteTimeZone )
+							.format( 'YYYY-MM-DD' ),
 						...getSearchParams(
 							searchTermsForViewReportLink.dispute
 						),

--- a/client/components/payment-activity/test/index.test.tsx
+++ b/client/components/payment-activity/test/index.test.tsx
@@ -74,6 +74,11 @@ declare const global: {
 			country: string;
 		};
 	};
+	wcSettings: {
+		admin: {
+			timeZone: string;
+		};
+	};
 };
 
 describe( 'PaymentActivity component', () => {
@@ -118,6 +123,11 @@ describe( 'PaymentActivity component', () => {
 		Date.now = jest.fn( () =>
 			new Date( '2024-04-08T12:33:37.000Z' ).getTime()
 		);
+		global.wcSettings = {
+			admin: {
+				timeZone: 'UTC',
+			},
+		};
 	} );
 
 	afterEach( () => {

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -176,6 +176,7 @@ declare global {
 				woocommerce_coming_soon: string;
 				woocommerce_private_link: string;
 			};
+			timeZone: string;
 		};
 		adminUrl: string;
 		countries: Record< string, string >;

--- a/includes/admin/class-wc-rest-payments-reporting-controller.php
+++ b/includes/admin/class-wc-rest-payments-reporting-controller.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Payments\Admin
  */
 
-use WCPay\Core\Server\Request;
 use WCPay\Core\Server\Request\Get_Reporting_Payment_Activity;
 use WCPay\Core\Server\Request\Request_Utils;
 

--- a/includes/admin/class-wc-rest-payments-reporting-controller.php
+++ b/includes/admin/class-wc-rest-payments-reporting-controller.php
@@ -5,7 +5,9 @@
  * @package WooCommerce\Payments\Admin
  */
 
+use WCPay\Core\Server\Request;
 use WCPay\Core\Server\Request\Get_Reporting_Payment_Activity;
+use WCPay\Core\Server\Request\Request_Utils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -44,11 +46,27 @@ class WC_REST_Payments_Reporting_Controller extends WC_Payments_REST_Controller 
 	 * @param WP_REST_Request $request The request.
 	 */
 	public function get_payment_activity( $request ) {
-		$wcpay_request = Get_Reporting_Payment_Activity::create();
-		$wcpay_request->set_date_start( $request->get_param( 'date_start' ) );
-		$wcpay_request->set_date_end( $request->get_param( 'date_end' ) );
+		$wcpay_request                = Get_Reporting_Payment_Activity::create();
+		$date_start_in_store_timezone = $this->format_date_to_wp_timezone( $request->get_param( 'date_start' ) );
+		$date_end_in_store_timezone   = $this->format_date_to_wp_timezone( $request->get_param( 'date_end' ) );
+		$wcpay_request->set_date_start( $date_start_in_store_timezone );
+		$wcpay_request->set_date_end( $date_end_in_store_timezone );
 		$wcpay_request->set_timezone( $request->get_param( 'timezone' ) );
 		$wcpay_request->set_currency( $request->get_param( 'currency' ) );
 		return $wcpay_request->handle_rest_request();
+	}
+
+
+
+	/**
+	 * Formats a date string to the WordPress timezone.
+	 *
+	 * @param string $date_string The date string to be formatted.
+	 * @return string The formatted date string in the 'Y-m-d\TH:i:s' format.
+	 */
+	private function format_date_to_wp_timezone( $date_string ) {
+		$date = Request_Utils::format_transaction_date_by_timezone( $date_string, '+00:00' );
+		$date = new DateTime( $date );
+		return $date->format( 'Y-m-d\\TH:i:s' );
 	}
 }


### PR DESCRIPTION
Fixes # https://github.com/Automattic/woocommerce-payments-server/issues/5934

#### Please do not merge until this task is completed

- [x] Deploy and test changes on WCCOM

#### Changes proposed in this Pull Request

The PR makes the Payment Activity Widget summary numbers match with the total shown in the landing pages that are seen via `View report` link of each tile. 

There was a mismatch earlier, since the summary numbers on the widget were set to UTC, whereas those on the transactions report pages with filter ( used for landing pages ),used [an adjustment](https://github.com/Automattic/woocommerce-payments/blob/bebe14e87eb2a4604c82dd212221efc1854302c1/includes/core/server/request/class-list-transactions.php#L80) to match the site settings. 

The PR adds a similar adjustment to the numbers on the Payment activity widget to make them at par with the Transactions report. 

The merchant will see the numbers effectively set to the timezone of the site. 

#### Testing instructions
* For the sake of simplicity and testing, set the timezone of the website in WP settings at UTC +02:00 
* Create a few test transactions - about 6 - 10. 
* We will need to tweak the dates of these transactions in the local database
(a) About 2-3 transactions need to have a date of `yesterday` and time anywhere between 22:01 to 23:59 hours
(b) About 2 transactions should have a date of 9 days ago. ( eg. for 2024-07-25, it would be 2024-07-17 ). Time should be between 22:01 to 23:59 hours
(c) create a few more transactions as fillers for the time in between
(d) Please also check the dates appearing on the transaction reports page. It should have the correct start and end dates. 
(e) Try changing the site timezone to different values and check if the start and end dates in the report pages still appear correctly.

#### When you are checked in to `develop` branch
* The number showing up on the tile will not match with the total that appears on the report screen.
![image](https://github.com/user-attachments/assets/06c78525-b5d3-4549-bab2-d404a9e3582a)

![image](https://github.com/user-attachments/assets/30d850d7-0b14-4f0c-ad98-624e613742b7)

#### When you check into  this branch - `fix/server-5934-payment-widget-data-mismatch`
* The number on the tile and the total will match.

![image](https://github.com/user-attachments/assets/d2f9fc65-8a1f-48f3-9c79-c66577f8c453)

![image](https://github.com/user-attachments/assets/32a6899d-b94f-4524-b3e9-57712e37bc94)



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
