### PR TITLE
Improve PHP unit tests handling of WP filters

### DIFF
--- a/changelog/dev-improve-unit-tests-handling-of-filters
+++ b/changelog/dev-improve-unit-tests-handling-of-filters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improvements to PHP unit tests to make them less flaky when it comes to WP filters.
+
+

--- a/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
+++ b/tests/unit/core/service/test-class-wc-payments-customer-service-api.php
@@ -74,11 +74,12 @@ class WC_Payments_Customer_Service_API_Test extends WCPAY_UnitTestCase {
 	 * Post-test teardown
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		remove_filter(
 			'wc_payments_http',
 			[ $this, 'replace_http_client' ]
 		);
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
+++ b/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
@@ -63,5 +63,7 @@ class Buyer_Fingerprinting_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$this->assertSame( $order_hashes, $expected_hashed_array );
+
+		remove_all_filters( 'woocommerce_geolocate_ip' );
 	}
 }

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -67,12 +67,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$this->add_mock_order_with_meta();
 		$this->set_is_admin( true );
 		$this->set_is_rest_request( true );
-		add_filter(
-			'woocommerce_is_rest_api_request',
-			function () {
-				return true;
-			}
-		);
+		add_filter( 'woocommerce_is_rest_api_request', '__return_true' );
 		// Add manage_woocommerce capability to user.
 		$cb = $this->create_can_manage_woocommerce_cap_override( true );
 		add_filter( 'user_has_cap', $cb );
@@ -98,8 +93,11 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	 * Post-test tear down.
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		$this->delete_mock_orders();
+
+		remove_filter( 'woocommerce_is_rest_api_request', '__return_true' );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -273,6 +271,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$expected = [ 'Santa Claus', 'Mrs. Claus' ];
 		add_filter( 'wcpay_multi_currency_disable_filter_select_clauses', '__return_true' );
 		$this->assertEquals( $expected, $this->analytics->filter_select_clauses( $expected, 'orders_stats' ) );
+
+		remove_filter( 'wcpay_multi_currency_disable_filter_select_clauses', '__return_true' );
 	}
 
 	public function test_filter_select_clauses_return_filter() {
@@ -285,6 +285,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 			}
 		);
 		$this->assertEquals( $expected, $this->analytics->filter_select_clauses( $clauses, 'orders_stats' ) );
+
+		remove_all_filters( 'wcpay_multi_currency_filter_select_clauses' );
 	}
 
 	public function test_filter_where_clauses_when_no_currency_provided() {
@@ -417,6 +419,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$_GET['currency_is'] = [ 'USD' ];
 
 		$this->assertEquals( $expected, $this->analytics->filter_where_clauses( $expected ) );
+
+		remove_filter( 'wcpay_multi_currency_disable_filter_where_clauses', '__return_true' );
 	}
 
 	/**
@@ -461,6 +465,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$expected = [ 'Santa Claus', 'Mrs. Claus' ];
 		add_filter( 'wcpay_multi_currency_disable_filter_join_clauses', '__return_true' );
 		$this->assertEquals( $expected, $this->analytics->filter_join_clauses( $expected, 'orders_stats' ) );
+
+		remove_filter( 'wcpay_multi_currency_disable_filter_join_clauses', '__return_true' );
 	}
 
 	public function test_filter_join_clauses_return_filter() {
@@ -473,6 +479,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 			}
 		);
 		$this->assertEquals( $expected, $this->analytics->filter_join_clauses( $clauses, 'orders_stats' ) );
+
+		remove_all_filters( 'wcpay_multi_currency_filter_join_clauses' );
 	}
 
 	/**
@@ -513,6 +521,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		$expected = [ 'Santa Claus', 'Mrs. Claus' ];
 		add_filter( 'wcpay_multi_currency_disable_filter_select_orders_clauses', '__return_true' );
 		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $expected ) );
+
+		remove_filter( 'wcpay_multi_currency_disable_filter_select_orders_clauses', '__return_true' );
 	}
 
 	public function test_filter_select_orders_clauses_return_filter() {
@@ -525,6 +535,8 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 			}
 		);
 		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $clauses ) );
+
+		remove_all_filters( 'wcpay_multi_currency_filter_select_orders_clauses' );
 	}
 
 	private function order_args_provider( $order_id, $parent_id, $num_items_sold, $total_sales, $tax_total, $shipping_total, $net_total ) {

--- a/tests/unit/multi-currency/test-class-geolocation.php
+++ b/tests/unit/multi-currency/test-class-geolocation.php
@@ -26,13 +26,25 @@ class WCPay_Multi_Currency_Geolocation_Tests extends WCPAY_UnitTestCase {
 	private $geolocation;
 
 	/**
-	 * Pre-test setup
+	 * Pre-test setup.
 	 */
 	public function set_up() {
 		parent::set_up();
 
 		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );
 		$this->geolocation               = new WCPay\MultiCurrency\Geolocation( $this->mock_localization_service );
