### PR TITLE
chore: use lodash functions directly instead of global import

### DIFF
--- a/changelog/test-lodash-bundle-size
+++ b/changelog/test-lodash-bundle-size
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: use lodash functions directly instead of global import
+
+

--- a/client/components/currency-information-for-methods/index.js
+++ b/client/components/currency-information-for-methods/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import _ from 'lodash';
+import { uniq } from 'lodash';
 import { sprintf, __, _n } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 
@@ -113,8 +113,8 @@ const CurrencyInformationForMethods = ( { selectedMethods } ) => {
 		} );
 	} );
 
-	missingCurrencyLabels = _.uniq( missingCurrencyLabels );
-	paymentMethodsWithMissingCurrencies = _.uniq(
+	missingCurrencyLabels = uniq( missingCurrencyLabels );
+	paymentMethodsWithMissingCurrencies = uniq(
 		paymentMethodsWithMissingCurrencies
 	);
 

--- a/client/multi-currency-setup/tasks/add-currencies-task/index.js
+++ b/client/multi-currency-setup/tasks/add-currencies-task/index.js
@@ -5,7 +5,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { sprintf, __, _n } from '@wordpress/i18n';
 import { Button, Card, CardBody } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
-import _ from 'lodash';
+import { without, isString, capitalize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -150,7 +150,7 @@ const AddCurrenciesTask = () => {
 			] );
 		} else {
 			setSelectedCurrencyCodes(
-				_.without( selectedCurrencyCodes, currencyCode )
+				without( selectedCurrencyCodes, currencyCode )
 			);
 		}
 	};
@@ -180,7 +180,7 @@ const AddCurrenciesTask = () => {
 				checked={ selectedCurrencyCodes.includes( code ) }
 				onChange={ handleChange }
 				currency={ availableCurrencies[ code ] }
-				testId={ _.isString( testId ) ? testId : null }
+				testId={ isString( testId ) ? testId : null }
 			/>
 		);
 
@@ -196,7 +196,7 @@ const AddCurrenciesTask = () => {
 					'woocommerce-payments'
 				),
 				selectedCurrencyCodesLength < 10
-					? _.capitalize( numberWords[ selectedCurrencyCodesLength ] )
+					? capitalize( numberWords[ selectedCurrencyCodesLength ] )
 					: selectedCurrencyCodesLength
 			) }
 			index={ 1 }

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -19,7 +19,7 @@ import moment from 'moment';
 import React, { useContext, useState } from 'react';
 import { createInterpolateElement } from '@wordpress/element';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies.
@@ -650,7 +650,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 					} }
 				/>
 			) }
-			{ ! _.isEmpty( charge ) && ! charge.order && ! isLoading && (
+			{ ! isEmpty( charge ) && ! charge.order && ! isLoading && (
 				<MissingOrderNotice
 					charge={ charge }
 					isLoading={ isLoading }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
