### PR TITLE
Redirect user to WooPay OTP when the email is saved

### DIFF
--- a/changelog/fix-woopay-email-redirect
+++ b/changelog/fix-woopay-email-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Redirect user to WooPay OTP when the email is saved.

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -75,8 +75,6 @@ button.wcpay-stripelink-modal-trigger:hover {
 
 #remember-me {
 	margin: 36px 0 0 0;
-	padding: 0;
-	border: 0;
 
 	h2 {
 		font-size: 18px;

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -285,5 +285,5 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 	}
 
-	openIframe( woopayEmailInput?.value );
+	openIframe( woopayEmailInput?.value || getConfig( 'woopaySessionEmail' ) );
 };

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -31,7 +31,7 @@ const renderSaveUserSection = () => {
 		)?.[ 0 ];
 
 		checkoutPageSaveUserContainer.className =
-			'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block ';
+			'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block wc-block-components-checkout-step ';
 		checkoutPageSaveUserContainer.id = 'remember-me';
 
 		if ( paymentOptions ) {

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -277,7 +277,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 									<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
 								</svg>
 							) }
-							<span>
+							<span className="wc-block-components-checkbox__label">
 								{ __(
 									'Securely save my information for 1-click checkout',
 									'woocommerce-payments'

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -86,7 +86,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		rememberMe.removeAttribute( 'disabled', 'disabled' );
 	}, [ checkoutIsProcessing, isBlocksCheckout ] );
 
-	const getPhoneFieldValue = () => {
+	const getPhoneFieldValue = useCallback( () => {
 		let phoneFieldValue = '';
 		if ( isBlocksCheckout ) {
 			phoneFieldValue =
@@ -109,7 +109,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		}
 
 		return phoneFieldValue;
-	};
+	}, [ isBlocksCheckout ] );
 
 	const sendExtensionData = useCallback(
 		( shouldClearData = false ) => {
@@ -172,7 +172,7 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		} );
 	}, [] );
 
-	const updatePhoneNumberValidationError = useCallback( () => {
+	useEffect( () => {
 		if ( ! isSaveDetailsChecked ) {
 			clearValidationError( errorId );
 			if ( isPhoneValid !== null ) {
@@ -218,6 +218,10 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		? isWCPayChosen
 		: isWCPayChosen && isNewPaymentTokenChosen;
 
+	useEffect( () => {
+		setPhoneNumber( getPhoneFieldValue() );
+	}, [ getPhoneFieldValue, isWCPayWithNewTokenChosen ] );
+
 	if (
 		! getConfig( 'forceNetworkSavedCards' ) ||
 		! isWCPayWithNewTokenChosen ||
@@ -231,8 +235,6 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		clearValidationError( errorId );
 		return null;
 	}
-
-	updatePhoneNumberValidationError();
 
 	return (
 		<Container

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -51,7 +51,7 @@ class WC_Payments_Utils {
 		'@^\/wc\/store(\/v[\d]+)?\/order\/(?P<id>[\d]+)@',
 		// The route below is not a Store API route. However, this REST endpoint is used by WooPay to indirectly reach the Store API.
 		// By adding it to this list, we're able to identify the user and load the correct session for this route.
-		'@^\/wc\/v3\/woopay\/session$@',
+		'@^\/payments\/woopay\/session$@',
 	];
 
 	/**

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use WCPay\Exceptions\Invalid_Price_Exception;
 use WCPay\Logger;
 use WCPay\Payment_Information;
+use WCPay\WooPay\WooPay_Session;
 use WCPay\WooPay\WooPay_Utilities;
 
 /**
@@ -148,10 +149,13 @@ class WC_Payments_WooPay_Button_Handler {
 	 * @return array The modified config array.
 	 */
 	public function add_woopay_config( $config ) {
+		$user = wp_get_current_user();
+
 		$config['woopayButton']           = $this->get_button_settings();
 		$config['woopayButtonNonce']      = wp_create_nonce( 'woopay_button_nonce' );
 		$config['addToCartNonce']         = wp_create_nonce( 'wcpay-add-to-cart' );
 		$config['shouldShowWooPayButton'] = $this->should_show_woopay_button();
+		$config['woopaySessionEmail']     = WooPay_Session::get_user_email( $user );
 
 		return $config;
 	}

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -405,10 +405,16 @@ class WooPay_Session {
 
 		// Get the email from the customer object if it's available.
 		if ( ! empty( WC()->customer ) ) {
-			$customer_changes = WC()->customer->get_changes();
+			$billing_email = WC()->customer->get_billing_email();
 
-			if ( isset( $customer_changes['billing'] ) && isset( $customer_changes['billing']['email'] ) ) {
-				return $customer_changes['billing']['email'];
+			if ( ! empty( $billing_email ) ) {
+				return $billing_email;
+			}
+
+			$customer_email = WC()->customer->get_email();
+
+			if ( ! empty( $customer_email ) ) {
+				return $customer_email;
 			}
 		}
 

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -403,6 +403,15 @@ class WooPay_Session {
 			}
 		}
 
+		// Get the email from the customer object if it's available.
+		if ( ! empty( WC()->customer ) ) {
+			$customer_changes = WC()->customer->get_changes();
+
+			if ( isset( $customer_changes['billing'] ) && isset( $customer_changes['billing']['email'] ) ) {
+				return $customer_changes['billing']['email'];
+			}
+		}
+
 		// As a last resort, we try to get the email from the customer logged in the store.
 		if ( $user->exists() ) {
 			return $user->user_email;

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -385,7 +385,7 @@ class WooPay_Session {
 	 * @param \WP_User $user The user object.
 	 * @return string The user email.
 	 */
-	private static function get_user_email( $user ) {
+	public static function get_user_email( $user ) {
 		if ( ! empty( $_POST['email'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return sanitize_email( wp_unslash( $_POST['email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}


### PR DESCRIPTION
Fixes #9294
Fixes #9350

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
When the guest user email is stored in session and the user clicks the WooPay express checkout button while logged out, automatically load the user email.

This PR needs to be tested alongside 2909-gh-Automattic/woopay.

This PR also fixes visual issues on the WooPay blocks component that happens while running the latest WooCommerce version on Storefront theme and #9350.

<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/3717a84c-4257-487a-ba19-f9f7d5d55b30" alt="Screenshot 2024-08-28 at 1 23 15 PM">
</td>
<td>
<img src="https://github.com/user-attachments/assets/21b0117d-9bda-4db1-960b-96fccba32a48" alt="Screenshot 2024-08-28 at 3 31 22 PM">
</td>
</tr>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a guest user, checkout on merchant store to save the email in session.
* Add products to the cart and click the WooPay express checkout button.
* If the email exists on WooPay, you should be redirected directly to the OTP page, if not, you should be redirected to the add phone page.
* On WCPay DevTools, check `Force the pre_check_save_my_info flag (aka Default Opt-in) in the account cache to be` and set it to be `true`.
* Access merchant store checkout page, change the email to a non WooPay user.
* The WooPay phone number should be pre-filled with the billing account phone number.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
