### PR TITLE
Bump WC tested up to version to 9.2.0

### DIFF
--- a/changelog/dev-bump-wc-version-9-2-0
+++ b/changelog/dev-bump-wc-version-9-2-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump WC tested up to version to 9.2.0

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 9.1.2
+ * WC tested up to: 9.2.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 8.0.1


### PR DESCRIPTION
9.2.0 is the release of WooCommerce, which will be available from August 13, before the next WooPayments release, according to 7bje6-p2 release plan (sidebar).