### PR TITLE
Fix broken Express Checkout buttons when size is set to "Large"

### DIFF
--- a/changelog/as-fix-max-height-allowed
+++ b/changelog/as-fix-max-height-allowed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure 55px is the maximum height for Apple Pay button.

--- a/client/express-checkout/blocks/components/express-checkout-component.js
+++ b/client/express-checkout/blocks/components/express-checkout-component.js
@@ -40,10 +40,11 @@ const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
 	// Apple Pay has a nearly imperceptible height difference. We increase it by 1px here.
 	if ( buttonOptions.buttonTheme.applePay === 'black' ) {
 		if ( expressPaymentMethod === 'applePay' ) {
+			// The maximum allowed size is 55px.
 			buttonOptions.buttonHeight = Math.min(
 				buttonOptions.buttonHeight + 0.4,
 				55
-			); // Max allowed size is 55px.
+			);
 		}
 	}
 

--- a/client/express-checkout/blocks/components/express-checkout-component.js
+++ b/client/express-checkout/blocks/components/express-checkout-component.js
@@ -40,7 +40,10 @@ const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
 	// Apple Pay has a nearly imperceptible height difference. We increase it by 1px here.
 	if ( buttonOptions.buttonTheme.applePay === 'black' ) {
 		if ( expressPaymentMethod === 'applePay' ) {
-			buttonOptions.buttonHeight = buttonOptions.buttonHeight + 0.4;
+			buttonOptions.buttonHeight = Math.min(
+				buttonOptions.buttonHeight + 0.4,
+				55
+			); // Max allowed size is 55px.
 		}
 	}
 

--- a/client/express-checkout/blocks/components/express-checkout-container.js
+++ b/client/express-checkout/blocks/components/express-checkout-container.js
@@ -27,9 +27,11 @@ const ExpressCheckoutContainer = ( props ) => {
 	};
 
 	return (
-		<Elements stripe={ stripePromise } options={ options }>
-			<ExpressCheckoutComponent { ...props } />
-		</Elements>
+		<div style={ { minHeight: '40px' } }>
+			<Elements stripe={ stripePromise } options={ options }>
+				<ExpressCheckoutComponent { ...props } />
+			</Elements>
+		</div>
 	);
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?

-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Requisites:**

- Merchant store via Jurassic Tube to ensure Apple Pay is visible as Express Checkout.
- Enable Express checkouts in Payments > Settings > Express Checkouts.
- Go to Payments > Settings > Express Checkouts > Customize. Set button size to "Large".
- Enable WooPay, although is not necessary.

**To reproduce:**

* Switch to `develop` branch.
* Visit merchant store, add a product to the cart.
* Visit the Cart (block-based).
* Express Checkout buttons should not be present.
* Check the browser console and you should see the following error:
  ```
  IntegrationError: Invalid value for elements.create('expressCheckout', options): buttonHeight should be a number from 40 to 55. You specified: 55.4.
  ```

<img width="230.5" alt="Screenshot 2024-08-23 at 4 34 53 PM" src="https://github.com/user-attachments/assets/b72a998c-e529-4112-bc72-a4122c013409">


**Confirm bug fix:**

* Switch to this branch `as-fix-max-height-allowed`.
* Visit merchant store, add a product to the cart.
* Visit the Cart (block-based).
* Express Checkout buttons should be visible. Including WooPay if you have it enabled.
* Error should not be present on the browser console.

<img width="232" alt="Screenshot 2024-08-23 at 4 34 14 PM" src="https://github.com/user-attachments/assets/390a87b5-7b13-4396-a7b5-df5f80a04589">


- Make sure the bug is gone for Small, Medium and Large button sizes. With or without WooPay enabled.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
