### PR TITLE
Fix logic to retrieve initial shipping rates for ECE on shortcode cart and checkout pages

### DIFF
--- a/changelog/fix-ece-shortcode-get-shipping-rates
+++ b/changelog/fix-ece-shortcode-get-shipping-rates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping rates retrieval method for shortcode cart/checkout.

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -210,10 +210,7 @@ jQuery( ( $ ) => {
 				}
 
 				return options.displayItems
-					.filter(
-						( i ) =>
-							i.label === __( 'Shipping', 'woocommerce-payments' )
-					)
+					.filter( ( i ) => i.key === 'total_shipping' )
 					.map( ( i ) => ( {
 						id: `rate-${ i.label }`,
 						amount: i.amount,
@@ -228,7 +225,7 @@ jQuery( ( $ ) => {
 			// Relying on what's provided in the cart response seems safest since it should always include a valid shipping
 			// rate if one is required and available.
 			// If no shipping rate is found we can't render the button so we just exit.
-			if ( options.requestShipping && ! shippingRates ) {
+			if ( options.requestShipping && ! shippingRates.length ) {
 				return;
 			}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -117,6 +117,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		if ( WC()->cart->needs_shipping() ) {
 			$shipping_tax = $this->cart_prices_include_tax() ? WC()->cart->shipping_tax_total : 0;
 			$items[]      = [
+				'key'    => 'total_shipping',
 				'label'  => esc_html( __( 'Shipping', 'woocommerce-payments' ) ),
 				'amount' => WC_Payments_Utils::prepare_amount( $shipping + $shipping_tax, $currency ),
 			];

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -430,6 +430,7 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 			[
 				'label'  => 'Shipping',
 				'amount' => $flat_rate['amount'],
+				'key'    => 'total_shipping',
 			],
 		];
 


### PR DESCRIPTION
Fixes p1724340668758779-slack-C7U3Y3VMY
Fixes #9368 

#### Changes proposed in this Pull Request

Updated the logic to retrieve the shipping cost for ECE. Previously, it was based on the translated string for "Shipping," but now it uses the key `total_shipping` to ensure consistency across translations.

#### Testing instructions

1. Test Express Checkout payments on the product page, shortcode cart, and shortcode checkout where shipping is required.
2. Verify that the payment sheet for Express Checkout methods accurately reflects the shipping options available on the cart page, including the names and respective amounts of the shipping options.
3. Ensure there are no console errors related to Express Checkout during the payment processing.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.