### PR TITLE
Fixed WooPay opt-in checks that would fail with a hidden message when the customer selected a payment method other than Credit Card

### DIFF
--- a/changelog/fix-opt-in-checks
+++ b/changelog/fix-opt-in-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+opt-in checks to prevent blocking customers using other payment methods

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+/* global jQuery */
 /**
  * External dependencies
  */
@@ -129,6 +130,14 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			recordUserEvent( 'checkout_woopay_save_my_info_mobile_enter' );
 		}
 	}, [ isPhoneValid ] );
+
+	useEffect( () => {
+		const checkoutForm = jQuery( 'form.woocommerce-checkout' );
+
+		checkoutForm.on( 'checkout_place_order', function () {
+			jQuery( '#validate-error-invalid-woopay-phone-number' ).show();
+		} );
+	}, [] );
 
 	const updatePhoneNumberValidationError = useCallback( () => {
 		if ( ! isSaveDetailsChecked ) {
@@ -276,10 +285,23 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 								isBlocksCheckout={ isBlocksCheckout }
 							/>
 						</div>
-						<ValidationInputError
-							elementId={ errorId }
-							propertyName={ errorId }
-						/>
+						{ isBlocksCheckout && (
+							<ValidationInputError
+								elementId={ errorId }
+								propertyName={ errorId }
+							/>
+						) }
+						{ ! isBlocksCheckout && ! isPhoneValid && (
+							<p
+								id="validate-error-invalid-woopay-phone-number"
+								hidden={ isPhoneValid !== false }
+							>
+								{ __(
+									'Please enter a valid mobile phone number.',
+									'woocommerce-payments'
+								) }
+							</p>
+						) }
 						<AdditionalInformation />
 						<Agreement />
 					</div>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -130,6 +130,37 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		}
 	}, [ isPhoneValid ] );
 
+	const updateFormSubmitButton = useCallback( () => {
+		if ( isSaveDetailsChecked && isPhoneValid ) {
+			clearValidationError( errorId );
+
+			// Set extension data if checkbox is selected and phone number is valid in blocks checkout.
+			if ( isBlocksCheckout ) {
+				sendExtensionData( false );
+			}
+		}
+
+		if ( isSaveDetailsChecked && ! isPhoneValid ) {
+			setValidationErrors( {
+				[ errorId ]: {
+					message: __(
+						'Please enter a valid mobile phone number.',
+						'woocommerce-payments'
+					),
+					// Hides errors when the number has not been typed yet but shows when trying to place the order.
+					hidden: isPhoneValid === null,
+				},
+			} );
+		}
+	}, [
+		clearValidationError,
+		isBlocksCheckout,
+		isPhoneValid,
+		isSaveDetailsChecked,
+		sendExtensionData,
+		setValidationErrors,
+	] );
+
 	useEffect( () => {
 		const formSubmitButton = isBlocksCheckout
 			? document.querySelector(
@@ -142,30 +173,6 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		if ( ! formSubmitButton ) {
 			return;
 		}
-
-		const updateFormSubmitButton = () => {
-			if ( isSaveDetailsChecked && isPhoneValid ) {
-				clearValidationError( errorId );
-
-				// Set extension data if checkbox is selected and phone number is valid in blocks checkout.
-				if ( isBlocksCheckout ) {
-					sendExtensionData( false );
-				}
-			}
-
-			if ( isSaveDetailsChecked && ! isPhoneValid ) {
-				setValidationErrors( {
-					[ errorId ]: {
-						message: __(
-							'Please enter a valid mobile phone number.',
-							'woocommerce-payments'
-						),
-						// Hides errors when the number has not been typed yet but shows when trying to place the order.
-						hidden: isPhoneValid === null,
-					},
-				} );
-			}
-		};
 
 		updateFormSubmitButton();
 
@@ -180,6 +187,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		isPhoneValid,
 		isSaveDetailsChecked,
 		sendExtensionData,
+		updateFormSubmitButton,
 	] );
 
 	// In classic checkout the saved tokens are under WCPay, so we need to check if new token is selected or not,
@@ -198,8 +206,11 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		if ( isBlocksCheckout && userDataSent ) {
 			sendExtensionData( true );
 		}
+		clearValidationError( errorId );
 		return null;
 	}
