### PR TITLE
 Remove unnecessary console.warn statements added in #9121

### DIFF
--- a/changelog/fix-remove-console-warns
+++ b/changelog/fix-remove-console-warns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove unnecessary console.warn statements added in #9121.

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -136,11 +136,7 @@ beforeAll( async () => {
 
 	capturePageEventsForTearDown();
 	page.on( 'dialog', async function ( dialog ) {
-		try {
-			await dialog.accept();
-		} catch ( err ) {
-			console.warn( err.message );
-		}
+		await dialog.accept();
 	} );
 	setTestTimeouts();
 	await setupBrowser();

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -136,7 +136,9 @@ beforeAll( async () => {
 
 	capturePageEventsForTearDown();
 	page.on( 'dialog', async function ( dialog ) {
-		await dialog.accept();
+		try {
+			await dialog.accept();
+		} catch ( err ) {}
 	} );
 	setTestTimeouts();
 	await setupBrowser();

--- a/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-subscription.spec.js
+++ b/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-subscription.spec.js
@@ -62,11 +62,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 		afterAll( async () => {
 			page.removeAllListeners( 'dialog' );
 			page.on( 'dialog', async function ( dialog ) {
-				try {
-					await dialog.accept();
-				} catch ( err ) {
-					console.warn( err.message );
-				}
+				await dialog.accept();
 			} );
 			await merchant.logout();
 		} );
@@ -91,11 +87,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 				page.removeAllListeners( 'dialog' ),
 				evalAndClick( 'button.save_order' ),
 				page.on( 'dialog', async ( dialog ) => {
-					try {
-						await dialog.accept();
-					} catch ( err ) {
-						console.warn( err.message );
-					}
+					await dialog.accept();
 				} ),
 				uiUnblocked(),
 				page.waitForNavigation( { waitUntil: 'networkidle0' } ),

--- a/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-subscription.spec.js
+++ b/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-subscription.spec.js
@@ -62,7 +62,9 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 		afterAll( async () => {
 			page.removeAllListeners( 'dialog' );
 			page.on( 'dialog', async function ( dialog ) {
-				await dialog.accept();
+				try {
+					await dialog.accept();
+				} catch ( err ) {}
 			} );
 			await merchant.logout();
 		} );
@@ -87,7 +89,9 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 				page.removeAllListeners( 'dialog' ),
 				evalAndClick( 'button.save_order' ),
 				page.on( 'dialog', async ( dialog ) => {
-					await dialog.accept();
+					try {
+						await dialog.accept();
+					} catch ( err ) {}
 				} ),
 				uiUnblocked(),
 				page.waitForNavigation( { waitUntil: 'networkidle0' } ),

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -64,7 +64,9 @@ describe( 'Disputes > Submit winning dispute', () => {
 	afterAll( async () => {
 		page.removeAllListeners( 'dialog' );
 		page.on( 'dialog', async function ( dialog ) {
-			await dialog.accept();
+			try {
+				await dialog.accept();
+			} catch ( err ) {}
 		} );
 		await merchant.logout();
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -64,11 +64,7 @@ describe( 'Disputes > Submit winning dispute', () => {
 	afterAll( async () => {
 		page.removeAllListeners( 'dialog' );
 		page.on( 'dialog', async function ( dialog ) {
-			try {
-				await dialog.accept();
-			} catch ( err ) {
-				console.warn( err.message );
-			}
+			await dialog.accept();
 		} );
 		await merchant.logout();
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
@@ -56,7 +56,9 @@ describe( 'Order > Full refund', () => {
 	afterAll( async () => {
 		page.removeAllListeners( 'dialog' );
 		page.on( 'dialog', async function ( dialog ) {
-			await dialog.accept();
+			try {
+				await dialog.accept();
+			} catch ( err ) {}
 		} );
 		await merchant.logout();
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
@@ -56,11 +56,7 @@ describe( 'Order > Full refund', () => {
 	afterAll( async () => {
 		page.removeAllListeners( 'dialog' );
 		page.on( 'dialog', async function ( dialog ) {
-			try {
-				await dialog.accept();
-			} catch ( err ) {
-				console.warn( err.message );
-			}
+			await dialog.accept();
 		} );
 		await merchant.logout();
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-partial-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-partial-refund.spec.js
@@ -89,11 +89,7 @@ describe.each( dataTable )(
 		afterEach( async () => {
 			page.removeAllListeners( 'dialog' );
 			page.on( 'dialog', async function ( dialog ) {
-				try {
-					await dialog.accept();
-				} catch ( err ) {
-					console.warn( err.message );
-				}
+				await dialog.accept();
 			} );
 		} );
 

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-partial-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-partial-refund.spec.js
@@ -89,7 +89,9 @@ describe.each( dataTable )(
 		afterEach( async () => {
 			page.removeAllListeners( 'dialog' );
 			page.on( 'dialog', async function ( dialog ) {
-				await dialog.accept();
+				try {
+					await dialog.accept();
+				} catch ( err ) {}
 			} );
 		} );
 

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-refund-failures.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-refund-failures.spec.js
@@ -57,7 +57,9 @@ describe( 'Order > Refund Failure', () => {
 	afterAll( async () => {
 		page.removeAllListeners( 'dialog' );
 		page.on( 'dialog', async function ( dialog ) {
-			await dialog.accept();
+			try {
+				await dialog.accept();
+			} catch ( err ) {}
 		} );
 		await merchant.logout();
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-refund-failures.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-refund-failures.spec.js
@@ -57,11 +57,7 @@ describe( 'Order > Refund Failure', () => {
 	afterAll( async () => {
 		page.removeAllListeners( 'dialog' );
 		page.on( 'dialog', async function ( dialog ) {
-			try {
-				await dialog.accept();
-			} catch ( err ) {
-				console.warn( err.message );
-			}
+			await dialog.accept();
 		} );
 		await merchant.logout();
 	} );

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -132,7 +132,6 @@ describe( 'Klarna checkout', () => {
 			} );
 			readyToBuy = true;
 		} catch ( err ) {
-			console.warn( err );
 			readyToBuy = false;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have seemingly unnecessary `console.warn` statements in a few Jest unit tests, probably added to debug issues caused by the Node 20 upgrade #9121.

If one or more of these warn statements are required, we can suppress linter warnings by putting an ignore comment in front of them like this:

```js
console.warn( error ); // eslint-disable-line no-console
```

For now, I have removed all of them as they did not seem to add value post the upgrade.

P.S. I noticed them in the linter-generated warnings in my PR:

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/753f4c13-b8a3-4f62-82a5-21bc5a563c54">


#### Testing instructions

This is a harmful change, nothing really to test here.

* Code changes look good.
* All tests are passing.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
