### PR TITLE
Add style support for the WooPay button

### DIFF
--- a/changelog/add-support-for-woo-button-controls
+++ b/changelog/add-support-for-woo-button-controls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add support for the style controls for the WooPay button

--- a/client/checkout/woopay/express-button/woopay-express-checkout-payment-method.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-payment-method.js
@@ -67,6 +67,7 @@ const wooPayExpressCheckoutPaymentMethod = () => ( {
 	paymentMethodId: PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT,
 	supports: {
 		features: getConfig( 'features' ),
+		style: [ 'height', 'borderRadius' ],
 	},
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The WooPay button is already rendered in the editor and supports `height` and `border radius` styles. Declaring support for it as introduced in https://github.com/woocommerce/woocommerce/pull/51296. Without doing so, the newly introduced button style controls will be hidden to merchants.

#### Testing instructions

Test with the latest WooCommerce Core trunk branch

1. With the WooPay button active, check that the uniform style controls are shown for both height and border radius in the inspector sidebar.
2. With the WooPay button active, and the `develop` branch of woocommerce-payments (or any other branch), check that the controls are hidden.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
