### PR TITLE
Remove Navigation integration

### DIFF
--- a/changelog/fix-navigation-feature
+++ b/changelog/fix-navigation-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove WooCommerce Navigation integration

--- a/client/index.js
+++ b/client/index.js
@@ -38,20 +38,11 @@ addFilter(
 	( pages ) => {
 		const { menuID, rootLink } = getMenuSettings();
 
-		const isNavigationEnabled =
-			window.wcAdminFeatures && window.wcAdminFeatures.navigation;
-		const connectionPageTitle = isNavigationEnabled
-			? 'WooPayments'
-			: __( 'Connect', 'woocommerce-payments' );
-
 		pages.push( {
 			container: ConnectAccountPage,
 			path: '/payments/connect',
 			wpOpenMenu: menuID,
-			breadcrumbs: [ rootLink, connectionPageTitle ],
-			navArgs: {
-				id: 'wc-payments',
-			},
+			breadcrumbs: [ rootLink, __( 'Connect', 'woocommerce-payments' ) ],
 			capability: 'manage_woocommerce',
 		} );
 
@@ -63,9 +54,6 @@ addFilter(
 				rootLink,
 				__( 'Onboarding', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-onboarding',
-			},
 			capability: 'manage_woocommerce',
 		} );
 
@@ -74,9 +62,6 @@ addFilter(
 			path: '/payments/overview',
 			wpOpenMenu: menuID,
 			breadcrumbs: [ rootLink, __( 'Overview', 'woocommerce-payments' ) ],
-			navArgs: {
-				id: 'wc-payments-overview',
-			},
 			capability: 'manage_woocommerce',
 		} );
 
@@ -85,9 +70,6 @@ addFilter(
 			path: '/payments/deposits',
 			wpOpenMenu: menuID,
 			breadcrumbs: [ rootLink, __( 'Deposits', 'woocommerce-payments' ) ],
-			navArgs: {
-				id: 'wc-payments-deposits',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
@@ -102,10 +84,6 @@ addFilter(
 				],
 				__( 'Deposit details', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-deposit-details',
-				parentPath: '/payments/deposits',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
@@ -116,9 +94,6 @@ addFilter(
 				rootLink,
 				__( 'Transactions', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-transactions',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
@@ -133,10 +108,6 @@ addFilter(
 				],
 				__( 'Payment details', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-transaction-details',
-				parentPath: '/payments/transactions',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
@@ -144,9 +115,6 @@ addFilter(
 			path: '/payments/disputes',
 			wpOpenMenu: menuID,
 			breadcrumbs: [ rootLink, __( 'Disputes', 'woocommerce-payments' ) ],
-			navArgs: {
-				id: 'wc-payments-disputes',
-			},
 			capability: 'manage_woocommerce',
 		} );
 
@@ -162,10 +130,6 @@ addFilter(
 				],
 				__( 'Dispute details', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-disputes-details-legacy-redirect',
-				parentPath: '/payments/disputes',
-			},
 			capability: 'manage_woocommerce',
 		} );
 
@@ -181,10 +145,6 @@ addFilter(
 				],
 				__( 'Challenge dispute', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-disputes-challenge',
-				parentPath: '/payments/disputes',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
@@ -215,9 +175,6 @@ addFilter(
 				rootLink,
 				__( 'Card readers', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-card-readers',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
@@ -228,9 +185,6 @@ addFilter(
 				rootLink,
 				__( 'Capital Loans', 'woocommerce-payments' ),
 			],
-			navArgs: {
-				id: 'wc-payments-capital',
-			},
 			capability: 'manage_woocommerce',
 		} );
 		if ( wcpaySettings && wcpaySettings.featureFlags.documents ) {
@@ -242,9 +196,6 @@ addFilter(
 					rootLink,
 					__( 'Documents', 'woocommerce-payments' ),
 				],
-				navArgs: {
-					id: 'wc-payments-documents',
-				},
 				capability: 'manage_woocommerce',
 			} );
 		}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -147,44 +147,28 @@ class WC_Payments_Admin {
 
 		$this->admin_child_pages = [
 			'wc-payments-overview'     => [
-				'id'       => 'wc-payments-overview',
-				'title'    => __( 'Overview', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/overview',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 10,
-				],
+				'id'     => 'wc-payments-overview',
+				'title'  => __( 'Overview', 'woocommerce-payments' ),
+				'parent' => 'wc-payments',
+				'path'   => '/payments/overview',
 			],
 			'wc-payments-deposits'     => [
-				'id'       => 'wc-payments-deposits',
-				'title'    => __( 'Deposits', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/deposits',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 20,
-				],
+				'id'     => 'wc-payments-deposits',
+				'title'  => __( 'Deposits', 'woocommerce-payments' ),
+				'parent' => 'wc-payments',
+				'path'   => '/payments/deposits',
 			],
 			'wc-payments-transactions' => [
-				'id'       => 'wc-payments-transactions',
-				'title'    => __( 'Transactions', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/transactions',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 30,
-				],
+				'id'     => 'wc-payments-transactions',
+				'title'  => __( 'Transactions', 'woocommerce-payments' ),
+				'parent' => 'wc-payments',
+				'path'   => '/payments/transactions',
 			],
 			'wc-payments-disputes'     => [
-				'id'       => 'wc-payments-disputes',
-				'title'    => __( 'Disputes', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/disputes',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 40,
-				],
+				'id'     => 'wc-payments-disputes',
+				'title'  => __( 'Disputes', 'woocommerce-payments' ),
+				'parent' => 'wc-payments',
+				'path'   => '/payments/disputes',
 			],
 		];
 	}
@@ -317,12 +301,6 @@ class WC_Payments_Admin {
 				'path'       => $top_level_link,
 				'position'   => '55.7', // After WooCommerce & Product menu items.
 				'icon'       => $menu_icon,
-				'nav_args'   => [
-					'title'        => 'WooPayments',
-					'is_category'  => $should_render_full_menu,
-					'menuId'       => 'plugins',
-					'is_top_level' => true,
-				],
 			]
 		);
 
@@ -344,9 +322,6 @@ class WC_Payments_Admin {
 						'parent'     => 'wc-payments',
 						'path'       => '/payments/onboarding',
 						'capability' => 'manage_woocommerce',
-						'nav_args'   => [
-							'parent' => 'wc-payments',
-						],
 					]
 				);
 				remove_submenu_page( 'wc-admin&path=/payments/connect', 'wc-admin&path=/payments/onboarding' );
