### PR TITLE
Remove text color from WooPay component

### DIFF
--- a/changelog/fix-remove-text-color-from-woopay-component
+++ b/changelog/fix-remove-text-color-from-woopay-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove text color from WooPay component.

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -69,15 +69,10 @@
 			font-weight: 400;
 			line-height: 21px;
 			text-align: left;
-			color: #000;
 		}
 
 		.tos {
 			font-size: 12px;
-			color: #6d6d6d;
-			:link {
-				color: #6d6d6d;
-			}
 		}
 
 		#validate-error-invalid-woopay-phone-number {


### PR DESCRIPTION
Fixes #9496

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Inherit the merchant site text color on the WooPay registration component.

<img width="810" alt="Screenshot 2024-09-26 at 1 47 30 PM" src="https://github.com/user-attachments/assets/289e0122-8e82-46b6-be67-aa63f4d782cb">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set the merchant site to a darker background color and lighter text and links.
* Access blocks or classic checkout.
* Type a non existent WooPay email.
* The WooPay T&C should have the site text color.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
