### PR TITLE
Make correction to changelog entry for Docker compose v2 improvement (`Fix` → `Dev`)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,6 @@
 * Fix - Fix uncaught error on the block based Cart page when WooPayments is disabled.
 * Fix - Fix WooPay checkboxes while signed in.
 * Fix - If a payment method fails to be created in the frontend during checkout, forward the errors to the server so it can be recorded in an order.
-* Fix - Migrate to Docker Compose V2 for test runner environment setup scripts
 * Fix - Reverts changes related to Direct Checkout that broke the PayPal extension.
 * Fix - Translate hardcoded strings on the Connect page
 * Update - refactor: separate BNPL methods from settings list
@@ -32,6 +31,7 @@
 * Dev - Match the Node version in nvm with the minimum version in package.json.
 * Dev - Remove unnecessary console.warn statements added in #9121.
 * Dev - Update bundle size checker workflow to support node v20
+* Dev - Migrate to Docker Compose V2 for test runner environment setup scripts
 
 = 8.0.2 - 2024-08-07 =
 * Fix - Add opt-in checks to prevent blocking customers using other payment methods.

--- a/changelog/dev-correct-docker-compose-v2-changelog-entry
+++ b/changelog/dev-correct-docker-compose-v2-changelog-entry
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Placeholder changelog entry - making a correction to previous changelog entry 'Fix - Migrate to Docker Compose V2 for test runner environment setup scripts'
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -114,7 +114,6 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fix uncaught error on the block based Cart page when WooPayments is disabled.
 * Fix - Fix WooPay checkboxes while signed in.
 * Fix - If a payment method fails to be created in the frontend during checkout, forward the errors to the server so it can be recorded in an order.
-* Fix - Migrate to Docker Compose V2 for test runner environment setup scripts
 * Fix - Reverts changes related to Direct Checkout that broke the PayPal extension.
 * Fix - Translate hardcoded strings on the Connect page
 * Update - refactor: separate BNPL methods from settings list
@@ -126,6 +125,7 @@ Please note that our support for the checkout block is still experimental and th
 * Dev - Match the Node version in nvm with the minimum version in package.json.
 * Dev - Remove unnecessary console.warn statements added in #9121.
 * Dev - Update bundle size checker workflow to support node v20
+* Dev - Migrate to Docker Compose V2 for test runner environment setup scripts
 
 = 8.0.2 - 2024-08-07 =
 * Fix - Add opt-in checks to prevent blocking customers using other payment methods.


### PR DESCRIPTION
Fixes #9366

Part of #9205

#### Changes proposed in this Pull Request

This is a small PR that corrects the changelog entry category for the Docker compose v2 change, introduced in #9212. This was marked as a `Fix` in the changelog, where it should be a `Dev` change categorisation.


```diff
-Fix - Migrate to Docker Compose V2 for test runner environment setup scripts
+Dev - Migrate to Docker Compose V2 for test runner environment setup scripts
```

As discussed in P2 paJDYF-euh-p2#comment-26010.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Look at code/changelog text change and ensure the category is `Dev`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A**
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : **N/A**
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **N/A**
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. **N/A**