@@ -356,40 +331,28 @@ class WC_Payments_Admin {
 		if ( $should_render_full_menu ) {
 			if ( $this->account->is_card_present_eligible() && $this->account->has_card_readers_available() ) {
 				$this->admin_child_pages['wc-payments-card-readers'] = [
-					'id'       => 'wc-payments-card-readers',
-					'title'    => __( 'Card Readers', 'woocommerce-payments' ),
-					'parent'   => 'wc-payments',
-					'path'     => '/payments/card-readers',
-					'nav_args' => [
-						'parent' => 'wc-payments',
-						'order'  => 50,
-					],
+					'id'     => 'wc-payments-card-readers',
+					'title'  => __( 'Card Readers', 'woocommerce-payments' ),
+					'parent' => 'wc-payments',
+					'path'   => '/payments/card-readers',
 				];
 			}
 
 			if ( $this->account->get_capital()['has_previous_loans'] ) {
 				$this->admin_child_pages['wc-payments-capital'] = [
-					'id'       => 'wc-payments-capital',
-					'title'    => __( 'Capital Loans', 'woocommerce-payments' ),
-					'parent'   => 'wc-payments',
-					'path'     => '/payments/loans',
-					'nav_args' => [
-						'parent' => 'wc-payments',
-						'order'  => 60,
-					],
+					'id'     => 'wc-payments-capital',
+					'title'  => __( 'Capital Loans', 'woocommerce-payments' ),
+					'parent' => 'wc-payments',
+					'path'   => '/payments/loans',
 				];
 			}
 
 			if ( WC_Payments_Features::is_documents_section_enabled() ) {
 				$this->admin_child_pages['wc-payments-documents'] = [
-					'id'       => 'wc-payments-documents',
-					'title'    => __( 'Documents', 'woocommerce-payments' ),
-					'parent'   => 'wc-payments',
-					'path'     => '/payments/documents',
-					'nav_args' => [
-						'parent' => 'wc-payments',
-						'order'  => 50,
-					],
+					'id'     => 'wc-payments-documents',
+					'title'  => __( 'Documents', 'woocommerce-payments' ),
+					'parent' => 'wc-payments',
+					'path'   => '/payments/documents',
 				];
 			}
 
@@ -409,12 +372,6 @@ class WC_Payments_Admin {
 					'parent'    => 'woocommerce-settings-payments',
 					'screen_id' => 'woocommerce_page_wc-settings-checkout-woocommerce_payments',
 					'title'     => 'WooPayments',
-					'nav_args'  => [
-						'parent' => 'wc-payments',
-						'title'  => __( 'Settings', 'woocommerce-payments' ),
-						'url'    => 'wc-settings&tab=checkout&section=woocommerce_payments',
-						'order'  => 99,
-					],
 				]
 			);
 			// Add the Settings submenu directly to the array, it's the only way to make it link to an absolute URL.


### PR DESCRIPTION
Relates to https://github.com/woocommerce/woocommerce/issues/48997

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Registration with the "new" WooCommerce Navigation was done in https://github.com/Automattic/woocommerce-payments/pull/1067 and will soon be removed. This PR removes the integration

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Building the plugin and making sure no errors occur when viewing any WooCommerce pages will be sufficient.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