+	}
+
+	/**
+	 * Post-test cleanup.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_all_filters( 'woocommerce_geolocate_ip' );
+		remove_all_filters( 'woocommerce_customer_default_location' );
+
+		parent::tear_down();
 	}
 
 	public function test_get_country_by_customer_location_returns_geolocation_country() {

--- a/tests/unit/test-class-compatibility-service.php
+++ b/tests/unit/test-class-compatibility-service.php
@@ -238,14 +238,13 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 			'stylesheet',
 			function ( $theme ) use ( $stylesheet ) {
 				return $stylesheet;
-			},
-			404 // 404 is used to be able to use remove_all_filters later.
+			}
 		);
 	}
 
 	// Removes all stylesheet/theme name filters.
 	private function remove_stylesheet_filters(): void {
-		remove_all_filters( 'stylesheet', 404 );
+		remove_all_filters( 'stylesheet' );
 	}
 
 	/**
@@ -262,14 +261,13 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 			'option_active_plugins',
 			function ( $active_plugins ) use ( $plugins ) {
 				return $plugins;
-			},
-			404 // 404 is used to be able to use remove_all_filters later.
+			}
 		);
 	}
 
 	// Removes all active plugin filters.
 	private function remove_option_active_plugins_filters() {
-		remove_all_filters( 'option_active_plugins', [ $this, 'active_plugins_filter_return' ], 404 );
+		remove_all_filters( 'option_active_plugins' );
 	}
 
 	// Used to purposely delete the active_plugins option in WP.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -217,9 +217,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 	 * @return void
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		WC_Payments::set_gateway( $this->wcpay_gateway );
 		WC()->session->set( 'wc_notices', [] );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -755,6 +756,9 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 
 		// Assert: woocommerce_order_status_pending was not called.
 		$this->assertFalse( $results['has_called_woocommerce_order_status_pending'] );
+
+		remove_all_actions( 'woocommerce_order_status_pending' );
+		remove_all_filters( 'woocommerce_default_order_status' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -3767,6 +3767,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->expect_router_factor( Factor::WCPAY_SUBSCRIPTION_SIGNUP(), false );
 		$this->card_gateway->should_use_new_process( $order );
+
+		remove_filter( 'wcpay_is_wcpay_subscriptions_enabled', '__return_true' );
 	}
 
 	public function test_new_process_payment() {

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -1294,6 +1294,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Account::is_on_boarding_disabled() );
 		// The option should be updated.
 		$this->assertFalse( (bool) get_option( 'wcpay_should_redirect_to_onboarding', false ) );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_after_plugin_activation_stripe_disconnected_and_onboarding_disabled_redirects() {
@@ -1323,6 +1325,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( WC_Payments_Account::is_on_boarding_disabled() );
 		// The option should be updated.
 		$this->assertFalse( (bool) get_option( 'wcpay_should_redirect_to_onboarding', false ) );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_after_plugin_activation_account_error() {
@@ -1349,6 +1353,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( $this->wcpay_account->maybe_redirect_after_plugin_activation() );
 		// The option should be updated.
 		$this->assertFalse( (bool) get_option( 'wcpay_should_redirect_to_onboarding', false ) );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_after_plugin_activation_account_valid() {
@@ -1384,6 +1390,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $this->wcpay_account->maybe_redirect_after_plugin_activation() );
 		// The option should be updated.
 		$this->assertFalse( (bool) get_option( 'wcpay_should_redirect_to_onboarding', false ) );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_after_plugin_activation_with_non_admin_user() {
@@ -1403,6 +1411,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $this->wcpay_account->maybe_redirect_after_plugin_activation() );
 		// The option should NOT be updated.
 		$this->assertTrue( (bool) get_option( 'wcpay_should_redirect_to_onboarding', false ) );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_after_plugin_activation_checks_the_account_once() {
@@ -1440,6 +1450,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $this->wcpay_account->maybe_redirect_after_plugin_activation() );
 		// The option should be updated.
 		$this->assertFalse( (bool) get_option( 'wcpay_should_redirect_to_onboarding', false ) );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_after_plugin_activation_returns_true_and_onboarding_re_enabled() {
@@ -1496,6 +1508,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		// Second call, on-boarding re-enabled.
 		$this->wcpay_account->maybe_redirect_after_plugin_activation();
 		$this->assertFalse( WC_Payments_Account::is_on_boarding_disabled() );
+
+		remove_filter( 'user_has_cap', $cb );
 	}
 
 	public function test_maybe_redirect_to_wcpay_connect_do_redirect() {

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -543,6 +543,8 @@ class WC_Payments_Customer_Service_Test extends WCPAY_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 
 		$this->customer_service->update_payment_method_with_billing_details_from_order( 'pm_mock', $order );
+
+		remove_all_filters( 'woocommerce_billing_fields' );
 	}
 
 	public function test_get_payment_methods_for_customer_not_throw_resource_missing_code_exception() {

--- a/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
@@ -201,6 +201,17 @@ class WC_Payments_Express_Checkout_Button_Display_Handler_Test extends WCPAY_Uni
 	}
 
 	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_all_filters( 'woocommerce_available_payment_gateways' );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @return WC_Payment_Gateway_WCPay
 	 */
 	private function make_wcpay_gateway() {

--- a/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
@@ -133,7 +133,6 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 		WC()->cart->empty_cart();
 		WC()->session->cleanup_sessions();
@@ -142,6 +141,8 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		remove_filter( 'wc_tax_enabled', '__return_false' );
 		remove_filter( 'pre_option_woocommerce_tax_display_cart', [ $this, '__return_excl' ] );
 		remove_filter( 'pre_option_woocommerce_tax_display_cart', [ $this, '__return_incl' ] );
+
+		parent::tear_down();
 	}
 
 	public function __return_excl() {
@@ -240,6 +241,8 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		$result = $this->mock_express_checkout_helper->get_total_label();
 
 		$this->assertEquals( 'Google Pay (via WooPayments)', $result );
+
+		remove_all_filters( 'wcpay_payment_request_total_label_suffix' );
 	}
 
 	public function test_filter_cart_needs_shipping_address_returns_false() {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -67,6 +67,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
+
 		parent::tear_down();
 	}
 
