### PR TITLE
Change WooPay session route namespace

### DIFF
--- a/changelog/fix-woopay-direct-checkout-route-namespace
+++ b/changelog/fix-woopay-direct-checkout-route-namespace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay direct checkout.

--- a/includes/admin/class-wc-rest-woopay-session-controller.php
+++ b/includes/admin/class-wc-rest-woopay-session-controller.php
@@ -21,7 +21,7 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v3';
+	protected $namespace = 'wc/store';
 
 	/**
 	 * Endpoint path.

--- a/includes/admin/class-wc-rest-woopay-session-controller.php
+++ b/includes/admin/class-wc-rest-woopay-session-controller.php
@@ -21,14 +21,14 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/store';
+	protected $namespace = 'wc/woopay';
 
 	/**
 	 * Endpoint path.
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'woopay/session';
+	protected $rest_base = 'session';
 
 	/**
 	 * Configure REST API routes.

--- a/includes/admin/class-wc-rest-woopay-session-controller.php
+++ b/includes/admin/class-wc-rest-woopay-session-controller.php
@@ -21,7 +21,7 @@ class WC_REST_WooPay_Session_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/woopay';
+	protected $namespace = 'payments/woopay';
 
 	/**
 	 * Endpoint path.

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -703,7 +703,7 @@ class WooPay_Session {
 	 * @param string $rest_route  The REST route being checked.
 	 */
 	public static function ensure_woopay_route_namespace_is_loaded( $should_load, $ns, $rest_route ) {
-		if ( str_starts_with( $rest_route, 'wc/v3/woopay/session' ) ) {
+		if ( str_starts_with( $rest_route, 'wc/store/woopay' ) ) {
 			return true;
 		}
 

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -47,13 +47,6 @@ class WooPay_Session {
 		register_deactivation_hook( WCPAY_PLUGIN_FILE, [ __CLASS__, 'run_and_remove_woopay_restore_order_customer_id_schedules' ] );
 
 		add_filter( 'automatewoo/referrals/referred_order_advocate', [ __CLASS__, 'automatewoo_refer_a_friend_referral_from_parameter' ] );
-
-		add_filter(
-			'wc_rest_should_load_namespace',
-			[ __CLASS__, 'ensure_woopay_route_namespace_is_loaded' ],
-			10,
-			3
-		);
 	}
 
 	/**
@@ -693,21 +686,6 @@ class WooPay_Session {
 		];
 
 		return WooPay_Utilities::encrypt_and_sign_data( $data );
-	}
-
-	/**
-	 * Ensure the WooPay session route namespace is loaded.
-	 *
-	 * @param bool   $should_load True if the namespace should be loaded, false otherwise.
-	 * @param string $ns          The namespace to check.
-	 * @param string $rest_route  The REST route being checked.
-	 */
-	public static function ensure_woopay_route_namespace_is_loaded( $should_load, $ns, $rest_route ) {
-		if ( str_starts_with( $rest_route, 'wc/store/woopay' ) ) {
-			return true;
-		}
-
-		return $should_load;
 	}
 
 	/**

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -47,6 +47,13 @@ class WooPay_Session {
 		register_deactivation_hook( WCPAY_PLUGIN_FILE, [ __CLASS__, 'run_and_remove_woopay_restore_order_customer_id_schedules' ] );
 
 		add_filter( 'automatewoo/referrals/referred_order_advocate', [ __CLASS__, 'automatewoo_refer_a_friend_referral_from_parameter' ] );
+
+		add_filter(
+			'wc_rest_should_load_namespace',
+			[ __CLASS__, 'ensure_woopay_route_namespace_is_loaded' ],
+			10,
+			3
+		);
 	}
 
 	/**
@@ -686,6 +693,21 @@ class WooPay_Session {
 		];
 
 		return WooPay_Utilities::encrypt_and_sign_data( $data );
+	}
+
+	/**
+	 * Ensure the WooPay session route namespace is loaded.
+	 *
+	 * @param bool   $should_load True if the namespace should be loaded, false otherwise.
+	 * @param string $ns          The namespace to check.
+	 * @param string $rest_route  The REST route being checked.
+	 */
+	public static function ensure_woopay_route_namespace_is_loaded( $should_load, $ns, $rest_route ) {
+		if ( str_starts_with( $rest_route, 'wc/v3/woopay/session' ) ) {
+			return true;
+		}
+
+		return $should_load;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9313

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
On https://github.com/woocommerce/woocommerce/pull/47704 introduced on WooCommerce 9.2 we are limiting loading some Store API routes only when the current route is from the `wc/store` route namespace, this made the WooPay session route stop working because it's loaded from the `wc/v3` namespace.

This PR fixes that by changing the WooPay session route namespace to `wc/store`.

This PR needs to be tested alongside https://github.com/Automattic/woopay/pull/2892.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Replace `WCPAY_VERSION_NUMBER` [here](https://github.com/Automattic/woocommerce-payments/blob/7713ed2708a6777c683c0d41fce0ff8b8c3c1504/includes/woopay/class-woopay-session.php#L469) and [here](https://github.com/Automattic/woocommerce-payments/blob/7713ed2708a6777c683c0d41fce0ff8b8c3c1504/includes/woopay/class-woopay-session.php#L680) with `8.2.0`.
* Follow https://github.com/Automattic/woocommerce-payments/issues/9313 reproduce instructions.
* Direct checkout should work as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
