### PR TITLE
Revert "Disable Direct Checkout if WooPayments is disabled (#9159)"

### DIFF
--- a/changelog/revert-9159-as-disable-woopay-if-woopayments-is-disabled
+++ b/changelog/revert-9159-as-disable-woopay-if-woopayments-is-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reverts changes related to Direct Checkout that broke the PayPal extension.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -825,10 +825,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
-		if ( ! $this->payment_method ) {
-			return false;
-		}
-
 		$processing_payment_method = $this->payment_methods[ $this->payment_method->get_id() ];
 		if ( ! $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) ) {
 			return false;
@@ -908,7 +904,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$supported_currencies = $this->account->get_account_customer_supported_currencies();
 		$current_currency     = strtolower( get_woocommerce_currency() );
 
-		if ( is_null( $supported_currencies ) || ( is_array( $supported_currencies ) && count( $supported_currencies ) === 0 ) ) {
+		if ( count( $supported_currencies ) === 0 ) {
 			// If we don't have info related to the supported currencies
 			// of the country, we won't disable the gateway.
 			return true;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -266,19 +266,6 @@ class WC_Payments_Features {
 	 * @return bool True if Direct Checkout is enabled, false otherwise.
 	 */
 	public static function is_woopay_direct_checkout_enabled() {
-		// If WooPayments is not enabled then disable Direct checkout.
-		// TODO: Change to WC()->payment_gateways->get_available_payment_gateways() once issue with WC Subscriptions is sorted out.
-		$wc_payment_gateways = WC_Payment_Gateways::instance();
-		$wc_payment_gateways->init();
-		$enabled_gateways = $wc_payment_gateways->payment_gateways();
-
-		// Only used for tests.
-		$enabled_gateways = apply_filters( 'woocommerce_payments_enabled_gateways_for_woopay', $enabled_gateways );
-
-		if ( ! isset( $enabled_gateways['woocommerce_payments'] ) || ! $enabled_gateways['woocommerce_payments']->is_available() ) {
-			return false;
-		}
-
 		$account_cache                   = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -66,9 +66,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
-
-		remove_all_filters( 'woocommerce_payments_enabled_gateways_for_woopay' );
-
 		parent::tear_down();
 	}
 
@@ -184,22 +181,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_true() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
-		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
-		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
-		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
-		$this->assertTrue( WC_Payments_Features::is_woopay_enabled() );
-	}
-
-	public function test_is_woopay_enabled_returns_false_if_only_woopayments_is_enabled() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
-		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
-	}
-
-	// We are disabling only DC for now. We should disable WooPay if WooPayments is disabled though.
-	// Leaving this test case so we can catch that later.
-	public function test_is_woopay_enabled_returns_true_if_woopayments_is_disabled_and_woopay_is_enabled() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'disable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
@@ -207,7 +188,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_false_when_express_checkout_flag_is_false() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '0' );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
@@ -215,7 +195,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_false_when_platform_checkout_flag_is_false() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'no' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
@@ -223,15 +202,9 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_false_when_ineligible() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
-		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
-	}
-
-	public function test_is_woopay_enabled_returns_false_when_woopayments_is_disabled() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'disable_woopayments' ] );
 		$this->assertFalse( WC_Payments_Features::is_woopay_enabled() );
 	}
 
@@ -254,7 +227,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_true() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
 		$this->mock_cache->method( 'get' )->willReturn(
@@ -263,17 +235,10 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 				'platform_direct_checkout_eligible' => true,
 			]
 		);
-		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 		$this->assertTrue( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
 	}
 
-	public function test_is_woopay_direct_checkout_enabled_returns_false_when_woopayments_is_disabled() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'disable_woopayments' ] );
-		$this->assertFalse( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
-	}
-
 	public function test_is_woopay_direct_checkout_enabled_returns_false_when_flag_is_false() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '0' );
 		$this->mock_cache->method( 'get' )->willReturn(
@@ -286,7 +251,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_false_when_woopay_eligible_is_false() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
 		$this->mock_cache->method( 'get' )->willReturn(
@@ -299,7 +263,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_true_when_first_party_auth_is_disabled() {
-		add_filter( 'woocommerce_payments_enabled_gateways_for_woopay', [ $this, 'enable_woopayments' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME, '0' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
@@ -309,7 +272,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 				'platform_direct_checkout_eligible' => true,
 			]
 		);
-		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 		$this->assertTrue( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
 	}
 
@@ -321,38 +283,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_frt_review_feature_active_returns_false_when_flag_is_not_set() {
 		$this->assertFalse( WC_Payments_Features::is_frt_review_feature_active() );
-	}
-
-	public function enable_woopayments( $gateways ) {
-		return array_map(
-			function ( $gateway ) {
-				if ( is_a( $gateway, 'WC_Payment_Gateway' ) && 'woocommerce_payments' === $gateway->id ) {
-					// Simple class to replace the WC_Payment_Gateway_WCPay instance. With this the `is_available` method will return `true` enabling the payment gateway.
-					return new class() extends WC_Payment_Gateway_WCPay {
-						public function __construct() {
-						}
-
-						public function is_available() {
-							return true;
-						}
-					};
-				}
-				return $gateway;
-			},
-			$gateways
-		);
-	}
-
-	public function disable_woopayments( $gateways ) {
-		return array_filter(
-			$gateways,
-			function ( $gateway ) {
-				if ( is_object( $gateway ) && 'woocommerce_payments' === $gateway->id ) {
-					return false;
-				}
-				return true;
-			}
-		);
 	}
 
 	private function setup_enabled_flags( array $enabled_flags ) {


### PR DESCRIPTION
Reverts https://github.com/Automattic/woocommerce-payments/pull/9159 since it breaks the PayPal extension.

Addresses https://github.com/Automattic/woocommerce-payments/issues/9196

Reference p1722437876296799-slack-CGGCLBN58