@@ -302,26 +303,14 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_embedded_kyc_enabled_returns_true() {
-		add_filter(
-			'pre_option_' . WC_Payments_Features::EMBEDDED_KYC_FLAG_NAME,
-			function ( $pre_option, $option, $default ) {
-				return '1';
-			},
-			10,
-			3
-		);
+		$this->set_feature_flag_option( WC_Payments_Features::EMBEDDED_KYC_FLAG_NAME, '1' );
+
 		$this->assertTrue( WC_Payments_Features::is_embedded_kyc_enabled() );
 	}
 
 	public function test_is_embedded_kyc_enabled_returns_false_when_flag_is_false() {
-		add_filter(
-			'pre_option_' . WC_Payments_Features::EMBEDDED_KYC_FLAG_NAME,
-			function ( $pre_option, $option, $default ) {
-				return '0';
-			},
-			10,
-			3
-		);
+		$this->set_feature_flag_option( WC_Payments_Features::EMBEDDED_KYC_FLAG_NAME, '0' );
+
 		$this->assertFalse( WC_Payments_Features::is_embedded_kyc_enabled() );
 		$this->assertArrayNotHasKey( 'isEmbeddedKycEnabled', WC_Payments_Features::to_array() );
 	}

--- a/tests/unit/test-class-wc-payments-incentives-service.php
+++ b/tests/unit/test-class-wc-payments-incentives-service.php
@@ -36,18 +36,30 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 		$this->incentives_service  = new WC_Payments_Incentives_Service( $this->mock_database_cache );
 		$this->incentives_service->init_hooks();
 
