### PR TITLE
Add Feature Flag for Embedded KYC

### DIFF
--- a/changelog/dev-9252-feature-flag-embedded-kyc
+++ b/changelog/dev-9252-feature-flag-embedded-kyc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Adding a feature flag to allow further development of embedded kyc - no effect on live stores yet.

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -16,6 +16,7 @@ declare global {
 			paymentTimeline: boolean;
 			isDisputeIssuerEvidenceEnabled: boolean;
 			isPaymentOverviewWidgetEnabled?: boolean;
+			isEmbeddedKycEnabled?: boolean;
 		};
 		fraudServices: unknown[];
 		testMode: boolean;

--- a/client/index.js
+++ b/client/index.js
@@ -70,19 +70,25 @@ addFilter(
 			capability: 'manage_woocommerce',
 		} );
 
-		pages.push( {
-			container: OnboardingKycPage,
-			path: '/payments/onboarding/kyc',
-			wpOpenMenu: menuID,
-			breadcrumbs: [
-				rootLink,
-				__( 'Continue onboarding', 'woocommerce-payments' ),
-			],
-			navArgs: {
-				id: 'wc-payments-continue-onboarding',
-			},
-			capability: 'manage_woocommerce',
-		} );
+		// Currently under feature flag.
+		if (
+			wcpaySettings &&
+			wcpaySettings.featureFlags.isEmbeddedKycEnabled
+		) {
+			pages.push( {
+				container: OnboardingKycPage,
+				path: '/payments/onboarding/kyc',
+				wpOpenMenu: menuID,
+				breadcrumbs: [
+					rootLink,
+					__( 'Continue onboarding', 'woocommerce-payments' ),
+				],
+				navArgs: {
+					id: 'wc-payments-continue-onboarding',
+				},
+				capability: 'manage_woocommerce',
+			} );
+		}
 
 		pages.push( {
 			container: OverviewPage,

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -48,8 +48,7 @@ const OnboardingStepper = () => {
 					<StoreDetails />
 				</OnboardingForm>
 			</Step>
-			{ wcpaySettings &&
-			wcpaySettings.featureFlags.isEmbeddedKycEnabled ? (
+			{ wcpaySettings?.featureFlags?.isEmbeddedKycEnabled ? (
 				<Step name="embedded" showHeading={ false }>
 					<EmbeddedKyc />
 				</Step>

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -18,6 +18,7 @@ import StoreDetails from './steps/store-details';
 import { trackStarted } from './tracking';
 import { getAdminUrl } from 'wcpay/utils';
 import './style.scss';
+import LoadingStep from 'wcpay/onboarding/steps/loading';
 
 const OnboardingStepper = () => {
 	const handleExit = () => {
@@ -47,9 +48,14 @@ const OnboardingStepper = () => {
 					<StoreDetails />
 				</OnboardingForm>
 			</Step>
-			<Step name="embedded" showHeading={ false }>
-				<EmbeddedKyc />
-			</Step>
+			{ wcpaySettings &&
+			wcpaySettings.featureFlags.isEmbeddedKycEnabled ? (
+				<LoadingStep name={ 'loading' } />
+			) : (
+				<Step name="embedded" showHeading={ false }>
+					<EmbeddedKyc />
+				</Step>
+			) }
 		</Stepper>
 	);
 };

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -50,11 +50,11 @@ const OnboardingStepper = () => {
 			</Step>
 			{ wcpaySettings &&
 			wcpaySettings.featureFlags.isEmbeddedKycEnabled ? (
-				<LoadingStep name={ 'loading' } />
-			) : (
 				<Step name="embedded" showHeading={ false }>
 					<EmbeddedKyc />
 				</Step>
+			) : (
+				<LoadingStep name={ 'loading' } />
 			) }
 		</Stepper>
 	);

--- a/client/onboarding/steps/loading.tsx
+++ b/client/onboarding/steps/loading.tsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { useOnboardingContext } from '../context';
+import { PoEligibleData, PoEligibleResult } from '../types';
+import { fromDotNotation } from '../utils';
+import { trackRedirected, useTrackAbandoned } from '../tracking';
+import LoadBar from 'components/load-bar';
+import strings from '../strings';
+
+interface Props {
+	name: string;
+}
+
+const LoadingStep: React.FC< Props > = () => {
+	const { data } = useOnboardingContext();
+
+	const { removeTrackListener } = useTrackAbandoned();
+
+	const isEligibleForPo = async () => {
+		if (
+			! data.country ||
+			! data.business_type ||
+			! data.mcc ||
+			! data.annual_revenue ||
+			! data.go_live_timeframe
+		) {
+			return false;
+		}
+		const eligibilityDetails: PoEligibleData = {
+			business: {
+				country: data.country,
+				type: data.business_type,
+				mcc: data.mcc,
+			},
+			store: {
+				annual_revenue: data.annual_revenue,
+				go_live_timeframe: data.go_live_timeframe,
+			},
+		};
+		const eligibleResult = await apiFetch< PoEligibleResult >( {
+			path: '/wc/v3/payments/onboarding/router/po_eligible',
+			method: 'POST',
+			data: eligibilityDetails,
+		} );
+
+		return 'eligible' === eligibleResult.result;
+	};
+
+	const handleComplete = async () => {
+		const { connectUrl } = wcpaySettings;
+
+		const urlParams = new URLSearchParams( window.location.search );
+		const urlSource =
+			urlParams.get( 'source' )?.replace( /[^\w-]+/g, '' ) || 'unknown';
+
+		let isEligible;
+		try {
+			isEligible = await isEligibleForPo();
+		} catch ( error ) {
+			// fall back to full KYC scenario.
+			// TODO maybe log these errors in future, e.g. with tracks.
+			isEligible = false;
+		}
+
+		trackRedirected( isEligible, urlSource );
+		removeTrackListener();
+
+		window.location.href = addQueryArgs( connectUrl, {
+			self_assessment: fromDotNotation( data ),
+			progressive: isEligible,
+			source: urlSource,
+			from: 'WCPAY_ONBOARDING_WIZARD',
+		} );
+	};
+
+	useEffect( () => {
+		handleComplete();
+		// We only want to run this once, so we disable the exhaustive deps rule.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return (
+		<div className="loading-step">
+			<h1 className="stepper__heading">
+				{ strings.steps.loading.heading }
+			</h1>
+			<LoadBar />
+			<h2 className="stepper__subheading">
+				{ strings.steps.loading.subheading }
+			</h2>
+		</div>
+	);
+};
+
+export default LoadingStep;

--- a/client/onboarding/steps/test/loading.tsx
+++ b/client/onboarding/steps/test/loading.tsx
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import Loading from '../loading';
+
+// Mock Api Fetch module and function
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// Mock wcpaySettings
+declare const global: {
+	wcpaySettings: {
+		connectUrl: string;
+	};
+};
+
+// Mock data, setData from OnboardingContext
+let data = {};
+const setData = jest.fn();
+
+jest.mock( '../../context', () => ( {
+	useOnboardingContext: jest.fn( () => ( {
+		data,
+		setData,
+	} ) ),
+} ) );
+
+jest.mock( 'components/stepper', () => ( {
+	useStepperContext: jest.fn( () => ( {
+		currentStep: 'loading',
+	} ) ),
+} ) );
+
+const checkLinkToContainNecessaryParams = ( link: string ) => {
+	expect( link ).toContain( 'self_assessment' );
+	expect( link ).toContain( 'progressive' );
+	expect( link ).toContain( 'country' );
+	expect( link ).toContain( 'mcc' );
+	expect( link ).toContain( 'annual_revenue' );
+	expect( link ).toContain( 'business_type' );
+	expect( link ).toContain( 'go_live_timeframe' );
+};
+
+describe( 'Loading', () => {
+	const originalWindowLocation = window.location;
+
+	beforeEach( () => {
+		// Prevent window.location.href redirect
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			enumerable: true,
+			value: new URL( window.location.href ),
+		} );
+		global.wcpaySettings = {
+			connectUrl: 'http://wcpay-connect-url',
+		};
+	} );
+
+	afterEach( () => {
+		// Roll back window.location.href behavior after test
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			enumerable: true,
+			value: originalWindowLocation,
+		} );
+	} );
+
+	it( 'renders loading screen and sends request to server in case of po eligible', async () => {
+		data = {
+			country: 'US',
+			business_type: 'individual',
+			mcc: 'most_popular__software_services',
+			annual_revenue: 'less_than_250k',
+			go_live_timeframe: 'within_1month',
+		};
+
+		jest.mocked( apiFetch ).mockResolvedValueOnce( {
+			result: 'eligible',
+			data: [],
+		} );
+
+		render( <Loading name="loading" /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				data: {
+					business: {
+						country: 'US',
+						type: 'individual',
+						mcc: 'most_popular__software_services',
+					},
+					store: {
+						annual_revenue: 'less_than_250k',
+						go_live_timeframe: 'within_1month',
+					},
+				},
+				method: 'POST',
+				path: `/wc/v3/payments/onboarding/router/po_eligible`,
+			} );
+		} );
+
+		checkLinkToContainNecessaryParams( window.location.href );
+	} );
+
+	it( 'renders loading screen and sends request to server in case of po not eligible', async () => {
+		data = {
+			country: 'GB',
+			business_type: 'individual',
+			mcc: 'most_popular__software_services',
+			annual_revenue: 'less_than_250k',
+			go_live_timeframe: 'within_1month',
+		};
+
+		jest.mocked( apiFetch ).mockResolvedValueOnce( {
+			result: 'not_eligible',
+			data: [],
+		} );
+
+		render( <Loading name="loading" /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				data: {
+					business: {
+						country: 'GB',
+						type: 'individual',
+						mcc: 'most_popular__software_services',
+					},
+					store: {
+						annual_revenue: 'less_than_250k',
+						go_live_timeframe: 'within_1month',
+					},
+				},
+				method: 'POST',
+				path: `/wc/v3/payments/onboarding/router/po_eligible`,
+			} );
+		} );
+
+		checkLinkToContainNecessaryParams( window.location.href );
+	} );
+} );

