### PR TITLE
Dev: Fix Klarna product page message E2E test

### DIFF
--- a/changelog/dev-fix-klarna-product-page-e2e
+++ b/changelog/dev-fix-klarna-product-page-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix Klarna product page message E2E test after the contents inside the iframe were updated.

--- a/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js
@@ -46,12 +46,10 @@ describe( 'Klarna checkout', () => {
 		const paymentMethodMessageIframe = await paymentMethodMessageFrameHandle.contentFrame();
 
 		// Click on Klarna link to open the modal.
-		await paymentMethodMessageIframe.evaluate( ( selector ) => {
-			const element = document.querySelector( selector );
-			if ( element ) {
-				element.click();
-			}
-		}, 'a[aria-label="Open Learn More Modal"]' );
+		const learnMoreLink = await paymentMethodMessageIframe.waitForSelector(
+			'a[aria-haspopup="dialog"]'
+		);
+		await learnMoreLink.click();
 
 		// Wait for the iframe to be added by Stripe JS after clicking on the element.
 		await page.waitForTimeout( 1000 );


### PR DESCRIPTION
Fixes #9339

#### Changes proposed in this Pull Request

The E2E tests for Klarna started to fail after the contents inside the iframe in the product page was modified by an external party. This fixes the issue and also changes the way the element is clicked so we get an error if said element doesn't exist, instead of just skipping it.

#### Testing instructions

* Setup the E2E environment locally and run `npm run test:e2e tests/e2e/specs/wcpay/shopper/shopper-klarna-checkout.spec.js`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply): N/A

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
