### PR TITLE
fix: testing instructions dark theme support

### DIFF
--- a/changelog/fix-testing-instructions-dark-theme-support
+++ b/changelog/fix-testing-instructions-dark-theme-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: testing instructions dark theme support

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -90,6 +90,7 @@ const PaymentElements = ( { api, ...props } ) => {
 					errorMessage={ errorMessage }
 					fingerprint={ fingerprint }
 					onLoadError={ setPaymentProcessorLoadErrorMessage }
+					theme={ appearance?.theme }
 					{ ...props }
 				/>
 			</Elements>

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -12,6 +12,7 @@ import {
 } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -64,6 +65,7 @@ const PaymentProcessor = ( {
 	shouldSavePayment,
 	fingerprint,
 	onLoadError = noop,
+	theme,
 } ) => {
 	const stripe = useStripe();
 	const elements = useElements();
@@ -267,7 +269,9 @@ const PaymentProcessor = ( {
 		<>
 			{ isTestMode && (
 				<p
-					className="content"
+					className={ classNames( 'content', {
+						[ `theme--${ theme }` ]: theme,
+					} ) }
 					dangerouslySetInnerHTML={ {
 						__html: testingInstructions,
 					} }

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -214,13 +214,20 @@ async function createStripePaymentElement(
 ) {
 	const amount = Number( getUPEConfig( 'cartTotal' ) );
 	const paymentMethodTypes = getPaymentMethodTypes( paymentMethodType );
+	const appearance = await initializeAppearance( api, elementsLocation );
+	document
+		.querySelector(
+			`.wcpay-upe-element[data-payment-method-type="${ paymentMethodType }"]`
+		)
+		?.closest( '.wc_payment_method' )
+		?.classList.add( `theme--${ appearance.theme || 'stripe' }` );
 	const options = {
 		mode: amount < 1 ? 'setup' : 'payment',
 		currency: getUPEConfig( 'currency' ).toLowerCase(),
 		amount: amount,
 		paymentMethodCreation: 'manual',
 		paymentMethodTypes: paymentMethodTypes,
-		appearance: await initializeAppearance( api, elementsLocation ),
+		appearance,
 		fonts: getFontRulesFromPage(),
 	};
 

--- a/client/checkout/style.scss
+++ b/client/checkout/style.scss
@@ -7,7 +7,8 @@
 	vertical-align: middle;
 	border-radius: 0;
 	border: none !important;
-	background-color: transparent;
+	// some themes might override the color on all `button`s - whose selector has higher specificity and our class selector.
+	background-color: transparent !important;
 	padding: 3px;
 
 	i {

--- a/client/checkout/style.scss
+++ b/client/checkout/style.scss
@@ -26,4 +26,10 @@
 	&:active i {
 		transform: scale( 0.9 );
 	}
+
+	.theme--night & {
+		i {
+			filter: invert( 100% ) hue-rotate( 180deg );
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9399

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding dark theme support for the testing instructions.
Otherwise the "copy" icon look very legible with a dark theme.

Before:
<img width="819" alt="Screenshot 2024-08-21 at 10 30 19 AM" src="https://github.com/user-attachments/assets/2d3e32eb-f476-44ef-98d4-16190ac00e3f">

After:
<img width="804" alt="Screenshot 2024-08-21 at 9 58 21 AM" src="https://github.com/user-attachments/assets/fade69bb-4773-4147-8e1f-03a8c00c6ecc">

I also tested it with a few variations, on both shortcode and blocks checkout:

<img width="1036" alt="Screenshot 2024-08-21 at 10 26 45 AM" src="https://github.com/user-attachments/assets/04c02e44-ff96-47ad-b68d-03cf9d4cbcf0">
<img width="811" alt="Screenshot 2024-08-21 at 10 00 31 AM" src="https://github.com/user-attachments/assets/30080eff-f39c-418d-b926-4198245a896c">
<img width="802" alt="Screenshot 2024-08-21 at 10 00 16 AM" src="https://github.com/user-attachments/assets/dcd27270-8193-4879-9cde-5a593d6e1de3">
<img width="806" alt="Screenshot 2024-08-21 at 9 59 10 AM" src="https://github.com/user-attachments/assets/24fcd7b2-8feb-4cc8-8192-08a2417a2860">
<img width="668" alt="Screenshot 2024-08-21 at 9 58 48 AM" src="https://github.com/user-attachments/assets/a19d4c83-5de8-4816-b3ed-eb937680aecf">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I used the Twenty-Twenty-Four theme, which allows to switch between different color palettes.
- Use the TT4 theme
- Comment out these lines, so that the transients are constantly refreshed as you switch color pallettes: https://github.com/Automattic/woocommerce-payments/blob/cd0e4b3c030781fbfd51f5848e5007065349a645/includes/class-wc-payments-checkout.php#L227-L237
- Go to the theme's customizer, to change color palettes: https://wcpay.test/wp-admin/site-editor.php?path=%2Fwp_global_styles
- Go to checkout (both shortcode and blocks)
- The copy icon should be slightly more legible when changing theme colors

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
