### PR TITLE
Update the focus color for Gutenberg Blueberry

### DIFF
--- a/changelog/fix-update-dark-blueberry-color
+++ b/changelog/fix-update-dark-blueberry-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix gutenberg blueberry focus color

--- a/client/onboarding/style.scss
+++ b/client/onboarding/style.scss
@@ -104,8 +104,8 @@ body.wcpay-onboarding__body {
 				&:hover {
 					background: var(
 						--wp-components-color-accent,
-						darken( $gutenberg-blueberry, 10% )
-					); // 10% darker Gutenberg Blueberry on hover.
+						$gutenberg-blueberry-focus
+					);
 				}
 			}
 		}

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -70,6 +70,7 @@ $wp-green-100: #001c05;
 // Missing from dependencies
 $gutenberg-blue: #007cba;
 $gutenberg-blueberry: #3858e9;
+$gutenberg-blueberry-focus: #1d35b4;
 
 // Accent color
 $components-color-accent: var(


### PR DESCRIPTION
Follow up of https://github.com/Automattic/woocommerce-payments/pull/9381

#### Changes proposed in this Pull Request

Update the color of MOX CTA on focus according to Tim's feedback. https://github.com/Automattic/woocommerce-payments/pull/9381#issuecomment-2362274116

#### Testing instructions

* Start new MOX
* Check that the focus color of CTA button is correct (#1D35B4)
<img width="768" alt="image" src="https://github.com/user-attachments/assets/2e7c02e4-f40e-4161-9e0d-73f0659d0ff8">

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
