### PR TITLE
Update bundle size checker version to support node v20

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -21,7 +21,7 @@ jobs:
                   node-version-file: '.nvmrc'
                   cache: npm
             - name: Checking for file changes
-              uses: preactjs/compressed-size-action@265b0667736973f2d83b1a35fdc5440d6cb3322e
+              uses: preactjs/compressed-size-action@75744b35590ae9b59f35351ed3f71aebae84453f
               with:
                   pattern: '{release/**/*.js,release/**/*.css}'
                   exclude: '{release/vendor/**}'

--- a/changelog/dev-update-bundle-size-check-node-version
+++ b/changelog/dev-update-bundle-size-check-node-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update bundle size checker workflow to support node v20


### PR DESCRIPTION
Fixes #9178 

#### Changes proposed in this Pull Request

Update bundle size checker version to support node v20

#### Testing instructions

* Bundle size check workflow should pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
