### PR TITLE
Translate hardcoded untranslated strings on the Connect page

### DIFF
--- a/changelog/fix-connect-page-untranslated-strings
+++ b/changelog/fix-connect-page-untranslated-strings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Translate hardcoded strings on the Connect page

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -205,18 +205,42 @@ const ConnectAccountPage: React.FC = () => {
 							<WooPaymentMethodsLogos maxElements={ 10 } />
 							<div className="connect-account-page__payment-methods__description">
 								<div>
-									<p>Deposits</p>
-									<span>Automatic - Daily</span>
+									<p>
+										{
+											strings.paymentMethods.deposits
+												.title
+										}
+									</p>
+									<span>
+										{
+											strings.paymentMethods.deposits
+												.value
+										}
+									</span>
 								</div>
 								<div className="connect-account-page__payment-methods__description__divider"></div>
 								<div>
-									<p>Payments capture</p>
-									<span>Capture on order</span>
+									<p>
+										{ strings.paymentMethods.capture.title }
+									</p>
+									<span>
+										{ strings.paymentMethods.capture.value }
+									</span>
 								</div>
 								<div className="connect-account-page__payment-methods__description__divider"></div>
 								<div>
-									<p>Recurring payments</p>
-									<span>Supported</span>
+									<p>
+										{
+											strings.paymentMethods.recurring
+												.title
+										}
+									</p>
+									<span>
+										{
+											strings.paymentMethods.recurring
+												.value
+										}
+									</span>
 								</div>
 							</div>
 						</div>

--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -26,6 +26,20 @@ export default {
 			firstName ? ` ${ firstName }` : '',
 			'WooPayments'
 		),
+	paymentMethods: {
+		deposits: {
+			title: __( 'Deposits', 'woocommerce-payments' ),
+			value: __( 'Automatic - Daily', 'woocommerce-payments' ),
+		},
+		capture: {
+			title: __( 'Payments capture', 'woocommerce-payments' ),
+			value: __( 'Capture on order', 'woocommerce-payments' ),
+		},
+		recurring: {
+			title: __( 'Recurring payments', 'woocommerce-payments' ),
+			value: __( 'Supported', 'woocommerce-payments' ),
+		},
+	},
 	usp1: __(
 		'Offer card payments, Apple Pay, iDeal, Affirm, Afterpay, and accept in-person payments with the Woo mobile app.',
 		'woocommerce-payments'


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR addresses and fixes the issue of hardcoded, non-translatable strings on the Connect page. By ensuring these strings are now translatable, we improve localization and provide a better experience for users in different languages.

#### Testing instructions
- Code changes should be logical and clear.
- Unit tests should pass successfully.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
