### PR TITLE
Add direct checkout to WooPay express checkout buttons

### DIFF
--- a/changelog/dev-woopay-performance-3
+++ b/changelog/dev-woopay-performance-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Direct checkout on WooPay express buttons

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -413,7 +413,7 @@ class WooPayDirectCheckout {
 
 			const url = new URL( woopayRedirectUrl );
 			// const redirectParams = new URLSearchParams( url );
-			url.searchParams.append( 'force_login', forceLogin );
+			url.searchParams.append( 'allow_login', forceLogin );
 
 			this.teardown();
 			// TODO: Add telemetry as to _how long_ it took to get to this step.

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -392,33 +392,39 @@ class WooPayDirectCheckout {
 
 				event.preventDefault();
 
-				try {
-					let woopayRedirectUrl = '';
-					if ( userIsLoggedIn ) {
-						woopayRedirectUrl = await this.getWooPayCheckoutUrl();
-					} else {
-						// Ensure WooPay is reachable before redirecting.
-						if ( ! ( await this.isWooPayReachable() ) ) {
-							throw new Error(
-								'WooPay is currently not available.'
-							);
-						}
-
-						woopayRedirectUrl = await this.getWooPayMinimumSessionUrl();
-					}
-
-					this.teardown();
-					// TODO: Add telemetry as to _how long_ it took to get to this step.
-					window.location.href = woopayRedirectUrl;
-				} catch ( error ) {
-					// TODO: Add telemetry as to _why_ we've short-circuited the WooPay checkout flow.
-					console.warn( error ); // eslint-disable-line no-console
-
-					this.teardown();
-					window.location.href = currTargetHref;
-				}
+				await this.forwardToWooPay( userIsLoggedIn, currTargetHref );
 			} );
 		} );
