### PR TITLE
Add error handling for `loadError` in ECE

### DIFF
--- a/changelog/fix-9414-unhandled-ece-loaderror
+++ b/changelog/fix-9414-unhandled-ece-loaderror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle loadError in ECE for Block Context Initialization.

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -2,7 +2,6 @@
 	margin-top: 1em;
 	width: 100%;
 	clear: both;
-	margin-bottom: 1.5em;
 
 	.woocommerce-cart & {
 		margin-bottom: 0;

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -244,6 +244,13 @@ jQuery( ( $ ) => {
 
 			wcpayECE.showButton( eceButton );
 
+			eceButton.on( 'loaderror', () => {
+				wcPayECEError = __(
+					'The cart is incompatible with express checkout.',
+					'woocommerce-payments'
+				);
+			} );
+
 			eceButton.on( 'click', function ( event ) {
 				// If login is required for checkout, display redirect confirmation dialog.
 				if ( getExpressCheckoutData( 'login_confirmation' ) ) {

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -242,13 +242,16 @@ jQuery( ( $ ) => {
 				getExpressCheckoutButtonStyleSettings()
 			);
 
-			wcpayECE.showButton( eceButton );
+			wcpayECE.renderButton( eceButton );
 
 			eceButton.on( 'loaderror', () => {
 				wcPayECEError = __(
 					'The cart is incompatible with express checkout.',
 					'woocommerce-payments'
 				);
+				if ( ! document.getElementById( 'wcpay-woopay-button' ) ) {
+					wcpayECE?.getButtonSeparator()?.hide();
+				}
 			} );
 
 			eceButton.on( 'click', function ( event ) {
@@ -333,7 +336,19 @@ jQuery( ( $ ) => {
 				onCancelHandler();
 			} );
 
-			eceButton.on( 'ready', onReadyHandler );
+			eceButton.on( 'ready', ( onReadyParams ) => {
+				onReadyHandler( onReadyParams );
+
+				if (
+					onReadyParams?.availablePaymentMethods &&
+					Object.values(
+						onReadyParams.availablePaymentMethods
+					).filter( Boolean ).length
+				) {
+					wcpayECE.show();
+					wcpayECE.getButtonSeparator().show();
+				}
+			} );
 
 			if ( getExpressCheckoutData( 'is_product_page' ) ) {
 				wcpayECE.attachProductPageEventListeners( elements );
@@ -527,18 +542,24 @@ jQuery( ( $ ) => {
 		},
 
 		getElements: () => {
-			return $(
-				'.wcpay-payment-request-wrapper,#wcpay-express-checkout-button-separator'
-			);
+			return $( '#wcpay-express-checkout-element' );
+		},
+
+		getButtonSeparator: () => {
+			return $( '#wcpay-express-checkout-button-separator' );
 		},
 
 		show: () => {
 			wcpayECE.getElements().show();
 		},
 
-		showButton: ( eceButton ) => {
+		hide: () => {
+			wcpayECE.getElements().hide();
+			wcpayECE.getButtonSeparator().hide();
+		},
+
+		renderButton: ( eceButton ) => {
 			if ( $( '#wcpay-express-checkout-element' ).length ) {
-				wcpayECE.show();
 				eceButton.mount( '#wcpay-express-checkout-element' );
 			}
 		},

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -47,6 +47,7 @@ export const checkPaymentMethodIsAvailable = memoize(
 				} }
 			>
 				<ExpressCheckoutElement
+					onLoadError={ () => resolve( false ) }
 					options={ {
 						paymentMethods: {
 							amazonPay: 'never',

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -141,7 +141,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 
 		// When Payment Request button is enabled, we need the separator markup on the page, but hidden in case the browser doesn't have any payment request methods to display.
 		// More details: https://github.com/Automattic/woocommerce-payments/pull/5399#discussion_r1073633776.
-		$separator_starts_hidden = ( $should_show_payment_request || $should_show_express_checkout_button ) && ! $should_show_woopay;
+		$separator_starts_hidden = ! $should_show_woopay;
 		if ( $should_show_woopay || $should_show_payment_request || $should_show_express_checkout_button ) {
 			?>
 			<div class='wcpay-payment-request-wrapper' >

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -288,7 +288,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 			return;
 		}
 		?>
-		<div id="wcpay-express-checkout-element"></div>
+		<div id="wcpay-express-checkout-element" style="display: none;"></div>
 		<?php
 	}
 


### PR DESCRIPTION
Fixes #9414 

#### Changes proposed in this Pull Request

Add error handling for `loadError` events in ECE.

#### Testing instructions

**Reproduce the issue on `develop`:**
- Refer to the steps outlined in issue #9414 to reproduce the error.

**Test the fix:**
1. Check out this branch.
2. Repeat the steps from issue #9414 and verify that the checkout block functions without any issues.
3. Verify that the shortcode checkout does not produce any console errors with the same cart configuration.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
