### PR TITLE
Manually modified the changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,6 @@
 * Fix - fix: cart association on tokenized PRB orders via custom session handler
 * Fix - fix: platform_global_theme_support_enabled undefined index
 * Fix - fix: translatable strings around currencies list
-* Fix - Fix caching with tracking cookie.
 * Fix - Fix GooglePay button missing in Safari.
 * Fix - Fix onboarding redirect loop when starting from Woo Settings Payments.
 * Fix - Fix spacing on Express Checkout buttons.

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,6 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - fix: cart association on tokenized PRB orders via custom session handler
 * Fix - fix: platform_global_theme_support_enabled undefined index
 * Fix - fix: translatable strings around currencies list
-* Fix - Fix caching with tracking cookie.
 * Fix - Fix GooglePay button missing in Safari.
 * Fix - Fix onboarding redirect loop when starting from Woo Settings Payments.
 * Fix - Fix spacing on Express Checkout buttons.


### PR DESCRIPTION
Due to revert of #9249 on release branch, changelog and readme has to be fixed manually. It appears changelog script does not pick up removal of the changelog files automatically.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
