### PR TITLE
Disable Direct Checkout When WooPayments Gateway Is Disabled

### DIFF
--- a/changelog/fix-disable-woopay-dc-when-woopayments-disabled
+++ b/changelog/fix-disable-woopay-dc-when-woopayments-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only enable Direct Checkout when WooPayments gateway is enabled.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -270,7 +270,7 @@ class WC_Payments_Features {
 		$is_direct_checkout_eligible     = is_array( $account_cache ) && ( $account_cache['platform_direct_checkout_eligible'] ?? false );
 		$is_direct_checkout_flag_enabled = '1' === get_option( self::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
 
-		return $is_direct_checkout_eligible && $is_direct_checkout_flag_enabled && self::is_woopay_enabled();
+		return $is_direct_checkout_eligible && $is_direct_checkout_flag_enabled && self::is_woopayments_gateway_enabled() && self::is_woopay_enabled();
 	}
 
 	/**
@@ -391,5 +391,17 @@ class WC_Payments_Features {
 				'isStripeEceEnabled'             => self::is_stripe_ece_enabled(),
 			]
 		);
+	}
+
+	/**
+	 * Checks if WooCommerce Payments gateway is enabled.
+	 *
+	 * @return bool True if WooCommerce Payments gateway is enabled, false otherwise.
+	 */
+	private static function is_woopayments_gateway_enabled() {
+		$woopayments_settings        = get_option( 'woocommerce_woocommerce_payments_settings' );
+		$woopayments_enabled_setting = $woopayments_settings['enabled'] ?? 'no';
+
+		return 'yes' === $woopayments_enabled_setting;
 	}
 }

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -226,7 +226,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_woopay_express_checkout_enabled() );
 	}
 
-	public function test_is_woopay_direct_checkout_enabled_returns_true() {
+	public function test_is_woopay_direct_checkout_enabled_returns_true_when_woopayments_gateway_enabled() {
 		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enabled' => 'yes' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
@@ -237,6 +237,19 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			]
 		);
 		$this->assertTrue( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
+	}
+
+	public function test_is_woopay_direct_checkout_enabled_returns_false_when_woopayments_gateway_disabled() {
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enabled' => 'no' ] );
+		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
+		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
+		$this->mock_cache->method( 'get' )->willReturn(
+			[
+				'platform_checkout_eligible'        => true,
+				'platform_direct_checkout_eligible' => true,
+			]
+		);
+		$this->assertFalse( WC_Payments_Features::is_woopay_direct_checkout_enabled() );
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_false_when_flag_is_false() {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -227,6 +227,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_true() {
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enabled' => 'yes' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );
 		$this->mock_cache->method( 'get' )->willReturn(
@@ -263,6 +264,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_direct_checkout_enabled_returns_true_when_first_party_auth_is_disabled() {
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enabled' => 'yes' ] );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME, '0' );
 		$this->set_feature_flag_option( WC_Payments_Features::WOOPAY_DIRECT_CHECKOUT_FLAG_NAME, '1' );


### PR DESCRIPTION
Fixes 2829-gh-Automattic/woopay

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that the WooPay Direct Checkout (DC) flow is enabled only when the WooPayments gateway is enabled.

Additionally, the changes in this PR ensure that filters/hooks are avoided to avoid compatibility issues with other gateways.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Reproduce Bug: DC Still Redirects to WooPay When WooPayments Gateway Is Disabled**
* Ensure you are on the `develop` branch.
* As a merchant, navigate to **Payments > Settings**.
* Enable WooPay, disable WooPayments, and click the **Save changes** button.
* As a shopper, ensure you are logged in to WooPay.
* Navigate to the merchant shop, add an item to the cart, and navigate to the cart page.
* Click the **Proceed to Checkout**.
* Confirm you are navigated to WooPay.
* Click **Place order** button.
* Confirm you received the following error: `Credit card / debit card is not available for this order—please choose a different payment method`.

**Confirm Fix: DC Does Not Redirect to WooPay When WooPayments Gateway Is Disabled**
* Ensure you are on the `fix/2829-disable-direct-checkout-when-woopayments-disabled` branch.
* As a merchant, navigate to **Payments > Settings**.
* Enable WooPay, disable WooPayments, and click the **Save changes** button.
* As a shopper, ensure you are logged in to WooPay.
* Navigate to the merchant shop, add an item to the cart, and navigate to the cart page.
* Click the **Proceed to Checkout**.
* Confirm you are navigated to merchant checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
