### PR TITLE
fix: contrast ratio for link within tooltip

### DIFF
--- a/changelog/fix-tooltip-link-contrast-ratio
+++ b/changelog/fix-tooltip-link-contrast-ratio
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: tooltip link color contrast ratio
+
+

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -57,6 +57,7 @@
 
 		a {
 			color: var( --wp-admin-theme-color-background-25, $wp-blue-5 );
+			text-decoration: underline;
 		}
 
 		ul {

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -56,7 +56,7 @@
 		text-align: center;
 
 		a {
-			color: var( --wp-admin-theme-color, $gutenberg-blue );
+			color: var( --wp-admin-theme-color-background-25, $wp-blue-5 );
 		}
 
 		ul {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
 import { PaymentMethod } from 'wcpay/types/payment-methods';
 import { createInterpolateElement } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
 
 const countryFeeStripeDocsBaseLink =
 	'https://woocommerce.com/document/woopayments/fees-and-debits/fees/#';
@@ -180,7 +181,7 @@ export const formatMethodFeesTooltip = (
 			{ wcpaySettings &&
 			wcpaySettings.connect &&
 			wcpaySettings.connect.country ? (
-				<div className={ 'wcpay-fees-tooltip__hint-text' }>
+				<div className="wcpay-fees-tooltip__hint-text">
 					<span>
 						{ stripeFeeSectionExistsForCountry(
 							wcpaySettings.connect.country
@@ -196,19 +197,17 @@ export const formatMethodFeesTooltip = (
 									),
 									components: {
 										linkToStripePage: (
-											<a
+											<ExternalLink
 												href={ getStripeFeeSectionUrl(
 													wcpaySettings.connect
 														.country
 												) }
-												target={ '_blank' }
-												rel={ 'noreferrer' }
 											>
 												{ __(
 													'Learn more',
 													'woocommerce-payments'
 												) }
-											</a>
+											</ExternalLink>
 										),
 									},
 							  } )
@@ -223,18 +222,16 @@ export const formatMethodFeesTooltip = (
 									),
 									components: {
 										linkToStripePage: (
-											<a
+											<ExternalLink
 												href={
 													countryFeeStripeDocsBaseLinkNoCountry
 												}
-												target={ '_blank' }
-												rel={ 'noreferrer' }
 											>
 												{ __(
 													'Learn more',
 													'woocommerce-payments'
 												) }
-											</a>
+											</ExternalLink>
 										),
 									},
 							  } ) }

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -44,11 +44,33 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     >
       <span>
         <a
+          class="components-external-link"
           href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
-          rel="noreferrer"
+          rel="external noreferrer noopener"
           target="_blank"
         >
           Learn more
+          <span
+            class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="VisuallyHidden"
+            style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+          >
+            (opens in a new tab)
+          </span>
+          <svg
+            aria-hidden="true"
+            class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+            />
+          </svg>
         </a>
          about WooPayments Fees in your country
       </span>
@@ -101,11 +123,33 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     >
       <span>
         <a
+          class="components-external-link"
           href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
-          rel="noreferrer"
+          rel="external noreferrer noopener"
           target="_blank"
         >
           Learn more
+          <span
+            class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="VisuallyHidden"
+            style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+          >
+            (opens in a new tab)
+          </span>
+          <svg
+            aria-hidden="true"
+            class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+            />
+          </svg>
         </a>
          about WooPayments Fees in your country
       </span>


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- I noticed the text color of the "Learn more" link is kinda low for the font size ([3.64](https://www.siegemedia.com/contrast-ratio#%23007cba-on-%231e1e1e)); Changing to `#bfdeed` ([11.81](https://www.siegemedia.com/contrast-ratio#%23bfdeed-on-%231e1e1e))
- Since this is an external link, we should probably use the `ExternalLink` component, because it adds the "(opens in a new tab)"  text for screen readers (which was missing before)

Before:
<img width="364" alt="Screenshot 2024-08-16 at 4 30 17 PM" src="https://github.com/user-attachments/assets/71fc82e6-3e9f-4f4b-b981-38a573b9e105">

After:
<img width="327" alt="Screenshot 2024-08-16 at 4 45 01 PM" src="https://github.com/user-attachments/assets/9a1d5b70-550f-4352-8bf2-aec421b1b6cb">


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the settings page at https://wcpay.test/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Click (or hover) the fees next to each payment method
- The color of the link should be updated

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
