### PR TITLE
Fix WooPay checkboxes while signed in

### DIFF
--- a/changelog/fix-woopay-checkboxes-while-signed-in
+++ b/changelog/fix-woopay-checkboxes-while-signed-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay checkboxes while signed in.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -398,8 +398,10 @@ export const handleWooPayEmailInput = async (
 				// Dispatch an event after we get the response.
 				dispatchUserExistEvent( data[ 'user-exists' ] );
 
-				if ( data[ 'user-exists' ] && shouldOpenIframe ) {
-					openIframe( email );
+				if ( data[ 'user-exists' ] ) {
+					if ( shouldOpenIframe ) {
+						openIframe( email );
+					}
 				} else if ( data.code !== 'rest_invalid_param' ) {
 					recordUserEvent( 'checkout_woopay_save_my_info_offered' );
 

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -325,7 +325,7 @@ export const handleWooPayEmailInput = async (
 		window.dispatchEvent( woopayUserCheckEvent );
 	};
 
-	const woopayLocateUser = async ( email ) => {
+	const woopayLocateUser = async ( email, shouldOpenIframe = true ) => {
 		parentDiv.insertBefore( spinner, woopayEmailInput );
 
 		if ( parentDiv.contains( errorMessage ) ) {
@@ -398,7 +398,7 @@ export const handleWooPayEmailInput = async (
 				// Dispatch an event after we get the response.
 				dispatchUserExistEvent( data[ 'user-exists' ] );
 
-				if ( data[ 'user-exists' ] ) {
+				if ( data[ 'user-exists' ] && shouldOpenIframe ) {
 					openIframe( email );
 				} else if ( data.code !== 'rest_invalid_param' ) {
 					recordUserEvent( 'checkout_woopay_save_my_info_offered' );
@@ -529,6 +529,14 @@ export const handleWooPayEmailInput = async (
 			closeIframe( false );
 		}
 	} );
+
+	if ( woopayEmailInput.value ) {
+		const email = woopayEmailInput.value;
+
+		if ( validateEmail( email ) ) {
+			woopayLocateUser( email, false );
+		}
+	}
 
 	if ( customerClickedBackButton ) {
 		// Dispatch an event declaring this user exists as returned via back button. Wait for the window to load.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -434,7 +434,11 @@ export const handleWooPayEmailInput = async (
 		timer = setTimeout( () => {
 			if ( validateEmail( email ) ) {
 				woopayLocateUser( email );
+
+				return;
 			}
+
+			dispatchUserExistEvent( false ); // Always show checkbox until the email is from a valid WooPay user.
 		}, waitTime );
 	} );
 

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -432,13 +432,11 @@ export const handleWooPayEmailInput = async (
 		spinner.remove();
 
 		timer = setTimeout( () => {
+			dispatchUserExistEvent( false ); // Always show checkbox until the email is from a valid WooPay user.
+
 			if ( validateEmail( email ) ) {
 				woopayLocateUser( email );
-
-				return;
 			}
-
-			dispatchUserExistEvent( false ); // Always show checkbox until the email is from a valid WooPay user.
 		}, waitTime );
 	} );
 

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -98,4 +98,8 @@
 			}
 		}
 	}
+
+	h2 {
+		margin-bottom: 4px;
+	}
 }

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -98,7 +98,7 @@
 			box-shadow: none;
 			border: 1px solid $gray-300;
 			border-radius: 5px;
-			margin-left: 0.125rem;
+			margin-left: 0.1rem;
 			width: calc( 100% - 0.25rem );
 
 			&::placeholder {
@@ -111,6 +111,16 @@
 			}
 		}
 	}
+
+	.iti {
+		margin-top: 16px;
+	}
+}
+
+.wc-block-components-form
+	.woopay-save-new-user-container
+	.wc-block-components-text-input:only-child {
+	margin-top: 0;
 }
 
 #phone-number {

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -347,7 +347,7 @@ class WC_Payments_Checkout {
 	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
 	 */
 	private function should_upe_payment_method_show_save_option( $payment_method ) {
-		if ( is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
+		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -347,9 +347,14 @@ class WC_Payments_Checkout {
 	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
 	 */
 	private function should_upe_payment_method_show_save_option( $payment_method ) {
+		if ( is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
+			return false;
+		}
+
 		if ( $payment_method->is_reusable() ) {
 			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
 		}
+
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #9186

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR updates the `Save payment information to my account for future purchases.` checkbox and the WooPay checkbox while the user is signed in to match what is described [here](https://github.com/Automattic/woocommerce-payments/issues/9186#issuecomment-2257205073).

Also updates the WooPay component spacing to match 2JyXNimI4oGeJZhgQNZE9V-fi-1168_19276.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Logout on WooPay.
* Sign in on the merchant store.
* Add products to the cart.
* Access the blocks checkout page.
* The `Save payment information to my account for future purchases.` checkbox should be hidden.
* If the user email exists on WooPay, the WooPay checkbox should be hidden, if not, the WooPay checkbox should be shown.
* Sign in on WooPay with the same email.
* Reload the checkbox page.
* The `Save payment information to my account for future purchases.` checkbox and the WooPay one should be hidden.
* Change the email to a non existent WooPay email.
* Click the WooPay checkbox.
* Design should match 2JyXNimI4oGeJZhgQNZE9V-fi-1168_19276.
* You can also follow [this comment](https://github.com/Automattic/woocommerce-payments/issues/9186#issuecomment-2257205073) to test while logged out on merchant store.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.