### PR TITLE
Default express checkout button label to "Only icon"

### DIFF
--- a/changelog/fix-9332-default-express-buttons-only-icon
+++ b/changelog/fix-9332-default-express-buttons-only-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Default express checkout button label to "Only icon".

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -188,7 +188,7 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 				className="payment-method-settings__cta-selection"
 				label={ __( 'Call to action', 'woocommerce-payments' ) }
 				help={ __(
-					'Select a button label that fits best wit the flow of purchase or payment experience on your store.',
+					'Select a button label that fits best with the flow of purchase or payment experience on your store.',
 					'woocommerce-payments'
 				) }
 				hideLabelFromVision

--- a/client/settings/express-checkout-settings/test/index.js
+++ b/client/settings/express-checkout-settings/test/index.js
@@ -23,7 +23,7 @@ jest.mock( '../../../data', () => ( {
 	useWooPayEnabledSettings: jest.fn().mockReturnValue( [ true, jest.fn() ] ),
 	useWooPayCustomMessage: jest.fn().mockReturnValue( [ 'test', jest.fn() ] ),
 	useWooPayStoreLogo: jest.fn().mockReturnValue( [ 'test', jest.fn() ] ),
-	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'buy' ] ),
+	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'default' ] ),
 	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'small' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
 	usePaymentRequestButtonBorderRadius: jest.fn().mockReturnValue( [ 4 ] ),

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -23,7 +23,7 @@ import {
 jest.mock( '../../../data', () => ( {
 	usePaymentRequestEnabledSettings: jest.fn(),
 	usePaymentRequestLocations: jest.fn(),
-	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'buy' ] ),
+	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'default' ] ),
 	usePaymentRequestButtonBorderRadius: jest.fn().mockReturnValue( [ 4 ] ),
 	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'small' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
@@ -148,7 +148,7 @@ describe( 'PaymentRequestSettings', () => {
 			screen.getByRole( 'combobox', {
 				name: 'Call to action',
 			} )
-		).toHaveValue( 'buy' );
+		).toHaveValue( 'default' );
 		expect( screen.getByLabelText( 'Small (40 px)' ) ).toBeChecked();
 		expect( screen.getByLabelText( /Dark/ ) ).toBeChecked();
 	} );
@@ -189,7 +189,7 @@ describe( 'PaymentRequestSettings', () => {
 		const setButtonThemeMock = jest.fn();
 
 		usePaymentRequestButtonType.mockReturnValue( [
-			'buy',
+			'default',
 			setButtonTypeMock,
 		] );
 		usePaymentRequestButtonSize.mockReturnValue( [

--- a/client/settings/express-checkout-settings/test/woopay-settings.test.js
+++ b/client/settings/express-checkout-settings/test/woopay-settings.test.js
@@ -93,7 +93,7 @@ describe( 'WooPaySettings', () => {
 		);
 
 		usePaymentRequestButtonType.mockReturnValue(
-			getMockPaymentRequestButtonType( [ 'buy' ], jest.fn() )
+			getMockPaymentRequestButtonType( [ 'default' ], jest.fn() )
 		);
 
 		usePaymentRequestButtonSize.mockReturnValue(

--- a/client/tokenized-payment-request/test/payment-request.test.js
+++ b/client/tokenized-payment-request/test/payment-request.test.js
@@ -71,7 +71,7 @@ describe( 'WooPaymentsPaymentRequest', () => {
 				currency_code: 'usd',
 			},
 			total_label: 'wcpay.test (via WooCommerce)',
-			button: { type: 'buy', theme: 'dark', height: '48' },
+			button: { type: 'default', theme: 'dark', height: '48' },
 		};
 		wcpayApi = {
 			getStripe: () => ( {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -401,7 +401,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Button type', 'woocommerce-payments' ),
 				'type'        => 'select',
 				'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
-				'default'     => 'buy',
+				'default'     => 'default',
 				'desc_tip'    => true,
 				'options'     => [
 					'default' => __( 'Only icon', 'woocommerce-payments' ),

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -550,7 +550,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_settings_saves_payment_request_button_type() {
-		$this->assertEquals( 'buy', $this->gateway->get_option( 'payment_request_button_type' ) );
+		$this->assertEquals( 'default', $this->gateway->get_option( 'payment_request_button_type' ) );
 
 		$request = new WP_REST_Request();
 		$request->set_param( 'payment_request_button_type', 'book' );

--- a/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-helper.php
@@ -190,7 +190,7 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	public function test_common_get_button_settings() {
 		$this->assertEquals(
 			[
-				'type'   => 'buy',
+				'type'   => 'default',
 				'theme'  => 'dark',
 				'height' => '48',
 				'radius' => '',

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -802,11 +802,11 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 
 		$this->assertEquals(
 			[
-				'type'         => 'buy',
+				'type'         => 'default',
 				'theme'        => 'dark',
 				'height'       => '48',
 				'locale'       => 'en',
-				'branded_type' => 'long',
+				'branded_type' => 'short',
 				'radius'       => '',
 			],
 			$this->pr->get_button_settings()

--- a/tests/unit/test-class-wc-payments-woopay-button-handler.php
+++ b/tests/unit/test-class-wc-payments-woopay-button-handler.php
@@ -521,7 +521,7 @@ class WC_Payments_WooPay_Button_Handler_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals(
 			[
-				'type'    => 'buy',
+				'type'    => 'default',
 				'theme'   => 'dark',
 				'height'  => '48',
 				'size'    => 'medium',


### PR DESCRIPTION
Fixes #9332 

#### Changes proposed in this Pull Request

Set the default Express Checkout button label to “Icon only”. Existing settings remain unchanged, and this will only apply to stores that have not previously configured a default label.

#### Testing instructions

**Test 1: Existing Store (Previously Configured for Express Checkout)**

1. Use a store that has previously configured Express Checkout button settings.
2. Go to the WooPayments Express Checkout settings in the WordPress admin.
3. Verify that the existing button label settings remain unchanged.

**Test 2: New Store (No Prior Express Checkout Configuration)**

1. Set up a new WooCommerce store or reset the WooPayments settings in an existing store to start fresh.
2. Install and configure the WooPayments plugin, but do not manually change the button label in the Express Checkout settings.
3. Go to the WooPayments Express Checkout settings.
4. Verify that the default button label is automatically set to "Icon only" for Express Checkout.

**Additional Notes:**
- For further reference on how to navigate and customize button settings for Apple Pay, Google Pay, or WooPay, refer to the following links:
   - [Apple Pay/Google Pay Customization Guide](https://woocommerce.com/document/woopayments/payment-methods/apple-pay/#customizing)
   - [WooPay Customization Guide](https://woocommerce.com/document/woopay-merchant-documentation/#customizing)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
