### PR TITLE
Update Dockerfile to allow for more Xdebug configs

### DIFF
--- a/changelog/dev-update-dockerfile-to-allow-more-xdebug-config
+++ b/changelog/dev-update-dockerfile-to-allow-more-xdebug-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update the Dockerfile to support more Xdebug config arguments.
+
+

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,12 +1,17 @@
 FROM wordpress:php8.1
+ARG XDEBUG_MODE=coverage,debug
 ARG XDEBUG_REMOTE_PORT
 ARG XDEBUG_REMOTE_HOST=host.docker.internal
 ARG XDEBUG_START_WITH_REQUEST=trigger
+ARG XDEBUG_SHOW_ERROR_TRACE=0
+ARG XDEBUG_SHOW_EXCEPTION_TRACE=0
 RUN pecl install xdebug \
-    && echo 'xdebug.mode=coverage,debug' >> $PHP_INI_DIR/php.ini \
+    && echo "xdebug.mode=${XDEBUG_MODE}" >> $PHP_INI_DIR/php.ini \
     && echo "xdebug.client_port=${XDEBUG_REMOTE_PORT}" >> $PHP_INI_DIR/php.ini \
     && echo "xdebug.client_host=${XDEBUG_REMOTE_HOST}" >> $PHP_INI_DIR/php.ini \
     && echo "xdebug.start_with_request=${XDEBUG_START_WITH_REQUEST}" >> $PHP_INI_DIR/php.ini \
+    && echo "xdebug.show_error_trace=${XDEBUG_SHOW_ERROR_TRACE}" >> $PHP_INI_DIR/php.ini \
+    && echo "xdebug.show_exception_trace=${XDEBUG_SHOW_EXCEPTION_TRACE}" >> $PHP_INI_DIR/php.ini \
     && docker-php-ext-enable xdebug
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq openssh-client


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we've moved to PHP 8.1 and Xdebug 3, some Xdebug behavior has changed because v3 reset many defaults when compared to v2. One of these is having traces associated with errors and exceptions. In a user-facing project like the WooPayments client, this can come in handy in identifying the source of errors and notices.

This PR introduces further arguments to the Dockerfile, to be overwritten via a `docker-compose.override.yml`:
- `XDEBUG_MODE`: defaults to the current hardcoded behavior `coverage,debug`
- `XDEBUG_SHOW_ERROR_TRACE`: useful if one activates the `trace` mode also
- `XDEBUG_SHOW_EXCEPTION_TRACE`: useful if one activates the `trace` mode also

I use the following in my `docker-compose.override.yml` file:
```
    build:
      args:
        - XDEBUG_MODE=coverage,debug,develop,trace # Xdebug's mode
        - XDEBUG_REMOTE_HOST=host.docker.internal # Xdebug's remote host
        - XDEBUG_SHOW_ERROR_TRACE=1 # Xdebug's show error trace
        - XDEBUG_SHOW_EXCEPTION_TRACE=1 # Xdebug's show exception trace
```
The `develop` mode is needed for the Xdebug-flavored `var_dump()` and `trace` is needed for traces :) 

#### Testing instructions

1. Checkout the `develop` branch on your local client environment
1. Run `npm run up:recreate` to make sure you are using Docker containers in sync with the Dockerfile behavior
1. Make sure WP_DEBUG is active. You can check this in Tools > Site Health > Info tab > WordPress constants section ([link](http://localhost:8082/wp-admin/site-health.php?tab=debug))  
1. Edit the `woocommerce-payments.php`file at the root of the repo, and add [here](https://github.com/Automattic/woocommerce-payments/blob/ca684b78dd2c52cd8ed6e59ba681904b46a05f08/woocommerce-payments.php#L21-L21):
```
trigger_error( 'This is a WooPayments test!', E_USER_NOTICE );
```
1. Go to your WordPress dashboard (for example, the WCPay Dev Tools [page](http://localhost:8082/wp-admin/admin.php?page=wcpaydev)) and you should see a notice at the top, without any trace information:
![Screenshot 2024-09-13 at 14 56 46](https://github.com/user-attachments/assets/e0419bd2-a64c-42d0-bda5-588a6774945b)
1. You can try `E_USER_WARNING` or `E_USER_ERROR` instead of `E_USER_NOTICE`. There should be no trace information
1. Checkout this PR's branch
1. Change the `XDEBUG_MODE` and add  `XDEBUG_SHOW_ERROR_TRACE` and `XDEBUG_SHOW_EXCEPTION_TRACE` to your `docker-compose.override.yml` file (if you don't have one, create a new one and place it at the root of your local clone):
```
services:
    build:
      args:
        - XDEBUG_MODE=coverage,debug,develop,trace # Xdebug's mode
        - XDEBUG_REMOTE_HOST=host.docker.internal # Xdebug's remote host
        - XDEBUG_SHOW_ERROR_TRACE=1 # Xdebug's show error trace
        - XDEBUG_SHOW_EXCEPTION_TRACE=1 # Xdebug's show exception trace
```
1. Run `npm run up:recreate` to recreate your container with the new enabled Xdebug modes
1. The same notices, warnings, or errors will now include stack traces:
![Screenshot 2024-09-13 at 15 02 51](https://github.com/user-attachments/assets/ba63aaaf-94eb-4f9a-84a5-8bff51dd55d0)
1. You should see the same stack traces in your `docker/wordpress/wp-content/debug.log` file:
![Screenshot 2024-09-13 at 15 04 12](https://github.com/user-attachments/assets/7d2b8a5d-1628-4ba9-9779-9529b4afac72)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
