### PR TITLE
Add link rules to appearance 

### DIFF
--- a/changelog/add-get-link-styles-by-selectors
+++ b/changelog/add-get-link-styles-by-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add link rules to appearance

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -41,6 +41,7 @@ const mockAppearance = {
 		'.Text--redirect': {},
 		'.Heading': {},
 		'.Button': {},
+		'.Link': {},
 	},
 	theme: 'stripe',
 	variables: {

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -9,6 +9,7 @@ import {
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
+	getHeadingColor,
 } from './utils.js';
 
 export const appearanceSelectors = {

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -38,6 +38,7 @@ export const appearanceSelectors = {
 		],
 		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 		buttonSelectors: [ '#place_order' ],
+		linkSelectors: [ 'a' ],
 	},
 	blocksCheckout: {
 		appendTarget: '#billing.wc-block-components-address-form',
@@ -62,6 +63,7 @@ export const appearanceSelectors = {
 		],
 		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 		buttonSelectors: [ '.wc-block-components-checkout-place-order-button' ],
+		linkSelectors: [ 'a' ],
 	},
 	bnplProductPage: {
 		appendTarget: '.product .cart .quantity',
@@ -79,6 +81,7 @@ export const appearanceSelectors = {
 		],
 		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 		buttonSelectors: [ '.single_add_to_cart_button' ],
+		linkSelectors: [ 'a' ],
 	},
 	bnplClassicCart: {
 		appendTarget: '.cart .quantity',
@@ -96,6 +99,7 @@ export const appearanceSelectors = {
 		],
 		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 		buttonSelectors: [ '.checkout-button' ],
+		linkSelectors: [ 'a' ],
 	},
 	bnplCartBlock: {
 		appendTarget: '.wc-block-cart .wc-block-components-quantity-selector',
@@ -117,6 +121,7 @@ export const appearanceSelectors = {
 		],
 		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 		buttonSelectors: [ '.wc-block-cart__submit-button' ],
+		linkSelectors: [ 'a' ],
 	},
 
 	/**
@@ -453,6 +458,7 @@ export const getAppearance = ( elementsLocation ) => {
 		backgroundColor
 	);
 	const buttonRules = getFieldStyles( selectors.buttonSelectors, '.Input' );
+	const linkRules = getFieldStyles( selectors.linkSelectors, '.Label' );
 	const globalRules = {
 		colorBackground: backgroundColor,
 		colorText: labelRules.color,
@@ -477,6 +483,7 @@ export const getAppearance = ( elementsLocation ) => {
 			'.Text--redirect': labelRules,
 			'.Heading': headingRules,
 			'.Button': buttonRules,
+			'.Link': linkRules,
 		},
 	};
 	// Remove hidden fields from DOM.

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -9,7 +9,6 @@ import {
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
-	getHeadingColor,
 } from './utils.js';
 
 export const appearanceSelectors = {

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -212,6 +212,13 @@ describe( 'Getting styles for automated theming', () => {
 					outline: '1px solid rgb(150, 88, 138)',
 					padding: '10px',
 				},
+				'.Link': {
+					color: 'rgb(109, 109, 109)',
+					fontFamily:
+						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
+					fontSize: '12px',
+					padding: '10px',
+				},
 			},
 		} );
 	} );

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -150,34 +150,6 @@ export const getBackgroundColor = ( selectors ) => {
 };
 
 /**
- * Searches through array of CSS selectors and returns first visible heading color.
- *
- * @param {Array} selectors List of CSS selectors to check.
- * @return {string} CSS color value.
- */
-export const getHeadingColor = ( selectors ) => {
-	const defaultColor = '#ffffff';
-	let color = null;
-	let i = 0;
-	while ( ! color && i < selectors.length ) {
-		const element = document.querySelector( selectors[ i ] );
-		if ( ! element ) {
-			i++;
-			continue;
-		}
-
-		const headingColor = window.getComputedStyle( element ).color;
-
-		// If headingColor property present and alpha > 0.
-		if ( headingColor && tinycolor( headingColor ).getAlpha() > 0 ) {
-			color = headingColor;
-		}
-		i++;
-	}
-	return color || defaultColor;
-};
-
-/**
  * Determines whether background color is light or dark.
  *
  * @param {string} color CSS color value.

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -150,6 +150,34 @@ export const getBackgroundColor = ( selectors ) => {
 };
 
 /**
+ * Searches through array of CSS selectors and returns first visible heading color.
+ *
+ * @param {Array} selectors List of CSS selectors to check.
+ * @return {string} CSS color value.
+ */
+export const getHeadingColor = ( selectors ) => {
+	const defaultColor = '#ffffff';
+	let color = null;
+	let i = 0;
+	while ( ! color && i < selectors.length ) {
+		const element = document.querySelector( selectors[ i ] );
+		if ( ! element ) {
+			i++;
+			continue;
+		}
+
+		const headingColor = window.getComputedStyle( element ).color;
+
+		// If headingColor property present and alpha > 0.
+		if ( headingColor && tinycolor( headingColor ).getAlpha() > 0 ) {
+			color = headingColor;
+		}
+		i++;
+	}
+	return color || defaultColor;
+};
+
+/**
  * Determines whether background color is light or dark.
  *
  * @param {string} color CSS color value.

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -89,6 +89,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			'.Text--redirect': {},
 			'.Heading': {},
 			'.Button': {},
+			'.Link': {},
 		},
 		theme: 'stripe',
 		variables: {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/pull/2845

#### Changes proposed in this Pull Request
This PR adds link rules to appearance to allow us to get link styles from the checkout, cart, and product pages.

EPIC https://github.com/Automattic/woopay/issues/2781
SPIKE [here](https://woopayp2.wordpress.com/2024/07/01/spike-global-themes-support/#proof-of-concept-for-option-3-preferred)
PT [here](https://woopayp2.wordpress.com/2024/07/11/project-thread-woopay-global-themes-support/)

<img width="802" alt="Screenshot 2024-08-01 at 3 43 52 PM" src="https://github.com/user-attachments/assets/ae3652aa-4894-47ff-a871-15b4b447865f">


#### Testing instructions

* Test with [WooPay PR](https://github.com/Automattic/woopay/pull/2845) to see link styles applied on WooPay checkout order summary section
* Go to WooPay admin -> WCPay Dev and enable the WooPay global theme support feature flag

Test 1 ( The latest WooPayments version ):
1. Test this PR with the latest WooPayments version that includes `getAppearance` on the merchant site
1. Open dev tools
2. Initialize WooPay on the Blocks Checkout/ Blocks Cart / Classic Cart / Product page
3. Find `get_woopay_session` request and find `appearance[rules][.Link]`


Test 2 ( An older WooPayments version ):
1. Test an older version of WooPayments like [7.6.0](https://github.com/Automattic/woocommerce-payments/releases/download/7.6.0/woocommerce-payments.zip) that doesn't have `getAppearance` on the merchant site for regression test
2. Repeat the above testing instructions

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
