### PR TITLE
Fix duplicated event prefix

### DIFF
--- a/changelog/fix-tracks-event-prefix-duplication
+++ b/changelog/fix-tracks-event-prefix-duplication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix event prefix duplication in Tracks events

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -148,18 +148,19 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @param bool   $record_on_frontend whether to record the event on the frontend to prevent cache break.
 	 */
 	public function maybe_record_wcpay_shopper_event( $event, $data = [], $record_on_frontend = true ) {
-		// Top level events should not be namespaced.
-		if ( '_aliasUser' !== $event ) {
-			$event = self::$user_prefix . '_' . $event;
-		}
-
 		$is_admin_event      = false;
 		$track_on_all_stores = true;
 
+		// Record the event immediately.
 		if ( ! $record_on_frontend ) {
+			// Top level events should not be namespaced.
+			if ( '_aliasUser' !== $event ) {
+				$event = self::$user_prefix . '_' . $event;
+			}
 			return $this->tracks_record_event( $event, $data, $is_admin_event, $track_on_all_stores );
 		}
 
+		// Route the event through frontend to avoid setting cookies on page load.
 		$data['record_event_data'] = compact( 'is_admin_event', 'track_on_all_stores' );
 
 		add_filter(


### PR DESCRIPTION

Fixes #9493

#### Changes proposed in this Pull Request

When certain Shopper Tracks events are recorded on the frontend (eg: for page view events), the event prefix is duplicated. This is happening only on events that are routed to frontend (introduced in https://github.com/Automattic/woocommerce-payments/pull/9249). This PR fixes it by only setting the prefix for the events that are recorded immediately. The events that get routed through the front end will have the prefix set later.

| Page | Fixed Event Name  | Current Event Name  |
| --- |---|---|
| Order Success Page | `wcpay_order_success_page_view`  | `wcpay_wcpay_order_success_page_view`  |
| Pay For Order Page |  `wcpay_pay_for_order_page_view` | `wcpay_wcpay_pay_for_order_page_view`  |
| Product Page |  `wcpay_product_page_view` | `wcpay_wcpay_product_page_view`  |
| Cart Page |  `wcpay_cart_page_view` | `wcpay_wcpay_cart_page_view`  |
| Checkout Page |  `wcpay_checkout_page_view` | `wcpay_wcpay_checkout_page_view`  |


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
We need to test each page in the above table and make sure the event name is correct. While we can lookup the event in MC Tracks, it is tricky to find the exact events from the local env, so we will only test if we're sending the correct event name to Tracks backend. 

#### Test the frontend-routed event names

* Add a breakpoint in https://github.com/Automattic/woocommerce-payments/blob/2bc236b6437c569f538fd5b7b8120e1f9ded3eaf/includes/class-woopay-tracker.php#L325
* View each page in the above table.
* When the breakpoint is reached, make sure the `$event_name` matches the name in "Fixed Event Name" column.

#### Test the events that are recorded immediately
* Place an order using WooPayments.
* Make sure the breakpoint is reached and contains the `$event_name`, `wcpay_checkout_order_placed`
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
