### PR TITLE
Fixed invalid appearance warning

### DIFF
--- a/changelog/fix-9384-invalid-appearence
+++ b/changelog/fix-9384-invalid-appearence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed invalid appearance warnings

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -466,7 +466,7 @@ export default class WCPayAPI {
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 				_wpnonce: nonce,
 				appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-					? getAppearance( appearanceType )
+					? getAppearance( appearanceType, true )
 					: null,
 				email: userEmail,
 				user_session: woopayUserSession,

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -443,7 +443,7 @@ export const getFontRulesFromPage = () => {
 	return fontRules;
 };
 
-export const getAppearance = ( elementsLocation ) => {
+export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 	const selectors = appearanceSelectors.getSelectors( elementsLocation );
 
 	// Add hidden fields to DOM for generating styles.
@@ -505,11 +505,18 @@ export const getAppearance = ( elementsLocation ) => {
 			'.TabIcon--selected': selectedTabIconRules,
 			'.Text': labelRules,
 			'.Text--redirect': labelRules,
+		},
+	};
+
+	if ( forWooPay ) {
+		appearance.rules = {
+			...appearance.rules,
 			'.Heading': headingRules,
 			'.Button': buttonRules,
 			'.Link': linkRules,
-		},
-	};
+		};
+	}
+
 	// Remove hidden fields from DOM.
 	hiddenElementsForUPE.cleanup();
 	return appearance;

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -119,7 +119,10 @@ describe( 'Getting styles for automated theming', () => {
 			return mockCSStyleDeclaration;
 		} );
 
-		const appearance = upeStyles.getAppearance( 'shortcode_checkout' );
+		const appearance = upeStyles.getAppearance(
+			'shortcode_checkout',
+			true
+		);
 		expect( appearance ).toEqual( {
 			variables: {
 				colorBackground: '#ffffff',

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -190,7 +190,7 @@ export const handleWooPayEmailInput = async (
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
 					appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-						? getAppearance( appearanceType )
+						? getAppearance( appearanceType, true )
 						: null,
 				}
 			).then( ( response ) => {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -110,7 +110,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
 					appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-						? getAppearance( appearanceType )
+						? getAppearance( appearanceType, true )
 						: null,
 				}
 			).then( ( response ) => {

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -232,7 +232,7 @@ export const WoopayExpressCheckoutButton = ( {
 						appearance: getConfig(
 							'isWooPayGlobalThemeSupportEnabled'
 						)
-							? getAppearance( appearanceType )
+							? getAppearance( appearanceType, true )
 							: null,
 					} )
 						.then( async ( response ) => {
@@ -278,7 +278,7 @@ export const WoopayExpressCheckoutButton = ( {
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
 					appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-						? getAppearance( appearanceType )
+						? getAppearance( appearanceType, true )
 						: null,
 				} )
 					.then( async ( response ) => {

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -36,8 +36,6 @@ const ERROR_MESSAGES_TO_IGNORE = [
 	'Failed to load resource: the server responded with a status of 400 (Bad Request)',
 	'No Amplitude API key provided',
 	'is registered with an invalid category',
-	'is not a supported class', // Silence stripe.js warnings regarding styles.
-	'is not a supported property for', // Silence stripe.js warnings regarding styles.
 ];
 
 ERROR_MESSAGES_TO_IGNORE.forEach( ( errorMessage ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a check to the `getApperance` function so it only returns Heading, Links and Buttons styles when initializing WooPay

Part of #9311

p1725473032776129/1725472660.619249-slack-C02CCT3F1QA

#### Testing instructions
- Make sure [this line](https://github.com/Automattic/woocommerce-payments/blob/039cbd5deac8e6d6cad695b064c6f024cb52cbb1/includes/class-wc-payments-checkout.php#L232) is set to false so it doesn't load the cached styling
- Make sure WooPay is enabled
- Open the dev Tools > console
- As a shopper visit a product page
- Make sure the `"Heading" is not a supported class` warning/error does not show up
- Check for other styling/appearance warnings/errors
- Click the WooPay button make sure you can checkout with WooPay
- Add another product to your cart and visit the cart page
- Check for warnings/errors again and checkout using WooPay
- Add another product to your cart and go to the checkout page
- Check for warnings/errors again and checkout using WooPay

- Repeat the checks with theming enabled and make sure the Buttons, Heading and Links styles load 
- To enable theming make sure to return `true` [here](https://github.com/Automattic/woocommerce-payments/blob/5c2c8a1b4afa5c64246ca7f07194ea9d59688dd4/includes/class-wc-payment-gateway-wcpay.php#L2574)
- Enable the theming option in your WooPay site at /wp-admin > WC Pay Dev tools
- Enable the theming option in your Merchant site at /wp-admin > Payments > Settings > WooPay

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.