### PR TITLE
Ensure 'wcSettings' Exists Before Checking for 'wcSettings.wcBlocksConfig'

### DIFF
--- a/changelog/fix-woopay-show-error-in-blocks-pages
+++ b/changelog/fix-woopay-show-error-in-blocks-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure that 'wcSettings' exists before attempting to use 'wcSettings.wcBlocksConfig'.

--- a/client/checkout/woopay/express-button/utils.js
+++ b/client/checkout/woopay/express-button/utils.js
@@ -11,7 +11,9 @@ import { getConfig } from 'wcpay/utils/checkout';
  */
 export const showErrorMessage = ( context, errorMessage ) => {
 	// Handle Blocks Cart and Checkout notices.
-	if ( wcSettings && wcSettings.wcBlocksConfig && context !== 'product' ) {
+	const isBlocksCartOrCheckout =
+		'wcSettings' in window && wcSettings.wcBlocksConfig;
+	if ( isBlocksCartOrCheckout && context !== 'product' ) {
 		// This handles adding the error notice to the cart page.
 		wp.data
 			.dispatch( 'core/notices' )

--- a/client/checkout/woopay/express-button/utils.js
+++ b/client/checkout/woopay/express-button/utils.js
@@ -11,7 +11,7 @@ import { getConfig } from 'wcpay/utils/checkout';
  */
 export const showErrorMessage = ( context, errorMessage ) => {
 	// Handle Blocks Cart and Checkout notices.
-	if ( wcSettings.wcBlocksConfig && context !== 'product' ) {
+	if ( wcSettings && wcSettings.wcBlocksConfig && context !== 'product' ) {
 		// This handles adding the error notice to the cart page.
 		wp.data
 			.dispatch( 'core/notices' )


### PR DESCRIPTION
Fixes n/a

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that the `wcSettings` global var exists before attempting to check for `wcSettings.wcBlocksConfig`. 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!tip]
> These tests should be executed in the staging site.

**Prerequisites**
* In order to cause the following tests to throw an error, ensure the `DEV_BLOG_TOKEN_SECRET` does not match.

**Test: Ensure error message is displayed when `Buy with WooPay` fails when in classic cart**
* As a merchant, navigate to **Pages > Cart** and add the `[woocommerce_cart]` shortcode.
* As a shopper, navigate to the merchant shop, add an item to the cart, and navigate to the cart page.
* Click the `Buy with WooPay` button. 
* Ensure you see the following error message: `Something went wrong. Please try again.`

**Test: Ensure error message is displayed when `Buy with WooPay` fails when in blocks cart**
* As a merchant, navigate to **Pages > Cart** and add the `cart` wc-block.
* As a shopper, navigate to the merchant shop, add an item to the cart, and navigate to the cart page.
* Click the `Buy with WooPay` button. 
* Ensure you see the following error message: `Something went wrong. Please try again.`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
