### PR TITLE
Apply some fixes in the e2e tests scripts

### DIFF
--- a/changelog/dev-fix-e2e-scripts
+++ b/changelog/dev-fix-e2e-scripts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix some aspects of the e2e tests scripts.
+
+

--- a/tests/e2e-pw/README.md
+++ b/tests/e2e-pw/README.md
@@ -9,6 +9,9 @@ See [tests/e2e/README.md](/tests/e2e/README.md) for detailed e2e environment set
 1. `npm run test:e2e-setup`
 1. `npm run test:e2e-up`
 
+> [!TIP]
+> In case some tests fail due to the lack of `data-test-id` attributes, you'll need to run `npm start` or `NODE_ENV=test npm run build:client` to re-build the assets.
+
 ## Running Playwright e2e tests
 
 -   `npm run test:e2e-pw` headless run from within a linux docker container.

--- a/tests/e2e/env/down.sh
+++ b/tests/e2e/env/down.sh
@@ -15,3 +15,8 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	step "Stopping server containers"
 	docker compose -f $E2E_ROOT/deps/wcp-server/docker-compose.yml down
 fi
+
+# Remove auth credentials from the Playwright config.
+# This must be kept when we fully migrate.
+step "Removing Playwright auth credentials"
+rm -rf "$E2E_ROOT/../e2e-pw/.auth"

--- a/tests/e2e/env/up.sh
+++ b/tests/e2e/env/up.sh
@@ -9,9 +9,9 @@ if [[ -f "$E2E_ROOT/config/local.env" ]]; then
 fi
 
 step "Starting client containers"
-docker compose -f "$E2E_ROOT/env/docker-compose.yml" start
+docker compose -f "$E2E_ROOT/env/docker-compose.yml" up -d
 
 if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	step "Starting server containers"
-	docker compose -f "$E2E_ROOT/deps/wcp-server/docker-compose.yml" start
+	docker compose -f "$E2E_ROOT/deps/wcp-server/docker-compose.yml" up -d
 fi


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After working on some e2e tests tasks I noticed some gaps and this PR addresses them to make working with e2e tests a better experience. This PR does the following:

- Adds a tip in the README about a potential issue that we can run when have the assets built for a different environment.
- Makes sure the Playwright credentials are removed if the environment is gone.
    - The context behind this change is that when we reset the environment and the credentials have been set up within 3 hours. The tests will fail because the new environment doesn't have the same cookies.
- Fixes the `up` script that wasn't working if we got the containers down.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**

1. Make sure you have the e2e environment setup before running the tests: `npm run test:e2e-setup`.
2. If you need to set it up from scratch, see [the README](https://github.com/Automattic/woocommerce-payments/blob/d89175a31643899e3abd8305e39ccefef899a5fd/tests/e2e/README.md).

**Confirm bug  # 1: `up` script doesn't work as expected**

1. On `develop`, run `npm run test:e2e-down`.
2. Try to bring the containers up: `npm run test:e2e-up`.
3. You should see an error: `service "db" has no container to start`.

**Confirm bug # 2: Invalid Playwright credentials makes all tests fail**

1. Delete the `tests/e2e-pw/.auth` folder.
2. Run the tests: `npm run test:e2e-pw`. All tests should pass.
3. Reset the environment: `npm run test:e2e-reset`.
4. Set up the environment again: `npm run test:e2e-setup`.
5. Run the tests: `npm run test:e2e-pw`. All tests should fail.

**Regression test: Ensure the Playwright e2e tests still work as expected**

1. Switch to this branch and reset the e2e environment.
6. Run the tests: `npm run test:e2e-pw`. All tests should pass.
7. Bring the containers down: `npm run test:e2e-down`.
8. Bring the containers up: `npm run test:e2e-up`. By running this step, we're already ensuring the `up` script is working as expected.
9. Run the tests again: `npm run test:e2e-pw`. All tests should pass.

> [!NOTE]
> The [`reset` script](https://github.com/Automattic/woocommerce-payments/blob/4b5b81c54401fd44289f570928ae2fd984377d60/package.json#L36) already benefits from the change in the `down` script because it runs the `down` as part of the reset.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
