### PR TITLE
E2E: Fix the dispute save draft challenge failing due to redirect race condition

### DIFF
--- a/changelog/fix-9281-e2e-dispute-save-challenge
+++ b/changelog/fix-9281-e2e-dispute-save-challenge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not a user-facing change: fix e2e test save draft dispute challenge failing due to disputes list redirect race condition
+
+


### PR DESCRIPTION
Fixes #9281

#### Changes proposed in this Pull Request

This PR fixes the failing e2e test `Disputes > Merchant can save and resume draft dispute challenge` which is failing due to a redirect to the dispute list screen.

Previously, this redirect was slow enough to allow the dispute details page refresh to occur beforehand.

I suspect an improvement in e2e environment performance is now causing the redirect to occur before the page refresh can, causing the test to check against the wrong screen (disputes list rather than dispute details). This e2e test [first started failing](https://github.com/Automattic/woocommerce-payments/actions/runs/10423228918/job/28872147112) alongside #9109, but it may just be a coincidence.

The fix in this PR will wait for the redirect to occur before navigating to the dispute details screen.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Ensure GH action `E2E tests all` `Disputes > Merchant can save and resume draft dispute challenge` tests pass.
	* Note this does not run in PR checks.
	* See [this run](https://github.com/Automattic/woocommerce-payments/actions/runs/10463227370), view `wcpay - merchant` workflows and search for `merchant-disputes-save-draft-challenge.spec.js`
* Optionally, run locally
	* `npm run test:e2e-setup` or `npm run test:e2e-up` if already setup
	* `npm run test:e2e -- tests/e2e/specs/wcpay/merchant/merchant-disputes-*` to run all merchant disputes tests

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
