### PR TITLE
Provide locale to ECE

### DIFF
--- a/changelog/add-9245-ece-locale
+++ b/changelog/add-9245-ece-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Provide locale to Express Checkout Element.

--- a/client/express-checkout/blocks/components/express-checkout-container.js
+++ b/client/express-checkout/blocks/components/express-checkout-container.js
@@ -8,7 +8,10 @@ import { Elements } from '@stripe/react-stripe-js';
  * Internal dependencies
  */
 import ExpressCheckoutComponent from './express-checkout-component';
-import { getExpressCheckoutButtonAppearance } from 'wcpay/express-checkout/utils';
+import {
+	getExpressCheckoutButtonAppearance,
+	getExpressCheckoutData,
+} from 'wcpay/express-checkout/utils';
 import '../express-checkout-element.scss';
 
 const ExpressCheckoutContainer = ( props ) => {
@@ -24,6 +27,7 @@ const ExpressCheckoutContainer = ( props ) => {
 		amount: billing.cartTotal.value,
 		currency: billing.currency.code.toLowerCase(),
 		appearance: getExpressCheckoutButtonAppearance( buttonAttributes ),
+		locale: getExpressCheckoutData( 'stripe' )?.locale ?? 'en',
 	};
 
 	return (

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -235,6 +235,7 @@ jQuery( ( $ ) => {
 				currency: options?.currency,
 				paymentMethodCreation: 'manual',
 				appearance: getExpressCheckoutButtonAppearance(),
+				locale: getExpressCheckoutData( 'stripe' )?.locale ?? 'en',
 			} );
 
 			const eceButton = wcpayECE.createButton(


### PR DESCRIPTION
Fixes #9245.

#### Changes proposed in this Pull Request

This PR makes sure a locale is passed over to the Express Checkout Element (ECE). This way we ensure a locale is set on ECE initialization instead of relying on Stripe detecting it for us.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Setup**

1. Switch to this branch and build the assets: `npm run build:client`.
2. Make sure you can access the site publicly via HTTPS.
3. As a merchant, navigate to **Payments > Settings**.
4. Scroll down to **Express checkouts** and click on **Customize** for Apple Pay/Google Pay.
5. Scroll down to **Settings**, modify the **Call to action** to `Buy with` and save changes.
6. Modify [this line](https://github.com/Automattic/woocommerce-payments/blob/2ce85a59a4d868b1f2964f38929ad38172fefa12/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php#L229) to the following just for testing purposes:
```php
'locale'         => WC_Payments_Utils::convert_to_stripe_locale( 'pt-BR' )
```

**Test: Ensure locale is loaded as expected**

1. As a shopper, click on a product and note the ECE button with the copy "Compre com (o) ...".
<img width="431" alt="image" src="https://github.com/user-attachments/assets/8127fad4-892b-4cff-8791-0bd186b5d970">

2. Add the product to the cart and ensure you see the same copy on the button across all cart and checkout pages in both classic and Blocks variations.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
