### PR TITLE
hacks to get e2e env running reliably for me

### DIFF
--- a/tests/e2e/env/docker-compose.service-e2e-override.yml
+++ b/tests/e2e/env/docker-compose.service-e2e-override.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+volumes:
+  mysql_data:
+
+services:
+  db:
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+  # mailhog:
+  #   image: mailhog/mailhog
+  #   ports:
+  #     - 8098:8025 # web ui to view emails sent from WooPayments Server, view on http://localhost:8088

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -1,3 +1,7 @@
+
+volumes:
+    mysql_data:
+
 services:
   wordpress:
     build: ./wordpress-xdebug
@@ -33,7 +37,8 @@ services:
     env_file:
       - ${E2E_ROOT}/env/default.env
     volumes:
-      - ${E2E_ROOT}/docker/data:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
+
   phpMyAdmin:
     container_name: wcp_e2e_phpmyadmin
     image: phpmyadmin/phpmyadmin:latest

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -68,10 +68,9 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 
 	step "Starting SERVER containers"
 	if [ -e $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE ]; then
-		echo "Using service override file: $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE"
+		echo "Using docker override file for WooPayments service (aka wcpay-server): $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE"
 		redirect_output docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE up --build --force-recreate -d
 	else
-		echo "bad"
 		redirect_output docker compose -f docker-compose.yml -f docker-compose.e2e.yml up --build --force-recreate -d
 	fi
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -29,6 +29,8 @@ WP_ADMIN_EMAIL=$(<"$DEFAULT_CONFIG_JSON_PATH" jq -r '.users.admin.email')
 SITE_TITLE="WooPayments E2E site"
 SITE_URL=$WP_URL
 
+E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE="$E2E_ROOT"/env/docker-compose.service-e2e-override.yml
+
 if [[ $FORCE_E2E_DEPS_SETUP ]]; then
 	sudo rm -rf tests/e2e/deps
 fi
@@ -65,7 +67,13 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	echo "Secrets created"
 
 	step "Starting SERVER containers"
-	redirect_output docker compose -f docker-compose.yml -f docker-compose.e2e.yml up --build --force-recreate -d
+	if [ -e $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE ]; then
+		echo "Using service override file: $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE"
+		redirect_output docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f $E2E_SERVICE_DOCKER_COMPOSE_OVERRIDE_FILE up --build --force-recreate -d
+	else
+		echo "bad"
+		redirect_output docker compose -f docker-compose.yml -f docker-compose.e2e.yml up --build --force-recreate -d
+	fi
 
 	# Get WordPress instance port number from running containers, and print a debug line to show if it works.
 	WP_LISTEN_PORT=$(docker ps | grep "$SERVER_CONTAINER" | sed -En "s/.*0:([0-9]+).*/\1/p")


### PR DESCRIPTION
- use named volume for db container (web/store)
- allow override of server config (service) so can use named volume there too

🎉 This branch will unblock me from using Playwright/running e2e. 

However I don't think we should merge this, I think we should switch to named volumes for all database containers.

- https://github.com/Automattic/woocommerce-payments/issues/3946

Fixes #9337

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
