### PR TITLE
Add backwards-compatible method for retrieving the multi-currency instance

### DIFF
--- a/changelog/fix-backwards-compat-mccy-instance
+++ b/changelog/fix-backwards-compat-mccy-instance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Provide backwards-compatible method for retrieving the multi-currency instance.

--- a/multi-currency/src/MultiCurrency.php
+++ b/multi-currency/src/MultiCurrency.php
@@ -208,6 +208,19 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Backwards compatibility for the old `instance()` static method.
+	 *
+	 * We need to use this as some plugins still call `MultiCurrency::instance()` directly.
+	 *
+	 * @return null|MultiCurrency - Main instance.
+	 */
+	public static function instance() {
+		if ( function_exists( 'WC_Payments_Multi_Currency' ) ) {
+			return WC_Payments_Multi_Currency();
+		}
+	}
+
+	/**
 	 * Initializes this class' WP hooks.
 	 *
 	 * @return void

--- a/multi-currency/src/MultiCurrency.php
+++ b/multi-currency/src/MultiCurrency.php
@@ -1120,7 +1120,7 @@ class MultiCurrency {
 		$script_file       = $script . '.js';
 		$script_src_url    = plugins_url( $script_file, $this->gateway_context['plugin_file_path'] );
 		$script_asset_path = plugin_dir_path( $this->gateway_context['plugin_file_path'] ) . $script . '.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ]; // nosemgrep: audit.php.lang.security.file.inclusion-arg -- server generated path is used.
 		$all_dependencies  = array_merge( $script_asset['dependencies'], $additional_dependencies );
 
 		wp_register_script(


### PR DESCRIPTION
Fixes 209-gh-Automattic/woopayments

#### Changes proposed in this Pull Request

During the MCCY back-end decoupling, we decided to move the singleton logic out of `MultiCurrency` (pcrvl0-1jD-p2#comment-668).

During our tests, we figured some extensions are calling the MCCY instance the wrong way – See comment from related issue. So, a backwards-compatible method is a requirement.

We also learned about a QIT warning that this PR addresses the same way as in [`register_script_with_dependencies`](https://github.com/Automattic/woocommerce-payments/blob/af3cc60d6e5dc41c20e384ce49e1cd05d7db89fa/includes/class-wc-payments.php#L1174).

#### Testing instructions

**WooCommerce Deposits fix:**
- Follow testing instructions from 209-gh-Automattic/woopayments and ensure the fatal error is no longer reproducible.

**Verify new QIT results:**
- p1726595299217699/1726481053.328369-slack-CGGCLBN58


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.