### PR TITLE
Fix for Express Checkout Element use with coupons

### DIFF
--- a/changelog/fix-9233-ece-coupons
+++ b/changelog/fix-9233-ece-coupons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix error in Express Checkout Element use with coupons.

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -7,14 +7,17 @@
  * @return {Array} An array of PaymentItems
  */
 export const normalizeLineItems = ( displayItems ) => {
-	return displayItems.map( ( displayItem ) =>
-		// The amount prop is already present on the item.
-		( {
-			...displayItem,
+	return displayItems.map( ( displayItem ) => {
+		let amount = displayItem?.amount ?? displayItem?.value;
+		if ( displayItem.key === 'total_discount' ) {
+			amount = -amount;
+		}
+
+		return {
 			name: displayItem.label,
-			amount: displayItem?.amount ?? displayItem?.value,
-		} )
-	);
+			amount,
+		};
+	} );
 };
 
 /**

--- a/client/express-checkout/utils/test/normalize.js
+++ b/client/express-checkout/utils/test/normalize.js
@@ -31,22 +31,15 @@ describe( 'Express checkout normalization', () => {
 			const expected = [
 				{
 					name: 'Item 1',
-					label: 'Item 1',
 					amount: 100,
-					value: 100,
 				},
 				{
 					name: 'Item 2',
-					label: 'Item 2',
 					amount: 200,
-					value: 200,
 				},
 				{
 					name: 'Item 3',
-					label: 'Item 3',
 					amount: 200,
-					valueWithTax: 300,
-					value: 200,
 				},
 			];
 
@@ -74,18 +67,60 @@ describe( 'Express checkout normalization', () => {
 			const expected = [
 				{
 					name: 'Item 1',
-					label: 'Item 1',
 					amount: 100,
 				},
 				{
 					name: 'Item 2',
-					label: 'Item 2',
 					amount: 200,
 				},
 				{
 					name: 'Item 3',
+					amount: 300,
+				},
+			];
+
+			expect( normalizeLineItems( displayItems ) ).toStrictEqual(
+				expected
+			);
+		} );
+
+		test( 'normalizes discount line item properly', () => {
+			const displayItems = [
+				{
+					label: 'Item 1',
+					amount: 100,
+				},
+				{
+					label: 'Item 2',
+					amount: 200,
+				},
+				{
 					label: 'Item 3',
 					amount: 300,
+				},
+				{
+					key: 'total_discount',
+					label: 'Discount',
+					amount: 50,
+				},
+			];
+
+			const expected = [
+				{
+					name: 'Item 1',
+					amount: 100,
+				},
+				{
+					name: 'Item 2',
+					amount: 200,
+				},
+				{
+					name: 'Item 3',
+					amount: 300,
+				},
+				{
+					name: 'Discount',
+					amount: -50,
 				},
 			];
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -124,6 +124,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 
 		if ( WC()->cart->has_discount() ) {
 			$items[] = [
+				'key'    => 'total_discount',
 				'label'  => esc_html( __( 'Discount', 'woocommerce-payments' ) ),
 				'amount' => WC_Payments_Utils::prepare_amount( $discounts, $currency ),
 			];


### PR DESCRIPTION
Fixes #9233 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
It was reported to us that Google Pay and Apple Pay were not working when used with a coupon. This started happening after the conversion to use the Express Checkout Element (ECE). The same behavior did not cause an error with PaymentRequestButtons (PRB), so this is an additional check that has been added to the ECE implementation.

As described in the initial issue, the total payment amount was less than the sum of the line items. This was due to the fact that WooCommerce does not mark discount amounts as negative and so there was a mismatch on total amount being charged between what we provided to Stripe ECE vs the sum of the line items provided to Stripe's ECE.

To fix this, I identified the `total_discount` key on the line items returned from WC and in those cases turned the amount negative. I made this change in the centralized `normalizeLineItems` function so that it will apply to all actions and updates to the payment sheet.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a store with a multiple coupon codes (one for Percentage Discount, Fixed Cart Discount, and Fixed Product Discount).
2. For the fixed product discount select a product you'll test with.
3. For one of the coupons (or a fourth coupon) mark Free Shipping with the coupon (this will involve providing a Free Shipping method in the tested shipping zone).

**Without this branch applied**
1. Add a product to the cart.
2. Go to the blocks checkout page and enter a coupon.
3. Confirm the coupon applied to correct discount.
4. Click on Google Pay.
5. Confirm that the payment sheet is not displayed and that there is a console error similar to: `The amount xxx is less than the total amount of the line items provided.`


**With this branch applied**
1. Add a product to the cart.
2. Go to the blocks checkout page and enter a coupon.
3. Confirm the coupon applied to correct discount.
4. Click on Google Pay.
5. Confirm the payment sheet opens with the correct amount.
6. Confirm payment and make sure the order goes through successfully.

Repeat the above steps with the branch applied on/with:
- Google Pay and Apple Pay
- Shortcode cart and Blocks cart
- Shortcode checkout and Blocks checkout
- With each of the three coupon types created above.



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
