### PR TITLE
Disables test instructions clipboard button on insecure sites

### DIFF
--- a/changelog/fix-catch-clipboard-navigator-undefined-error-in-http
+++ b/changelog/fix-catch-clipboard-navigator-undefined-error-in-http
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disables testing instructions clipboard button on HTTP sites when navigator.clipboard is undefined.

--- a/client/checkout/utils/copy-test-number.js
+++ b/client/checkout/utils/copy-test-number.js
@@ -6,10 +6,6 @@ import { __ } from '@wordpress/i18n';
 document.addEventListener(
 	'click',
 	function ( event ) {
-		if ( ! navigator.clipboard ) {
-			return;
-		}
-
 		const copyNumberButton = event.target?.closest(
 			'.js-woopayments-copy-test-number'
 		);
@@ -21,6 +17,14 @@ document.addEventListener(
 		const number = copyNumberButton.parentElement.querySelector(
 			'.js-woopayments-test-number'
 		).innerText;
+
+		if ( ! navigator.clipboard ) {
+			prompt(
+				__( 'Copy the test number:', 'woocommerce-payments' ),
+				number
+			);
+			return;
+		}
 		navigator.clipboard.writeText( number );
 
 		window.wp?.data

--- a/client/checkout/utils/copy-test-number.js
+++ b/client/checkout/utils/copy-test-number.js
@@ -6,31 +6,37 @@ import { __ } from '@wordpress/i18n';
 document.addEventListener(
 	'click',
 	function ( event ) {
+		if ( ! navigator.clipboard ) {
+			return;
+		}
+
 		const copyNumberButton = event.target?.closest(
 			'.js-woopayments-copy-test-number'
 		);
-		if ( copyNumberButton ) {
-			event.preventDefault();
-			const number = copyNumberButton.parentElement.querySelector(
-				'.js-woopayments-test-number'
-			).innerText;
-			navigator.clipboard.writeText( number );
-
-			window.wp?.data
-				?.dispatch( 'core/notices' )
-				?.createInfoNotice(
-					__(
-						'Test number copied to your clipboard!',
-						'woocommerce-payments'
-					),
-					{
-						// the unique `id` prevents the JS from creating multiple notices with the same text before they're dismissed.
-						id: 'woopayments/test-number-copied',
-						type: 'snackbar',
-						context: 'wc/checkout/payments',
-					}
-				);
+		if ( ! copyNumberButton ) {
+			return;
 		}
+
+		event.preventDefault();
+		const number = copyNumberButton.parentElement.querySelector(
+			'.js-woopayments-test-number'
+		).innerText;
+		navigator.clipboard.writeText( number );
+
+		window.wp?.data
+			?.dispatch( 'core/notices' )
+			?.createInfoNotice(
+				__(
+					'Test number copied to your clipboard!',
+					'woocommerce-payments'
+				),
+				{
+					// the unique `id` prevents the JS from creating multiple notices with the same text before they're dismissed.
+					id: 'woopayments/test-number-copied',
+					type: 'snackbar',
+					context: 'wc/checkout/payments',
+				}
+			);
 	},
 	false
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
#9279 added a button to our test instructions which copies the test card number to clipboard when clicked, using `navigator.clipboard.writeText`. However, while testing #9295, I noticed that the button was producing an error on my test site, which happened to be an insecure HTTP site, rather than an HTTPS site. 

![Clipboard error](https://cdn-std.droplr.net/files/acc_1104206/mXdPj8)
_This is the error_

I discovered that this is a security feature supported by most browsers (I am able to replicate on Firefox, at least), where `navigator.clipboard` is ["is available only in secure contexts (HTTPS), in some or all supporting browsers."](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard). 

This PR adds a minor modification to the current behaviour to exit the event listener when `navigator.clipboard` is `undefined` to avoid creating this error. 
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Before pulling this PR, on `develop`, navigate to an HTTP test site, click the copy button in the card testing instructions, and notice that the test card number is not copied to clipboard and the error above appears in your console instead.
2. Pull the changes in this PR and repeat the above and confirm that, while the test card number is still not copied to clipboard, no error appears anymore. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
