### PR TITLE
Fix uncaught error on the block based Cart page when WooPayments is disabled

### DIFF
--- a/changelog/as-fix-error-cart-block
+++ b/changelog/as-fix-error-cart-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix uncaught error on the block based Cart page when WooPayments is disabled.

--- a/client/cart/blocks/index.js
+++ b/client/cart/blocks/index.js
@@ -6,7 +6,7 @@ import { getUPEConfig } from 'wcpay/utils/checkout';
 
 const { registerPlugin } = window.wp.plugins;
 
-const paymentMethods = getUPEConfig( 'paymentMethodsConfig' );
+const paymentMethods = getUPEConfig( 'paymentMethodsConfig' ) || {};
 
 const BNPL_PAYMENT_METHODS = {
 	AFFIRM: 'affirm',

--- a/client/multi-currency-setup/tasks/add-currencies-task/index.scss
+++ b/client/multi-currency-setup/tasks/add-currencies-task/index.scss
@@ -3,7 +3,7 @@
 		.components-card__body {
 			padding-left: 0;
 			padding-right: 0;
-			.add-currencies-task__content h4,
+			h4,
 			.add-currencies-task__content .enabled-currency-checkbox,
 			.add-currencies-task__search {
 				padding-left: 16px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fixes an uncaught error on the block based Cart page when WooPayments is disabled.

When WooPayments is disabled `getUPEConfig( 'paymentMethodsConfig' )` will return `null` given that the parent object `wc.wcSettings.getSetting('woocommerce_payments_data')` is not defined.

```
index.js:18 Uncaught TypeError: Cannot use 'in' operator to search for 'affirm' in null
    at eval (index.js:18:22)
    at Array.filter (<anonymous>)
    at eval (index.js:17:66)
    at ./client/cart/blocks/index.js (cart-block.js?ver=8.0.1:29:1)
    at __webpack_require__ (cart-block.js?ver=8.0.1:228:42)
    at cart-block.js?ver=8.0.1:316:37
    at cart-block.js?ver=8.0.1:318:12
```

I'm also including a minor CSS fix to a misaligned element I've noticed on the Multi-Currency Wizard.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Verify uncaught error fix**

* Switch to `develop` branch.
* Disable WooPayments.
* Add a product to the cart.
* Go to the block-based Cart Page.
* Observe uncaught error in the browser's console.
* Switch to this branch.
* Refresh cart page.
* ✅ Observe error is gone.


**Verify CSS Fix**

* Switch to `develop` branch.
* Go to WooPayments > Settings.
* Enable Muti-Currrency.
* Go to WooCommerce > Home 
* Find the "Sell worldwide in multiple currencies" message in the Inbox section then click the "Set up now" button.
  * If you don't find the message try `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fmulti-currency-setup`
  * In case you need it you can reset multy-currency settings with: `wp db query "DELETE FROM wp_options where option_name like '%multi_currency%'";`
* Search and observe the "Search results" title being misaligned.
  <img width="400" alt="Screenshot 2024-08-02 at 4 58 24 PM" src="https://github.com/user-attachments/assets/3e183767-48b8-4a9d-a740-4bfbcda9b554">
* Switch to this branch then refresh the page.
* Search and observe the "Search results" is aligned correctly.
  <img width="400" alt="Screenshot 2024-08-02 at 5 02 14 PM" src="https://github.com/user-attachments/assets/0c1dd7ce-f627-4521-aa21-2add42ea00e2">


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
