### PR TITLE
Sending RGBA colors to Stripe Appearance API

### DIFF
--- a/changelog/fix-dark-mode-stripe-appearance
+++ b/changelog/fix-dark-mode-stripe-appearance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed CC form input fields appearance when using RGBA

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -5,7 +5,6 @@ import { upeRestrictedProperties } from './upe-styles';
 import {
 	generateHoverRules,
 	generateOutlineStyle,
-	maybeConvertRGBAtoRGB,
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
@@ -380,8 +379,8 @@ export const getFieldStyles = (
 	for ( let i = 0; i < styles.length; i++ ) {
 		const camelCase = dashedToCamelCase( styles[ i ] );
 		if ( validProperties.includes( camelCase ) ) {
-			filteredStyles[ camelCase ] = maybeConvertRGBAtoRGB(
-				styles.getPropertyValue( styles[ i ] )
+			filteredStyles[ camelCase ] = styles.getPropertyValue(
+				styles[ i ]
 			);
 		}
 	}

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -134,7 +134,7 @@ describe( 'Getting styles for automated theming', () => {
 			theme: 'stripe',
 			rules: {
 				'.Input': {
-					backgroundColor: 'rgb(255, 255, 255)',
+					backgroundColor: 'rgba(0, 0, 0, 0)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -143,7 +143,7 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 				'.Input--invalid': {
-					backgroundColor: 'rgb(255, 255, 255)',
+					backgroundColor: 'rgba(0, 0, 0, 0)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -159,24 +159,24 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 				'.Tab': {
-					backgroundColor: 'rgb(255, 255, 255)',
+					backgroundColor: 'rgba(0, 0, 0, 0)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 				},
 				'.Tab:hover': {
-					backgroundColor: 'rgb(237, 237, 237)',
-					color: 'rgb(0, 0, 0)',
+					backgroundColor: 'rgba(18, 18, 18, 0)',
+					color: 'rgb(255, 255, 255)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 				},
 				'.Tab--selected': {
-					backgroundColor: 'rgb(255, 255, 255)',
+					backgroundColor: 'rgba(0, 0, 0, 0)',
 					color: 'rgb(109, 109, 109)',
 					outline: '1px solid rgb(150, 88, 138)',
 				},
 				'.TabIcon:hover': {
-					color: 'rgb(0, 0, 0)',
+					color: 'rgb(255, 255, 255)',
 				},
 				'.TabIcon--selected': {
 					color: 'rgb(109, 109, 109)',
@@ -207,7 +207,7 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 				'.Button': {
-					backgroundColor: 'rgb(255, 255, 255)',
+					backgroundColor: 'rgba(0, 0, 0, 0)',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -44,7 +44,7 @@ describe( 'Getting styles for automated theming', () => {
 			'.Input'
 		);
 		expect( fieldStyles ).toEqual( {
-			backgroundColor: 'rgb(255, 255, 255)',
+			backgroundColor: 'rgba(0, 0, 0, 0)',
 			color: 'rgb(109, 109, 109)',
 			fontFamily:
 				'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',

--- a/client/checkout/upe-styles/test/utils.js
+++ b/client/checkout/upe-styles/test/utils.js
@@ -100,32 +100,6 @@ describe( 'UPE Utilities to generate UPE styles', () => {
 		} );
 	} );
 
-	test( 'maybeConvertRGBAtoRGB returns valid colors', () => {
-		const hex = '#ffffff';
-		const color = 'red';
-		const rgb = 'rgb(1, 2, 3)';
-		const rgbNoSpaces = 'rgb(1,2,3)';
-		const rgba = 'rgba(1, 2, 3, 1)';
-		const rgbaNoSpaces = 'rgba(1,2,3,1)';
-		const shadow = 'rgb(1,2,3) 0px 1px 1px 0px';
-		const shadowTransparent = 'rgba(1,2,3,1) 0px 1px 1px 0px';
-		const pixel = '0px';
-
-		expect( upeUtils.maybeConvertRGBAtoRGB( hex ) ).toEqual( hex );
-		expect( upeUtils.maybeConvertRGBAtoRGB( color ) ).toEqual( color );
-		expect( upeUtils.maybeConvertRGBAtoRGB( rgb ) ).toEqual( rgb );
-		expect( upeUtils.maybeConvertRGBAtoRGB( rgbNoSpaces ) ).toEqual(
-			rgbNoSpaces
-		);
-		expect( upeUtils.maybeConvertRGBAtoRGB( rgba ) ).toEqual( rgb );
-		expect( upeUtils.maybeConvertRGBAtoRGB( rgbaNoSpaces ) ).toEqual( rgb );
-		expect( upeUtils.maybeConvertRGBAtoRGB( shadow ) ).toEqual( shadow );
-		expect( upeUtils.maybeConvertRGBAtoRGB( shadowTransparent ) ).toEqual(
-			shadowTransparent
-		);
-		expect( upeUtils.maybeConvertRGBAtoRGB( pixel ) ).toEqual( pixel );
-	} );
-
 	test( 'isColorLight returns valid brightness values', () => {
 		const white = '#ffffff';
 		const black = '#000000';

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -103,26 +103,6 @@ export const dashedToCamelCase = ( string ) => {
 };
 
 /**
- * Converts rgba to rgb format, since Stripe Appearances API does not accept rgba format for background.
- *
- * @param {string} color CSS color value.
- * @return {string} Accepted CSS color value.
- */
-export const maybeConvertRGBAtoRGB = ( color ) => {
-	const colorParts = color.match(
-		/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0?(\.\d+)?|1?(\.0+)?)\s*\)$/
-	);
-	if ( colorParts ) {
-		const alpha = colorParts[ 4 ] || 1;
-		const newColorParts = colorParts.slice( 1, 4 ).map( ( part ) => {
-			return Math.round( part * alpha + 255 * ( 1 - alpha ) );
-		} );
-		color = `rgb(${ newColorParts.join( ', ' ) })`;
-	}
-	return color;
-};
-
-/**
  * Searches through array of CSS selectors and returns first visible background color.
  *
  * @param {Array} selectors List of CSS selectors to check.


### PR DESCRIPTION
Fixes #9415

#### Changes proposed in this Pull Request

While investigating this issue I noticed Stripe does not throw a warning regarding rgba values anymore, so this PR removes the `maybeConvertRGBAtoRGB` method.

#### Testing instructions


1. Comment out [these lines](https://github.com/Automattic/woocommerce-payments/blob/a9955a104367ac0974ae8cfccda8371a23cc0990/includes/class-wc-payments-checkout.php#L227-L233) to make sure the appearance is not cached.
1. Change the theme to Storefront
1. Go to /wp-admin > Appearance > Customize > Background
1. Set the background as black
1. Go to /wp-admin > Pages > edit the blocks checkout page
1. Click on the Checkout element
1. Click block
1. Enable dark mode inputs
1. Save
1. As a customer add a product to your cart
1. Go to the checkout page
1. Notice the white credit card inputs

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
