### PR TITLE
Fix WooPay pre-checking place order bug when buying a subscription

### DIFF
--- a/changelog/fix-woopay-pre-checking-save-my-info-place-order
+++ b/changelog/fix-woopay-pre-checking-save-my-info-place-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay pre-checking place order bug when buying a subscription.


### PR DESCRIPTION
Fixes #9449

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
* Fixes the `Save my info` getting hidden.
* Fixes the place order bug.

When buying a subscription via blocks checkout while WooPay pre-checking is enabled.

This bug was introduced on https://github.com/Automattic/woocommerce-payments/pull/9378 due to the late loading of the payment methods section, this way [this line](https://github.com/Automattic/woocommerce-payments/blob/532e9fc38f23dde2eb5225582db8d1e4bbdf00e7/client/components/woopay/save-user/checkout-page-save-user.js#L51) would initially return `undefined, undefined` as it checks the existence of the section radio buttons before it's loaded.

It looks like WC Blocks wait the `registerExpressPaymentMethod` [here](https://github.com/Automattic/woocommerce-payments/blob/dbd21e8b83051d2df3f18c416563a9de7e8ac62c/client/checkout/blocks/index.js#L169) get fully loaded (since the mentioned PR it uses a Promise) to the payment methods section on the checkout page.

To fix it, I simply used the hooks used by WC Blocks itself to detect the current payment method, checking if the current one is `woocommerce_payments` and the load the `Save my info` section, for the classic checkout, it works the same way it worked before.

The `Place order` button bug was caused by the WooPay component (`Save my info` section) phone number validation, it was loaded even though it was hidden.

![Screenshot 2024-09-13 at 5 14 31 PM](https://github.com/user-attachments/assets/abd1634c-5c8c-4c1d-8ced-00df1877b5e0)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable WooPay pre-checking (you can use WCPay DevTools).
* Add a subscription to the cart.
* Access the blocks checkout page.
* The `Save my info` should show up.
* The `Place order` button should work as expected.
* Add a new subscription to the cart.
* Access the classic checkout page.
* The `Save my info` should show up.
* The `Place order` button should work as expected.
* Enable more payment methods.
* Access the blocks checkout page.
* The `Save my info` section should be shown only when the WCPay payment method is selected.
* Access the classic checkout page.
* The `Save my info` section should be shown only when the WCPay payment method is selected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
