### PR TITLE
Fix React error when the Express Checkout's container element is not found.

### DIFF
--- a/changelog/as-fix-react-error-container-not-found
+++ b/changelog/as-fix-react-error-container-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Create div container element with JS dynamically.

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -71,6 +71,7 @@ export const checkPaymentMethodIsAvailable = memoize(
 						}
 						resolve( canMakePayment );
 						root.unmount();
+						containerlEl.remove();
 					} }
 				/>
 			</Elements>

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -15,11 +15,11 @@ import { getUPEConfig } from 'wcpay/utils/checkout';
 
 export const checkPaymentMethodIsAvailable = memoize(
 	( paymentMethod, cart, resolve ) => {
-		const root = ReactDOM.createRoot(
-			document.getElementById(
-				`express-checkout-check-availability-container-${ paymentMethod }`
-			)
-		);
+		// Create the DIV container on the fly
+		const containerlEl = document.createElement( 'div' );
+		document.querySelector( 'body' ).appendChild( containerlEl );
+
+		const root = ReactDOM.createRoot( containerlEl );
 
 		const api = new WCPayAPI(
 			{

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -16,23 +16,23 @@ import { getUPEConfig } from 'wcpay/utils/checkout';
 export const checkPaymentMethodIsAvailable = memoize(
 	( paymentMethod, cart, resolve ) => {
 		// Create the DIV container on the fly
-		const containerlEl = document.createElement( 'div' );
+		const containerEl = document.createElement( 'div' );
 
 		// Ensure the element is hidden and doesn’t interfere with the page layout.
-		containerlEl.style.border = 0;
-		containerlEl.style.height = '0';
-		containerlEl.style.margin = '0';
-		containerlEl.style.overflow = 'hidden';
-		containerlEl.style.padding = '0';
-		containerlEl.style.position = 'absolute';
-		containerlEl.style.width = '0';
-		containerlEl.style.float = 'left';
-		containerlEl.style.opacity = '0';
-		containerlEl.style.pointerEvents = 'none';
+		containerEl.style.border = 0;
+		containerEl.style.height = '0';
+		containerEl.style.margin = '0';
+		containerEl.style.overflow = 'hidden';
+		containerEl.style.padding = '0';
+		containerEl.style.position = 'absolute';
+		containerEl.style.width = '0';
+		containerEl.style.float = 'left';
+		containerEl.style.opacity = '0';
+		containerEl.style.pointerEvents = 'none';
 
-		document.querySelector( 'body' ).appendChild( containerlEl );
+		document.querySelector( 'body' ).appendChild( containerEl );
 
-		const root = ReactDOM.createRoot( containerlEl );
+		const root = ReactDOM.createRoot( containerEl );
 
 		const api = new WCPayAPI(
 			{
@@ -84,7 +84,7 @@ export const checkPaymentMethodIsAvailable = memoize(
 						}
 						resolve( canMakePayment );
 						root.unmount();
-						containerlEl.remove();
+						containerEl.remove();
 					} }
 				/>
 			</Elements>

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -17,6 +17,19 @@ export const checkPaymentMethodIsAvailable = memoize(
 	( paymentMethod, cart, resolve ) => {
 		// Create the DIV container on the fly
 		const containerlEl = document.createElement( 'div' );
+
+		// Ensure the element is hidden and doesn’t interfere with the page layout.
+		containerlEl.style.border = 0;
+		containerlEl.style.height = '0';
+		containerlEl.style.margin = '0';
+		containerlEl.style.overflow = 'hidden';
+		containerlEl.style.padding = '0';
+		containerlEl.style.position = 'absolute';
+		containerlEl.style.width = '0';
+		containerlEl.style.float = 'left';
+		containerlEl.style.opacity = '0';
+		containerlEl.style.pointerEvents = 'none';
+
 		document.querySelector( 'body' ).appendChild( containerlEl );
 
 		const root = ReactDOM.createRoot( containerlEl );

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -19,16 +19,7 @@ export const checkPaymentMethodIsAvailable = memoize(
 		const containerEl = document.createElement( 'div' );
 
 		// Ensure the element is hidden and doesn’t interfere with the page layout.
-		containerEl.style.border = 0;
-		containerEl.style.height = '0';
-		containerEl.style.margin = '0';
-		containerEl.style.overflow = 'hidden';
-		containerEl.style.padding = '0';
-		containerEl.style.position = 'absolute';
-		containerEl.style.width = '0';
-		containerEl.style.float = 'left';
-		containerEl.style.opacity = '0';
-		containerEl.style.pointerEvents = 'none';
+		containerEl.style.display = 'none';
 
 		document.querySelector( 'body' ).appendChild( containerEl );
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -95,10 +95,6 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 		$is_woopay_enabled          = WC_Payments_Features::is_woopay_enabled();
 		$is_payment_request_enabled = 'yes' === $this->gateway->get_option( 'payment_request' );
 
-		if ( $is_payment_request_enabled ) {
-			$this->add_html_container_for_test_express_checkout_buttons();
-		}
-
 		if ( $is_woopay_enabled || $is_payment_request_enabled ) {
 			add_action( 'wc_ajax_wcpay_add_to_cart', [ $this->express_checkout_ajax_handler, 'ajax_add_to_cart' ] );
 			add_action( 'wc_ajax_wcpay_empty_cart', [ $this->express_checkout_ajax_handler, 'ajax_empty_cart' ] );
@@ -176,31 +172,6 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	 */
 	public function add_order_attribution_inputs() {
 		echo '<wc-order-attribution-inputs id="wcpay-express-checkout__order-attribution-inputs"></wc-order-attribution-inputs>';
-	}
-
-
-	/**
-	 * Add HTML containers to be used by the Express Checkout buttons that check if the payment method is available.
-	 *
-	 * @return void
-	 */
-	private function add_html_container_for_test_express_checkout_buttons() {
-		add_filter(
-			'the_content',
-			function ( $content ) {
-				$supported_payment_methods = [ 'applePay' , 'googlePay' ];
-				// Restrict adding these HTML containers to only the necessary pages.
-				if ( $this->express_checkout_helper->is_checkout() || $this->express_checkout_helper->is_cart() ) {
-					foreach ( $supported_payment_methods as $value ) {
-						// The inline styles ensure that the HTML elements don't occupy space on the page.
-						$content = '<div id="express-checkout-check-availability-container-' . $value . '" style="height: 0; float:left; opacity: 0; pointer-events: none;"></div>' . $content;
-					}
-				}
-				return $content;
-			},
-			10,
-			1
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9419

### Changes proposed in this Pull Request

Since the `the_content` filter is never triggered when the checkout page is assigned a block-based template, the elements we were printing as containers for the buttons used to check the availability of ApplePay/GooglePay payment methods were not rendered. As a result, React failed to mount the button because the containers didn’t exist.

We’re changing the approach by creating the container dynamically and appending it to the page using JavaScript. This ensures the buttons are rendered in both cases, whether using a standard theme or a block-based theme.

### Why is it happening?

When a page uses a block-based template, it includes the `template-canvas.php` file as base ([ref](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/template-canvas.php)), which prints the HTML generated from the block template. Notably, this file never calls `the_content()`. (This the [block template](https://gist.github.com/asumaran/c2880283978339421d43800ede07a50d) the site that reported the issue was using). – As side note, @reykjalin' [fix](https://github.com/Automattic/woocommerce-payments/pull/9424) works because this file [do call](https://github.com/WordPress/wordpress-develop/blob/47122105f20624e5a6b8ed151d732157f2f2605c/src/wp-includes/template-canvas.php#L25) `wp_footer()`, which applies the `wp_footer` action ([ref](https://github.com/WordPress/wordpress-develop/blob/47122105f20624e5a6b8ed151d732157f2f2605c/src/wp-includes/general-template.php#L3080)).

However, when using a regular theme, the checkout block is rendered as part of the page content. In themes, the page content is printed using `the_content()` ([ref](https://developer.wordpress.org/reference/functions/the_content/)), which applies the `the_content` filter ([ref](https://github.com/WordPress/wordpress-develop/blob/47122105f20624e5a6b8ed151d732157f2f2605c/src/wp-includes/post-template.php#L256)).

Unfortunately, to render the elements that would be used as containers for the buttons used to check the availability of payment methods, this `the_content` filter was used, which is not always called. We should have used the `wp_footer` action or perhaps used JS to create the element.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

**To reproduce the bug**

* **Log in as as admin** – The error is shown only for admins.
* Switch to the `develop` branch.
* Install the following theme [what-theme.zip](https://github.com/user-attachments/files/16981278/what-theme.zip)
* Create a shortcode-based checkout page if you don't have one already
  * Add the "Classic Checkout" block or add the `[woocommerce_checkout]` using the shortcode block.
  * Assign the `page-checkout` template to it.
* Go to store and add a product to the cart.
* Go to the newly created page.
* ❌ You'll observe the React error.

**To confirm the fix**
- Switch to this branch `as-fix-react-error-container-not-found`
- Repeat the previous steps.
- There shouldn't be any error displayed.
- ✅ Express Checkout buttons should be displayed.
- Log out from the store.
- Refresh the Checkout page.
- ✅ Express Checkout buttons should be displayed.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
