### PR TITLE
Reorder onboarding wizard business types options to have company first

### DIFF
--- a/changelog/update-reorder-business-types-with-company-first
+++ b/changelog/update-reorder-business-types-with-company-first
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Reorder onboarding wizard business types to always have Company as the first option.

--- a/client/onboarding/steps/business-details.tsx
+++ b/client/onboarding/steps/business-details.tsx
@@ -34,7 +34,13 @@ const BusinessDetails: React.FC = () => {
 		return country.key === data.country;
 	} );
 
-	const selectedBusinessType = selectedCountry?.types.find(
+	// Reorder the country business types so company is always first, if it exists.
+	const reorderedBusinessTypes = selectedCountry?.types.sort( ( a, b ) =>
+		// eslint-disable-next-line no-nested-ternary
+		a.key === 'company' ? -1 : b.key === 'company' ? 1 : 0
+	);
+
+	const selectedBusinessType = reorderedBusinessTypes?.find(
 		( type ) => type.key === data.business_type
 	);
 
@@ -43,7 +49,6 @@ const BusinessDetails: React.FC = () => {
 		selectedBusinessType?.structures.find(
 			( structure ) => structure.key === data[ 'company.structure' ]
 		);
-
 	const selectedMcc = mccsFlatList.find( ( mcc ) => mcc.key === data.mcc );
 
 	const handleTiedChange = (


### PR DESCRIPTION
Fixes #9170

#### Changes proposed in this Pull Request

Following this proposal ( paJDYF-enZ-p2 ), we make sure that "Company" is always the first business type option in the dropdown during our onboarding flow. Previously, it was always the second, after "Individual".

#### Testing instructions

* Checkout the PR branch on your local client installation and build the client with `npm run build:client`
* Delete/reset any account you have
* Go to the Connect page and start a new live onboarding (non-builder flow)
* Once in the wizard, go through each WooPayments-eligible country (by using the "Change" link next to the Business location):
![4UV3tv.png](https://github.com/user-attachments/assets/0f42d3f8-acf2-43fa-afc3-7a93e252ce33)
* For each country, check that the options for the "What type of legal entity is your business?" dropdown have "Company as the first one"
![elEues.png](https://github.com/user-attachments/assets/3659e12b-a45a-426b-807a-c62a667246f3)
* After you've gone through all the countries, select United States
* Make sure that when you select a business type the options for the next "What category of legal entity identify your business?" dropdown adjust accordingly
* Finish onboarding a new `company` account

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.