+
+	updateFormSubmitButton();
 
 	return (
 		<Container

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -261,11 +261,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 							name="woopay_viewport"
 							value={ `${ viewportWidth }x${ viewportHeight }` }
 						/>
-						<div
-							className={
-								isPhoneValid === false ? 'has-error' : ''
-							}
-						>
+						<div className={ isPhoneValid ? '' : 'has-error' }>
 							<PhoneNumberInput
 								value={ phoneNumber }
 								onValueChange={ setPhoneNumber }

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -130,7 +130,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		}
 	}, [ isPhoneValid ] );
 
-	const updateFormSubmitButton = useCallback( () => {
+	const updatePhoneNumberValidationError = useCallback( () => {
 		if ( isSaveDetailsChecked && isPhoneValid ) {
 			clearValidationError( errorId );
 
@@ -161,35 +161,6 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		setValidationErrors,
 	] );
 
-	useEffect( () => {
-		const formSubmitButton = isBlocksCheckout
-			? document.querySelector(
-					'button.wc-block-components-checkout-place-order-button'
-			  )
-			: document.querySelector(
-					'form.woocommerce-checkout button[type="submit"]'
-			  );
-
-		if ( ! formSubmitButton ) {
-			return;
-		}
-
-		updateFormSubmitButton();
-
-		return () => {
-			clearValidationError( errorId );
-		};
-	}, [
-		setValidationErrors,
-		errorId,
-		clearValidationError,
-		isBlocksCheckout,
-		isPhoneValid,
-		isSaveDetailsChecked,
-		sendExtensionData,
-		updateFormSubmitButton,
-	] );
-
 	// In classic checkout the saved tokens are under WCPay, so we need to check if new token is selected or not,
 	// under WCPay. For blocks checkout considering isWCPayChosen is enough.
 	const isWCPayWithNewTokenChosen = isBlocksCheckout
@@ -210,7 +181,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		return null;
 	}
 
-	updateFormSubmitButton();
+	updatePhoneNumberValidationError();
 
 	return (
 		<Container

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -131,6 +131,14 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	}, [ isPhoneValid ] );
 
 	const updatePhoneNumberValidationError = useCallback( () => {
+		if ( ! isSaveDetailsChecked ) {
+			clearValidationError( errorId );
+			if ( isPhoneValid !== null ) {
+				onPhoneValidationChange( null );
+			}
+			return;
+		}
+
 		if ( isSaveDetailsChecked && isPhoneValid ) {
 			clearValidationError( errorId );
 
@@ -138,6 +146,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			if ( isBlocksCheckout ) {
 				sendExtensionData( false );
 			}
+			return;
 		}
 
 		if ( isSaveDetailsChecked && ! isPhoneValid ) {

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -6,6 +6,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // eslint-disable-next-line import/no-unresolved
 import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
+import { addAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -15,6 +16,30 @@ import useWooPayUser from '../../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../../hooks/use-selected-payment-method';
 import { getConfig } from 'utils/checkout';
 import { useDispatch } from '@wordpress/data';
+
+const jQueryMock = ( selector ) => {
+	if ( typeof selector === 'function' ) {
+		return selector( jQueryMock );
+	}
+
+	return {
+		on: ( event, callbackOrSelector, callback2 ) =>
+			addAction(
+				`payment-request-test.jquery-event.${ selector }${
+					typeof callbackOrSelector === 'string'
+						? `.${ callbackOrSelector }`
+						: ''
+				}.${ event }`,
+				'tests',
+				typeof callbackOrSelector === 'string'
+					? callback2
+					: callbackOrSelector
+			),
+		val: () => null,
+		is: () => null,
+		remove: () => null,
+	};
+};
 
 jest.mock( '../../hooks/use-woopay-user', () => jest.fn() );
 jest.mock( '../../hooks/use-selected-payment-method', () => jest.fn() );
@@ -79,6 +104,8 @@ const BlocksCheckoutEnvironmentMock = ( { children } ) => (
 
 describe( 'CheckoutPageSaveUser', () => {
 	beforeEach( () => {
+		global.$ = jQueryMock;
+		global.jQuery = jQueryMock;
 		useDispatch.mockImplementation( () => {
 			return {
 				setValidationErrors: jest.fn(),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1799,6 +1799,7 @@ class WC_Payments {
 			// Update email field location.
 			add_action( 'woocommerce_checkout_billing', [ __CLASS__, 'woopay_fields_before_billing_details' ], -50 );
 			add_filter( 'woocommerce_form_field_email', [ __CLASS__, 'filter_woocommerce_form_field_woopay_email' ], 20, 4 );
+			add_action( 'woocommerce_checkout_process', [ __CLASS__, 'maybe_show_woopay_phone_number_error' ] );
 
 			include_once __DIR__ . '/woopay-user/class-woopay-save-user.php';
 
@@ -2025,6 +2026,19 @@ class WC_Payments {
 	public static function maybe_disable_wcpay_subscriptions_on_update() {
 		if ( WC_Payments_Features::is_wcpay_subscriptions_enabled() && ( class_exists( 'WC_Subscriptions' ) || ! WC_Payments_Features::is_wcpay_subscriptions_eligible() ) ) {
 			update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '0' );
+		}
+	}
+
+	/**
+	 * Show error when WooPay opt-in is checked but no phone number was typed.
+	 */
+	public static function maybe_show_woopay_phone_number_error() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST['save_user_in_woopay'] ) && 'true' === $_POST['save_user_in_woopay'] ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( ! isset( $_POST['woopay_user_phone_field'] ) || ! isset( $_POST['woopay_user_phone_field']['no-country-code'] ) || empty( $_POST['woopay_user_phone_field']['no-country-code'] ) ) {
+				wc_add_notice( '<strong>' . __( 'Mobile Number', 'woocommerce-payments' ) . '</strong> ' . __( 'is required to create an WooPay account.', 'woocommerce-payments' ), 'error' );
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds extra checks to prevent throwing errors about missing opt-in phone number when the customer selects another payment method because only the credit card payment method should allow customers to create a WooPay account.

#### Testing instructions
To enable the default opt in change [this value](https://github.com/Automattic/woocommerce-payments/blob/b0436e9a9525c5d43bc1e89db70849ba945982ff/includes/woopay-user/class-woopay-save-user.php#L70) to `true`

To Disable the default opt in change [this value](https://github.com/Automattic/woocommerce-payments/blob/b0436e9a9525c5d43bc1e89db70849ba945982ff/includes/woopay-user/class-woopay-save-user.php#L70) to `false`

Remember to refresh the page after each test to make sure you are getting a clean state and running all start up code.

- Try as much as possible to break the opt-in phone number validation in both the blocks and shortcode checkouts
	**Default Opt-in off**
	- Don't do anything then place an order ( Must not show any errors )
	- Don't check the opt in and place the order ( Must allow to place order button without errors )
	- Check the opt in and then select another payment method ( Must allow to place order without errors )
	- Check the opt in and don't type any phone number ( Must show errors only after clicking the place order button )
	- Check the opt in and click inside the phone number field then outside ( Must show error right away )
	- Check the opt in and click inside the phone number field then outside. Then uncheck the opt-in ( Must allow to place order without errors )
	**Default Opt-in on**
	- Don't do anything ( Must not show any errors )
	- Don't type the phone number and try to place an order ( Must show errors )
	- Click inside the phone number field then outside then try to place an order ( Must show errors )
	- Un-check then check the opt-in then place an order ( Must not show any errors )
	- Use another payment method (eg: Klarna) without adding a phone number or checking/unchecking the opt-in checkbox ( Checkbox must hide after changing the payment method and it must allow to place order without errors )
	- Change between payment methods back and forth and place the order( Expected results will depend on which payment method you selected last)

- Think of other possible ways to break the opt in. Read the code carefully to try to figure out possible ways to break it.
	
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
