### PR TITLE
Fix QIT error `OutputNotEscaped`

### DIFF
--- a/changelog/fix-9288-fix-qit-error-escape-output
+++ b/changelog/fix-9288-fix-qit-error-escape-output
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix QIT error "EscapeOutput.OutputNotEscaped"

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -120,7 +120,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 		$html_id = WC_Payments_Features::is_stripe_ece_enabled() ? 'wcpay-express-checkout-button-separator' : 'wcpay-payment-request-button-separator';
 		if ( $this->express_checkout_helper->is_checkout() ) {
 			?>
-			<p id="<?php echo $html_id; ?>" style="margin-top:1.5em;text-align:center;<?php echo $separator_starts_hidden ? 'display:none;' : ''; ?>">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
+			<p id="<?php echo esc_attr( $html_id ); ?>" style="margin-top:1.5em;text-align:center;<?php echo $separator_starts_hidden ? 'display:none;' : ''; ?>">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
 			<?php
 		}
 	}


### PR DESCRIPTION
Fixes #9288

#### Changes proposed in this Pull Request

- Fix QIT error missing `esc_attr`.

#### Testing instructions

Code review only.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
