### PR TITLE
Hot Fix Payments > Settings test mode disable with test drive account 

### DIFF
--- a/changelog/fix-9296-payments-settings-test-mode-disable-with-test-drive-account
+++ b/changelog/fix-9296-payments-settings-test-mode-disable-with-test-drive-account
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed sandbox mode accounts being able to disable test mode for the payment gateway settings.

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -12,7 +12,7 @@ import strings from './strings';
 import './styles.scss';
 import ResetAccountModal from 'wcpay/overview/modal/reset-account';
 import { trackAccountReset } from 'wcpay/onboarding/tracking';
-import { isInDevMode } from 'wcpay/utils';
+import { isInTestModeOnboarding } from 'wcpay/utils';
 
 interface Props {
 	openModal: () => void;
@@ -30,8 +30,8 @@ const handleReset = () => {
 export const AccountTools: React.FC< Props > = () => {
 	const [ modalVisible, setModalVisible ] = useState( false );
 
-	// Only render when in dev/sandbox mode.
-	if ( ! isInDevMode() ) {
+	// Only render when in test/sandbox mode onboarding.
+	if ( ! isInTestModeOnboarding() ) {
 		return null;
 	}
 

--- a/client/components/account-status/account-tools/strings.tsx
+++ b/client/components/account-status/account-tools/strings.tsx
@@ -7,11 +7,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { isInDevMode } from 'utils';
+import { isInTestModeOnboarding } from 'utils';
 
 export default {
 	title: __( 'Account Tools', 'woocommerce-payments' ),
-	description: isInDevMode()
+	description: isInTestModeOnboarding()
 		? __(
 				'Your account is in sandbox mode. If you are experiencing problems completing account setup, or wish to test with a different email/country associated with your account, you can reset your account and start from the beginning.',
 				'woocommerce-payments'

--- a/client/components/account-status/account-tools/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-status/account-tools/test/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AccountTools should NOT render in live mode 1`] = `<div />`;
 
-exports[`AccountTools should render in sandbox mode 1`] = `
+exports[`AccountTools should render in test/sandbox mode onboarding 1`] = `
 <div>
   <div
     class="account-tools"

--- a/client/components/account-status/account-tools/test/index.test.tsx
+++ b/client/components/account-status/account-tools/test/index.test.tsx
@@ -14,14 +14,14 @@ const openModal = jest.fn();
 
 declare const global: {
 	wcpaySettings: {
-		devMode: boolean;
+		testModeOnboarding: boolean;
 	};
 };
 
 describe( 'AccountTools', () => {
 	it( 'should NOT render in live mode', () => {
 		global.wcpaySettings = {
-			devMode: false,
+			testModeOnboarding: false,
 		};
 
 		const { container } = render(
@@ -31,9 +31,9 @@ describe( 'AccountTools', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should render in sandbox mode', () => {
+	it( 'should render in test/sandbox mode onboarding', () => {
 		global.wcpaySettings = {
-			devMode: true,
+			testModeOnboarding: true,
 		};
 
 		const { container } = render(

--- a/client/components/account-status/test/index.js
+++ b/client/components/account-status/test/index.js
@@ -122,7 +122,7 @@ describe( 'AccountStatus', () => {
 	} );
 
 	test( 'renders account tools', () => {
-		global.wcpaySettings.devMode = true;
+		global.wcpaySettings.testModeOnboarding = true;
 
 		const { container: accountStatus } = renderAccountStatus(
 			{

--- a/client/components/test-mode-notice/index.tsx
+++ b/client/components/test-mode-notice/index.tsx
@@ -26,7 +26,7 @@ interface Props {
 	currentPage: CurrentPage;
 	actions?: React.ComponentProps< typeof BannerNotice >[ 'actions' ];
 	isDetailsView?: boolean;
-	isOnboardingTestMode?: boolean;
+	isTestModeOnboarding?: boolean;
 }
 
 const nounToUse = {
@@ -50,11 +50,11 @@ const verbToUse = {
 const getNoticeContent = (
 	currentPage: CurrentPage,
 	isDetailsView: boolean,
-	isOnboardingTestMode: boolean
+	isTestModeOnboarding: boolean
 ): JSX.Element => {
 	switch ( currentPage ) {
 		case 'overview':
-			return isOnboardingTestMode ? (
+			return isTestModeOnboarding ? (
 				<>
 					{ interpolateComponents( {
 						mixedString: sprintf(
@@ -163,7 +163,7 @@ export const TestModeNotice: React.FC< Props > = ( {
 	currentPage,
 	actions,
 	isDetailsView = false,
-	isOnboardingTestMode = false,
+	isTestModeOnboarding = false,
 } ) => {
 	if ( ! isInTestMode() ) return null;
 
@@ -176,7 +176,7 @@ export const TestModeNotice: React.FC< Props > = ( {
 			{ getNoticeContent(
 				currentPage,
 				isDetailsView,
-				isOnboardingTestMode
+				isTestModeOnboarding
 			) }
 		</BannerNotice>
 	);

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -33,7 +33,7 @@ import InlineNotice from 'components/inline-notice';
 import { WooPaymentMethodsLogos } from 'components/payment-method-logos';
 import WooPaymentsLogo from 'assets/images/logo.svg?asset';
 import { sanitizeHTML } from 'wcpay/utils/sanitize';
-import { isInDevMode } from 'wcpay/utils';
+import { isInTestModeOnboarding } from 'wcpay/utils';
 import ResetAccountModal from 'wcpay/overview/modal/reset-account';
 import { trackAccountReset } from 'wcpay/onboarding/tracking';
 import SandboxModeSwitchToLiveNotice from 'wcpay/components/sandbox-mode-switch-to-live-notice';
@@ -96,8 +96,7 @@ const ConnectAccountPage: React.FC = () => {
 	const {
 		connectUrl,
 		connect: { availableCountries, country },
-		devMode,
-		onboardingTestMode,
+		testModeOnboarding,
 		isJetpackConnected,
 		isAccountConnected,
 		isAccountValid,
@@ -467,7 +466,7 @@ const ConnectAccountPage: React.FC = () => {
 					) }
 					{
 						// Show general sandbox notice when no account is connected but sandbox mode is active.
-						! isAccountConnected && devMode ? (
+						! isAccountConnected && testModeOnboarding ? (
 							<SandboxModeNotice />
 						) : (
 							// If we already have a sandbox account connected (but in an invalid state) and
@@ -475,7 +474,7 @@ const ConnectAccountPage: React.FC = () => {
 							// show the switch to live sandbox notice.
 							isAccountConnected &&
 							! isAccountValid &&
-							onboardingTestMode &&
+							testModeOnboarding &&
 							isJetpackConnected && (
 								<SandboxModeSwitchToLiveNotice
 									from="WCPAY_CONNECT"
@@ -551,7 +550,7 @@ const ConnectAccountPage: React.FC = () => {
 								isAccountConnected &&
 									( ! wcpaySettings.accountStatus
 										.detailsSubmitted ||
-										isInDevMode() ) && (
+										isInTestModeOnboarding() ) && (
 										<Button
 											variant={ 'tertiary' }
 											onClick={ () =>

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -85,6 +85,12 @@ export const useTestMode = () => {
 	return [ isTestModeEnabled, updateIsTestModeEnabled ];
 };
 
+export const useTestModeOnboarding = () =>
+	useSelect(
+		( select ) => select( STORE_NAME ).getIsTestModeOnboarding(),
+		[]
+	);
+
 export const useDevMode = () =>
 	useSelect( ( select ) => select( STORE_NAME ).getIsDevModeEnabled(), [] );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -153,6 +153,10 @@ export const getIsTestModeEnabled = ( state ) => {
 	return getSettings( state ).is_test_mode_enabled || false;
 };
 
+export const getIsTestModeOnboarding = ( state ) => {
+	return getSettings( state ).is_test_mode_onboarding || false;
+};
+
 export const getIsDevModeEnabled = ( state ) => {
 	return getSettings( state ).is_dev_mode_enabled || false;
 };

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -19,6 +19,7 @@ declare global {
 		};
 		fraudServices: unknown[];
 		testMode: boolean;
+		testModeOnboarding: boolean;
 		devMode: boolean;
 		isJetpackConnected: boolean;
 		isJetpackIdcActive: boolean;
@@ -97,7 +98,6 @@ declare global {
 		accountDefaultCurrency: string;
 		isFRTReviewFeatureActive: boolean;
 		frtDiscoverBannerSettings: string;
-		onboardingTestMode: boolean;
 		onboardingFieldsData?: {
 			business_types: Country[];
 			mccs_display_tree: MccsDisplayTreeItem[];

--- a/client/overview/connection-sucess-notice.tsx
+++ b/client/overview/connection-sucess-notice.tsx
@@ -21,7 +21,7 @@ const ConnectionSuccessNotice: React.FC = () => {
 			},
 			status: accountStatus,
 		},
-		onboardingTestMode,
+		testModeOnboarding,
 	} = wcpaySettings;
 
 	const DismissMenu = () => {
@@ -41,7 +41,7 @@ const ConnectionSuccessNotice: React.FC = () => {
 		);
 	};
 	const isPoDisabledOrCompleted = ! isPoEnabled || isPoComplete;
-	return ! isDismissed && ! onboardingTestMode && isPoDisabledOrCompleted ? (
+	return ! isDismissed && ! testModeOnboarding && isPoDisabledOrCompleted ? (
 		<Card className="wcpay-connection-success">
 			<DismissMenu />
 			<img src={ ConfettiImage } alt="confetti" />

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -67,7 +67,7 @@ const OverviewPage = () => {
 		wpcomReconnectUrl,
 	} = wcpaySettings;
 
-	const isOnboardingTestMode = wcpaySettings.onboardingTestMode;
+	const isTestModeOnboarding = wcpaySettings.testModeOnboarding;
 	const { isLoading: settingsIsLoading } = useSettings();
 	const [
 		isTestDriveSuccessDisplayed,
@@ -175,7 +175,7 @@ const OverviewPage = () => {
 					) }
 				</Notice>
 			) }
-			{ isOnboardingTestMode ? (
+			{ isTestModeOnboarding ? (
 				<SandboxModeSwitchToLiveNotice
 					from="WCPAY_OVERVIEW"
 					source="wcpay-overview-page"
@@ -183,7 +183,7 @@ const OverviewPage = () => {
 			) : (
 				<TestModeNotice
 					currentPage="overview"
-					isOnboardingTestMode={ isOnboardingTestMode }
+					isTestModeOnboarding={ isTestModeOnboarding }
 					actions={ [] }
 				/>
 			) }

--- a/client/overview/modal/reset-account/strings.tsx
+++ b/client/overview/modal/reset-account/strings.tsx
@@ -7,11 +7,11 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { isInDevMode } from 'utils';
+import { isInTestModeOnboarding } from 'utils';
 
 export default {
 	title: __( 'Reset account', 'woocommerce-payments' ),
-	description: isInDevMode()
+	description: isInTestModeOnboarding()
 		? __(
 				'In sandbox mode, you can reset your account and onboard again at any time. Please note that all current WooPayments account details, test transactions, and deposits history will be lost.',
 				'woocommerce-payments'

--- a/client/overview/task-list/tasks.tsx
+++ b/client/overview/task-list/tasks.tsx
@@ -19,7 +19,7 @@ import { CachedDispute } from 'wcpay/types/disputes';
 import { TaskItemProps } from './types';
 import { getAddApmsTask } from './tasks/add-apms-task';
 import { getGoLiveTask } from './tasks/go-live-task';
-import { isInDevMode } from 'wcpay/utils';
+import { isInTestModeOnboarding } from 'wcpay/utils';
 
 // Requirements we don't want to show to the user because they are too generic/not useful. These refer to Stripe error codes.
 const requirementBlacklist = [ 'invalid_value_other' ];
@@ -88,7 +88,8 @@ export const getTasks = ( {
 		detailsSubmitted &&
 		! isPoInProgress;
 
-	const isGoLiveTaskVisible = isInDevMode( false ) && showGoLiveTask;
+	const isGoLiveTaskVisible =
+		isInTestModeOnboarding( false ) && showGoLiveTask;
 
 	return [
 		isUpdateDetailsTaskVisible &&

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -9,7 +9,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 /**
  * Internal dependencies
  */
-import { useDevMode, useTestMode } from 'wcpay/data';
+import { useTestMode, useTestModeOnboarding } from 'wcpay/data';
 import CardBody from '../card-body';
 import InlineNotice from 'wcpay/components/inline-notice';
 import SetupLivePaymentsModal from 'wcpay/components/sandbox-mode-switch-to-live-notice/modal';
@@ -20,7 +20,7 @@ import { recordEvent } from 'wcpay/tracks';
 const GeneralSettings = () => {
 	const [ isEnabled, updateIsTestModeEnabled ] = useTestMode();
 	const [ modalVisible, setModalVisible ] = useState( false );
-	const isDevModeEnabled = useDevMode();
+	const isTestModeOnboarding = useTestModeOnboarding();
 	const [ testModeModalVisible, setTestModeModalVisible ] = useState( false );
 
 	return (
@@ -28,7 +28,7 @@ const GeneralSettings = () => {
 			<Card>
 				<CardBody>
 					<EnableWooPaymentsCheckbox />
-					{ ! isDevModeEnabled && (
+					{ ! isTestModeOnboarding && (
 						<>
 							<h4>
 								{ __( 'Test mode', 'woocommerce-payments' ) }
@@ -82,7 +82,7 @@ const GeneralSettings = () => {
 							/>
 						</>
 					) }
-					{ isDevModeEnabled && (
+					{ isTestModeOnboarding && (
 						<InlineNotice
 							status="warning"
 							isDismissible={ false }

--- a/client/settings/general-settings/test/general-settings.test.js
+++ b/client/settings/general-settings/test/general-settings.test.js
@@ -7,12 +7,18 @@ import { fireEvent, render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import GeneralSettings from '..';
-import { useDevMode, useIsWCPayEnabled, useTestMode } from 'wcpay/data';
+import {
+	useDevMode,
+	useIsWCPayEnabled,
+	useTestMode,
+	useTestModeOnboarding,
+} from 'wcpay/data';
 
 jest.mock( 'wcpay/data', () => ( {
 	useDevMode: jest.fn(),
 	useIsWCPayEnabled: jest.fn(),
 	useTestMode: jest.fn(),
+	useTestModeOnboarding: jest.fn(),
 	useEnabledPaymentMethodIds: jest.fn().mockReturnValue( [ [ 'card' ] ] ),
 	useWooPayEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
 	usePaymentRequestEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
@@ -21,6 +27,7 @@ jest.mock( 'wcpay/data', () => ( {
 describe( 'GeneralSettings', () => {
 	beforeEach( () => {
 		useDevMode.mockReturnValue( false );
+		useTestModeOnboarding.mockReturnValue( false );
 		useIsWCPayEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useTestMode.mockReturnValue( [ false, jest.fn() ] );
 	} );

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -11,7 +11,7 @@ import { useState, useEffect, useRef } from 'react';
 import {
 	useAccountBusinessSupportPhone,
 	useGetSavingError,
-	useDevMode,
+	useTestModeOnboarding,
 } from 'wcpay/data';
 import PhoneNumberInput from 'wcpay/settings/phone-input';
 
@@ -23,9 +23,9 @@ const SupportPhoneInput = ( { setInputVallid } ) => {
 
 	const currentPhone = useRef( supportPhone ).current;
 	const isEmptyPhoneValid = supportPhone === '' && currentPhone === '';
-	const isDevModeEnabled = useDevMode();
+	const isTestModeOnboarding = useTestModeOnboarding();
 	const isTestPhoneValid =
-		isDevModeEnabled && supportPhone === '+10000000000';
+		isTestModeOnboarding && supportPhone === '+10000000000';
 
 	const [ isPhoneValid, setPhoneValidity ] = useState( true );
 	if ( ! isTestPhoneValid && ! isPhoneValid && ! isEmptyPhoneValid ) {
@@ -49,7 +49,7 @@ const SupportPhoneInput = ( { setInputVallid } ) => {
 	}, [ supportPhoneError, setInputVallid ] );
 
 	let labelText = __( 'Support phone number', 'woocommerce-payments' );
-	if ( isDevModeEnabled ) {
+	if ( isTestModeOnboarding ) {
 		labelText += __(
 			' (+1 0000000000 can be used in sandbox mode)',
 			'woocommerce-payments'

--- a/client/settings/support-phone-input/test/support-phone-input.test.js
+++ b/client/settings/support-phone-input/test/support-phone-input.test.js
@@ -16,7 +16,7 @@ import {
 jest.mock( 'wcpay/data', () => ( {
 	useAccountBusinessSupportPhone: jest.fn(),
 	useGetSavingError: jest.fn(),
-	useDevMode: jest.fn(),
+	useTestModeOnboarding: jest.fn(),
 } ) );
 
 describe( 'SupportPhoneInput', () => {

--- a/client/settings/support-phone-input/test/support-phone-input.test.js
+++ b/client/settings/support-phone-input/test/support-phone-input.test.js
@@ -10,7 +10,7 @@ import SupportPhoneInput from '..';
 import {
 	useGetSavingError,
 	useAccountBusinessSupportPhone,
-	useDevMode,
+	useTestModeOnboarding,
 } from 'wcpay/data';
 
 jest.mock( 'wcpay/data', () => ( {
@@ -103,7 +103,7 @@ describe( 'SupportPhoneInput', () => {
 			'+10000000000', // test phone number.
 			jest.fn(),
 		] );
-		useDevMode.mockReturnValue( true );
+		useTestModeOnboarding.mockReturnValue( true );
 
 		const { container } = render( <SupportPhoneInput /> );
 		expect(

--- a/client/settings/transactions/test/index.test.js
+++ b/client/settings/transactions/test/index.test.js
@@ -41,6 +41,7 @@ jest.mock( 'wcpay/data', () => ( {
 	useGetSavingError: jest.fn(),
 	useSavedCards: jest.fn(),
 	useDevMode: jest.fn(),
+	useTestModeOnboarding: jest.fn(),
 	useCardPresentEligible: jest.fn(),
 } ) );
 

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -43,6 +43,26 @@ export const isInTestMode = ( fallback = false ) => {
 };
 
 /**
+ * Returns true if WooPayments is in test/sandbox mode onboarding, false otherwise.
+ *
+ * @param {boolean} fallback Fallback in case test/sandbox mode onboarding value can't be found
+ * 							 (for example if the wcpaySettings are undefined).
+ *
+ * @return {boolean} True if in test/sandbox mode onboarding, false otherwise.
+ * 					 Fallback value if test/sandbox mode onboarding value can't be found.
+ */
+export const isInTestModeOnboarding = ( fallback = false ) => {
+	if (
+		! isObject( wcpaySettings ) ||
+		! wcpaySettings.hasOwnProperty( 'testModeOnboarding' )
+	) {
+		return fallback;
+	}
+
+	return !! wcpaySettings.testModeOnboarding || fallback;
+};
+
+/**
  * Returns true if WooPayments is in dev/sandbox mode, false otherwise.
  *
  * @param {boolean} fallback Fallback in case dev/sandbox mode value can't be found (for example if the wcpaySettings are undefined).

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -808,11 +808,18 @@ class WC_Payments_Admin {
 			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in test mode! Message: %s', $e->getMessage() ), 'warning' );
 		}
 
+		$test_mode_onboarding = false;
+		try {
+			$test_mode_onboarding = WC_Payments::mode()->is_test_mode_onboarding();
+		} catch ( Exception $e ) {
+			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in sandbox mode! Message: %s', $e->getMessage() ), 'warning' );
+		}
+
 		$dev_mode = false;
 		try {
 			$dev_mode = WC_Payments::mode()->is_dev();
 		} catch ( Exception $e ) {
-			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in sandbox mode! Message: %s', $e->getMessage() ), 'warning' );
+			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in dev mode! Message: %s', $e->getMessage() ), 'warning' );
 		}
 
 		$connect_url       = WC_Payments_Account::get_connect_url();
@@ -838,7 +845,7 @@ class WC_Payments_Admin {
 			'connectIncentive'                   => $connect_incentive,
 			'devMode'                            => $dev_mode,
 			'testMode'                           => $test_mode,
-			'onboardingTestMode'                 => WC_Payments_Onboarding_Service::is_test_mode_enabled(),
+			'testModeOnboarding'                 => $test_mode_onboarding,
 			// Set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
 			'onBoardingDisabled'                 => WC_Payments_Account::is_on_boarding_disabled(),
 			'onboardingFieldsData'               => $this->onboarding_service->get_fields_data( get_user_locale() ),

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -481,6 +481,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_wcpay_enabled'                       => $this->wcpay_gateway->is_enabled(),
 				'is_manual_capture_enabled'              => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
 				'is_test_mode_enabled'                   => WC_Payments::mode()->is_test(),
+				'is_test_mode_onboarding'                => WC_Payments::mode()->is_test_mode_onboarding(),
 				'is_dev_mode_enabled'                    => WC_Payments::mode()->is_dev(),
 				'is_multi_currency_enabled'              => WC_Payments_Features::is_customer_multi_currency_enabled(),
 				'is_wcpay_subscriptions_enabled'         => WC_Payments_Features::is_wcpay_subscriptions_enabled(),


### PR DESCRIPTION
Fixes #9296 

#### Changes proposed in this Pull Request

Fix Payments > Settings test mode disable with test drive account

#### Testing instructions

Note from @dmallory42: for testing this PR, I recommend launching a new JN site using https://jurassic.ninja/ and manually uploading a build of this release (rather than using the Jetpack Live Branches feature). The reason for this is that the live branches includes Dev Tools, and sets the environment of the site to development, which can affect the behaviour and mask possible issues.

1. Spin up a JN site with WooCommerce but without Dev Tools.
1. Install WooPayments from the built zip from this branch. See `npm run build:release` command.
1. Go to Payments page.
1. Click Enable sandbox mode at bottom.
1. Connect to WordPress.com
1. Wait for the test account to finish creating.
1. You'll land back in wp-admin.
1. Go to Payments > Settings.
1. Add a real phone number to get around https://github.com/Automattic/woocommerce-payments/issues/6782.
1. Save Changes.
1. Still on Payments > Settings, check that test mode can't be disabled.
1. Use the prompt on the `Settings` page to enable live mode. Go through the onboarding again, ensure that it is not in test/sandbox mode (there should be no `test` label on the Stripe KYC. 
1. After the onboarding, you should be taken to the Overview page with a fully onboarded account. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
