### PR TITLE
POC: disable save settings button by default

### DIFF
--- a/client/components/csv-export-modal/test/index.test.tsx
+++ b/client/components/csv-export-modal/test/index.test.tsx
@@ -44,6 +44,7 @@ describe( 'RefundModal', () => {
 
 		mockUseSettings.mockReturnValue( {
 			isLoading: false,
+			isDirty: false,
 			isSaving: false,
 			saveSettings: ( a ) => a,
 		} );

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -328,6 +328,7 @@ export const useSettings = () => {
 	const isSaving = useSelect( ( select ) =>
 		select( STORE_NAME ).isSavingSettings()
 	);
+	const isDirty = useSelect( ( select ) => select( STORE_NAME ).isDirty() );
 
 	const isLoading = useSelect( ( select ) => {
 		select( STORE_NAME ).getSettings();
@@ -342,6 +343,7 @@ export const useSettings = () => {
 		isLoading,
 		saveSettings,
 		isSaving,
+		isDirty,
 	};
 };
 

--- a/client/data/settings/reducer.js
+++ b/client/data/settings/reducer.js
@@ -16,7 +16,6 @@ export const receiveSettings = (
 	state = defaultState,
 	{ type, ...action }
 ) => {
-	console.log( '###', type );
 	switch ( type ) {
 		case ACTION_TYPES.SET_SETTINGS:
 			return {

--- a/client/data/settings/reducer.js
+++ b/client/data/settings/reducer.js
@@ -38,6 +38,8 @@ export const receiveSettings = (
 		case ACTION_TYPES.SET_IS_SAVING_SETTINGS:
 			return {
 				...state,
+				isDirty:
+					action.isSaving || action.error ? state.isDirty : false,
 				isSaving: action.isSaving,
 				savingError: action.error,
 			};

--- a/client/data/settings/reducer.js
+++ b/client/data/settings/reducer.js
@@ -6,6 +6,7 @@
 import ACTION_TYPES from './action-types';
 
 const defaultState = {
+	isDirty: false,
 	isSaving: false,
 	savingError: null,
 	data: {},
@@ -15,17 +16,20 @@ export const receiveSettings = (
 	state = defaultState,
 	{ type, ...action }
 ) => {
+	console.log( '###', type );
 	switch ( type ) {
 		case ACTION_TYPES.SET_SETTINGS:
 			return {
 				...state,
 				data: action.data,
+				isDirty: false,
 			};
 
 		case ACTION_TYPES.SET_SETTINGS_VALUES:
 			return {
 				...state,
 				savingError: null,
+				isDirty: true,
 				data: {
 					...state.data,
 					...action.payload,
@@ -42,6 +46,7 @@ export const receiveSettings = (
 		case ACTION_TYPES.SET_SELECTED_PAYMENT_METHOD:
 			return {
 				...state,
+				isDirty: true,
 				data: {
 					...state.data,
 					enabled_payment_method_ids: state.data.enabled_payment_method_ids.concat(
@@ -53,6 +58,7 @@ export const receiveSettings = (
 		case ACTION_TYPES.SET_UNSELECTED_PAYMENT_METHOD:
 			return {
 				...state,
+				isDirty: true,
 				data: {
 					...state.data,
 					enabled_payment_method_ids: state.data.enabled_payment_method_ids.filter(

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -49,6 +49,10 @@ export const isSavingSettings = ( state ) => {
 	return getSettingsState( state ).isSaving || false;
 };
 
+export const isDirty = ( state ) => {
+	return getSettingsState( state ).isDirty || false;
+};
+
 export const getAccountStatementDescriptor = ( state ) => {
 	return getSettings( state ).account_statement_descriptor || '';
 };

--- a/client/disputes/test/index.tsx
+++ b/client/disputes/test/index.tsx
@@ -173,6 +173,7 @@ describe( 'Disputes list', () => {
 		mockUseReportingExportLanguage.mockReturnValue( [ 'en', jest.fn() ] );
 
 		mockUseSettings.mockReturnValue( {
+			isDirty: false,
 			isLoading: false,
 			isSaving: false,
 			saveSettings: ( a ) => a,

--- a/client/multi-currency/multi-currency-settings/store-settings/index.js
+++ b/client/multi-currency/multi-currency-settings/store-settings/index.js
@@ -56,6 +56,7 @@ const StoreSettings = () => {
 		isLoading,
 		submitStoreSettingsUpdate,
 	} = useStoreSettings();
+	const [ isDirty, setIsDirty ] = useState( false );
 	const [ isSavingSettings, setIsSavingSettings ] = useState( false );
 	const [
 		isAutomaticSwitchEnabledValue,
@@ -77,6 +78,7 @@ const StoreSettings = () => {
 			setIsAutomaticSwitchEnabledValue(
 				storeSettings.enable_auto_currency
 			);
+			setIsDirty( false );
 		}
 	}, [
 		setIsAutomaticSwitchEnabledValue,
@@ -86,10 +88,12 @@ const StoreSettings = () => {
 
 	const handleIsAutomaticSwitchEnabledClick = ( value ) => {
 		setIsAutomaticSwitchEnabledValue( value );
+		setIsDirty( true );
 	};
 
 	const handleIsStorefrontSwitcherEnabledClick = ( value ) => {
 		setIsStorefrontSwitcherEnabledValue( value );
+		setIsDirty( true );
 	};
 
 	const saveSettings = () => {
@@ -99,6 +103,7 @@ const StoreSettings = () => {
 			isStorefrontSwitcherEnabledValue
 		);
 		setIsSavingSettings( false );
+		setIsDirty( false );
 	};
 
 	return (
@@ -190,7 +195,7 @@ const StoreSettings = () => {
 				<Button
 					isPrimary
 					isBusy={ isSavingSettings }
-					disabled={ isSavingSettings }
+					disabled={ isSavingSettings || ! isDirty }
 					onClick={ saveSettings }
 				>
 					{ __( 'Save changes', 'woocommerce-payments' ) }

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -42,6 +42,7 @@ const SingleCurrencySettings = () => {
 	const { currencies } = useCurrencies();
 	const { enabledCurrencies } = useEnabledCurrencies();
 	const { storeSettings } = useStoreSettings();
+	const [ isDirty, setIsDirty ] = useState( false );
 
 	const {
 		currencySettings,
@@ -82,6 +83,10 @@ const SingleCurrencySettings = () => {
 	const [ isSaving, setIsSaving ] = useState( false );
 
 	useEffect( () => {
+		setIsDirty( true );
+	}, [ exchangeRateType, manualRate, priceCharmType ] );
+
+	useEffect( () => {
 		if ( currencySettings[ currency ] ) {
 			setExchangeRateType(
 				currencySettings[ currency ].exchange_rate_type ||
@@ -98,6 +103,7 @@ const SingleCurrencySettings = () => {
 				currencySettings[ currency ].price_charm ||
 					initialPriceCharmType
 			);
+			setIsDirty( false );
 		}
 	}, [ currencySettings, currency, initialPriceRoundingType ] );
 
@@ -162,6 +168,7 @@ const SingleCurrencySettings = () => {
 		}
 
 		setIsSaving( false );
+		setIsDirty( false );
 	};
 
 	return (
@@ -522,7 +529,7 @@ const SingleCurrencySettings = () => {
 					<Button
 						isPrimary
 						isBusy={ isSaving }
-						disabled={ isSaving }
+						disabled={ isSaving || ! isDirty }
 						onClick={ saveSingleCurrencySettings }
 					>
 						{ __( 'Save changes', 'woocommerce-payments' ) }

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
@@ -37,6 +37,7 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 		protectionSettingsUI,
 		setProtectionSettingsUI,
 		setProtectionSettingsChanged,
+		setHasChanges,
 	} = useContext( FraudPreventionSettingsContext );
 
 	const settingUI = useMemo(
@@ -97,7 +98,10 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 						placeholder={ '0' }
 						value={ minItemsCount }
 						type="number"
-						onChange={ setMinItemsCount }
+						onChange={ ( value ) => {
+							setMinItemsCount( value );
+							setHasChanges( true );
+						} }
 						onKeyDown={ ( e ) =>
 							/^[+-.,e]$/m.test( e.key ) && e.preventDefault()
 						}
@@ -121,7 +125,10 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 						placeholder={ '0' }
 						type="number"
 						value={ maxItemsCount }
-						onChange={ setMaxItemsCount }
+						onChange={ ( value ) => {
+							setMaxItemsCount( value );
+							setHasChanges( true );
+						} }
 						onKeyDown={ ( e ) =>
 							/^[+-.,e]$/m.test( e.key ) && e.preventDefault()
 						}

--- a/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
@@ -56,6 +56,7 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 		protectionSettingsUI,
 		setProtectionSettingsUI,
 		setProtectionSettingsChanged,
+		setHasChanges,
 	} = useContext( FraudPreventionSettingsContext );
 
 	const settingUI = useMemo(
@@ -111,7 +112,10 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 						prefix={ currencySymbol }
 						placeholder={ '0.00' }
 						value={ minAmount.toString() }
-						onChange={ ( val ) => setMinAmount( Number( val ) ) }
+						onChange={ ( val ) => {
+							setMinAmount( Number( val ) );
+							setHasChanges( true );
+						} }
 						help={ __(
 							'Leave blank for no limit',
 							'woocommerce-payments'
@@ -130,7 +134,10 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 						prefix={ currencySymbol }
 						placeholder={ '0.00' }
 						value={ maxAmount.toString() }
-						onChange={ ( val ) => setMaxAmount( Number( val ) ) }
+						onChange={ ( val ) => {
+							setMaxAmount( Number( val ) );
+							setHasChanges( true );
+						} }
 						help={ __(
 							'Leave blank for no limit',
 							'woocommerce-payments'

--- a/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.tsx
@@ -34,7 +34,6 @@ describe( 'Address mismatch card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
-		hasChanges: false,
 		setHasChanges: jest.fn(),
 	};
 	test( 'renders correctly', () => {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.tsx
@@ -34,6 +34,8 @@ describe( 'Address mismatch card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
+		hasChanges: false,
+		setHasChanges: jest.fn(),
 	};
 	test( 'renders correctly', () => {
 		settings.address_mismatch.enabled = false;

--- a/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.tsx
@@ -42,6 +42,8 @@ describe( 'AVS mismatch card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
+			hasChanges: false,
+			setHasChanges: jest.fn(),
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>
@@ -70,6 +72,8 @@ describe( 'AVS mismatch card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
+			hasChanges: false,
+			setHasChanges: jest.fn(),
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>

--- a/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.tsx
@@ -42,7 +42,6 @@ describe( 'AVS mismatch card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
-			hasChanges: false,
 			setHasChanges: jest.fn(),
 		};
 		const { container } = render(
@@ -72,7 +71,6 @@ describe( 'AVS mismatch card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
-			hasChanges: false,
 			setHasChanges: jest.fn(),
 		};
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.tsx
@@ -42,7 +42,6 @@ describe( 'CVC verification card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
-			hasChanges: false,
 			setHasChanges: jest.fn(),
 		};
 		const { container } = render(
@@ -75,7 +74,6 @@ describe( 'CVC verification card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
-			hasChanges: false,
 			setHasChanges: jest.fn(),
 		};
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.tsx
@@ -42,6 +42,8 @@ describe( 'CVC verification card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
+			hasChanges: false,
+			setHasChanges: jest.fn(),
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>
@@ -73,6 +75,8 @@ describe( 'CVC verification card', () => {
 			setProtectionSettingsUI: setSettings,
 			protectionSettingsChanged: false,
 			setProtectionSettingsChanged: jest.fn(),
+			hasChanges: false,
+			setHasChanges: jest.fn(),
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>

--- a/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.tsx
@@ -43,6 +43,8 @@ describe( 'International IP address card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
+		hasChanges: false,
+		setHasChanges: jest.fn(),
 	};
 	global.wcSettings = {
 		admin: {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.tsx
@@ -43,7 +43,6 @@ describe( 'International IP address card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
-		hasChanges: false,
 		setHasChanges: jest.fn(),
 	};
 	global.wcSettings = {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/ip-address-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/ip-address-mismatch.test.tsx
@@ -40,6 +40,8 @@ describe( 'International billing address card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
+		hasChanges: false,
+		setHasChanges: jest.fn(),
 	};
 	global.wcSettings = {
 		admin: {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/ip-address-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/ip-address-mismatch.test.tsx
@@ -40,7 +40,6 @@ describe( 'International billing address card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
-		hasChanges: false,
 		setHasChanges: jest.fn(),
 	};
 	global.wcSettings = {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.tsx
@@ -39,6 +39,8 @@ describe( 'Order items threshold card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
+		hasChanges: false,
+		setHasChanges: jest.fn(),
 	};
 	test( 'renders correctly', () => {
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.tsx
@@ -39,7 +39,6 @@ describe( 'Order items threshold card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
-		hasChanges: false,
 		setHasChanges: jest.fn(),
 	};
 	test( 'renders correctly', () => {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.tsx
@@ -67,6 +67,8 @@ describe( 'Purchase price threshold card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
+		hasChanges: false,
+		setHasChanges: jest.fn(),
 	};
 	test( 'renders correctly', () => {
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.tsx
@@ -67,7 +67,6 @@ describe( 'Purchase price threshold card', () => {
 		setProtectionSettingsUI: setSettings,
 		protectionSettingsChanged: false,
 		setProtectionSettingsChanged: jest.fn(),
-		hasChanges: false,
 		setHasChanges: jest.fn(),
 	};
 	test( 'renders correctly', () => {

--- a/client/settings/fraud-protection/advanced-settings/context.ts
+++ b/client/settings/fraud-protection/advanced-settings/context.ts
@@ -9,6 +9,8 @@ const FraudPreventionSettingsContext = createContext( {
 	setProtectionSettingsUI: () => null,
 	protectionSettingsChanged: false,
 	setProtectionSettingsChanged: () => false,
+	hasChanges: false,
+	setHasChanges: () => null,
 } as FraudPreventionSettingsContextType );
 
 export default FraudPreventionSettingsContext;

--- a/client/settings/fraud-protection/advanced-settings/context.ts
+++ b/client/settings/fraud-protection/advanced-settings/context.ts
@@ -9,7 +9,6 @@ const FraudPreventionSettingsContext = createContext( {
 	setProtectionSettingsUI: () => null,
 	protectionSettingsChanged: false,
 	setProtectionSettingsChanged: () => false,
-	hasChanges: false,
 	setHasChanges: () => null,
 } as FraudPreventionSettingsContextType );
 

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -102,6 +102,8 @@ const SaveFraudProtectionSettingsButton: React.FC = ( { children } ) => {
 };
 
 const FraudProtectionAdvancedSettingsPage: React.FC = () => {
+	const [ hasChanges, setHasChanges ] = useState( false );
+
 	const { saveSettings, isLoading, isSaving } = useSettings() as SettingsHook;
 
 	const cardObserver = useRef< IntersectionObserver >();
@@ -327,7 +329,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			disabled={
 				isSaving ||
 				isLoading ||
-				'error' === advancedFraudProtectionSettings
+				'error' === advancedFraudProtectionSettings ||
+				! hasChanges
 			}
 		>
 			{ __( 'Save Changes', 'woocommerce-payments' ) }
@@ -341,6 +344,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				setProtectionSettingsUI,
 				protectionSettingsChanged,
 				setProtectionSettingsChanged,
+				hasChanges,
+				setHasChanges,
 			} }
 		>
 			<SettingsLayout displayBanner={ false }>

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -344,7 +344,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				setProtectionSettingsUI,
 				protectionSettingsChanged,
 				setProtectionSettingsChanged,
-				hasChanges,
 				setHasChanges,
 			} }
 		>

--- a/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
@@ -58,6 +58,7 @@ const FraudProtectionRuleToggle: React.FC< FraudProtectionRuleToggleProps > = ( 
 		protectionSettingsUI,
 		setProtectionSettingsUI,
 		setProtectionSettingsChanged,
+		setHasChanges,
 	} = useContext( FraudPreventionSettingsContext );
 
 	const { isFRTReviewFeatureActive } = wcpaySettings;
@@ -100,6 +101,7 @@ const FraudProtectionRuleToggle: React.FC< FraudProtectionRuleToggleProps > = ( 
 
 	const handleToggleChange = () => {
 		setToggleState( ( value ) => ! value );
+		setHasChanges( true );
 	};
 
 	if ( ! protectionSettingsUI ) {

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -4743,6 +4743,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
             </a>
             <button
               class="components-button is-primary"
+              disabled=""
               type="button"
             >
               Save Changes
@@ -5568,6 +5569,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
           </a>
           <button
             class="components-button is-primary"
+            disabled=""
             type="button"
           >
             Save Changes

--- a/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
@@ -19,7 +19,6 @@ const mockContext = {
 	protectionSettingsChanged: false,
 	setProtectionSettingsUI: jest.fn(),
 	setProtectionSettingsChanged: jest.fn(),
-	hasChanges: false,
 	setHasChanges: jest.fn(),
 };
 

--- a/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
@@ -19,6 +19,8 @@ const mockContext = {
 	protectionSettingsChanged: false,
 	setProtectionSettingsUI: jest.fn(),
 	setProtectionSettingsChanged: jest.fn(),
+	hasChanges: false,
+	setHasChanges: jest.fn(),
 };
 
 declare const global: {

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -29,6 +29,7 @@ jest.mock( '@wordpress/data', () => ( {
 		createSuccessNotice: jest.fn(),
 		createErrorNotice: jest.fn(),
 		onLoad: jest.fn(),
+		onHistoryChange: jest.fn(),
 	} ) ),
 	registerStore: jest.fn(),
 	select: jest.fn(),
@@ -186,8 +187,8 @@ describe( 'Advanced fraud protection settings', () => {
 				advanced_fraud_protection_settings: 'error',
 			},
 			saveSettings: jest.fn(),
-			isDirty: false,
 			isSaving: false,
+			isDirty: false,
 			isLoading: false,
 		} );
 		mockUseAdvancedFraudProtectionSettings.mockReturnValue( [
@@ -243,8 +244,8 @@ describe( 'Advanced fraud protection settings', () => {
 			},
 			saveSettings: jest.fn(),
 			isLoading: false,
-			isDirty: false,
 			isSaving: false,
+			isDirty: false,
 		} );
 
 		container = render(
@@ -256,6 +257,11 @@ describe( 'Advanced fraud protection settings', () => {
 			</div>
 		);
 
+		const avsThresholdToggle = await container.findByLabelText(
+			'Block transactions for mismatched AVS'
+		);
+		avsThresholdToggle.click();
+		avsThresholdToggle.click();
 		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
 		saveButton.click();
 		expect( mockUseSettings().saveSettings.mock.calls.length ).toBe( 0 );
@@ -303,6 +309,12 @@ describe( 'Advanced fraud protection settings', () => {
 				<FraudProtectionAdvancedSettingsPage />
 			</div>
 		);
+
+		const avsThresholdToggle = await container.findByLabelText(
+			'Block transactions for mismatched AVS'
+		);
+		avsThresholdToggle.click();
+		avsThresholdToggle.click();
 		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
 		saveButton.click();
 		await waitFor( () => {
@@ -364,6 +376,12 @@ describe( 'Advanced fraud protection settings', () => {
 				<FraudProtectionAdvancedSettingsPage />
 			</div>
 		);
+
+		const avsThresholdToggle = await container.findByLabelText(
+			'Block transactions for mismatched AVS'
+		);
+		avsThresholdToggle.click();
+		avsThresholdToggle.click();
 		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
 		saveButton.click();
 		await waitFor( () => {
@@ -429,6 +447,12 @@ describe( 'Advanced fraud protection settings', () => {
 				<FraudProtectionAdvancedSettingsPage />
 			</div>
 		);
+
+		const avsThresholdToggle = await container.findByLabelText(
+			'Block transactions for mismatched AVS'
+		);
+		avsThresholdToggle.click();
+		avsThresholdToggle.click();
 		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
 		saveButton.click();
 		await waitFor( () => {
@@ -477,7 +501,13 @@ describe( 'Advanced fraud protection settings', () => {
 				<FraudProtectionAdvancedSettingsPage />
 			</div>
 		);
+		const avsThresholdToggle = await container.findByLabelText(
+			'Block transactions for mismatched AVS'
+		);
+		avsThresholdToggle.click();
+		avsThresholdToggle.click();
 		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
+
 		saveButton.click();
 		await waitFor( () => {
 			expect( mockUseSettings().saveSettings.mock.calls.length ).toBe(

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -84,6 +84,7 @@ const mockUseAdvancedFraudProtectionSettings = jest.mocked(
 const mockUseSettings = useSettings as jest.MockedFunction<
 	() => {
 		settings: any;
+		isDirty: boolean;
 		isLoading: boolean;
 		saveSettings: jest.Mock;
 		isSaving: boolean;
@@ -169,6 +170,7 @@ describe( 'Advanced fraud protection settings', () => {
 			},
 			saveSettings: jest.fn(),
 			isSaving: false,
+			isDirty: false,
 			isLoading: false,
 		} );
 		mockUseAdvancedFraudProtectionSettings.mockReturnValue( [
@@ -184,6 +186,7 @@ describe( 'Advanced fraud protection settings', () => {
 				advanced_fraud_protection_settings: 'error',
 			},
 			saveSettings: jest.fn(),
+			isDirty: false,
 			isSaving: false,
 			isLoading: false,
 		} );
@@ -240,6 +243,7 @@ describe( 'Advanced fraud protection settings', () => {
 			},
 			saveSettings: jest.fn(),
 			isLoading: false,
+			isDirty: false,
 			isSaving: false,
 		} );
 
@@ -284,6 +288,7 @@ describe( 'Advanced fraud protection settings', () => {
 			},
 			saveSettings: jest.fn(),
 			isSaving: false,
+			isDirty: false,
 			isLoading: false,
 		} );
 		mockUseAdvancedFraudProtectionSettings.mockReturnValue( [
@@ -343,6 +348,7 @@ describe( 'Advanced fraud protection settings', () => {
 				advanced_fraud_protection_settings: defaultSettings,
 			},
 			isSaving: false,
+			isDirty: false,
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );
@@ -408,6 +414,7 @@ describe( 'Advanced fraud protection settings', () => {
 			},
 			saveSettings: jest.fn(),
 			isSaving: false,
+			isDirty: false,
 			isLoading: false,
 		} );
 		mockUseAdvancedFraudProtectionSettings.mockReturnValue( [
@@ -454,6 +461,7 @@ describe( 'Advanced fraud protection settings', () => {
 				advanced_fraud_protection_settings: defaultSettings,
 			},
 			isSaving: false,
+			isDirty: false,
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -26,7 +26,6 @@ interface mockContext {
 	protectionSettingsChanged: boolean;
 	setProtectionSettingsUI: jest.Mock;
 	setProtectionSettingsChanged: jest.Mock;
-	hasChanges: boolean;
 	setHasChanges: jest.Mock;
 }
 
@@ -45,7 +44,6 @@ describe( 'Fraud protection rule toggle tests', () => {
 		protectionSettingsChanged: false,
 		setProtectionSettingsUI: jest.fn(),
 		setProtectionSettingsChanged: jest.fn(),
-		hasChanges: false,
 		setHasChanges: jest.fn(),
 	};
 
@@ -60,7 +58,6 @@ describe( 'Fraud protection rule toggle tests', () => {
 			protectionSettingsChanged: false,
 			setProtectionSettingsUI: jest.fn(),
 			setProtectionSettingsChanged: jest.fn(),
-			hasChanges: false,
 			setHasChanges: jest.fn(),
 		};
 	} );

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -26,6 +26,8 @@ interface mockContext {
 	protectionSettingsChanged: boolean;
 	setProtectionSettingsUI: jest.Mock;
 	setProtectionSettingsChanged: jest.Mock;
+	hasChanges: boolean;
+	setHasChanges: jest.Mock;
 }
 
 describe( 'Fraud protection rule toggle tests', () => {
@@ -43,6 +45,8 @@ describe( 'Fraud protection rule toggle tests', () => {
 		protectionSettingsChanged: false,
 		setProtectionSettingsUI: jest.fn(),
 		setProtectionSettingsChanged: jest.fn(),
+		hasChanges: false,
+		setHasChanges: jest.fn(),
 	};
 
 	beforeEach( () => {
@@ -56,6 +60,8 @@ describe( 'Fraud protection rule toggle tests', () => {
 			protectionSettingsChanged: false,
 			setProtectionSettingsUI: jest.fn(),
 			setProtectionSettingsChanged: jest.fn(),
+			hasChanges: false,
+			setHasChanges: jest.fn(),
 		};
 	} );
 

--- a/client/settings/fraud-protection/components/protection-levels/index.tsx
+++ b/client/settings/fraud-protection/components/protection-levels/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { __ } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 import { useState } from '@wordpress/element';
@@ -20,6 +20,7 @@ import { ProtectionLevel } from '../../advanced-settings/constants';
 import InlineNotice from 'components/inline-notice';
 import { recordEvent } from 'tracks';
 import { CurrentProtectionLevelHook } from '../../interfaces';
+import WCPaySettingsContext from '../../../wcpay-settings-context';
 
 const ProtectionLevels: React.FC = () => {
 	const [ isBasicModalOpen, setBasicModalOpen ] = useState( false );

--- a/client/settings/fraud-protection/interfaces.ts
+++ b/client/settings/fraud-protection/interfaces.ts
@@ -69,6 +69,7 @@ export type AdvancedFraudPreventionSettingsHook = [
 
 export interface SettingsHook {
 	isSaving: boolean;
+	isDirty: boolean;
 	isLoading: boolean;
 	saveSettings: () => void;
 }

--- a/client/settings/fraud-protection/interfaces.ts
+++ b/client/settings/fraud-protection/interfaces.ts
@@ -36,6 +36,8 @@ export interface FraudPreventionSettingsContextType {
 	setProtectionSettingsUI: ( settings: ProtectionSettingsUI ) => void;
 	protectionSettingsChanged: boolean;
 	setProtectionSettingsChanged: Dispatch< SetStateAction< boolean > >;
+	hasChanges: boolean;
+	setHasChanges: Dispatch< SetStateAction< boolean > >;
 }
 
 export interface FraudProtectionSettingsSingleCheck {
@@ -69,7 +71,6 @@ export type AdvancedFraudPreventionSettingsHook = [
 
 export interface SettingsHook {
 	isSaving: boolean;
-	isDirty: boolean;
 	isLoading: boolean;
 	saveSettings: () => void;
 }

--- a/client/settings/fraud-protection/interfaces.ts
+++ b/client/settings/fraud-protection/interfaces.ts
@@ -36,7 +36,6 @@ export interface FraudPreventionSettingsContextType {
 	setProtectionSettingsUI: ( settings: ProtectionSettingsUI ) => void;
 	protectionSettingsChanged: boolean;
 	setProtectionSettingsChanged: Dispatch< SetStateAction< boolean > >;
-	hasChanges: boolean;
 	setHasChanges: Dispatch< SetStateAction< boolean > >;
 }
 

--- a/client/settings/fraud-protection/test/index.test.tsx
+++ b/client/settings/fraud-protection/test/index.test.tsx
@@ -87,8 +87,8 @@ describe( 'FraudProtection', () => {
 		] );
 		mockUseSettings.mockReturnValue( {
 			settings: {},
-			isDirty: false,
 			isSaving: false,
+			isDirty: false,
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );

--- a/client/settings/fraud-protection/test/index.test.tsx
+++ b/client/settings/fraud-protection/test/index.test.tsx
@@ -56,6 +56,7 @@ const mockUseSettings = useSettings as jest.MockedFunction<
 	() => {
 		settings: any;
 		isLoading: boolean;
+		isDirty: boolean;
 		saveSettings: () => void;
 		isSaving: boolean;
 	}
@@ -86,6 +87,7 @@ describe( 'FraudProtection', () => {
 		] );
 		mockUseSettings.mockReturnValue( {
 			settings: {},
+			isDirty: false,
 			isSaving: false,
 			saveSettings: jest.fn(),
 			isLoading: false,

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -16,7 +16,7 @@ import './style.scss';
 import WooPayDisableFeedback from '../woopay-disable-feedback';
 
 const SaveSettingsSection = ( { disabled = false } ) => {
-	const { saveSettings, isSaving, isLoading } = useSettings();
+	const { saveSettings, isSaving, isLoading, isDirty } = useSettings();
 	const settings = useGetSettings();
 
 	// Keep the inital value of is_payment_request_enabled
@@ -111,7 +111,7 @@ const SaveSettingsSection = ( { disabled = false } ) => {
 			<Button
 				isPrimary
 				isBusy={ isSaving }
-				disabled={ isSaving || isLoading || disabled }
+				disabled={ isSaving || isLoading || disabled || ! isDirty }
 				onClick={ saveOnClick }
 			>
 				{ __( 'Save changes', 'woocommerce-payments' ) }

--- a/client/transactions/test/index.tsx
+++ b/client/transactions/test/index.tsx
@@ -105,6 +105,7 @@ describe( 'TransactionsPage', () => {
 		mockUseSettings.mockReturnValue( {
 			isLoading: false,
 			isSaving: false,
+			isDirty: false,
 			saveSettings: ( a ) => a,
 		} );
 


### PR DESCRIPTION
Alternative to https://github.com/Automattic/woocommerce-payments/pull/9386 to leverage the Redux store's behavior when settings change.