+	}
+
+	static async forwardToWooPay( userIsLoggedIn, onFailUrl, forceLogin ) {
+		try {
+			let woopayRedirectUrl = '';
+			if ( userIsLoggedIn ) {
+				woopayRedirectUrl = await this.getWooPayCheckoutUrl();
+			} else {
+				// Ensure WooPay is reachable before redirecting.
+				if ( ! ( await this.isWooPayReachable() ) ) {
+					throw new Error( 'WooPay is currently not available.' );
+				}
+
+				woopayRedirectUrl = await this.getWooPayMinimumSessionUrl();
+			}
+
+			const url = new URL( woopayRedirectUrl );
+			// const redirectParams = new URLSearchParams( url );
+			url.searchParams.append( 'force_login', forceLogin );
+
+			this.teardown();
+			// TODO: Add telemetry as to _how long_ it took to get to this step.
+			window.location.href = url.toString();
+		} catch ( error ) {
+			// TODO: Add telemetry as to _why_ we've short-circuited the WooPay checkout flow.
+			console.warn( error ); // eslint-disable-line no-console
+
+			this.teardown();
+			window.location.href = onFailUrl;
+		}
 	}
 
 	/**

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -397,7 +397,11 @@ class WooPayDirectCheckout {
 		} );
 	}
 
-	static async forwardToWooPay( userIsLoggedIn, onFailUrl, forceLogin ) {
+	static async forwardToWooPay(
+		userIsLoggedIn,
+		onFailUrl,
+		allowLogin = false
+	) {
 		try {
 			let woopayRedirectUrl = '';
 			if ( userIsLoggedIn ) {
@@ -411,13 +415,16 @@ class WooPayDirectCheckout {
 				woopayRedirectUrl = await this.getWooPayMinimumSessionUrl();
 			}
 
-			const url = new URL( woopayRedirectUrl );
-			// const redirectParams = new URLSearchParams( url );
-			url.searchParams.append( 'allow_login', forceLogin );
+			if ( allowLogin ) {
+				const url = new URL( woopayRedirectUrl );
+				// const redirectParams = new URLSearchParams( url );
+				url.searchParams.append( 'allow_login', allowLogin );
+				woopayRedirectUrl = url.toString();
+			}
 
 			this.teardown();
 			// TODO: Add telemetry as to _how long_ it took to get to this step.
-			window.location.href = url.toString();
+			window.location.href = woopayRedirectUrl;
 		} catch ( error ) {
 			// TODO: Add telemetry as to _why_ we've short-circuited the WooPay checkout flow.
 			console.warn( error ); // eslint-disable-line no-console

--- a/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
+++ b/client/checkout/woopay/direct-checkout/woopay-direct-checkout.js
@@ -392,46 +392,42 @@ class WooPayDirectCheckout {
 
 				event.preventDefault();
 
-				await this.forwardToWooPay( userIsLoggedIn, currTargetHref );
+				await this.forwardToWooPay( userIsLoggedIn ).catch(
+					( error ) => {
+						// TODO: Add telemetry as to _why_ we've short-circuited the WooPay checkout flow.
+						console.warn( error ); // eslint-disable-line no-console
+
+						this.teardown();
+						window.location.href = currTargetHref;
+					}
+				);
 			} );
 		} );
 	}
 
-	static async forwardToWooPay(
-		userIsLoggedIn,
-		onFailUrl,
-		allowLogin = false
-	) {
-		try {
-			let woopayRedirectUrl = '';
-			if ( userIsLoggedIn ) {
-				woopayRedirectUrl = await this.getWooPayCheckoutUrl();
-			} else {
-				// Ensure WooPay is reachable before redirecting.
-				if ( ! ( await this.isWooPayReachable() ) ) {
-					throw new Error( 'WooPay is currently not available.' );
-				}
-
-				woopayRedirectUrl = await this.getWooPayMinimumSessionUrl();
+	static async forwardToWooPay( userIsLoggedIn, allowLogin = false ) {
+		let woopayRedirectUrl = '';
+		if ( userIsLoggedIn ) {
+			woopayRedirectUrl = await this.getWooPayCheckoutUrl();
+		} else {
+			// Ensure WooPay is reachable before redirecting.
+			if ( ! ( await this.isWooPayReachable() ) ) {
+				throw new Error( 'WooPay is currently not available.' );
 			}
 
-			if ( allowLogin ) {
-				const url = new URL( woopayRedirectUrl );
-				// const redirectParams = new URLSearchParams( url );
-				url.searchParams.append( 'allow_login', allowLogin );
-				woopayRedirectUrl = url.toString();
-			}
-
-			this.teardown();
-			// TODO: Add telemetry as to _how long_ it took to get to this step.
-			window.location.href = woopayRedirectUrl;
-		} catch ( error ) {
-			// TODO: Add telemetry as to _why_ we've short-circuited the WooPay checkout flow.
-			console.warn( error ); // eslint-disable-line no-console
-
-			this.teardown();
-			window.location.href = onFailUrl;
+			woopayRedirectUrl = await this.getWooPayMinimumSessionUrl();
 		}
+
+		if ( allowLogin ) {
+			const url = new URL( woopayRedirectUrl );
+			// const redirectParams = new URLSearchParams( url );
+			url.searchParams.append( 'allow_login', allowLogin );
+			woopayRedirectUrl = url.toString();
+		}
+
+		this.teardown();
+		// TODO: Add telemetry as to _how long_ it took to get to this step.
+		window.location.href = woopayRedirectUrl;
 	}
 
 	/**

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -100,7 +100,12 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 	beforeEach( () => {
 		expressCheckoutIframe.mockImplementation( () => jest.fn() );
-		getConfig.mockReturnValue( 'foo' );
+		getConfig.mockImplementation( ( name ) => {
+			if ( name === 'isWooPayDirectCheckoutEnabled' ) {
+				return false;
+			}
+			return 'foo';
+		} );
 		useExpressCheckoutProductHandler.mockImplementation( () => ( {
 			addToCart: mockAddToCart,
 		} ) );
@@ -174,6 +179,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					return 1;
 				case 'appearance':
 					return mockAppearance;
+				case 'isWooPayDirectCheckoutEnabled':
+					return false;
 				default:
 					return 'foo';
 			}
@@ -207,7 +214,13 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 	test( 'call `expressCheckoutIframe` on button click when `isPreview` is false', () => {
 		getConfig.mockImplementation( ( v ) => {
-			return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
+			switch ( v ) {
+				case 'isWoopayFirstPartyAuthEnabled':
+				case 'isWooPayDirectCheckoutEnabled':
+					return false;
+				default:
+					return 'foo';
+			}
 		} );
 		render(
 			<WoopayExpressCheckoutButton
@@ -272,7 +285,13 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 		test( 'should show an alert when clicking the button when add to cart button is disabled', () => {
 			getConfig.mockImplementation( ( v ) => {
-				return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
+				switch ( v ) {
+					case 'isWoopayFirstPartyAuthEnabled':
+					case 'isWooPayDirectCheckoutEnabled':
+						return false;
+					default:
+						return 'foo';
+				}
 			} );
 			useExpressCheckoutProductHandler.mockImplementation( () => ( {
 				addToCart: mockAddToCart,
@@ -310,7 +329,13 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 		test( 'call `addToCart` and `expressCheckoutIframe` on express button click on product page', async () => {
 			getConfig.mockImplementation( ( v ) => {
-				return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
+				switch ( v ) {
+					case 'isWoopayFirstPartyAuthEnabled':
+					case 'isWooPayDirectCheckoutEnabled':
+						return false;
+					default:
+						return 'foo';
+				}
 			} );
 			useExpressCheckoutProductHandler.mockImplementation( () => ( {
 				addToCart: mockAddToCart,
@@ -345,7 +370,13 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 		test( 'do not call `addToCart` on express button click on product page when validation fails', async () => {
 			getConfig.mockImplementation( ( v ) => {
-				return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
+				switch ( v ) {
+					case 'isWoopayFirstPartyAuthEnabled':
+					case 'isWooPayDirectCheckoutEnabled':
+						return false;
+					default:
+						return 'foo';
+				}
 			} );
 			useExpressCheckoutProductHandler.mockImplementation( () => ( {
 				addToCart: mockAddToCart,

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -190,7 +190,7 @@ export const WoopayExpressCheckoutButton = ( {
 		const productData = getProductDataRef.current();
 
 		if ( ! productData ) {
-			return Promise.reject( 'asdf' );
+			return Promise.reject();
 		}
 
 		if ( typeof listenForCartChanges?.stop === 'function' ) {

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -341,6 +341,8 @@ export const WoopayExpressCheckoutButton = ( {
 
 	const directCheckoutFlow = useCallback(
 		( e ) => {
+			isLoadingRef.current = true;
+			setIsLoading( true );
 			if ( isProductPage ) {
 				maybeAddProductToCart()
 					.catch( () => {} )
@@ -349,12 +351,16 @@ export const WoopayExpressCheckoutButton = ( {
 							false,
 							true
 						).catch( () => {
+							isLoadingRef.current = false;
+							setIsLoading( false );
 							directCheckoutFallbackMethods( e );
 						} );
 					} );
 			} else {
 				WooPayDirectCheckout.forwardToWooPay( false, true ).catch(
 					() => {
+						isLoadingRef.current = false;
+						setIsLoading( false );
 						directCheckoutFallbackMethods( e );
 					}
 				);

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -23,6 +23,7 @@ import {
 import WooPayFirstPartyAuth from 'wcpay/checkout/woopay/express-button/woopay-first-party-auth';
 import { getAppearance } from 'wcpay/checkout/upe-styles';
 import { getAppearanceType } from 'wcpay/checkout/utils';
+import WooPayDirectCheckout from 'wcpay/checkout/woopay/direct-checkout/woopay-direct-checkout';
 
 const BUTTON_WIDTH_THRESHOLD = 140;
 
@@ -344,12 +345,20 @@ export const WoopayExpressCheckoutButton = ( {
 		};
 	}, [] );
 
+	const handleClick = () => {
+		WooPayDirectCheckout.forwardToWooPay(
+			false,
+			'http://woopaymerchant.test/checkout/',
+			true
+		);
+	};
+
 	return (
 		<button
 			ref={ buttonRef }
 			key={ `${ buttonType }-${ theme }-${ size }` }
 			aria-label={ buttonText }
-			onClick={ ( e ) => onClickCallbackRef.current( e ) }
+			onClick={ handleClick }
 			className={ classNames( 'woopay-express-button', {
 				'is-loading': isLoading,
 			} ) }

--- a/includes/admin/class-wc-rest-woopay-session-controller.php
+++ b/includes/admin/class-wc-rest-woopay-session-controller.php
@@ -45,7 +45,7 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 					'email' => [
 						'type'     => 'string',
 						'format'   => 'email',
-						'required' => true,
+						'required' => false,
 					],
 				],
 			]

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -208,6 +208,7 @@ class WC_Payments_Checkout {
 			'woopayMerchantId'                => Jetpack_Options::get_option( 'id' ),
 			'icon'                            => $this->gateway->get_icon_url(),
 			'woopayMinimumSessionData'        => WooPay_Session::get_woopay_minimum_session_data(),
+			'checkoutPageUrl'                 => wc_get_page_permalink( 'checkout' ),
 		];
 
 		/**

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -208,7 +208,6 @@ class WC_Payments_Checkout {
 			'woopayMerchantId'                => Jetpack_Options::get_option( 'id' ),
 			'icon'                            => $this->gateway->get_icon_url(),
 			'woopayMinimumSessionData'        => WooPay_Session::get_woopay_minimum_session_data(),
-			'checkoutPageUrl'                 => wc_get_page_permalink( 'checkout' ),
 		];
 
 		/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the direct checkout to the WooPay express checkout button to reduce the number of api calls executed before the customer gets redirected to WooPay.

#### Testing instructions
- Checkout to https://github.com/Automattic/woopay/pull/2849 in your WooPay site
- In your merchant store go to /wp-admin > WcPay Dev > Account cache
- Make sure `platform_direct_checkout_eligible` is set to true


**Product Page**
- Log out from WooPay and the merchant site
- Go to product page
- Open the browser code inspector and add a break point [here](https://github.com/Automattic/woocommerce-payments/blob/76a7e098826af7f514c6ae271704d19cac5ee882/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L350) and [here](https://github.com/Automattic/woocommerce-payments/blob/76a7e098826af7f514c6ae271704d19cac5ee882/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L354)
- Click the WooPay button
- Make sure the execution stops at the first breakpoint
- Let the execution run and make sure it did not stop at the second one
- You'll be forwarded to the WooPay checkout login page
- Make sure the correct product and quantities were loaded
- Log in as usual
- Place the order
- Make sure the order goes thru with the correct info both in the merchant and WooPay sites
- Repeat with a logged in WooPay user
- Repeat with a logged in Merchant user

**Cart Page**
- Log out from WooPay and the merchant site
- Go to product page
- Add a product to your cart
- Go to the cart page
- Open the browser code inspector and add a break point [here](https://github.com/Automattic/woocommerce-payments/blob/76a7e098826af7f514c6ae271704d19cac5ee882/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L360) and [here](https://github.com/Automattic/woocommerce-payments/blob/76a7e098826af7f514c6ae271704d19cac5ee882/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L362)
- Click the WooPay button
- Make sure the execution stops at the first breakpoint
- Let the execution run and make sure it did not stop at the second one
- You'll be forwarded to the WooPay checkout login page
- Make sure the correct product and quantities were loaded
- Log in as usual
- Place the order
- Make sure the order goes thru with the correct info both in the merchant and WooPay sites
- Repeat with a logged in WooPay user
- Repeat with a logged in Merchant user

**Checkout Page**
- Log out from WooPay and the merchant site
- Go to product page
- Add a product to your cart
- Go to the checkout page
- Open the browser code inspector and add a break point [here](https://github.com/Automattic/woocommerce-payments/blob/76a7e098826af7f514c6ae271704d19cac5ee882/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L360) and [here](https://github.com/Automattic/woocommerce-payments/blob/76a7e098826af7f514c6ae271704d19cac5ee882/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L362)
- Click the WooPay button
- Make sure the execution stops at the first breakpoint
- Let the execution run and make sure it did not stop at the second one
- You'll be forwarded to the WooPay checkout login page
- Make sure the correct product and quantities were loaded
- Log in as usual
- Place the order
- Make sure the order goes thru with the correct info both in the merchant and WooPay sites
- Repeat with a logged in WooPay user
- Repeat with a logged in Merchant user

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.