### PR TITLE
Fixed default borderRadius value for the express checkout buttons

### DIFF
--- a/changelog/9311-fix-default-border-radius
+++ b/changelog/9311-fix-default-border-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed default borderRadius value for the express checkout buttons

--- a/client/express-checkout/utils/index.ts
+++ b/client/express-checkout/utils/index.ts
@@ -179,7 +179,7 @@ export const getExpressCheckoutButtonAppearance = () => {
 	return {
 		variables: {
 			borderRadius: `${
-				buttonSettings?.radius ?? getDefaultBorderRadius()
+				buttonSettings?.radius || getDefaultBorderRadius()
 			}px`,
 			spacingUnit: '6px',
 		},

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -185,4 +185,11 @@ declare global {
 		homeUrl: string;
 		siteTitle: string;
 	};
+
+	interface Window {
+		wcpaySettings: typeof wcpaySettings;
+		wc: typeof wc;
+		wcTracks: typeof wcTracks;
+		wcSettings: typeof wcSettings;
+	}
 }

--- a/client/payment-methods-map.tsx
+++ b/client/payment-methods-map.tsx
@@ -24,20 +24,6 @@ import {
 	SofortIcon,
 } from 'wcpay/payment-methods-icons';
 
-declare global {
-	interface Window {
-		wcpaySettings: {
-			accountStatus: {
-				country: string;
-			};
-		};
-		wcPayFrontendTracks: {
-			event: string;
-			properties: Record< string, unknown >;
-		};
-	}
-}
-
 const accountCountry = window.wcpaySettings?.accountStatus?.country || 'US';
 
 export interface PaymentMethodMapEntry {

--- a/client/utils/express-checkout/index.js
+++ b/client/utils/express-checkout/index.js
@@ -24,7 +24,7 @@ export const getExpressCheckoutConfig = ( key ) => {
 
 export const getDefaultBorderRadius = () => {
 	return parseInt(
-		wcpaySettings?.defaultExpressCheckoutBorderRadius ?? 4,
+		window?.wcpaySettings?.defaultExpressCheckoutBorderRadius || 4,
 		10
 	);
 };


### PR DESCRIPTION
Part of #9311 

#### Changes proposed in this Pull Request

In #9010 we added an option to customize the border radius for the express checkout buttons, however, the default value was not being properly handled. This PR fixes the following warning:

```
[Stripe.js] stripe.elements(): invalid variable value "px" provided to "borderRadius"; "borderRadius" accepts a valid CSS length unit.
```

![image](https://github.com/user-attachments/assets/4d96d6d7-7d08-4f28-9c71-b0087be3a35f)


#### Testing instructions

1. Enable the express checkout buttons
2. In your wp_options table, edit the `woocommerce_woocommerce_payments_settings` to remove the `payment_request_button_border_radius` if present.
3. Using jurassic tube, access the cart or the checkout page and notice the warning above in the console in `develop`
4. Switch to this branch and notice the warning is not displayed anymore

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
