### PR TITLE
Remove obsolete ApplePay wp-admin notice for test accounts.

### DIFF
--- a/changelog/fix-remove-apple-pay-admin-notice-for-live-account
+++ b/changelog/fix-remove-apple-pay-admin-notice-for-live-account
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove obsolete ApplePay warning on wp-admin for test sites.

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -95,7 +95,6 @@ class WC_Payments_Apple_Pay_Registration {
 		add_action( 'parse_request', [ $this, 'parse_domain_association_request' ], 10, 1 );
 
 		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_error_notice' ] );
-		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_live_account_notice' ] );
 		add_action( 'add_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_new_settings' ], 10, 2 );
 		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_updated_settings' ], 10, 2 );
 	}
@@ -351,30 +350,6 @@ class WC_Payments_Apple_Pay_Registration {
 		if ( ! $this->was_enabled( $prev_settings ) ) {
 			$this->verify_domain_if_configured();
 		}
-	}
-
-	/**
-	 * Display warning notice explaining that the domain can't be registered without a live account.
-	 */
-	public function display_live_account_notice() {
-		if ( ! $this->is_enabled() || $this->account->get_is_live() ) {
-			return;
-		}
-
-		?>
-		<div class="notice notice-warning apple-pay-message">
-			<p>
-				<strong><?php echo esc_html( 'Apple Pay:' ); ?></strong>
-				<?php
-					printf(
-						/* translators: %s: WooPayments */
-						esc_html__( 'Express checkouts are enabled. To use Apple Pay, please use a live %s account.', 'woocommerce-payments' ),
-						'WooPayments'
-					);
-				?>
-			</p>
-		</div>
-		<?php
 	}
 
 	/**


### PR DESCRIPTION
Fixed #9323 

#### Changes proposed in this Pull Request

Removes the Apple Pay wp-admin notice (`Express checkouts are enabled. To use Apple Pay, please use a live...`) for test accounts. With the implementation of ECE, Apple Pay is now supported in test mode.

#### Testing instructions

Connect WooPayments in test mode and verify that the warning message is no longer visible in the wp-admin:

`Express checkouts are enabled. To use Apple Pay, please use a live...`

![image](https://github.com/user-attachments/assets/45fa927c-3188-42eb-b3f1-4b5ec0578a1f)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
