### PR TITLE
Add intent id to the terminal order during the intent creation.

### DIFF
--- a/changelog/fix-add-payment-intent-id-to-order
+++ b/changelog/fix-add-payment-intent-id-to-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added intent it to the terminal order.

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -1325,6 +1325,33 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 404, $data['status'] );
 	}
 
+	public function test_create_terminal_intent_error_when_intent_id_exists() {
+		$order = $this->create_mock_order();
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id' => $order->get_id(),
+			]
+		);
+
+		$this->order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_123' );
+
+		$this->order_service
+			->expects( $this->never() )
+			->method( 'set_intent_id_for_order' );
+
+		$response = $this->controller->create_terminal_intent( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 400, $data['status'] );
+	}
+
 	public function test_create_terminal_intent_invalid_payment_method_format() {
 		$order = $this->create_mock_order();
 


### PR DESCRIPTION
Check issue 3067 on the server.

#### Changes proposed in this Pull Request

This PR adds an intent ID to terminal orders and validates the intent ID before order creation to prevent duplicate charges.


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Create a new terminal intent using the provider API. Ensure there is an order without an attached intent ID beforehand.
* After the request completes, verify that the intent ID is added to the order metadata.
* Reuse the same order to create another terminal intent.
* Confirm that an error response is shown, indicating that the intent ID already exists for the order.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
