### PR TITLE
Tokenized Cart - update customer ID when user logs in

### DIFF
--- a/changelog/fix-9145-tokenized-cart-customer-id-mismatch
+++ b/changelog/fix-9145-tokenized-cart-customer-id-mismatch
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix for unreleased tokenized cart feature
+
+

--- a/includes/class-wc-payments-payment-request-session-handler.php
+++ b/includes/class-wc-payments-payment-request-session-handler.php
@@ -66,10 +66,13 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 		// If an account has been created after the session has been initialized, update the session.
 		// This method is called directly by WC blocks when an account is created right before placing an order.
 		$previous_session_data = null;
+		parent::init_session_cookie();
+
 		if ( is_user_logged_in() && strval( get_current_user_id() ) !== $this->_customer_id ) {
 			$previous_session_data = $this->_data;
+			$this->_customer_id    = strval( get_current_user_id() );
 		}
-		parent::init_session_cookie();
+
 		$this->init_session_from_token();
 		if ( ! empty( $previous_session_data ) ) {
 			$this->_data = $previous_session_data;

--- a/includes/class-wc-payments-payment-request-session-handler.php
+++ b/includes/class-wc-payments-payment-request-session-handler.php
@@ -70,7 +70,13 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 
 		if ( is_user_logged_in() && strval( get_current_user_id() ) !== $this->_customer_id ) {
 			$previous_session_data = $this->_data;
-			$this->_customer_id    = strval( get_current_user_id() );
+			/**
+			 * This is borrowed from WooCommerce core, which also converts the user ID to a string.
+			 * https://github.com/woocommerce/woocommerce/blob/f01e9452045e2d483649670adc2f042391774e38/plugins/woocommerce/includes/class-wc-session-handler.php#L107
+			 *
+			 * @psalm-suppress InvalidPropertyAssignmentValue
+			 */
+			$this->_customer_id = strval( get_current_user_id() );
 		}
 
 		$this->init_session_from_token();


### PR DESCRIPTION
Fixes #9145 

#### Changes proposed in this Pull Request

With tokenized carts, a new session handler was added. We were running into a really tough to reproduce issue where the customer ID didn't match the between the cookie and session, leading to an exception being thrown. We thought this was only happening on live WPCom sites, but in the end, I was able to reproduce it locally as well. Making things more difficult, the issue would randomly resolve and the same steps that previously reproduced the issue would no longer work. I'm still not sure why it began happening locally. 

The problem is linked to customers that have just logged in. What's happening is that when [parent::init_session_cookie() is called](https://github.com/Automattic/woocommerce-payments/blob/5fd5ff21255726e90b300c1bb7a1ad4c9e032fb4/includes/class-wc-payments-payment-request-session-handler.php#L72) after logging in, there is no cookie, which leads to [here in core, generating a tokenized customer ID](https://github.com/woocommerce/woocommerce/blob/f7f280fd1bcf85dca31c70c5c98a0c5975b81b78/plugins/woocommerce/includes/class-wc-session-handler.php#L134). This ID doesn't match the real customer ID, which leads to an exception. The solution is to set the correct customer ID after `parent::init_session_cookie()` completes, which is [what that method itself does](https://github.com/woocommerce/woocommerce/blob/f7f280fd1bcf85dca31c70c5c98a0c5975b81b78/plugins/woocommerce/includes/class-wc-session-handler.php#L107) for logged in user customer ID mismatches. 

#### Testing instructions

To reproduce the issue: 

- Test on the `develop` branch
- Disable ECE with the following snippet:
```php
add_filter( 'pre_option__wcpay_feature_stripe_ece', function () {
    return '0'; 
}, 100 );
```
- Enable the "Enable Cart-Token implementation for PRBs" flag in your dev tools (you'll need to update them)
- Ensure you have Google Pay/Apple Pay enabled in the merchant's settings
- Visit a product page, Empty the cart, Log out
- Log in as admin
- Visit a product page
- Click the PRB
- In the network tab, the `update-customer` request will fail with the error `Invalid token: cookie and session customer mismatch`.

Once you can consistently reproduce the error, apply this PR and try a few more times. The error should no longer occur.

If you're unable to reproduce the error, please reach out in p1722260329391019-slack-CU6SYV31A. It might be necessary( for some reason) to test on a WPCom site.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.