### PR TITLE
Temporarily disables custom field detection notices

### DIFF
--- a/changelog/chore-disable-custom-checkout-field-detection
+++ b/changelog/chore-disable-custom-checkout-field-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disables custom checkout field detection due to compatibility issues and false positives.

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -491,11 +491,6 @@ export const useWooPayShowIncompatibilityNotice = () =>
 		select( STORE_NAME ).getShowWooPayIncompatibilityNotice()
 	);
 
-export const useExpressCheckoutShowIncompatibilityNotice = () =>
-	useSelect( ( select ) =>
-		select( STORE_NAME ).getShowExpressCheckoutIncompatibilityNotice()
-	);
-
 export const useStripeBilling = () => {
 	const { updateIsStripeBillingEnabled } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -253,13 +253,6 @@ export const getShowWooPayIncompatibilityNotice = ( state ) => {
 	return getSettings( state ).show_woopay_incompatibility_notice || false;
 };
 
-export const getShowExpressCheckoutIncompatibilityNotice = ( state ) => {
-	return (
-		getSettings( state ).show_express_checkout_incompatibility_notice ||
-		false
-	);
-};
-
 export const getIsStripeBillingEnabled = ( state ) => {
 	return getSettings( state ).is_stripe_billing_enabled || false;
 };

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -14,9 +14,7 @@ import GeneralPaymentRequestButtonSettings from './general-payment-request-butto
 import {
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
-	useExpressCheckoutShowIncompatibilityNotice,
 } from 'wcpay/data';
-import { ExpressCheckoutIncompatibilityNotice } from 'wcpay/settings/settings-warnings/incompatibility-notice';
 
 const PaymentRequestSettings = ( { section } ) => {
 	const [
@@ -42,15 +40,10 @@ const PaymentRequestSettings = ( { section } ) => {
 		}
 	};
 
-	const showIncompatibilityNotice = useExpressCheckoutShowIncompatibilityNotice();
-
 	return (
 		<Card>
 			{ section === 'enable' && (
 				<CardBody>
-					{ showIncompatibilityNotice && (
-						<ExpressCheckoutIncompatibilityNotice />
-					) }
 					<CheckboxControl
 						checked={ isPaymentRequestEnabled }
 						onChange={ updateIsPaymentRequestEnabled }

--- a/client/settings/express-checkout-settings/test/index.js
+++ b/client/settings/express-checkout-settings/test/index.js
@@ -33,6 +33,7 @@ jest.mock( '../../../data', () => ( {
 	useWooPayLocations: jest
 		.fn()
 		.mockReturnValue( [ [ true, true, true ], jest.fn() ] ),
+	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {

--- a/client/settings/express-checkout-settings/test/index.js
+++ b/client/settings/express-checkout-settings/test/index.js
@@ -33,10 +33,6 @@ jest.mock( '../../../data', () => ( {
 	useWooPayLocations: jest
 		.fn()
 		.mockReturnValue( [ [ true, true, true ], jest.fn() ] ),
-	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
-	useExpressCheckoutShowIncompatibilityNotice: jest
-		.fn()
-		.mockReturnValue( false ),
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -18,7 +18,6 @@ import {
 	usePaymentRequestButtonSize,
 	usePaymentRequestButtonTheme,
 	useWooPayEnabledSettings,
-	useExpressCheckoutShowIncompatibilityNotice,
 } from '../../../data';
 
 jest.mock( '../../../data', () => ( {
@@ -29,7 +28,6 @@ jest.mock( '../../../data', () => ( {
 	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'small' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
 	useWooPayEnabledSettings: jest.fn(),
-	useExpressCheckoutShowIncompatibilityNotice: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
 	useWooPayGlobalThemeSupportEnabledSettings: jest
 		.fn()
@@ -259,29 +257,5 @@ describe( 'PaymentRequestSettings', () => {
 		expect(
 			updatePaymentRequestLocationsHandler
 		).toHaveBeenLastCalledWith( [ 'checkout', 'product' ] );
-	} );
-
-	it( 'triggers the hooks when the enable setting is being interacted with', () => {
-		useExpressCheckoutShowIncompatibilityNotice.mockReturnValue( true );
-
-		render( <PaymentRequestSettings section="enable" /> );
-
-		expect(
-			screen.queryByText(
-				'Your custom checkout fields may not be compatible with these payment methods.'
-			)
-		).toBeInTheDocument();
-	} );
-
-	it( 'triggers the hooks when the enable setting is being interacted with', () => {
-		useExpressCheckoutShowIncompatibilityNotice.mockReturnValue( false );
-
-		render( <PaymentRequestSettings section="enable" /> );
-
-		expect(
-			screen.queryByText(
-				'Your custom checkout fields may not be compatible with these payment methods.'
-			)
-		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/express-checkout/apple-google-pay-item.tsx
+++ b/client/settings/express-checkout/apple-google-pay-item.tsx
@@ -10,13 +10,9 @@ import React, { useContext } from 'react';
  * Internal dependencies
  */
 import { getPaymentMethodSettingsUrl } from '../../utils';
-import {
-	usePaymentRequestEnabledSettings,
-	useExpressCheckoutShowIncompatibilityNotice,
-} from 'wcpay/data';
+import { usePaymentRequestEnabledSettings } from 'wcpay/data';
 import { PaymentRequestEnabledSettingsHook } from './interfaces';
 import { ApplePayIcon, GooglePayIcon } from 'wcpay/payment-methods-icons';
-import { ExpressCheckoutIncompatibilityNotice } from 'wcpay/settings/settings-warnings/incompatibility-notice';
 import DuplicateNotice from 'wcpay/components/duplicate-notice';
 import DuplicatedPaymentMethodsContext from '../settings-manager/duplicated-payment-methods-context';
 
@@ -28,7 +24,6 @@ const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
 		updateIsPaymentRequestEnabled,
 	] = usePaymentRequestEnabledSettings() as PaymentRequestEnabledSettingsHook;
 
-	const showIncompatibilityNotice = useExpressCheckoutShowIncompatibilityNotice();
 	const {
 		duplicates,
 		dismissedDuplicateNotices,
@@ -176,9 +171,6 @@ const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
 					</div>
 				</div>
 			</div>
-			{ showIncompatibilityNotice && (
-				<ExpressCheckoutIncompatibilityNotice />
-			) }
 			{ isDuplicate && (
 				<DuplicateNotice
 					paymentMethod={ id }

--- a/client/settings/express-checkout/test/index.test.js
+++ b/client/settings/express-checkout/test/index.test.js
@@ -12,7 +12,6 @@ import userEvent from '@testing-library/user-event';
 import ExpressCheckout from '..';
 import {
 	useEnabledPaymentMethodIds,
-	useExpressCheckoutShowIncompatibilityNotice,
 	useGetAvailablePaymentMethodIds,
 	usePaymentRequestEnabledSettings,
 	useWooPayEnabledSettings,
@@ -27,7 +26,6 @@ jest.mock( 'wcpay/data', () => ( {
 	useEnabledPaymentMethodIds: jest.fn(),
 	useGetAvailablePaymentMethodIds: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn(),
-	useExpressCheckoutShowIncompatibilityNotice: jest.fn(),
 	useGetDuplicatedPaymentMethodIds: jest.fn(),
 } ) );
 
@@ -217,26 +215,6 @@ describe( 'ExpressCheckout', () => {
 		expect(
 			screen.queryByText(
 				'One or more of your extensions are incompatible with WooPay.'
-			)
-		).toBeInTheDocument();
-	} );
-
-	it( 'should show Express Checkout incompatibility warning', async () => {
-		const context = { featureFlags: { woopay: true } };
-		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'link', 'card' ] );
-		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card', 'link' ] ] );
-
-		useExpressCheckoutShowIncompatibilityNotice.mockReturnValue( true );
-
-		render(
-			<WCPaySettingsContext.Provider value={ context }>
-				<ExpressCheckout />
-			</WCPaySettingsContext.Provider>
-		);
-
-		expect(
-			screen.queryByText(
-				'Your custom checkout fields may not be compatible with these payment methods.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/settings/settings-warnings/incompatibility-notice.js
+++ b/client/settings/settings-warnings/incompatibility-notice.js
@@ -40,14 +40,3 @@ export const WooPayIncompatibilityNotice = () => (
 		learnMoreLinkHref="https://woocommerce.com/document/woopay-merchant-documentation/#compatibility"
 	/>
 );
-
-export const ExpressCheckoutIncompatibilityNotice = () => (
-	<IncompatibilityNotice
-		message={ __(
-			'Your custom checkout fields may not be compatible with these payment methods.',
-			'woocommerce-payments'
-		) }
-		// eslint-disable-next-line max-len
-		learnMoreLinkHref="https://woocommerce.com/document/woopayments/payment-methods/apple-pay-and-google-pay-compatibility/#faq-extra-fields-on-checkout"
-	/>
-);

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -513,7 +513,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_card_present_eligible'               => $this->wcpay_gateway->is_card_present_eligible() && isset( WC()->payment_gateways()->get_available_payment_gateways()['cod'] ),
 				'is_woopay_enabled'                      => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
 				'show_woopay_incompatibility_notice'     => get_option( 'woopay_invalid_extension_found', false ),
-				'show_express_checkout_incompatibility_notice' => $this->should_show_express_checkout_incompatibility_notice(),
 				'woopay_custom_message'                  => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
 				'woopay_store_logo'                      => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),
 				'woopay_enabled_locations'               => $this->wcpay_gateway->get_option( 'platform_checkout_button_locations', array_keys( $wcpay_form_fields['payment_request_button_locations']['options'] ) ),
@@ -1100,39 +1099,5 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$reporting_export_language = $request->get_param( 'reporting_export_language' );
 
 		$this->wcpay_gateway->update_option( 'reporting_export_language', $reporting_export_language );
-	}
-
-	/**
-	 * Whether to show the express checkout incompatibility notice.
-	 *
-	 * @return bool
-	 */
-	private function should_show_express_checkout_incompatibility_notice() {
-		// Apply filters to empty arrays to check if any plugin is modifying the checkout fields.
-		$after_apply_billing  = apply_filters( 'woocommerce_billing_fields', [], '' );
-		$after_apply_shipping = apply_filters( 'woocommerce_shipping_fields', [], '' );
-		$after_apply_checkout = array_filter(
-			apply_filters(
-				'woocommerce_checkout_fields',
-				[
-					'billing'  => [],
-					'shipping' => [],
-					'account'  => [],
-					'order'    => [],
-				]
-			)
-		);
-		// All the input values are empty, so if any of them is not empty, it means that the checkout fields are being modified.
-		$is_modifying_checkout_fields = ! empty(
-			array_filter(
-				[
-					'after_apply_billing'  => $after_apply_billing,
-					'after_apply_shipping' => $after_apply_shipping,
-					'after_apply_checkout' => $after_apply_checkout,
-				]
-			)
-		);
-
-		return $is_modifying_checkout_fields;
 	}
 }


### PR DESCRIPTION
Fixes #8752 

#### Changes proposed in this Pull Request

This PR temporarily disables custom checkout field detection notices in payments settings. The purpose of this feature was to detect when custom checkout fields might be present at checkout that could cause errors with express checkout payment methods. The notice would warn admins that their EPMs might not work as expected while these custom fields are present on the checkout.

![Notice](https://cdn-std.droplr.net/files/acc_1104206/4MrosT)
_This notice_

<!--
Title: A descriptive, yet concise, title.
-->

However, this detection worked by checking whether any plugin was hooking into either `woocommerce_billing_fields`, `woocommerce_shipping_fields`, or `woocommerce_checkout_fields`. These filters could be used for benign reasons without altering the checkout in a way that might break EPM functionality, but this would still trigger the warning.

Moreover, since our implementation called `apply_filter` on these checkout hooks from the admin, this caused errors with plugins that hooked into this filter with checkout-specific functionality that would not work in the admin (described in #8752).

Due to these excessive false positives and other errors, we have decided to temporarily disable this feature, in view of exploring a client-side custom field detection mechanism instead. Consequently, when this issue is merged, we should probably reopen #8299, where we can develop a longer term solution for this problem.

Note that this PR only ensures that the notice will no longer appear. I am leaving the client-side code in place, because we plan to revisit this functionality and hopefully will be able to reuse those components created in #8339. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Before pulling this PR, on `develop`, activate a plugin that adds or removes custom fields to the checkout. Here is a snippet that I used to simulate this.

```php
function add_shipping_phone_field( $fields ) {
	$defaults = array(
		'label'        => __( 'Phone', 'woocommerce-services' ),
		'type'         => 'tel',
		'required'     => false,
		'class'        => array( 'form-row-wide' ),
		'clear'        => true,
		'validate'     => array( 'phone' ),
		'autocomplete' => 'tel',
	);
	$field = isset( $fields['shipping_phone'] )
		? array_merge( $defaults, $fields['shipping_phone'] )
		: $defaults;
	$fields['shipping_phone'] = $field;
	return $fields;
}

add_filter( 'woocommerce_shipping_fields', 'add_shipping_phone_field' );
```

This filter basically just replaces the shipping phone field with itself (this was borrowed from a similar application in Woo Shipping), so it will not affect any EPM functionality, but it will still trigger the warning notice as a false positive.

2. Visit Payments settings and confirm that the notice appears.
3. Pull the changes in this PR and revisit Payments settings and confirm that the notice no longer appears.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