--- a/client/onboarding/types.ts
+++ b/client/onboarding/types.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 
-export type OnboardingSteps = 'business' | 'store' | 'embedded';
+export type OnboardingSteps = 'business' | 'store' | 'embedded' | 'loading';
 
 export type OnboardingFields = {
 	country?: string;

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -348,7 +348,7 @@ class WC_Payments_Admin {
 		}
 
 		// Register /payments/onboarding/kyc only when we have a Stripe account, but the Stripe KYC is not finished (details not submitted).
-		if ( $this->account->is_stripe_connected() && ! $this->account->is_details_submitted() ) {
+		if ( WC_Payments_Features::is_embedded_kyc_enabled() && $this->account->is_stripe_connected() && ! $this->account->is_details_submitted() ) {
 			wc_admin_register_page(
 				[
 					'id'         => 'wc-payments-onboarding-kyc',

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1817,7 +1817,8 @@ class WC_Payments_Account {
 		// If we are in the middle of an embedded onboarding, go to the KYC page.
 		// In this case, we don't need to generate a return URL from Stripe, and we
 		// can rely on the JS logic to generate the session.
-		if ( $this->onboarding_service->is_embedded_kyc_in_progress() ) {
+		// Currently under feature flag.
+		if ( WC_Payments_Features::is_embedded_kyc_enabled() && $this->onboarding_service->is_embedded_kyc_in_progress() ) {
 			// We want to carry over the connect link from value because with embedded KYC
 			// there is no interim step for the user.
 			$additional_args['from'] = WC_Payments_Onboarding_Service::get_from();

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -32,6 +32,7 @@ class WC_Payments_Features {
 	const TOKENIZED_CART_PRB_FLAG_NAME          = '_wcpay_feature_tokenized_cart_prb';
 	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME     = '_wcpay_feature_payment_overview_widget';
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME = '_wcpay_feature_woopay_global_theme_support';
+	const EMBEDDED_KYC_FLAG_NAME                = '_wcpay_feature_embedded_kyc';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -73,6 +74,15 @@ class WC_Payments_Features {
 	 */
 	public static function is_customer_multi_currency_enabled() {
 		return '1' === get_option( '_wcpay_feature_customer_multi_currency', '1' );
+	}
+
+	/**
+	 * Checks whether Embedded KYC is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_embedded_kyc_enabled(): bool {
+		return '1' === get_option( self::EMBEDDED_KYC_FLAG_NAME, '0' );
 	}
 
 	/**
@@ -387,6 +397,7 @@ class WC_Payments_Features {
 				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 				'isPaymentOverviewWidgetEnabled' => self::is_payment_overview_widget_ui_enabled(),
 				'isStripeEceEnabled'             => self::is_stripe_ece_enabled(),
+				'isEmbeddedKycEnabled'           => self::is_embedded_kyc_enabled(),
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -95,6 +95,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		unset( $_GET );
 		unset( $_REQUEST );
 		parent::tear_down();
+		delete_option( '_wcpay_feature_embedded_kyc' );
 	}
 
 	public function test_filters_registered_properly() {
@@ -834,6 +835,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_redirect_service
 			->expects( $this->never() )
 			->method( 'redirect_to_onboarding_wizard' );
+
+		update_option( '_wcpay_feature_embedded_kyc', '1' );
 
 		// If embedded KYC is in progress, we expect different URL.
 		$this->mock_onboarding_service

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -30,6 +30,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		'_wcpay_feature_documents'               => 'documents',
 		'_wcpay_feature_auth_and_capture'        => 'isAuthAndCaptureEnabled',
 		'_wcpay_feature_stripe_ece'              => 'isStripeEceEnabled',
+		'_wcpay_feature_embedded_kyc'            => 'isEmbeddedKycEnabled',
 	];
 
 	public function set_up() {
@@ -298,6 +299,35 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_frt_review_feature_active_returns_false_when_flag_is_not_set() {
 		$this->assertFalse( WC_Payments_Features::is_frt_review_feature_active() );
+	}
+
+	public function test_is_embedded_kyc_enabled_returns_true() {
+		add_filter(
+			'pre_option_' . WC_Payments_Features::EMBEDDED_KYC_FLAG_NAME,
+			function ( $pre_option, $option, $default ) {
+				return '1';
+			},
+			10,
+			3
+		);
+		$this->assertTrue( WC_Payments_Features::is_embedded_kyc_enabled() );
+	}
+
+	public function test_is_embedded_kyc_enabled_returns_false_when_flag_is_false() {
+		add_filter(
+			'pre_option_' . WC_Payments_Features::EMBEDDED_KYC_FLAG_NAME,
+			function ( $pre_option, $option, $default ) {
+				return '0';
+			},
+			10,
+			3
+		);
+		$this->assertFalse( WC_Payments_Features::is_embedded_kyc_enabled() );
+		$this->assertArrayNotHasKey( 'isEmbeddedKycEnabled', WC_Payments_Features::to_array() );
+	}
+
+	public function test_is_embedded_kyc_enabled_returns_false_when_flag_is_not_set() {
+		$this->assertFalse( WC_Payments_Features::is_embedded_kyc_enabled() );
 	}
 
 	private function setup_enabled_flags( array $enabled_flags ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9252 

#### Changes proposed in this Pull Request

* Add a feature flag for the embedded KYC feature
* Use it in the code

#### Testing instructions

* Check that the change makes sense and tests pass.
* Go to the connect page, then complete MOX and you should be redirected to Stripe
* Reset account
* Use dev tools version from https://github.com/Automattic/woocommerce-payments-dev-tools/pull/123 and enable the feature flag
* Change client version to 8.2.0
* Go to the connect page, then complete MOX and you should be redirected to the embedded KYC
* Leave the embedded KYC and check that continue onboarding from connect page loads embedded KYC form too.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
