### PR TITLE
Disable WooPay component while placing an order

### DIFF
--- a/changelog/fix-disable-woopay-component-placing-an-order
+++ b/changelog/fix-disable-woopay-component-placing-an-order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Disable WooPay component while placing an order.
+
+

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -76,7 +76,9 @@ button.wcpay-stripelink-modal-trigger:hover {
 }
 
 #remember-me {
-	margin-top: 36px;
+	margin: 36px 0 0 0;
+	padding: 0;
+	border: 0;
 
 	h2 {
 		font-size: 18px;

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -23,7 +23,9 @@ const renderSaveUserSection = () => {
 	);
 
 	if ( blocksCheckout.length ) {
-		const checkoutPageSaveUserContainer = document.createElement( 'div' );
+		const checkoutPageSaveUserContainer = document.createElement(
+			'fieldset'
+		);
 		const paymentOptions = document.getElementsByClassName(
 			'wp-block-woocommerce-checkout-payment-block'
 		)?.[ 0 ];

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -5,12 +5,15 @@
  */
 import React, { useEffect, useState, useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	extensionCartUpdate,
 	ValidationInputError,
 } from '@woocommerce/blocks-checkout'; // eslint-disable-line import/no-unresolved
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data'; // eslint-disable-line import/no-unresolved
+import {
+	VALIDATION_STORE_KEY,
+	CHECKOUT_STORE_KEY,
+} from '@woocommerce/block-data'; // eslint-disable-line import/no-unresolved
 
 /**
  * Internal dependencies
@@ -40,6 +43,10 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const [ isPhoneValid, onPhoneValidationChange ] = useState( null );
 	const [ userDataSent, setUserDataSent ] = useState( false );
 
+	const checkoutIsProcessing = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).isProcessing()
+	);
+
 	const isRegisteredUser = useWooPayUser();
 	const { isWCPayChosen, isNewPaymentTokenChosen } = useSelectedPaymentMethod(
 		isBlocksCheckout
@@ -52,6 +59,32 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		'9.1',
 		'>='
 	);
+
+	useEffect( () => {
+		if ( ! isBlocksCheckout ) {
+			return;
+		}
+
+		const rememberMe = document.querySelector( '#remember-me' );
+
+		if ( ! rememberMe ) {
+			return;
+		}
+
+		if ( checkoutIsProcessing ) {
+			rememberMe.classList.add(
+				'wc-block-components-checkout-step--disabled'
+			);
+			rememberMe.setAttribute( 'disabled', 'disabled' );
+
+			return;
+		}
+
+		rememberMe.classList.remove(
+			'wc-block-components-checkout-step--disabled'
+		);
+		rememberMe.removeAttribute( 'disabled', 'disabled' );
+	}, [ checkoutIsProcessing, isBlocksCheckout ] );
 
 	const getPhoneFieldValue = () => {
 		let phoneFieldValue = '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Currently when placing an order on Blocks checkout all sections are disabled except the WooPay one, this PR fixes that.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/7388d97e-65dc-48c4-b07c-5444472943b6" alt="Screenshot 2024-08-13 at 12 26 08 AM">
</td>
<td>
<img src="https://github.com/user-attachments/assets/5f7ad1cc-1528-4f34-97d2-e25df7213871" alt="Screenshot 2024-08-13 at 12 26 41 AM">
</td>
</tr>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a product to the cart.
* Access checkout page.
* Type a non WooPay email.
* Check `Securely save my information for 1-click checkout`.
* Type a valid phone.
* Fill out all fields and click `Place order`.
* The WooPay component should be disabled.
* Interact with the phone field, it should be disabled too.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
