### PR TITLE
Define WooPay URL for E2E setup

### DIFF
--- a/changelog/update-e2e-setup-script
+++ b/changelog/update-e2e-setup-script
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Define WooPay url for e2e env setup
+
+

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -60,6 +60,7 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	define( 'WCPAY_STRIPE_LIVE_PUBLIC_KEY', 'pk_live_XXXXXXX' );
 	define( 'WCPAY_STRIPE_LIVE_SECRET_KEY', 'sk_live_XXXXXXX' );
 	define( 'WCPAY_ONBOARDING_ENCRYPT_KEY', str_repeat( 'a', SODIUM_CRYPTO_SECRETBOX_KEYBYTES ) );
+	define( 'WOOPAY_URL', 'https://pay.woo.com' );
 	"
 	printf "$SECRETS" > "local/secrets.php"
 	echo "Secrets created"


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Adds WooPay default URL to server secrets during E2E environment setup. This is required to prevent failures with the upcoming PHP 8.1 upgrade in server.

This PR will be merged to trunk first, so server repository can pick up the changes.

#### Testing instructions

* NA

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
