### PR TITLE
Move `PaymentMethodsCompatibility` logic out of the `MultiCurrency` namespace

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -42,6 +42,7 @@ use WCPay\WooPay\WooPay_Scheduler;
 use WCPay\WooPay\WooPay_Session;
 use WCPay\Compatibility_Service;
 use WCPay\Duplicates_Detection_Service;
+use WCPay\WC_Payments_Currency_Manager;
 
 /**
  * Main class for the WooPayments extension. Its responsibility is to initialize the extension.
@@ -300,6 +301,13 @@ class WC_Payments {
 	private static $duplicates_detection_service;
 
 	/**
+	 * Instance of WC_Payments_Currency_Manager, created in init function
+	 *
+	 * @var WC_Payments_Currency_Manager
+	 */
+	private static $currency_manager;
+
+	/**
 	 * Entry point to the initialization logic.
 	 */
 	public static function init() {
@@ -484,6 +492,7 @@ class WC_Payments {
 		include_once __DIR__ . '/class-wc-payments-incentives-service.php';
 		include_once __DIR__ . '/class-compatibility-service.php';
 		include_once __DIR__ . '/multi-currency/wc-payments-multi-currency.php';
+		include_once __DIR__ . '/class-wc-payments-currency-manager.php';
 		include_once __DIR__ . '/class-duplicates-detection-service.php';
 
 		self::$woopay_checkout_service = new Checkout_Service();
@@ -575,6 +584,9 @@ class WC_Payments {
 		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 
 		self::$customer_service_api = new WC_Payments_Customer_Service_API( self::$customer_service );
+
+		self::$currency_manager = new WC_Payments_Currency_Manager( self::get_gateway() );
+		self::$currency_manager->init_hooks();
 
 		// Only register hooks of the new `src` service with the same feature of Duplicate_Payment_Prevention_Service.
 		// To avoid register the same hooks twice.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -7,8 +7,6 @@
 
 namespace WCPay\MultiCurrency;
 
-use WC_Payments;
-use WCPay\MultiCurrency\Logger;
 use WCPay\MultiCurrency\Exceptions\InvalidCurrencyException;
 use WCPay\MultiCurrency\Exceptions\InvalidCurrencyRateException;
 use WCPay\MultiCurrency\Helpers\OrderMetaHelper;
@@ -16,6 +14,7 @@ use WCPay\MultiCurrency\Interfaces\MultiCurrencyAccountInterface;
 use WCPay\MultiCurrency\Interfaces\MultiCurrencyApiClientInterface;
 use WCPay\MultiCurrency\Interfaces\MultiCurrencyCacheInterface;
 use WCPay\MultiCurrency\Interfaces\MultiCurrencyLocalizationInterface;
+use WCPay\MultiCurrency\Logger;
 use WCPay\MultiCurrency\Notes\NoteMultiCurrencyAvailable;
 use WCPay\MultiCurrency\Utils;
 
@@ -263,9 +262,8 @@ class MultiCurrency {
 			$this->update_manual_rate_currencies_notice_option();
 		}
 
-		$payment_method_compat = new PaymentMethodsCompatibility( $this, WC_Payments::get_gateway() );
-		$admin_notices         = new AdminNotices();
-		$user_settings         = new UserSettings( $this );
+		$admin_notices = new AdminNotices();
+		$user_settings = new UserSettings( $this );
 		new Analytics( $this );
 
 		$this->frontend_prices     = new FrontendPrices( $this, $this->compatibility );
@@ -275,7 +273,6 @@ class MultiCurrency {
 		$this->order_meta_helper   = new OrderMetaHelper( $this->payments_api_client, $this->backend_currencies );
 
 		// Init all of the hooks.
-		$payment_method_compat->init_hooks();
 		$admin_notices->init_hooks();
 		$user_settings->init_hooks();
 		$this->frontend_prices->init_hooks();


### PR DESCRIPTION
Fixes 74-gh-Automattic/woopayments

#### Changes proposed in this Pull Request

The main goal of this PR is to move the old `PaymentMethodsCompatibility` logic to add missing currencies to outside of the multi-currency module, because that's very coupled with V1 payment methods.

There's still some unfortunate coupling between the `window.multiCurrencyPaymentMethodsMap` JS object and payment method image assets in the multi-currency settings, but to fix that we would need to abstract the front-end further.

#### Testing instructions

**MCCY critical flows:**

Make sure these critical flows pass:

- [Multi-currency: Edit](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#multi-currency-edit)
- [Multi-currency: Add widget](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#multi-currency-set-up)
- [Multi-currency: Checkout as a guest shopper](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#multi-currency-onboarding)

**Regression test: Add missing currencies**

1. As a merchant, enable MCCY and navigate to MCCY settings.
2. Remove all currencies except for USD.
3. Navigate to **Payments > Settings** and disable all payment methods except Credit / Debit card and click "Save changes".
4. Enable P24 and click "Save changes".
5. Navigate back to MCCY settings and ensure EUR and PLN were added.
6. Ensure EUR is added for Bancontact or EPS.
7. Temporarily change the store currency to EUR and ensure USD is added for Klarna.

**Regression test: Confirm delete currency**

- When deleting a currency from MCCY settings, ensure there's a confirmation dialog mentioning the payment method which requires that currency.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.