+		// Ensure the Payments menu is present.
 		global $menu;
 		// phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
 		$menu = [
 			[ 'Payments', null, 'wc-admin&path=/payments/connect' ],
 		];
+
+		// Ensure no payment gateways are available.
+		add_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
 	}
 
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
 	public function tear_down() {
-		parent::tear_down();
-
 		global $menu;
 		$menu = null; // phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
+
+		parent::tear_down();
 	}
 
 	public function test_filters_registered_properly() {
@@ -127,6 +139,8 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 		);
 
 		$this->assertNull( $this->incentives_service->get_cached_connect_incentive() );
+
+		remove_all_filters( 'woocommerce_countries_base_country' );
 	}
 
 	public function test_get_cached_connect_incentive_cached_error() {

--- a/tests/unit/test-class-wc-payments-localization-service.php
+++ b/tests/unit/test-class-wc-payments-localization-service.php
@@ -31,6 +31,8 @@ class WC_Payments_Localization_Service_Test extends WCPAY_UnitTestCase {
 		wp_set_current_user( 0 );
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'wcpay_eur_format' );
+
+		parent::tear_down();
 	}
 
 	public function test_get_currency_format_returns_default_format() {

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1021,12 +1021,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Assert: Check that the order status was updated to processing status.
 		$this->assertTrue( $this->order->has_status( [ Order_Status::PROCESSING ] ) );
 
-		remove_filter(
-			'wcpay_terminal_payment_completed_order_status',
-			function () {
-				return Order_Status::PROCESSING;
-			}
-		);
+		remove_all_filters( 'wcpay_terminal_payment_completed_order_status' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -162,7 +162,6 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 		WC()->cart->empty_cart();
 		WC()->session->cleanup_sessions();
@@ -178,6 +177,9 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 		remove_filter( 'wc_tax_enabled', '__return_true' );
 		remove_filter( 'wc_tax_enabled', '__return_false' );
 		remove_filter( 'wc_shipping_enabled', '__return_false' );
+		remove_all_filters( 'woocommerce_find_rates' );
+
+		parent::tear_down();
 	}
 
 	public function __return_yes() {
@@ -661,6 +663,8 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 
 		// Restore the sign-up fee after the test.
 		WC_Subscriptions_Product::set_sign_up_fee( 0 );
+
+		remove_all_filters( 'test_deposit_get_product' );
 	}
 
 	public function test_get_product_price_includes_variable_subscription_sign_up_fee() {
@@ -679,6 +683,8 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 
 		// Restore the sign-up fee after the test.
 		WC_Subscriptions_Product::set_sign_up_fee( 0 );
+
+		remove_all_filters( 'test_deposit_get_product' );
 	}
 
 	public function test_get_product_price_throws_exception_for_products_without_prices() {
@@ -709,6 +715,8 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 
 		// Restore the sign-up fee after the test.
 		WC_Subscriptions_Product::set_sign_up_fee( 0 );
+
+		remove_all_filters( 'test_deposit_get_product' );
 	}
 
 	private function create_mock_subscription( $type ) {

--- a/tests/unit/test-class-wc-payments-session-service.php
+++ b/tests/unit/test-class-wc-payments-session-service.php
@@ -53,6 +53,11 @@ class WC_Payments_Session_Service_Test extends WCPAY_UnitTestCase {
 		add_filter( 'pre_option_' . WC_Payments_Session_Service::SESSION_STORE_ID_OPTION, [ $this, 'mock_session_store_id' ] );
 	}
 
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
 	public function tear_down() {
 		parent::tear_down();
 

--- a/tests/unit/test-class-wc-payments-woopay-button-handler.php
+++ b/tests/unit/test-class-wc-payments-woopay-button-handler.php
@@ -135,9 +135,12 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		WC()->cart->empty_cart();
 		WC()->session->cleanup_sessions();
+
+		remove_all_filters( 'woocommerce_available_payment_gateways' );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -238,6 +241,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertTrue( $this->mock_pr->should_show_woopay_button() );
+
+		remove_filter( 'wcpay_platform_checkout_button_are_cart_items_supported', '__return_true' );
 	}
 
 	public function test_should_only_load_common_config_script() {
@@ -334,6 +339,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertFalse( $this->mock_pr->should_show_woopay_button() );
+
+		remove_filter( 'wcpay_platform_checkout_button_are_cart_items_supported', '__return_false' );
 	}
 
 	public function test_should_show_woopay_button_all_good_at_product() {
@@ -359,6 +366,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertTrue( $this->mock_pr->should_show_woopay_button() );
+
+		remove_filter( 'wcpay_woopay_button_is_product_supported', '__return_true' );
 	}
 
 	public function test_should_show_woopay_button_unsupported_product_at_product() {
@@ -384,6 +393,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertFalse( $this->mock_pr->should_show_woopay_button() );
+
+		remove_filter( 'wcpay_woopay_button_is_product_supported', '__return_false' );
 	}
 
 	public function test_should_show_woopay_button_not_available_at_product() {
@@ -409,6 +420,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			->willReturn( false );
 
 		$this->assertFalse( $this->mock_pr->should_show_woopay_button() );
+
+		remove_filter( 'wcpay_woopay_button_is_product_supported', '__return_true' );
 	}
 
 	public function test_should_show_woopay_button_page_not_supported() {
@@ -476,6 +489,8 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 			->method( 'is_product' );
 
 		$this->assertFalse( $this->mock_pr->should_show_woopay_button() );
+
+		remove_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
 	}
 
 	public function test_should_show_woopay_button_woopay_not_enabled() {

--- a/tests/unit/woopay/class-woopay-scheduler-test.php
+++ b/tests/unit/woopay/class-woopay-scheduler-test.php
@@ -57,6 +57,8 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 		$this->scheduler->update_compatibility_and_maybe_show_incompatibility_warning();
 
 		$this->assertTrue( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+
+		remove_filter( 'pre_option_active_plugins', $active_plugins_mock );
 	}
 
 	/**
@@ -82,6 +84,8 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 		$this->scheduler->update_compatibility_and_maybe_show_incompatibility_warning();
 
 		$this->assertNull( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+
+		remove_filter( 'pre_option_active_plugins', $active_plugins_mock );
 	}
 
 	/**
@@ -127,6 +131,8 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 		$this->scheduler->hide_warning_when_incompatible_extension_is_disabled( 'test-extension/test-extension.php' );
 
 		$this->assertNull( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+
+		remove_filter( 'pre_option_active_plugins', $active_plugins_mock );
 	}
 
 	/**
@@ -154,6 +160,8 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 		$this->scheduler->hide_warning_when_incompatible_extension_is_disabled( 'test-extension/test-extension.php' );
 
 		$this->assertTrue( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+
+		remove_filter( 'pre_option_active_plugins', $active_plugins_mock );
 	}
 
 	/**
@@ -218,6 +226,8 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 		$this->assertEquals( get_option( WooPay_Scheduler::ADAPTED_EXTENSIONS_LIST_OPTION_NAME ), $adapted_extensions );
 		$this->assertEquals( get_option( WooPay_Utilities::AVAILABLE_COUNTRIES_OPTION_NAME ), '["US","BR"]' );
 		$this->assertEquals( get_option( WooPay_Scheduler::ENABLED_ADAPTED_EXTENSIONS_OPTION_NAME, [] ), [ 'test-extension' ] );
+
+		remove_filter( 'pre_option_active_plugins', $active_plugins_mock );
 	}
 
 	/**

--- a/tests/unit/woopay/test-class-woopay-session.php
+++ b/tests/unit/woopay/test-class-woopay-session.php
@@ -62,6 +62,8 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 
 		wp_set_current_user( 0 );
 
+		remove_filter( 'wcpay_woopay_is_signed_with_blog_token', '__return_true' );
+
 		parent::tear_down();
 	}
 

--- a/tests/unit/woopay/test-class-woopay-utilities.php
+++ b/tests/unit/woopay/test-class-woopay-utilities.php
@@ -24,6 +24,7 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	public function tear_down() {
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
+
 		parent::tear_down();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We ensure that WP filters added by tests are properly removed to avoid flakiness. We also make Incentives service unit tests more contained by arranging the available gateways.

Additional context: p1725083369590499-slack-C064G2D24LE

#### Testing instructions

* Code changes make sense
* PHP Unit tests pass

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows): Not applicable
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post: Not applicable