### PR TITLE
Fixed the utils path for getAppearanceType

### DIFF
--- a/changelog/fix-wrong-utils-path
+++ b/changelog/fix-wrong-utils-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixed wrong utils path that would prevent checkout with WooPay OTP

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -9,12 +9,12 @@ import { buildAjaxURL } from 'utils/express-checkout';
 import { getAppearance } from 'checkout/upe-styles';
 import {
 	getTargetElement,
-	getAppearanceType,
 	validateEmail,
 	appendRedirectionParams,
 	shouldSkipWooPay,
 	deleteSkipWooPayCookie,
-} from './utils';
+} from 'wcpay/checkout/woopay/utils';
+import { getAppearanceType } from 'wcpay/checkout/utils';
 
 export const handleWooPayEmailInput = async (
 	field,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a bug introduced in #9468 that would prevent WooPay E2E tests from working and would prevent WooPay first party auth from working on the OTP modal.

#### Testing instructions
- Checkout to this branch
- Add a product to your cart
- Go to the checkout page
- Add a breakpoint to [this line](https://github.com/Automattic/woocommerce-payments/blob/bc2a737194dfc38db685f80ad3b9043a0e9bb892/client/checkout/woopay/email-input-iframe.js#L182)
- Type a WooPay user email in the email field
- Make sure no error shows up in the console when after executing the breakpoint line
- Make sure it's possible to checkout using WooPay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
