### PR TITLE
Support merchant site styles for WooPay when initializing through classic checkout

### DIFF
--- a/changelog/fix-woopay-theme-support-from-classic-checkout
+++ b/changelog/fix-woopay-theme-support-from-classic-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix support for merchant site styling when initializing WooPay via classic checkout

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -123,6 +123,27 @@ export const appearanceSelectors = {
 		buttonSelectors: [ '.wc-block-cart__submit-button' ],
 		linkSelectors: [ 'a' ],
 	},
+	wooPayClassicCheckout: {
+		appendTarget: '.woocommerce-billing-fields__field-wrapper',
+		upeThemeInputSelector: '#billing_first_name',
+		upeThemeLabelSelector: '.woocommerce-checkout .form-row label',
+		rowElement: 'p',
+		validClasses: [ 'form-row' ],
+		invalidClasses: [
+			'form-row',
+			'woocommerce-invalid',
+			'woocommerce-invalid-required-field',
+		],
+		backgroundSelectors: [
+			'#customer_details',
+			'#order_review',
+			'form.checkout',
+			'body',
+		],
+		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
+		buttonSelectors: [ '#place_order' ],
+		linkSelectors: [ 'a' ],
+	},
 
 	/**
 	 * Update selectors to use alternate if not present on DOM.
@@ -174,6 +195,9 @@ export const appearanceSelectors = {
 				break;
 			case 'bnpl_cart_block':
 				appearanceSelector = this.bnplCartBlock;
+				break;
+			case 'woopay_shortcode_checkout':
+				appearanceSelector = this.wooPayClassicCheckout;
 				break;
 		}
 

--- a/client/checkout/utils/index.js
+++ b/client/checkout/utils/index.js
@@ -20,7 +20,7 @@ export const getAppearanceType = () => {
 	}
 
 	if ( document.querySelector( '.woocommerce-billing-fields' ) ) {
-		return 'shortcode_checkout';
+		return 'woopay_shortcode_checkout';
 	}
 
 	if ( document.querySelector( '.wp-block-woocommerce-cart' ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2835

#### Changes proposed in this Pull Request

Introduce custom selectors, so that WooPay prioritizes background styles from the customer details section instead of the payment form. This is because the payment form on classic checkout has different background colors which differs from the rest of the page.

Before
![CleanShot 2024-08-22 at 10 36 48](https://github.com/user-attachments/assets/671d7d27-4d7c-431b-a6a6-2c43b50f69a2)

After
![CleanShot 2024-08-22 at 10 32 48](https://github.com/user-attachments/assets/eb2cbead-8c6c-48bc-8e30-22fb17c42d8e)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to WooPay admin -> WCPay Dev and enable the `WooPay global theme support` feature flag
2. Make the merchant's classic checkout page background color different than the payment method section background color
3. As a shopper, add a product to the cart.
4. Go to classic checkout page.
5. Click on the WooPay express button.
6. Once on the WooPay checkout page, make sure the page background matches the merchant site's classic checkout page.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.