### PR TITLE
Add rate limiter to compatibility data updates

### DIFF
--- a/changelog/add-server-6156-compatibility-data-rate-limiter
+++ b/changelog/add-server-6156-compatibility-data-rate-limiter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add rate limiter to compatibility data updates

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -47,7 +47,7 @@ class Compatibility_Service {
 	}
 
 	/**
-	 * Schedules the sending of the compatibility data to 5 minutes to send only the last update in 5 minutes.
+	 * Schedules the sending of the compatibility data to send only the last update in T minutes.
 	 *
 	 * @return void
 	 */

--- a/includes/class-compatibility-service.php
+++ b/includes/class-compatibility-service.php
@@ -7,6 +7,7 @@
 
 namespace WCPay;
 
+use WC_Payments;
 use WC_Payments_API_Client;
 use WCPay\Exceptions\API_Exception;
 
@@ -16,6 +17,8 @@ defined( 'ABSPATH' ) || exit; // block direct access.
  * Class to send compatibility data to the server.
  */
 class Compatibility_Service {
+	const UPDATE_COMPATIBILITY_DATA = 'wcpay_update_compatibility_data';
+
 	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
@@ -44,16 +47,22 @@ class Compatibility_Service {
 	}
 
 	/**
-	 * Gets the data we need to confirm compatibility and sends it to the server.
+	 * Schedules the sending of the compatibility data to 5 minutes to send only the last update in 5 minutes.
 	 *
 	 * @return void
 	 */
 	public function update_compatibility_data() {
-		try {
-			$this->payments_api_client->update_compatibility_data( $this->get_compatibility_data() );
-		} catch ( API_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// The exception is already logged if logging is on, nothing else needed.
-		}
+		// This will delete the previous compatibility requests in the last two minutes, and only send the last update to the server, ensuring there's only one update in two minutes.
+		WC_Payments::get_action_scheduler_service()->schedule_job( time() + 2 * MINUTE_IN_SECONDS, self::UPDATE_COMPATIBILITY_DATA );
+	}
+
+	/**
+	 * Gets the data we need to confirm compatibility and sends it to the server.
+	 *
+	 * @return  void
+	 */
+	public function update_compatibility_data_hook() {
+		$this->payments_api_client->update_compatibility_data( $this->get_compatibility_data() );
 	}
 
 	/**

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments
  */
 
+use WCPay\Compatibility_Service;
 use WCPay\Constants\Order_Mode;
 
 defined( 'ABSPATH' ) || exit;
@@ -30,19 +31,28 @@ class WC_Payments_Action_Scheduler_Service {
 	 */
 	private $order_service;
 
+	/**
+	 * Compatibility service instance for updating compatibility data.
+	 *
+	 * @var Compatibility_Service
+	 */
+	private $compatibility_service;
 
 	/**
 	 * Constructor for WC_Payments_Action_Scheduler_Service.
 	 *
 	 * @param WC_Payments_API_Client    $payments_api_client - WooCommerce Payments API client.
 	 * @param WC_Payments_Order_Service $order_service - Order Service.
+	 * @param Compatibility_Service     $compatibility_service - Compatibility service instance.
 	 */
 	public function __construct(
 		WC_Payments_API_Client $payments_api_client,
-		WC_Payments_Order_Service $order_service
+		WC_Payments_Order_Service $order_service,
+		Compatibility_Service $compatibility_service
 	) {
-		$this->payments_api_client = $payments_api_client;
-		$this->order_service       = $order_service;
+		$this->payments_api_client   = $payments_api_client;
+		$this->order_service         = $order_service;
+		$this->compatibility_service = $compatibility_service;
 
 		$this->add_action_scheduler_hooks();
 	}
@@ -56,6 +66,7 @@ class WC_Payments_Action_Scheduler_Service {
 		add_action( 'wcpay_track_new_order', [ $this, 'track_new_order_action' ] );
 		add_action( 'wcpay_track_update_order', [ $this, 'track_update_order_action' ] );
 		add_action( WC_Payments_Order_Service::ADD_FEE_BREAKDOWN_TO_ORDER_NOTES, [ $this->order_service, 'add_fee_breakdown_to_order_notes' ], 10, 3 );
+		add_action( Compatibility_Service::UPDATE_COMPATIBILITY_DATA, [ $this->compatibility_service, 'update_compatibility_data_hook' ], 10, 0 );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -502,7 +502,8 @@ class WC_Payments {
 		include_once WCPAY_ABSPATH . 'includes/class-woopay-tracker.php';
 
 		self::$order_service                        = new WC_Payments_Order_Service( self::$api_client );
-		self::$action_scheduler_service             = new WC_Payments_Action_Scheduler_Service( self::$api_client, self::$order_service );
+		self::$compatibility_service                = new Compatibility_Service( self::$api_client );
+		self::$action_scheduler_service             = new WC_Payments_Action_Scheduler_Service( self::$api_client, self::$order_service, self::$compatibility_service );
 		self::$session_service                      = new WC_Payments_Session_Service( self::$api_client );
 		self::$redirect_service                     = new WC_Payments_Redirect_Service( self::$api_client );
 		self::$onboarding_service                   = new WC_Payments_Onboarding_Service( self::$api_client, self::$database_cache, self::$session_service );
@@ -519,7 +520,6 @@ class WC_Payments {
 		self::$woopay_tracker                       = new WooPay_Tracker( self::get_wc_payments_http() );
 		self::$incentives_service                   = new WC_Payments_Incentives_Service( self::$database_cache );
 		self::$duplicate_payment_prevention_service = new Duplicate_Payment_Prevention_Service();
-		self::$compatibility_service                = new Compatibility_Service( self::$api_client );
 		self::$duplicates_detection_service         = new Duplicates_Detection_Service();
 
 		( new WooPay_Scheduler( self::$api_client ) )->init();

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -8,6 +8,7 @@
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\RestApi;
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Compatibility_Service;
 use WCPay\Constants\Country_Code;
 use WCPay\Constants\Payment_Method;
 use WCPay\Database_Cache;
@@ -126,7 +127,8 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$order_service                           = new WC_Payments_Order_Service( $this->mock_api_client );
 		$customer_service                        = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_wcpay_account, $this->mock_db_cache, $this->mock_session_service, $order_service );
 		$token_service                           = new WC_Payments_Token_Service( $this->mock_api_client, $customer_service );
-		$action_scheduler_service                = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client, $order_service );
+		$compatibility_service                   = new Compatibility_Service( $this->mock_api_client );
+		$action_scheduler_service                = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client, $order_service, $compatibility_service );
 		$mock_rate_limiter                       = $this->createMock( Session_Rate_Limiter::class );
 		$mock_dpps                               = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 		$this->mock_localization_service         = $this->createMock( WC_Payments_Localization_Service::class );

--- a/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Compatibility_Service;
 use WCPay\Core\Server\Request\Add_Account_Tos_Agreement;
 use WCPay\Database_Cache;
 use WCPay\Duplicate_Payment_Prevention_Service;
@@ -63,7 +64,8 @@ class WC_REST_Payments_Tos_Controller_Test extends WCPAY_UnitTestCase {
 		$order_service                     = new WC_Payments_Order_Service( $this->createMock( WC_Payments_API_Client::class ) );
 		$customer_service                  = new WC_Payments_Customer_Service( $mock_api_client, $mock_wcpay_account, $mock_db_cache, $mock_session_service, $order_service );
 		$token_service                     = new WC_Payments_Token_Service( $mock_api_client, $customer_service );
-		$action_scheduler_service          = new WC_Payments_Action_Scheduler_Service( $mock_api_client, $order_service );
+		$mock_compatibility_service        = $this->createMock( Compatibility_Service::class );
+		$action_scheduler_service          = new WC_Payments_Action_Scheduler_Service( $mock_api_client, $order_service, $mock_compatibility_service );
 		$mock_dpps                         = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 		$mock_payment_method               = $this->createMock( CC_Payment_Method::class );
 		$mock_duplicates_detection_service = $this->createMock( Duplicates_Detection_Service::class );

--- a/tests/unit/test-class-compatibility-service.php
+++ b/tests/unit/test-class-compatibility-service.php
@@ -120,21 +120,53 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 		];
 	}
 
-	public function test_update_compatibility_data() {
-		// Arrange: Create the expected value to be passed to update_compatibility_data.
-		$expected = $this->get_mock_compatibility_data();
-
-		// Arrange/Assert: Set the expectations for update_compatibility_data.
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'update_compatibility_data' )
-			->with( $expected );
+	public function test_update_compatibility_data_adds_scheduled_job() {
+		// Arrange: Clear all previously scheduled compatibility update jobs.
+		as_unschedule_all_actions( Compatibility_Service::UPDATE_COMPATIBILITY_DATA );
 
 		// Act: Call the method we're testing.
 		$this->compatibility_service->update_compatibility_data();
+
+		// Assert: Test the scheduled actions.
+		$actions = as_get_scheduled_actions(
+			[
+				'hook'   => Compatibility_Service::UPDATE_COMPATIBILITY_DATA,
+				'status' => ActionScheduler_Store::STATUS_PENDING,
+				'group'  => WC_Payments_Action_Scheduler_Service::GROUP_ID,
+			]
+		);
+
+		$this->assertCount( 1, $actions );
+		$action = array_pop( $actions );
+		$this->assertInstanceOf( ActionScheduler_Action::class, $action );
 	}
 
-	public function test_update_compatibility_data_active_plugins_false() {
+	public function test_update_compatibility_data_adds_a_single_scheduled_job() {
+
+		// Arrange: Clear all previously scheduled compatibility update jobs.
+		as_unschedule_all_actions( Compatibility_Service::UPDATE_COMPATIBILITY_DATA );
+
+		// Act: Call the method we're testing.
+		$this->compatibility_service->update_compatibility_data();
+		$this->compatibility_service->update_compatibility_data();
+		$this->compatibility_service->update_compatibility_data();
+		$this->compatibility_service->update_compatibility_data();
+
+		// Assert: Test the scheduled actions.
+		$actions = as_get_scheduled_actions(
+			[
+				'hook'   => Compatibility_Service::UPDATE_COMPATIBILITY_DATA,
+				'status' => ActionScheduler_Store::STATUS_PENDING,
+				'group'  => WC_Payments_Action_Scheduler_Service::GROUP_ID,
+			]
+		);
+
+		$this->assertCount( 1, $actions );
+		$action = array_pop( $actions );
+		$this->assertInstanceOf( ActionScheduler_Action::class, $action );
+	}
+
+	public function test_update_compatibility_data_hook_active_plugins_false() {
 		// Arrange: Create the expected value to be passed to update_compatibility_data.
 		$expected = $this->get_mock_compatibility_data(
 			[
@@ -152,7 +184,7 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 			->with( $expected );
 
 		// Act: Call the method we're testing.
-		$this->compatibility_service->update_compatibility_data();
+		$this->compatibility_service->update_compatibility_data_hook();
 
 		// Arrange: Fix the broke active_plugins option in WP.
 		$this->fix_active_plugins_option();
@@ -163,7 +195,7 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @dataProvider provider_update_compatibility_data_permalinks_not_set
 	 */
-	public function test_update_compatibility_data_permalinks_not_set( $page_name ) {
+	public function test_update_compatibility_data_hook_permalinks_not_set( $page_name ) {
 		// Arrange: Create the expected value to be passed to update_compatibility_data.
 		$expected = $this->get_mock_compatibility_data(
 			[
@@ -181,7 +213,7 @@ class Compatibility_Service_Test extends WCPAY_UnitTestCase {
 			->with( $expected );
 
 		// Act: Call the method we're testing.
-		$this->compatibility_service->update_compatibility_data();
+		$this->compatibility_service->update_compatibility_data_hook();
 	}
 
 	public function provider_update_compatibility_data_permalinks_not_set(): array {

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Compatibility_Service;
 use WCPay\Exceptions\API_Exception;
 
 /**
@@ -34,15 +35,27 @@ class WC_Payments_Action_Scheduler_Service_Test extends WCPAY_UnitTestCase {
 	private $mock_order_service;
 
 	/**
+	 * Mock Compatibility_Service.
+	 *
+	 * @var Compatibility_Service|MockObject
+	 */
+	private $mock_compatibility_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_api_client    = $this->createMock( WC_Payments_API_Client::class );
-		$this->mock_order_service = $this->createMock( WC_Payments_Order_Service::class );
+		$this->mock_api_client            = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_order_service         = $this->createMock( WC_Payments_Order_Service::class );
+		$this->mock_compatibility_service = $this->createMock( Compatibility_Service::class );
 
-		$this->action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client, $this->mock_order_service );
+		$this->action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client, $this->mock_order_service, $this->mock_compatibility_service );
+	}
+
+	public function test_update_compatibility_data_hook_registered() {
+		$this->assertEquals( 10, has_action( Compatibility_Service::UPDATE_COMPATIBILITY_DATA, [ $this->mock_compatibility_service, 'update_compatibility_data_hook' ] ) );
 	}
 
 	public function test_track_new_order_action() {


### PR DESCRIPTION
Fixes Automattic/woocommerce-payments-server#6156

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR adds a rate limiter for only sending the last compatibility data update in 2 minutes to the server. The reason for adding this is to reduce the unnecessary load of the server, and to trigger less actions bound to this update.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Update your theme on the client admin page: Appearance > Themes
* Navigate to Tools > Scheduled Actions page, and click "Pending"
* Check that a `wcpay_update_compatibility_data` task is added, to be executed in two minutes.
* Update your theme again 
* On the scheduled actions page, check that there's still a single event for the compatibility data update, and a cancelled previous one. 
* Check that the task is executed after 2 minutes without any errors
* Check your server DB account meta table if the compatibility data is updated, and the blog theme name is in the saved data, containing the last theme name you've chosen.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
