### PR TITLE
Added better error message when mandate is wrong.

### DIFF
--- a/changelog/fix-3075-add-better-error-message-when-mandate-is-wrong
+++ b/changelog/fix-3075-add-better-error-message-when-mandate-is-wrong
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added better error message when mandate is invalid.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -775,6 +775,8 @@ class WC_Payments_Webhook_Processing_Service {
 				return __( 'Microdeposit transfers failed. Please check the account, institution and transit numbers.', 'woocommerce-payments' );
 			case 'payment_method_microdeposit_verification_attempts_exceeded':
 				return __( 'You have exceeded the number of allowed verification attempts.', 'woocommerce-payments' );
+			case 'payment_intent_mandate_invalid':
+				return __( 'The mandate used for this renewal payment is invalid. You may need to bring the customer back to your store and ask them to resubmit their payment information.', 'woocommerce-payments' );
 			case 'card_declined':
 				switch ( $decline_code ) {
 					case 'debit_notification_undelivered':


### PR DESCRIPTION
Fixes #3075 

#### Changes proposed in this Pull Request

This PR captures the `payment_intent_mandate_invalid` error code and displays a clearer error message to the end user.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have a subscription.
* Change store currency to INR or use multi currency
* Buy subscription using credit cards that would trigger mandate error. These can be found [here](https://docs.stripe.com/india-recurring-payments?integration=paymentIntents-setupIntents#testing).
* When subscription fails, look at the order notes and confirm that the error message is the one that is added within this PR.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
