### PR TITLE
Fix progressive onboarding broken e2e test

### DIFF
--- a/changelog/dev-fix-po-test
+++ b/changelog/dev-fix-po-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix progressive onboarding e2e test

--- a/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js
@@ -88,13 +88,9 @@ describe( 'Admin merchant progressive onboarding', () => {
 			}
 		);
 
-		// Loading screen before redirect to Stripe.
-		await expect( page ).toMatchElement( 'h1.stepper__heading', {
-			text: 'One last step! Verify your identity with our partner',
-		} );
-
-		// Merchant is redirected away to payments/connect again (because of force fisconnected option)
-		// todo at some point test real Stripe KYC
-		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+		// Check that Stripe Embedded KYC iframe is loaded.
+		await page.waitForSelector(
+			'iframe[data-testid="stripe-connect-ui-layer-stripe-connect-account-onboarding"]'
+		);
 	} );
 } );


### PR DESCRIPTION
After merging Stripe Embedded PRs, we got e2e tests failed on develop
![image](https://github.com/user-attachments/assets/4d34aa5e-296d-47b6-bcf5-9d56da256ae4)

#### Changes proposed in this Pull Request

* Fix progressive onboarding broken e2e test

#### Testing instructions

* Run `npm run test:e2e-up`
* Setup e2e tests with `npm run test:e2e-setup` if you don't have one
* Run `npm run test:e2e-dev tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.js` to check the test does not fail anymore

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
