### PR TITLE
Using Floating Labels with Stripe Appearance API

### DIFF
--- a/changelog/add-stripe-floating-labels
+++ b/changelog/add-stripe-floating-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Using Floating Labels with Stripe Appearance API for Blocks Checkout

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -50,6 +50,7 @@ const mockAppearance = {
 		fontFamily: undefined,
 		fontSizeBase: undefined,
 	},
+	labels: 'above',
 };
 
 describe( 'WCPayAPI', () => {

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -36,7 +36,7 @@ const PaymentElements = ( { api, ...props } ) => {
 	useEffect( () => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance( 'blocks_checkout' );
+			let upeAppearance = getAppearance( 'blocks_checkout', false, true );
 			upeAppearance = await api.saveUPEAppearance(
 				upeAppearance,
 				'blocks_checkout'

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -8,6 +8,7 @@ import {
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
+	handleAppearanceForFloatingLabel,
 } from './utils.js';
 
 export const appearanceSelectors = {
@@ -449,75 +450,6 @@ export const getFontRulesFromPage = () => {
 	return fontRules;
 };
 
-const handleAppearanceForFloatingLabel = ( appearance, selectors ) => {
-	// Add floating label styles.
-	appearance.rules[ '.Label--floating' ] = getFieldStyles(
-		selectors.hiddenValidActiveLabel,
-		'.Label--floating'
-	);
-
-	// Update line-height for floating label to account for scaling.
-	if (
-		appearance.rules[ '.Label--floating' ].transform &&
-		appearance.rules[ '.Label--floating' ].transform !== 'none'
-	) {
-		// Extract the scaling factors from the matrix
-		const transformMatrix =
-			appearance.rules[ '.Label--floating' ].transform;
-		const matrixValues = transformMatrix.match( /matrix\((.+)\)/ )[ 1 ];
-		if ( matrixValues ) {
-			const splitMatrixValues = matrixValues.split( ', ' );
-			const scaleX = parseFloat( splitMatrixValues[ 0 ] );
-			const scaleY = parseFloat( splitMatrixValues[ 3 ] );
-			const scale = ( scaleX + scaleY ) / 2;
-
-			const lineHeight = parseFloat(
-				appearance.rules[ '.Label--floating' ].lineHeight
-			);
-			const newLineHeight = Math.floor( lineHeight * scale );
-			appearance.rules[
-				'.Label--floating'
-			].lineHeight = `${ newLineHeight }px`;
-			appearance.rules[
-				'.Label--floating'
-			].fontSize = `${ newLineHeight }px`;
-		}
-		delete appearance.rules[ '.Label--floating' ].transform;
-	}
-
-	// Subtract the label's lineHeight from padding-top to account for floating label height.
-	// Minus 4px which is a constant value added by stripe to the padding-top.
-	// Minus 1px for each vertical padding to account for the unpredictable input height
-	// (see https://github.com/Automattic/woocommerce-payments/issues/9476#issuecomment-2374766540).
-	// When the result is less than 0, it will automatically use 0.
-	if ( appearance.rules[ '.Input' ].paddingTop ) {
-		appearance.rules[
-			'.Input'
-			// eslint-disable-next-line max-len
-		].paddingTop = `calc(${ appearance.rules[ '.Input' ].paddingTop } - ${ appearance.rules[ '.Label--floating' ].lineHeight } - 4px - 1px)`;
-	}
-	if ( appearance.rules[ '.Input' ].paddingBottom ) {
-		const originalPaddingBottom = parseFloat(
-			appearance.rules[ '.Input' ].paddingBottom
-		);
-		appearance.rules[
-			'.Input'
-			// eslint-disable-next-line max-len
-		].paddingBottom = `${ originalPaddingBottom - 1 }px`;
-
-		const originalLabelMarginTop =
-			appearance.rules[ '.Label' ].marginTop ?? '0';
-		appearance.rules[ '.Label' ].marginTop = `${ Math.floor(
-			( originalPaddingBottom - 1 ) / 3
-		) }px`;
-		appearance.rules[
-			'.Label--floating'
-		].marginTop = originalLabelMarginTop;
-	}
-
-	return appearance;
-};
-
 export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 	const selectors = appearanceSelectors.getSelectors( elementsLocation );
 
@@ -591,7 +523,13 @@ export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 	};
 
 	if ( isFloatingLabel ) {
-		appearance = handleAppearanceForFloatingLabel( appearance, selectors );
+		appearance = handleAppearanceForFloatingLabel(
+			appearance,
+			getFieldStyles(
+				selectors.hiddenValidActiveLabel,
+				'.Label--floating'
+			)
+		);
 	}
 
 	if ( forWooPay ) {

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -464,23 +464,24 @@ const handleAppearanceForFloatingLabel = ( appearance, selectors ) => {
 		// Extract the scaling factors from the matrix
 		const transformMatrix =
 			appearance.rules[ '.Label--floating' ].transform;
-		const matrixValues = transformMatrix
-			.match( /matrix\((.+)\)/ )[ 1 ]
-			.split( ', ' );
-		const scaleX = parseFloat( matrixValues[ 0 ] );
-		const scaleY = parseFloat( matrixValues[ 3 ] );
-		const scale = ( scaleX + scaleY ) / 2;
+		const matrixValues = transformMatrix.match( /matrix\((.+)\)/ )[ 1 ];
+		if ( matrixValues ) {
+			const splitMatrixValues = matrixValues.split( ', ' );
+			const scaleX = parseFloat( splitMatrixValues[ 0 ] );
+			const scaleY = parseFloat( splitMatrixValues[ 3 ] );
+			const scale = ( scaleX + scaleY ) / 2;
 
-		const lineHeight = parseFloat(
-			appearance.rules[ '.Label--floating' ].lineHeight
-		);
-		const newLineHeight = Math.floor( lineHeight * scale );
-		appearance.rules[
-			'.Label--floating'
-		].lineHeight = `${ newLineHeight }px`;
-		appearance.rules[
-			'.Label--floating'
-		].fontSize = `${ newLineHeight }px`;
+			const lineHeight = parseFloat(
+				appearance.rules[ '.Label--floating' ].lineHeight
+			);
+			const newLineHeight = Math.floor( lineHeight * scale );
+			appearance.rules[
+				'.Label--floating'
+			].lineHeight = `${ newLineHeight }px`;
+			appearance.rules[
+				'.Label--floating'
+			].fontSize = `${ newLineHeight }px`;
+		}
 		delete appearance.rules[ '.Label--floating' ].transform;
 	}
 
@@ -517,11 +518,7 @@ const handleAppearanceForFloatingLabel = ( appearance, selectors ) => {
 	return appearance;
 };
 
-export const getAppearance = (
-	elementsLocation,
-	forWooPay = false,
-	isFloatingLabel = false
-) => {
+export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 	const selectors = appearanceSelectors.getSelectors( elementsLocation );
 
 	// Add hidden fields to DOM for generating styles.
@@ -567,6 +564,9 @@ export const getAppearance = (
 		fontFamily: labelRules.fontFamily,
 		fontSizeBase: labelRules.fontSize,
 	};
+
+	const isFloatingLabel =
+		elementsLocation === 'blocks_checkout' ? 'floating' : 'above';
 
 	let appearance = {
 		variables: globalRules,

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -497,8 +497,7 @@ export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 		fontSizeBase: labelRules.fontSize,
 	};
 
-	const isFloatingLabel =
-		elementsLocation === 'blocks_checkout' ? 'floating' : 'above';
+	const isFloatingLabel = elementsLocation === 'blocks_checkout';
 
 	let appearance = {
 		variables: globalRules,

--- a/client/checkout/upe-styles/test/index.js
+++ b/client/checkout/upe-styles/test/index.js
@@ -223,6 +223,7 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 			},
+			labels: 'above',
 		} );
 	} );
 

--- a/client/checkout/upe-styles/upe-styles.js
+++ b/client/checkout/upe-styles/upe-styles.js
@@ -93,6 +93,7 @@ const restrictedTabIconSelectedProperties = [ 'color' ];
 
 export const upeRestrictedProperties = {
 	'.Label': upeSupportedProperties[ '.Label' ],
+	'.Label--floating': [ ...upeSupportedProperties[ '.Label' ], 'transform' ],
 	'.Input': [
 		...upeSupportedProperties[ '.Input' ],
 		'outlineColor',

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -138,3 +138,79 @@ export const getBackgroundColor = ( selectors ) => {
 export const isColorLight = ( color ) => {
 	return tinycolor( color ).getBrightness() > 125;
 };
+
+/**
+ * Modifies the appearance object to include styles for floating label.
+ *
+ * @param {Object} appearance object to modify.
+ * @param {Object} floatingLabelStyles Floating label styles.
+ * @return {Object} Modified appearance object.
+ */
+export const handleAppearanceForFloatingLabel = (
+	appearance,
+	floatingLabelStyles
+) => {
+	// Add floating label styles.
+	appearance.rules[ '.Label--floating' ] = floatingLabelStyles;
+
+	// Update line-height for floating label to account for scaling.
+	if (
+		appearance.rules[ '.Label--floating' ].transform &&
+		appearance.rules[ '.Label--floating' ].transform !== 'none'
+	) {
+		// Extract the scaling factors from the matrix
+		const transformMatrix =
+			appearance.rules[ '.Label--floating' ].transform;
+		const matrixValues = transformMatrix.match( /matrix\((.+)\)/ )[ 1 ];
+		if ( matrixValues ) {
+			const splitMatrixValues = matrixValues.split( ', ' );
+			const scaleX = parseFloat( splitMatrixValues[ 0 ] );
+			const scaleY = parseFloat( splitMatrixValues[ 3 ] );
+			const scale = ( scaleX + scaleY ) / 2;
+
+			const lineHeight = parseFloat(
+				appearance.rules[ '.Label--floating' ].lineHeight
+			);
+			const newLineHeight = Math.floor( lineHeight * scale );
+			appearance.rules[
+				'.Label--floating'
+			].lineHeight = `${ newLineHeight }px`;
+			appearance.rules[
+				'.Label--floating'
+			].fontSize = `${ newLineHeight }px`;
+		}
+		delete appearance.rules[ '.Label--floating' ].transform;
+	}
+
+	// Subtract the label's lineHeight from padding-top to account for floating label height.
+	// Minus 4px which is a constant value added by stripe to the padding-top.
+	// Minus 1px for each vertical padding to account for the unpredictable input height
+	// (see https://github.com/Automattic/woocommerce-payments/issues/9476#issuecomment-2374766540).
+	// When the result is less than 0, it will automatically use 0.
+	if ( appearance.rules[ '.Input' ].paddingTop ) {
+		appearance.rules[
+			'.Input'
+			// eslint-disable-next-line max-len
+		].paddingTop = `calc(${ appearance.rules[ '.Input' ].paddingTop } - ${ appearance.rules[ '.Label--floating' ].lineHeight } - 4px - 1px)`;
+	}
+	if ( appearance.rules[ '.Input' ].paddingBottom ) {
+		const originalPaddingBottom = parseFloat(
+			appearance.rules[ '.Input' ].paddingBottom
+		);
+		appearance.rules[
+			'.Input'
+			// eslint-disable-next-line max-len
+		].paddingBottom = `${ originalPaddingBottom - 1 }px`;
+
+		const originalLabelMarginTop =
+			appearance.rules[ '.Label' ].marginTop ?? '0';
+		appearance.rules[ '.Label' ].marginTop = `${ Math.floor(
+			( originalPaddingBottom - 1 ) / 3
+		) }px`;
+		appearance.rules[
+			'.Label--floating'
+		].marginTop = originalLabelMarginTop;
+	}
+
+	return appearance;
+};

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -161,9 +161,9 @@ export const handleAppearanceForFloatingLabel = (
 		// Extract the scaling factors from the matrix
 		const transformMatrix =
 			appearance.rules[ '.Label--floating' ].transform;
-		const matrixValues = transformMatrix.match( /matrix\((.+)\)/ )[ 1 ];
-		if ( matrixValues ) {
-			const splitMatrixValues = matrixValues.split( ', ' );
+		const matrixValues = transformMatrix.match( /matrix\((.+)\)/ );
+		if ( matrixValues && matrixValues[ 1 ] ) {
+			const splitMatrixValues = matrixValues[ 1 ].split( ', ' );
 			const scaleX = parseFloat( splitMatrixValues[ 0 ] );
 			const scaleY = parseFloat( splitMatrixValues[ 3 ] );
 			const scale = ( scaleX + scaleY ) / 2;

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -98,6 +98,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			fontFamily: undefined,
 			fontSizeBase: undefined,
 		},
+		labels: 'above',
 	};
 
 	beforeEach( () => {


### PR DESCRIPTION
Fixes #9476

#### Changes proposed in this Pull Request

This PR implements the Floating Labels style for Stripe Payment Element on Blocks Checkout.
It also fixes how we get the style of the input and the label for the Blocks Checkout as some features were broken before.

<img width="498" alt="image" src="https://github.com/user-attachments/assets/9ca03ce2-8047-497c-9439-69460361723e">

<img width="493" alt="image" src="https://github.com/user-attachments/assets/0bc9e77c-2fe6-4424-bb84-4d16dba150d6">


<img width="841" alt="image" src="https://github.com/user-attachments/assets/768a5b51-e6dd-4c53-8f08-1a74824d66c9">

<img width="813" alt="image" src="https://github.com/user-attachments/assets/838bd1c4-97e7-4895-b565-64b9d5ed3df2">


#### Testing instructions

1. Comment [these lines](https://github.com/Automattic/woocommerce-payments/blob/447eb9b446e7583928d1d6fa23c4403d5221d757/includes/class-wc-payments-checkout.php#L227-L233) to prevent the appearance object from caching
1. Checkout this branch
2. Add something to your cart
3. Go to the blocks checkout
4. Check the credit card form is using floating labels style and that it matches the style of the store
5. Check there's no warning in the console (ignore the RGBA ones, I'm creating an issue for that)
6. Change the theme and ensure the form updates accordingly

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
