### PR TITLE
Move WooPay global theme checkbox to the appearance section

### DIFF
--- a/changelog/fix-move-woopay-theme-checkbox
+++ b/changelog/fix-move-woopay-theme-checkbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move woopay theme support checkbox to the appearance section.

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -7,7 +7,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
-	CheckboxControl,
 	SelectControl,
 	RadioControl,
 	RangeControl,
@@ -32,7 +31,6 @@ import {
 	usePaymentRequestButtonBorderRadius,
 	usePaymentRequestEnabledSettings,
 	useWooPayEnabledSettings,
-	useWooPayGlobalThemeSupportEnabledSettings,
 } from 'wcpay/data';
 
 const makeButtonSizeText = ( string ) =>
@@ -167,11 +165,6 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 		isPaymentRequestEnabled &&
 		isWooPayFeatureFlagEnabled;
 
-	const [
-		isWooPayGlobalThemeSupportEnabled,
-		updateIsWooPayGlobalThemeSupportEnabled,
-	] = useWooPayGlobalThemeSupportEnabledSettings();
-
 	return (
 		<CardBody>
 			{ showWarning && (
@@ -267,30 +260,6 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 					</p>
 				</>
 			) }
-			{ wcpaySettings.isWooPayGlobalThemeSupportEligible &&
-				type === 'woopay' && (
-					<>
-						<h4>
-							{ __(
-								'WooPay Global Theme Support',
-								'woocommerce-payments'
-							) }
-						</h4>
-						<div className="test">
-							<CheckboxControl
-								disabled={ ! isWooPayEnabled }
-								checked={ isWooPayGlobalThemeSupportEnabled }
-								onChange={
-									updateIsWooPayGlobalThemeSupportEnabled
-								}
-								label={ __(
-									'Enable WooPay Global Theme Support',
-									'woocommerce-payments'
-								) }
-							/>
-						</div>
-					</>
-				) }
 			<h4>{ __( 'Preview', 'woocommerce-payments' ) }</h4>
 			<div className="payment-method-settings__option-help-text">
 				{ __(

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -31,9 +31,6 @@ jest.mock( '../../../data', () => ( {
 	useWooPayEnabledSettings: jest.fn(),
 	useExpressCheckoutShowIncompatibilityNotice: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
-	useWooPayGlobalThemeSupportEnabledSettings: jest
-		.fn()
-		.mockReturnValue( [ false, jest.fn() ] ),
 } ) );
 
 jest.mock( '../payment-request-button-preview' );

--- a/client/settings/express-checkout-settings/test/woopay-settings.test.js
+++ b/client/settings/express-checkout-settings/test/woopay-settings.test.js
@@ -30,6 +30,9 @@ jest.mock( '../../../data', () => ( {
 	usePaymentRequestButtonTheme: jest.fn(),
 	useWooPayLocations: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
+	useWooPayGlobalThemeSupportEnabledSettings: jest
+		.fn()
+		.mockReturnValue( [ false, jest.fn() ] ),
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -26,6 +26,7 @@ import {
 	useWooPayStoreLogo,
 	useWooPayLocations,
 	useWooPayShowIncompatibilityNotice,
+	useWooPayGlobalThemeSupportEnabledSettings,
 } from 'wcpay/data';
 import GeneralPaymentRequestButtonSettings from './general-payment-request-button-settings';
 import { WooPayIncompatibilityNotice } from '../settings-warnings/incompatibility-notice';
@@ -40,6 +41,11 @@ const WooPaySettings = ( { section } ) => {
 		woopayCustomMessage,
 		setWooPayCustomMessage,
 	] = useWooPayCustomMessage();
+
+	const [
+		isWooPayGlobalThemeSupportEnabled,
+		updateIsWooPayGlobalThemeSupportEnabled,
+	] = useWooPayGlobalThemeSupportEnabledSettings();
 
 	const [ woopayStoreLogo, setWooPayStoreLogo ] = useWooPayStoreLogo();
 
@@ -203,6 +209,31 @@ const WooPaySettings = ( { section } ) => {
 							updateFileID={ setWooPayStoreLogo }
 						/>
 					</div>
+					{ wcpaySettings.isWooPayGlobalThemeSupportEligible && (
+						<div className="woopay-global-theme-support">
+							<h4>
+								{ __(
+									'WooPay Global Theme Support',
+									'woocommerce-payments'
+								) }
+							</h4>
+							<div className="woopay-settings__global-theme-checkbox">
+								<CheckboxControl
+									disabled={ ! isWooPayEnabled }
+									checked={
+										isWooPayGlobalThemeSupportEnabled
+									}
+									onChange={
+										updateIsWooPayGlobalThemeSupportEnabled
+									}
+									label={ __(
+										'Enable WooPay Global Theme Support',
+										'woocommerce-payments'
+									) }
+								/>
+							</div>
+						</div>
+					) }
 					<div className="woopay-settings__custom-message-wrapper">
 						<h4>
 							{ __(


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/2887

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This PR moves the position of the WooPay global theme support checkbox to the appearance section, which was previously under the Settings section.

![CleanShot 2024-08-23 at 10 22 58](https://github.com/user-attachments/assets/25843bda-d34c-4e80-824e-61348f8e941e)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. As a merchant, go to Payments -> Settings -> WooPay -> Click Customize button.
2. WooPay global theme support checkbox should appear in the Appearance section instead of the Settings section.
3. Toggle the checkbox and save, the setting should persist on page refresh.
4. Go to Payments -> Settings -> Apple Pay / Google Pay -> Click Customize button.
5. The checkbox should not appear.
6. Go through WooPay checkout. WooPay checkout page theme should match the state of the setting.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
