### PR TITLE
Fix Connect page scrolls to top when the Enable Sandbox Mode button is clicked

### DIFF
--- a/changelog/fix-9324-test-drive-onboarding-scoll
+++ b/changelog/fix-9324-test-drive-onboarding-scoll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed an issue where the Connect page would scroll to the top upon clicking the Enable Sandbox Mode button.

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -206,11 +206,6 @@ const ConnectAccountPage: React.FC = () => {
 		setTestDriveModeSubmitted( true );
 		trackConnectAccountClicked( true );
 
-		// Scroll the page to the top to ensure the logo is visible.
-		window.scrollTo( {
-			top: 0,
-		} );
-
 		const customizedConnectUrl = addQueryArgs( connectUrl, {
 			test_drive: 'true',
 		} );


### PR DESCRIPTION
Fixes #9324 

#### Changes proposed in this Pull Request
This PR addresses the issue where clicking the Enable Sandbox Mode button under the I’m setting up a store for someone else section causes the page to scroll unexpectedly to the top. This unintended behavior hides the button’s loading state, potentially leading to confusion among merchants who may not realize that the action is being processed.

#### Testing instructions
- Ensure Jetpack is disconnected.
- Navigate to the `Payments` page with no account connected.
- Scroll down to the “I’m setting up a store for someone else” section.
- Click the “Enable Sandbox Mode” button.
- Verify that the page is not scrolled to the top, hiding the button from view.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
