### PR TITLE
Fix broken Express Checkout buttons when size is set to "Large" (#9327)

### DIFF
--- a/changelog/as-fix-max-height-allowed
+++ b/changelog/as-fix-max-height-allowed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure 55px is the maximum height for Apple Pay button.

--- a/client/express-checkout/blocks/components/express-checkout-component.js
+++ b/client/express-checkout/blocks/components/express-checkout-component.js
@@ -40,7 +40,11 @@ const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
 	// Apple Pay has a nearly imperceptible height difference. We increase it by 1px here.
 	if ( buttonOptions.buttonTheme.applePay === 'black' ) {
 		if ( expressPaymentMethod === 'applePay' ) {
-			buttonOptions.buttonHeight = buttonOptions.buttonHeight + 0.4;
+			// The maximum allowed size is 55px.
+			buttonOptions.buttonHeight = Math.min(
+				buttonOptions.buttonHeight + 0.4,
+				55
+			);
 		}
 	}
 

--- a/client/express-checkout/blocks/components/express-checkout-container.js
+++ b/client/express-checkout/blocks/components/express-checkout-container.js
@@ -27,9 +27,11 @@ const ExpressCheckoutContainer = ( props ) => {
 	};
 
 	return (
-		<Elements stripe={ stripePromise } options={ options }>
-			<ExpressCheckoutComponent { ...props } />
-		</Elements>
+		<div style={ { minHeight: '40px' } }>
+			<Elements stripe={ stripePromise } options={ options }>
+				<ExpressCheckoutComponent { ...props } />
+			</Elements>
+		</div>
 	);
 };
 


### PR DESCRIPTION
This PR contains the changes made in https://github.com/Automattic/woocommerce-payments/pull/9327 to be applied in the upcoming 8.1.1 release