### PR TITLE
Fix onboarding flows edge cases around onboarding mode

### DIFF
--- a/changelog/fix-onboarding-flows-edge-cases-around-onboarding-mode
+++ b/changelog/fix-onboarding-flows-edge-cases-around-onboarding-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Dealing with some edge cases around account data caching.
+
+

--- a/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button, Modal } from '@wordpress/components';
@@ -26,7 +26,10 @@ const SetupLivePaymentsModal: React.FC< Props > = ( {
 	source,
 	onClose,
 }: Props ) => {
+	const [ isSubmitted, setSubmitted ] = useState( false );
 	const handleSetup = () => {
+		setSubmitted( true );
+
 		recordEvent( 'wcpay_onboarding_flow_setup_live_payments', {
 			from,
 			source,
@@ -40,6 +43,8 @@ const SetupLivePaymentsModal: React.FC< Props > = ( {
 	};
 
 	const trackAndClose = () => {
+		setSubmitted( false );
+
 		recordEvent( 'wcpay_setup_live_payments_modal_exit', {
 			from,
 			source,
@@ -85,7 +90,12 @@ const SetupLivePaymentsModal: React.FC< Props > = ( {
 				<Button variant="tertiary" onClick={ trackAndClose }>
 					{ __( 'Cancel', 'woocommerce-payments' ) }
 				</Button>
-				<Button variant="primary" onClick={ handleSetup }>
+				<Button
+					variant="primary"
+					isBusy={ isSubmitted }
+					disabled={ isSubmitted }
+					onClick={ handleSetup }
+				>
 					{ __( 'Continue setup', 'woocommerce-payments' ) }
 				</Button>
 			</div>

--- a/client/overview/modal/reset-account/index.tsx
+++ b/client/overview/modal/reset-account/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, CardDivider, Modal } from '@wordpress/components';
 
 /**
@@ -18,13 +18,17 @@ interface Props {
 
 const ResetAccountModal: React.FC< Props > = ( props: Props ) => {
 	const { isVisible, onDismiss, onSubmit } = props;
+	const [ isSubmitted, setSubmitted ] = useState( false );
 	if ( ! isVisible ) return null;
 
 	return (
 		<Modal
 			title={ strings.title }
 			className="wcpay-reset-account-modal"
-			onRequestClose={ onDismiss }
+			onRequestClose={ () => {
+				setSubmitted( false );
+				onDismiss();
+			} }
 		>
 			<p className="wcpay-reset-account-modal__headline">
 				{ strings.description }
@@ -40,13 +44,24 @@ const ResetAccountModal: React.FC< Props > = ( props: Props ) => {
 				<b>{ strings.confirmation }</b>
 			</div>
 			<div className="wcpay-reset-account-modal__footer">
-				<Button variant="tertiary" onClick={ onDismiss }>
+				<Button
+					variant="tertiary"
+					onClick={ () => {
+						setSubmitted( false );
+						onDismiss();
+					} }
+				>
 					{ strings.cancel }
 				</Button>
 				<Button
 					variant="primary"
 					isDestructive={ true }
-					onClick={ onSubmit }
+					isBusy={ isSubmitted }
+					disabled={ isSubmitted }
+					onClick={ () => {
+						setSubmitted( true );
+						onSubmit();
+					} }
 				>
 					{ strings.reset }
 				</Button>

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -224,20 +224,25 @@ const Deposits = () => {
 							'Manage and update your deposit account information to receive payments and deposits.',
 							'woocommerce-payments'
 						) }{ ' ' }
-						<ExternalLink
-							href={ accountLink }
-							onClick={ () => {
-								recordEvent(
-									'wcpay_settings_deposits_manage_in_stripe_click'
-								);
-								recordEvent(
-									'wcpay_account_details_link_clicked',
-									{ source: 'settings-deposits' }
-								);
-							} }
-						>
-							{ __( 'Manage in Stripe', 'woocommerce-payments' ) }
-						</ExternalLink>
+						{ accountLink && (
+							<ExternalLink
+								href={ accountLink }
+								onClick={ () => {
+									recordEvent(
+										'wcpay_settings_deposits_manage_in_stripe_click'
+									);
+									recordEvent(
+										'wcpay_account_details_link_clicked',
+										{ source: 'settings-deposits' }
+									);
+								} }
+							>
+								{ __(
+									'Manage in Stripe',
+									'woocommerce-payments'
+								) }
+							</ExternalLink>
+						) }
 					</p>
 				</div>
 			</CardBody>

--- a/client/settings/fraud-protection/components/fp-modal/index.tsx
+++ b/client/settings/fraud-protection/components/fp-modal/index.tsx
@@ -80,7 +80,7 @@ export const BasicFraudProtectionModal: React.FC< BasicFraudProtectionModalProps
 						<Button
 							className="component-modal__button--confirm"
 							onClick={ () => setBasicModalOpen( false ) }
-							isTertiary
+							variant="secondary"
 						>
 							{ __( 'Got it', 'woocommerce-payments' ) }
 						</Button>

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -844,8 +844,8 @@ class WC_Payments_Admin {
 			],
 			'connectIncentive'                   => $connect_incentive,
 			'devMode'                            => $dev_mode,
-			'testMode'                           => $test_mode,
 			'testModeOnboarding'                 => $test_mode_onboarding,
+			'testMode'                           => $test_mode,
 			// Set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
 			'onBoardingDisabled'                 => WC_Payments_Account::is_on_boarding_disabled(),
 			'onboardingFieldsData'               => $this->onboarding_service->get_fields_data( get_user_locale() ),

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -805,21 +805,21 @@ class WC_Payments_Admin {
 		try {
 			$test_mode = WC_Payments::mode()->is_test();
 		} catch ( Exception $e ) {
-			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in test mode! Message: %s', $e->getMessage() ), 'warning' );
+			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if the gateway should process payments in test mode! Message: %s', $e->getMessage() ), 'warning' );
 		}
 
 		$test_mode_onboarding = false;
 		try {
 			$test_mode_onboarding = WC_Payments::mode()->is_test_mode_onboarding();
 		} catch ( Exception $e ) {
-			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in sandbox mode! Message: %s', $e->getMessage() ), 'warning' );
+			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if we should onboard accounts in test mode! Message: %s', $e->getMessage() ), 'warning' );
 		}
 
 		$dev_mode = false;
 		try {
 			$dev_mode = WC_Payments::mode()->is_dev();
 		} catch ( Exception $e ) {
-			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if WCPay should be in dev mode! Message: %s', $e->getMessage() ), 'warning' );
+			Logger::log( sprintf( 'WooPayments JS settings: Could not determine if the gateway should be in dev mode! Message: %s', $e->getMessage() ), 'warning' );
 		}
 
 		$connect_url       = WC_Payments_Account::get_connect_url();

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -479,7 +479,7 @@ class WC_Payments_Admin {
 			plugins_url( 'assets/css/admin.css', WCPAY_PLUGIN_FILE ),
 			[],
 			WC_Payments::get_file_version( 'assets/css/admin.css' ),
-			'all',
+			'all'
 		);
 
 		$this->add_menu_notification_badge();

--- a/includes/admin/class-wc-rest-payments-accounts-controller.php
+++ b/includes/admin/class-wc-rest-payments-accounts-controller.php
@@ -72,6 +72,7 @@ class WC_REST_Payments_Accounts_Controller extends WC_Payments_REST_Controller {
 			// Add extra properties to account if necessary.
 			$account['card_present_eligible'] = false;
 			$account['test_mode']             = WC_Payments::mode()->is_test();
+			$account['test_mode_onboarding']  = WC_Payments::mode()->is_test_mode_onboarding();
 		}
 
 		return rest_ensure_response( $account );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1555,8 +1555,8 @@ class WC_Payments_Account {
 		$gateway->update_option( 'enabled', 'no' );
 		$gateway->update_option( 'test_mode', 'no' );
 
-		delete_option( '_wcpay_onboarding_stripe_connected' );
-		delete_option( WC_Payments_Onboarding_Service::TEST_MODE_OPTION );
+		update_option( '_wcpay_onboarding_stripe_connected', [] );
+		update_option( WC_Payments_Onboarding_Service::TEST_MODE_OPTION, 'no' );
 
 		// Discard any ongoing onboarding session.
 		delete_transient( self::ONBOARDING_STATE_TRANSIENT );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1959,7 +1959,7 @@ class WC_Payments_Account {
 		$incentive_id     = ! empty( $_GET['promo'] ) ? sanitize_text_field( wp_unslash( $_GET['promo'] ) ) : '';
 		$event_properties = [
 			'incentive' => $incentive_id,
-			'mode'      => 'test' === $mode ? 'test' : 'live',
+			'mode'      => 'live' !== $mode ? 'test' : 'live',
 			'from'      => $additional_args['from'] ?? '',
 			'source'    => $additional_args['source'] ?? '',
 		];

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -236,13 +236,14 @@ class WC_Payments_Onboarding_Service {
 
 	/**
 	 * Set onboarding test mode.
-	 * Will also switch WC_Payments mode immediately.
+	 *
+	 * Will also switch the WC_Payments onboarding mode immediately.
 	 *
 	 * @param boolean $test_mode Whether to enable test mode.
 	 * @return void
 	 */
 	public static function set_test_mode( bool $test_mode ): void {
-		update_option( self::TEST_MODE_OPTION, $test_mode );
+		update_option( self::TEST_MODE_OPTION, $test_mode ? 'yes' : 'no', true );
 
 		// Switch WC_Payments onboarding mode immediately.
 		if ( $test_mode ) {
@@ -253,12 +254,12 @@ class WC_Payments_Onboarding_Service {
 	}
 
 	/**
-	 * Returns whether onboarding test mode is enabled.
+	 * Determine if test mode onboarding is enabled.
 	 *
 	 * @return bool
 	 */
 	public static function is_test_mode_enabled(): bool {
-		return get_option( self::TEST_MODE_OPTION, false );
+		return 'yes' === get_option( self::TEST_MODE_OPTION, 'no' );
 	}
 
 	/**

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -245,7 +245,11 @@ class WC_Payments_Onboarding_Service {
 		update_option( self::TEST_MODE_OPTION, $test_mode );
 
 		// Switch WC_Payments onboarding mode immediately.
-		\WC_Payments::mode()->set_test_mode_onboarding( $test_mode );
+		if ( $test_mode ) {
+			\WC_Payments::mode()->test_mode_onboarding();
+		} else {
+			\WC_Payments::mode()->live_mode_onboarding();
+		}
 	}
 
 	/**

--- a/includes/core/README.md
+++ b/includes/core/README.md
@@ -60,7 +60,7 @@ This is a singular `WCPay\Core\Mode` object, accessible through `WC_Payments::mo
 During initialization, the following logic is used:
 
 1. Sandbox mode would be entered if:
-    - Either [WordPress's environment type](https://developer.wordpress.org/reference/functions/wp_get_environment_type/#description) is either `development` or 		`staging`.
+    - Either [WordPress's environment type](https://developer.wordpress.org/reference/functions/wp_get_environment_type/#description) is either `development` or `staging`.
     - or `WCPAY_DEV_MODE` is defined and set to boolean true.
 2. Test mode is entered if:
     - Either Sandbox mode is already enabled.
@@ -82,13 +82,16 @@ Once the mode has been initialized, the gateway will work in that mode. The sett
 __Checking the current mode:__
 
 ```php
-// Check for live mode:
+// Check for live mode payments processing:
 WC_Payments::mode()->is_live();
 
-// Check for test mode:
+// Check for test mode payments processing:
 WC_Payments::mode()->is_test();
 
-// Check for dev mode:
+// Check for test mode onboarding:
+WC_Payments::mode()->is_test_mode_onboarding();
+
+// Check for overall gateway dev mode:
 WC_Payments::mode()->is_dev();
 ```
 

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -74,20 +74,21 @@ class Mode {
 		 * Allows WooPayments to enter dev (aka sandbox) mode.
 		 *
 		 * @see https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/
-		 * @param bool $dev_mode The pre-determined dev mode.
+		 * @param bool $dev_mode Whether to enter WooPayments in dev mode.
 		 */
 		$this->dev_mode = (bool) apply_filters( 'wcpay_dev_mode', $dev_mode );
 
+		// If dev mode is active, we enable test mode onboarding.
 		$test_mode_onboarding = $this->dev_mode || \WC_Payments_Onboarding_Service::is_test_mode_enabled();
 
 		/**
-		 * Allows WooPayments to onboard in test mode.
+		 * Allows WooPayments to use test mode onboarding.
 		 *
-		 * @param bool $test_mode_onboarding The pre-determined test mode onboarding.
+		 * @param bool $test_mode_onboarding Whether to use test mode onboarding.
 		 */
 		$this->test_mode_onboarding = (bool) apply_filters( 'wcpay_test_mode_onboarding', $test_mode_onboarding );
 
-		// If the current mode of onboarding is test, we should force enable test mode.
+		// If the current mode of onboarding is test, we will enable test mode payments processing.
 		// Otherwise, follow the gateway settings.
 		if ( $this->test_mode_onboarding ) {
 			$test_mode = true;
@@ -99,10 +100,10 @@ class Mode {
 		}
 
 		/**
-		 * Allows WooPayments to enter test payments processing.
+		 * Allows WooPayments to process payments in test mode.
 		 *
 		 * @see https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#enabling-test-mode
-		 * @param bool $test_mode The pre-determined test mode.
+		 * @param bool $test_mode Whether to process payments in test mode.
 		 */
 		$this->test_mode = (bool) apply_filters( 'wcpay_test_mode', $test_mode );
 	}
@@ -115,6 +116,7 @@ class Mode {
 	 */
 	public function is_live(): bool {
 		$this->maybe_init();
+
 		return ! $this->test_mode;
 	}
 
@@ -220,7 +222,7 @@ class Mode {
 	 * @return bool Whether `WCPAY_DEV_MODE` is defined and true.
 	 */
 	protected function is_wcpay_dev_mode_defined(): bool {
-		return(
+		return (
 			defined( 'WCPAY_DEV_MODE' )
 			&& WCPAY_DEV_MODE
 		);

--- a/tests/unit/core/server/request/test-class-core-get-account-login-data.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-login-data.php
@@ -38,7 +38,6 @@ class Get_Account_Login_Data_Test extends WCPAY_UnitTestCase {
 
 		// Reset the mode.
 		WC_Payments::mode()->live();
-		WC_Payments::mode()->set_test_mode_onboarding( false );
 
 		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
 		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
@@ -69,8 +68,8 @@ class Get_Account_Login_Data_Test extends WCPAY_UnitTestCase {
 		$request_live = new Get_Account_Login_Data( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->assertFalse( $request_live->get_default_params()['test_mode'] );
 
-		// enable just test mode onboarding.
-		WC_Payments::mode()->set_test_mode_onboarding( true );
+		// enable test mode onboarding.
+		WC_Payments::mode()->test_mode_onboarding();
 		$request_dev = new Get_Account_Login_Data( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->assertTrue( $request_dev->get_default_params()['test_mode'] );
 

--- a/tests/unit/core/server/request/test-class-core-get-account-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-request.php
@@ -56,8 +56,8 @@ class Get_Account_Test extends WCPAY_UnitTestCase {
 		$request_live = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->assertFalse( $request_live->get_default_params()['test_mode'] );
 
-		// enable just test mode onboarding.
-		WC_Payments::mode()->set_test_mode_onboarding( true );
+		// enable test mode onboarding.
+		WC_Payments::mode()->test_mode_onboarding();
 		$request_dev = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->assertTrue( $request_dev->get_default_params()['test_mode'] );
 

--- a/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
+++ b/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
@@ -55,7 +55,6 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 
 		// Reset the mode.
 		WC_Payments::mode()->live();
-		WC_Payments::mode()->set_test_mode_onboarding( false );
 
 		// mock WC_Payments_Http and use it to set up system under test.
 		$this->mock_http_client = $this

--- a/tests/unit/core/test-class-mode.php
+++ b/tests/unit/core/test-class-mode.php
@@ -52,6 +52,7 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertTrue( $this->mode->is_dev() );
+		$this->assertTrue( $this->mode->is_test_mode_onboarding() );
 		$this->assertTrue( $this->mode->is_test() );
 		$this->assertFalse( $this->mode->is_live() );
 	}
@@ -59,7 +60,11 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 	public function test_init_enters_dev_mode_through_filter() {
 		// Force dev mode to be entered through the filter.
 		add_filter( 'wcpay_dev_mode', '__return_true' );
+
 		$this->assertTrue( $this->mode->is_dev() );
+		$this->assertTrue( $this->mode->is_test_mode_onboarding() );
+		$this->assertTrue( $this->mode->is_test() );
+		$this->assertFalse( $this->mode->is_live() );
 	}
 
 	public function test_init_enters_test_mode_with_gateway_test_mode_settings() {
@@ -67,15 +72,17 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 
 		// Reset and check.
 		$this->assertFalse( $this->mode->is_dev() );
+		$this->assertFalse( $this->mode->is_test_mode_onboarding() );
 		$this->assertTrue( $this->mode->is_test() );
 	}
 
 	public function test_init_enters_test_mode_through_filter() {
-		// FOrce test mode to be entered through the filter.
+		// Force test mode to be entered through the filter.
 		add_filter( 'wcpay_test_mode', '__return_true' );
 
 		$this->assertTrue( $this->mode->is_test() );
 		$this->assertFalse( $this->mode->is_dev() );
+		$this->assertFalse( $this->mode->is_test_mode_onboarding() );
 	}
 
 	public function test_init_test_init_enters_dev_mode_when_environment_is_dev() {
@@ -84,5 +91,71 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 			->willReturn( 'development' );
 
 		$this->assertTrue( $this->mode->is_dev() );
+		$this->assertTrue( $this->mode->is_test_mode_onboarding() );
+		$this->assertTrue( $this->mode->is_test() );
+		$this->assertFalse( $this->mode->is_live() );
+	}
+
+	public function test_live() {
+		// Reset to dev.
+		$this->mode->dev();
+
+		// Act.
+		$this->mode->live();
+
+		// Assert.
+		// Everything is changed.
+		$this->assertTrue( $this->mode->is_live() );
+		$this->assertFalse( $this->mode->is_test() );
+		$this->assertFalse( $this->mode->is_test_mode_onboarding() );
+		$this->assertFalse( $this->mode->is_dev() );
+	}
+
+	public function test_test() {
+		// Reset to live.
+		$this->mode->live();
+
+		// Act.
+		$this->mode->test();
+
+		// Assert.
+		// Only the payments processing mode is changed.
+		$this->assertTrue( $this->mode->is_test() );
+		$this->assertFalse( $this->mode->is_live() );
+		$this->assertFalse( $this->mode->is_test_mode_onboarding() );
+		$this->assertFalse( $this->mode->is_dev() );
+	}
+
+	public function test_test_mode_onboarding() {
+		// Reset to live.
+		$this->mode->live();
+
+		// Act.
+		$this->mode->test_mode_onboarding();
+
+		// Assert.
+		// Payments processing mode is changed.
+		$this->assertTrue( $this->mode->is_test() );
+		$this->assertFalse( $this->mode->is_live() );
+		$this->assertTrue( $this->mode->is_test_mode_onboarding() );
+		// Dev mode is left unchanged.
+		$this->assertFalse( $this->mode->is_dev() );
+	}
+
+	public function test_live_mode_onboarding() {
+		// Reset to dev.
+		$this->mode->dev();
+
+		// Act.
+		$this->mode->live_mode_onboarding();
+
+		// Assert.
+		// The payments processing mode is left unchanged.
+		$this->assertFalse( $this->mode->is_live() );
+		$this->assertTrue( $this->mode->is_test() );
+		// The onboarding mode is changed.
+		$this->assertFalse( $this->mode->is_test_mode_onboarding() );
+		// Dev mode is deactivated.
+		$this->assertFalse( $this->mode->is_dev() );
 	}
 }

--- a/tests/unit/src/Internal/Service/ExampleServiceWithDependenciesTest.php
+++ b/tests/unit/src/Internal/Service/ExampleServiceWithDependenciesTest.php
@@ -26,7 +26,6 @@ class ExampleServiceWithDependenciesTest extends WCPAY_UnitTestCase {
 
 		// Reset the mode.
 		\WC_Payments::mode()->live();
-		\WC_Payments::mode()->set_test_mode_onboarding( false );
 
 		// Loading through the container to increase coverage.
 		$this->sut = wcpay_get_container()->get( ExampleServiceWithDependencies::class );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -216,6 +216,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'create_and_confirm_setup_intent',
 					'get_payment_method',
 					'get_timeline',
+					'get_latest_fraud_ruleset',
 				]
 			)
 			->getMock();
@@ -3441,7 +3442,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$mode->dev();
 		$this->assertTrue( $this->card_gateway->is_in_dev_mode() );
 
-		$mode->test();
+		$mode->live_mode_onboarding();
 		$this->assertFalse( $this->card_gateway->is_in_dev_mode() );
 
 		$mode->live();
@@ -3455,6 +3456,9 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$mode = WC_Payments::mode();
 
 		$mode->dev();
+		$this->assertTrue( $this->card_gateway->is_in_test_mode() );
+
+		$mode->test_mode_onboarding();
 		$this->assertTrue( $this->card_gateway->is_in_test_mode() );
 
 		$mode->test();

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -193,13 +193,13 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 	public function test_set_test_mode() {
 		$this->onboarding_service->set_test_mode( true );
 
-		$this->assertTrue( get_option( 'wcpay_onboarding_test_mode' ) );
+		$this->assertEquals( 'yes', get_option( WC_Payments_Onboarding_Service::TEST_MODE_OPTION, 'no' ) );
 
 		$this->onboarding_service->set_test_mode( false );
 
-		$this->assertFalse( get_option( 'wcpay_onboarding_test_mode' ) );
+		$this->assertEquals( 'no', get_option( WC_Payments_Onboarding_Service::TEST_MODE_OPTION, 'no' ) );
 
-		delete_option( 'wcpay_onboarding_test_mode' );
+		delete_option( WC_Payments_Onboarding_Service::TEST_MODE_OPTION );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9342 

### Changes proposed in this Pull Request

We've investigated some weird edge cases (p1724745169469109-slack-C03KTTK2YMA) and while we haven't been able to pinpoint a single source of trouble, we've come to a set of highly confident suspicions:
- on JN sites with Memcached active (the default when creating them from the web UI), we could end up with the test mode onboarding option cached as active even if it was not longer in the WP DB: we fixed this by using `yes` and `no` values rather than boolean (WP is wonky about saving booleans in options (https://core.trac.wordpress.org/ticket/40007)
- when switching from test to live accounts, there were potential code paths where the account cache would not be cleared: we've implemented a more opportunistic approach to clearing the account cache (after establishing a Jetpack connection and after we attempt a Stripe account init). This will provide some escape hatches via connect links from the Connect page in case something goes wrong with the account data.
- there was a possibility of double-clicking the CTA buttons for switching from test to live or resetting the account: we've added disabled and busy states to these buttons to prevent that.

### Testing instructions

#### Testing without Dev Tools on JurassicNinja

1. Spin up a JN site with WooCommerce but without Dev Tools ([direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce)).
1. Install WooPayments from the [actions built ZIP](https://github.com/Automattic/woocommerce-payments/actions/runs/10595224918)
1. On your JN site, go to the Payments page.
1. Click Enable sandbox mode at the bottom, in the "I'm setting up a store for someone else" section.
1. Connect your site to WordPress.com and you will be redirected to the test-drive account loading screen.
1. Wait for the test account to finish creating.
1. You'll be redirected to the Payments Overview page.
1. Go to Payments > Settings.
1. Add a real phone number to get around https://github.com/Automattic/woocommerce-payments/issues/6782.
1. Save Changes.
1. Still on Payments > Settings, check that test mode can't be disabled:
![lSvSJn.png](https://github.com/user-attachments/assets/bd80fbc5-4aa6-43b4-b1f4-e02164469783)
1. Use the "Set up payments" prompt on the Payments > Settings page to switch to live mode. Go through the onboarding again, ensure that it is not in test/sandbox mode (there should be no `test` label in the Stripe KYC). 
1. After the onboarding, you should be taken to the Overview page with a fully onboarded account.

#### Testing with Dev Tools locally, in dev mode

1. Checkout the PR branch on your local environment
1. Build the assets by running `npm run build:client`
1. Make sure the "Enable the WCPay dev mode" checkbox is checked on the WCPay Dev page.
1. Go to the Payments page and you should see a notice at the top saying "Sandbox mode is enabled, only test accounts will be created. If you want to process live transactions, please [disable it](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/)."
1. Onboard a test-drive account from the Payments page, "I'm setting up a store for someone else" section.
1. Then use "Reset account" from the Account tools section on the Payments > Overview page
1. Onboard another test-drive account from the Payments page, "I'm setting up a store for someone else" section.

1. Go to Payments > Settings, click on "Set up payments" button, click on the "Continue setup" button in the modal, and you should be redirected to the MOX wizard.
1. Finish the MOX and you should be taken to the Stripe KYC for our WCPay Dev Express platform account
![5V7j3O.png](https://github.com/user-attachments/assets/284ff5d0-d354-466e-b2a3-13c0ca5ea4c7)
1. Finish the Stripe KYC and you should have a working account and see the sandbox notice at the top of the Payments > Overview page.
![bBJGiF.png](https://github.com/user-attachments/assets/28ce4a5c-8b66-4e37-a4d2-f54c867cdae8)
1. Click on the "set up a live WooPayments account" link in the notice. A modal should open. Click on "Continue setup" and you should be redirected to the MOX.
1. Close the MOX and you should be taken to the Connect page with a sandbox mode notice at the top:
![L6b030.png](https://github.com/user-attachments/assets/7067dd8a-8bd6-486a-a5f4-033b2da9e7e8)


#### Testing with Dev Tools locally, without dev mode

1. Checkout the PR branch on your local environment
1. Build the assets by running `npm run build:client`
1. Make sure the "Enable the WCPay dev mode" checkbox is NOT checked on the WCPay Dev Tools page.
1. Go to the Payments page and you should NOT see a sandbox notice at the top
![ePUevR.png](https://github.com/user-attachments/assets/cee64380-2c3f-4c17-a342-f7d5fd07192d)
1. Onboard a test-drive account from the Payments page, "I'm setting up a store for someone else" section.
1. Then use "Reset account" from the Account tools section on the Payments > Overview page
1. Onboard another test-drive account from the Payments page, "I'm setting up a store for someone else" section.
1. Go to Payments > Settings, click on "Set up payments" button, click on the "Continue setup" button in the modal, and you should be redirected to the MOX wizard.
1. Finish the MOX and you should be taken to the Stripe KYC for our WooPayments production platform account (still in test mode because of the Stripe API keys you are using locally). As far as WooPayments is concerned, this is a live account.
![s7vxlR.png](https://github.com/user-attachments/assets/86cbd63e-1720-4566-aee1-ab7d7296dd2c)
1. Finish the Stripe KYC and you should have a working account and NOT see the sandbox notice at the top of the Payments > Overview page.
![zF5qCd.png](https://github.com/user-attachments/assets/eab48fe9-12ab-4e3b-87d9-474928517673)
1. Go to Payments > Settings and you should be able to enable test mode
![P8ShXv.png](https://github.com/user-attachments/assets/34f9129c-c8c8-4037-89b8-b0a402442c0c)
Please note that retrieving deposits and transactions will not work with test mode active because of the "double test mode"; that is expected, at least until we decide to make some changes to our platform to cover this case - but since it is only a testing scenario for devs, we are OK with it.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.