### PR TITLE
Fix not rendering express checkout buttons on block template pages

### DIFF
--- a/changelog/fix-not-rendering-express-checkout-buttons-on-block-template-pages
+++ b/changelog/fix-not-rendering-express-checkout-buttons-on-block-template-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Create express checkout test div using wp_footer instead of the_content

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -185,18 +185,17 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	 * @return void
 	 */
 	private function add_html_container_for_test_express_checkout_buttons() {
-		add_filter(
-			'the_content',
-			function ( $content ) {
+		add_action(
+			'wp_footer',
+			function () {
 				$supported_payment_methods = [ 'applePay' , 'googlePay' ];
 				// Restrict adding these HTML containers to only the necessary pages.
 				if ( $this->express_checkout_helper->is_checkout() || $this->express_checkout_helper->is_cart() ) {
 					foreach ( $supported_payment_methods as $value ) {
 						// The inline styles ensure that the HTML elements don't occupy space on the page.
-						$content = '<div id="express-checkout-check-availability-container-' . $value . '" style="height: 0; float:left; opacity: 0; pointer-events: none;"></div>' . $content;
+						echo '<div id="express-checkout-check-availability-container-' . $value . '" style="height: 0; float:left; opacity: 0; pointer-events: none;"></div>';
 					}
 				}
-				return $content;
 			},
 			10,
 			1


### PR DESCRIPTION
> [!NOTE]
> Description copied from #9420

Fixes https://github.com/Automattic/woocommerce-payments/issues/9419

## Changes proposed in this Pull Request

Since the `the_content` filter is never triggered when the checkout page is assigned a block-based template, the elements we were printing as containers for the buttons used to check the availability of ApplePay/GooglePay payment methods were not rendered. As a result, React failed to mount the button because the containers didn’t exist.

We’re changing the approach by creating the container dynamically and appending it to the page using JavaScript. This ensures the buttons are rendered in both cases, whether using a standard theme or a block-based theme.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

**To reproduce the bug**

* **Log in as as admin** – The error is shown only for admins.
* Switch to the `develop` branch.
* Install the following theme [what-theme.zip](https://github.com/user-attachments/files/16972615/what-theme.zip)
* Create a shortcode-based checkout page if you don't have one already
  * Add the "Classic Checkout" block or add the `[woocommerce_checkout]` using the shortcode block.
  * Assign the `page-checkout` template to it.
* Go to store and add a product to the cart.
* Go to the newly created page.
* ❌ You'll observe the React error.

**To confirm the fix**
- Switch to this branch `as-fix-react-error-container-not-found`
- Repeat the previous steps.
- There shouldn't be any error displayed.
- ✅ Express Checkout buttons should be displayed.
- Log out from the store.
- Refresh the Checkout page.
- ✅ Express Checkout buttons should be displayed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
