### PR TITLE
Do not enqueue Cart scripts if WooPayments is not enabled

### DIFF
--- a/changelog/as-fix-track-event
+++ b/changelog/as-fix-track-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Do not enqueue Cart scripts if WooPayments is not enabled

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1775,7 +1775,7 @@ class WC_Payments {
 	 * @return void
 	 */
 	public static function enqueue_cart_scripts() {
-		if ( ! WC_Payments_Utils::is_cart_page() ) {
+		if ( ! WC_Payments_Utils::is_cart_page() || ! self::get_gateway()->is_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9208

#### Changes proposed in this Pull Request

Avoids enqueuing  the `wp-content/plugins/woocommerce-payments/dist/cart.js` file on the Cart page when WooPayments is disabled to prevent firing the `wcpay_proceed_to_checkout_button_click` unnecessarily.

#### Testing instructions

This PR solely focus on preventing the user event wcpay_proceed_to_checkout_button_click from being registered when the WooPayments gateway is disabled. However, I wanted to review all user events and ensure that no events are still being registered to avoid compromising the integrity of the metrics.

- `client/cart/index.js`
    - `wcpay_proceed_to_checkout_button_click`
        - WooPayments is enabled
          - ✅ Event fires when clicking the 'Proceed to checkout' button on the block-based cart page and the shortcode-based cart page.
        - WooPayments is disabled
          - ✅ This event should not fire when clicking the 'Proceed to checkout' button on the cart pages.
          - ✅ File `wp-content/plugins/woocommerce-payments/dist/cart.js` shouldn't load on the cart pages.
- `client/checkout/blocks/index.js`
    - `checkout_place_order_button_click`
        - WooPayments is enabled
          - ✅ Event fires when clicking the "Place Order" button on the block-based checkout page.
        - WooPayments is disabled
          - ✅ Event shouldn't fire when clicking the "Place Order" button on the block-based checkout page.
          - ✅ File `/wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn't load on the block-based checkout page.
- `client/checkout/classic/event-handlers.js`
    - `checkout_place_order_button_click`
        - WooPayments is enabled
          - ✅ Event fires when clicking the "Place Order" on the shortcode-based checkout page.
        - WooPayments is disabled
          - ✅ Event shouldn't fire when clicking the "Place Order" button on the shortcode-based checkout page.
          - ✅ File `/wp-content/plugins/woocommerce-payments/dist/checkout.js` shouldn't load on the shortcode-based checkout page.
- `client/checkout/woopay/email-input-iframe.js`
    - `checkout_email_address_woopay_check`
        - WooPayments is enabled
          - ✅ The event fires when entering an email on the Email field on both the blocks-based and the shortcode-based checkout page.
        - WooPayments is disabled
          - ✅ The event shouldn’t fire after entering an email on both the blocks-based and the shortcode-based checkout page.
          - ✅ The file `wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn't be loaded on either of the checkout pages.
    - `checkout_woopay_save_my_info_offered`
        - WooPayments is enabled
          - ✅The event fires after entering an email on the Email field on both the blocks-based and the shortcode-based checkout page.
        - WooPayments is disabled
          - ✅ The event shouldn’t fire after entering an email on the email field on the blocks-based and the shortcode-based checkout page.
          - ✅ The file `wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn't be loaded on either of the checkout pages.
    - `checkout_save_my_info_click`
        - Before testing
            - Make sure you have the latest WCPay Dev Tools (https://github.com/Automattic/woocommerce-payments-dev-tools)
            - On the merchant check the “Force the `pre_check_save_my_info` flag (aka Default Opt-in) in the account cache to be true”
        - WooPayments is enabled
            - ✅ Event fires after entering a non WooPay email on both the blocks-based and the shortcode-based checkout page.
        - WooPayments is disabled
            - ✅ Event shouldn’t fire after entering a non WooPay email because the “Save my info” section shouldn’t even render on either of the checkout pages.
            - ✅ File `wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn’t load on the blocks-based checkout page.
            - ✅ File `wp-content/plugins/woocommerce-payments/dist/checkout.js` shouldn’t load on the shortcode-based checkout page.
    - `woopay_skipped`
        - Before testing
            - Make sure WooPay as express checkout is enabled.
        - WooPayments is enabled
            - ✅ Event fires when clicking the “WooPay” button on the checkout page and navigating back to the checkout page using the “←” browser button. Applies to both blocks-based and shortcode-based checkout pages.
        - WooPayments is disabled
            - ✅ Event shouldn’t fire since there’s no WooPay button anymore. And even if you manage to navigate to the checkout page from. WooPay it shouldn’t fire the event. Applies to both blocks-based and shortcode-based checkout pages.
            - ✅ File `wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn’t load on the blocks-based checkout page.
            - ✅ File `wp-content/plugins/woocommerce-payments/dist/checkout.js` shouldn’t load on the shortcode-based checkout page.
- `client/checkout/woopay/express-button/woopay-express-checkout-button.js`
    - Before testing
        - Make sure WooPay is enabled as express checkout.
    - `woopay_button_load`
        - WooPayments is enabled
            - ✅ Event fires on page load after the WooPay button is loaded. Applies to both blocks-based and shortcode-based checkout pages.
    - `woopay_button_click`
        - WooPayments is enabled
            - ✅ Event fires when clicking the WooPay button.  Applies to both blocks-based and shortcode-based checkout pages.
    - WooPayments is disabled (Apply to all events in this file):
        - ✅ Shouldn’t be possible to fire the event since there’s no WoPay button anymore on either of the checkout pages.
        - ✅ File `/wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn’t load on the blocks-based checkout page.
        - ✅ File `wp-content/plugins/woocommerce-payments/dist/woopay-express-button.js`  shouldn’t load on the shortcode-based checkout page.
- `client/components/woopay/save-user/agreement.js`
    - `checkout_save_my_info_tos_click`
        - WooPayments is enabled
            - ✅ Event fires after entering an email on the checkout page then checking the “Securely save my information for 1-click checkout” on the “Save my info” section and ultimately clicking the “Terms of Service” link. Applies to both block-based and shortcode-based checkout pages.
        - WooPayments is disabled
            - ✅Shouldn’t be possible to fire the event since there’s no option to “Save my info” anymore on either of the checkout pages.
            - ✅ File `wp-content/plugins/woocommerce-payments/dist/woopay.js` shouldn’t load on either of the checkout pages.
    - `checkout_save_my_info_privacy_policy_click`
        - WooPayments is enabled
            - ✅ Event fires after entering an email on the checkout page then checking the “Securely save my information for 1-click checkout” on the “Save my info” section and ultimately clicking the “Privacy Policy” link. Applies to both block-based and shortcode-based checkout pages.
        - WooPayments is disabled
            - ✅ Shouldn’t be possible to fire the event since there’s no option to “Save my info” anymore on either of the checkout pages.
            - ✅ File `wp-content/plugins/woocommerce-payments/dist/woopay.js` shouldn’t load on either of the checkout pages.
- `client/components/woopay/save-user/checkout-page-save-user.js`
    - `checkout_woopay_save_my_info_country_click`
        - WooPayments is enabled
            - ✅ Event fires when clicking the “Securely save my information for 1-click checkout” then clicking the dropdown with the flag next to the phone input.  Applies to both block-based and shortcode-based checkout pages.
    - `checkout_save_my_info_click`
        - WooPayments is enabled
            - ✅ Event fires when clicking the “Securely save my information for 1-click checkout”.  Applies to both block-based and shortcode-based checkout pages.
    - `checkout_woopay_save_my_info_mobile_enter`
        - WooPayments is enabled
            - ✅ Event fires when clicking the “Securely save my information for 1-click checkout” then entering a valid phone number. Applies to both block-based and shortcode-based checkout pages.
    - WooPayments is disabled (Apply to all events in this file):
        - ✅ Shouldn’t be possible to fire the event since there’s no option to “Save my info” anymore on either of the checkout pages.
        - ✅ File `/wp-content/plugins/woocommerce-payments/dist/woopay.js` shouldn’t load on either of the checkout pages.
- `client/payment-request/index.js`
    - Before Testing
        - Make sure Google Pay and Apple Pay express checkouts are enabled.
        - Disable ECE with `wp option update _wcpay_feature_stripe_ece 0` on the merchant store.
    - `gpay_button_click`
        - WooPayments is enabled
            - ✅ Event fires after clicking the Google Pay button on the shortcode-based checkout page.
    - `gpay_button_load`
        - WooPayments is enabled
            - ✅ Event fires on page load after the Google Pay button is displayed on the shortcode-based checkout page.
    - Should be the same for `applepay_button_click` and`applepay_button_load` events using Safari with Apple Pay configured.
    - WooPayments is disabled (Apply to all events in this file):
        - ✅ Shouldn’t be possible to fire the events since there’s no express checkout section on the shortcode-based checkout page.
        - ✅ File `/wp-content/plugins/woocommerce-payments/dist/payment-request.js` shouldn’t load on the shortcode-based checkout page.
- `client/payment-request/blocks/payment-request-express.js`
    - Before Testing
        - Make sure Google Pay and Apple Pay express checkouts are enabled.
        - Enable ECE with `wp option update _wcpay_feature_stripe_ece 1` on the merchant store.
    - `gpay_button_load`
        - WooPayments is enabled
            - ✅ Event fires on page load after the Google Pay button is displayed on the block-based checkout page.
    - `gpay_button_click`
        - WooPayments is enabled
            - ✅ Event fires after clicking the Google Pay button on the block-based checkout page.
    - Should be the same for `applepay_button_load` and `applepay_button_click` events using Safari with Apple Pay configured.
    - WooPayments is disabled (Apply to all events in this file):
        - ✅ Shouldn’t be possible to fire the events since there’s no express checkout section on the block-based checkout page.
        - ✅ File  `wp-content/plugins/woocommerce-payments/dist/blocks-checkout.js` shouldn’t load on either of the checkout pages.
- `client/tokenized-payment-request/blocks/payment-request-express.js`
    - ✅ Tokenized Payment Request won’t work for me but I confirmed the file won't load if WooPayments is disabled.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
