### PR TITLE
Add a null check to handle malformed urls in is_store_api_request

### DIFF
--- a/changelog/fix-9214-missing-null-check
+++ b/changelog/fix-9214-missing-null-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Added a simple null check for an edge case.
+
+

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1084,7 +1084,7 @@ class WC_Payments_Utils {
 			$rest_route = sanitize_text_field( $_REQUEST['rest_route'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.NonceVerification
 		} else {
 			$url_parts    = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			$request_path = rtrim( $url_parts['path'], '/' );
+			$request_path = $url_parts ? rtrim( $url_parts['path'], '/' ) : '';
 			$rest_route   = str_replace( trailingslashit( rest_get_url_prefix() ), '', $request_path );
 		}
 

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -621,4 +621,10 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 
 		unset( $_REQUEST['rest_route'] );
 	}
+
+	public function test_is_store_api_request_with_malformed_url() {
+		$_SERVER['REQUEST_URI'] = '///wp-json/wp/v2/users';
+
+		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
+	}
 }


### PR DESCRIPTION
Fixes #9214

#### Changes proposed in this Pull Request

A super-simple fix that adds a null-check in the `WC_Payments_Utils::is_store_api_request` method.

#### Testing instructions

As there are no side effects:

* All tests are passing.
* The code change looks good.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
