### PR TITLE
Ensure ‘Proceed to Checkout’ Button Does Not Collapse Through WooPay Direct Checkout Flow

### DIFF
--- a/changelog/fix-9165-prevent-proceed-to-checkout-from-collapsing-in-dc
+++ b/changelog/fix-9165-prevent-proceed-to-checkout-from-collapsing-in-dc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the 'Proceed to Checkout' button does not collapse when adding a loading spinner, in the Direct Checkout flow.

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -302,20 +302,27 @@ class WooPayDirectCheckout {
 		 * @param {Element} element The element to add the loading spinner to.
 		 */
 		const addLoadingSpinner = ( element ) => {
+			const elementCss = window.getComputedStyle( element, null );
+			const originalColor = elementCss.getPropertyValue( 'color' );
+
 			// Create a spinner to show when the user clicks the button.
 			const spinner = document.createElement( 'span' );
 			spinner.classList.add( 'wc-block-components-spinner' );
-			spinner.style.position = 'relative';
+			spinner.style.position = 'absolute';
+			spinner.style.top = '0';
+			spinner.style.left = '0';
+			spinner.style.width = '100%';
+			spinner.style.height = '100%';
+			spinner.style.color = originalColor;
 			spinner.style.fontSize = 'unset';
 			spinner.style.display = 'inline';
 			spinner.style.lineHeight = '0';
 			spinner.style.margin = '0';
 			spinner.style.border = '0';
 			spinner.style.padding = '0';
-			// Remove the existing content of the button.
-			// Set innerHTML to '&nbsp;' to keep the button's height.
-			element.innerHTML = '&nbsp;';
-			element.classList.remove( 'wc-forward' );
+			// Hide the existing content of the button.
+			element.style.color = 'rgba( 0, 0, 0, 0 )';
+			element.style.position = 'relative';
 			// Add the spinner to the button.
 			element.appendChild( spinner );
 		};


### PR DESCRIPTION
Fixes #9165 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that the `Proceed to Checkout` button does not collapse after being clicked while using the WooPay Direct Checkout (DC) flow.

When the `Proceed to Checkout` button is clicked in the DC flow, the button's content is replaced with a loading spinner. However, since the button is set to hug the content when the button's content is replaced with the loading spinner, the button changes widths since the spinner is more narrow than the existing content.

The changes in this PR ensure that the content remains but is hidden. Then, it adds the spinner on top of the content to ensure the button's width does not resize.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!Tip]
> The following tests should be performed on more than one theme.

**Prerequisites**
* Ensure WooPay Direct Checkout is enabled on your merchant site.

**Test: Ensure `Proceed to Checkout` button does not collapse in classic cart**
* As a merchant, navigate to **Pages > Cart Page** and replace the body with the `[woocommerce_cart]` shortcode.
* As a shopper, navigate to the merchant's shop, add an item to your cart, and navigate to the cart page.
* Click on the `Proceed to Checkout` button.
* Ensure the button's content is replaced with a loading spinner.
* Ensure the button's width does not jump around.

**Test: Ensure `Go to Checkout` button does not collapse in wc-blocks mini-cart**
* As a merchant, ensure you are not using a theme that includes the `wc-blocks footer mini-cart`.
* Navigate to **Appearance > Widgets** and add a `mini-cart` widget to the sidebar.
* As a shopper, navigate to the merchant's shop, add an item to your cart, and click on the wc-blocks mini-cart.
* Click on the `Go to Checkout` button.
* Ensure the button's content is replaced with a loading spinner.
* Ensure the button's width does not jump around.

**Test: Ensure `Go to Checkout` button does not collapse in wc-blocks footer mini-cart**
* As a merchant, ensure you are using the [Tsubaki theme](https://wordpress.com/theme/tsubaki)
* As a shopper, navigate to the merchant's shop, add an item to your cart, and click on the cart icon at the top to reveal the wc-blocks mini-cart.
* Click on the `Go to Checkout` button.
* Ensure the button's content is replaced with a loading spinner.
* Ensure the button's width does not jump around.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
