### PR TITLE
fix: e2e tests save settings button

### DIFF
--- a/changelog/fix-e2e-save-settings-button-disabled
+++ b/changelog/fix-e2e-save-settings-button-disabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: e2e tests w/ save settings button disabled.
+
+

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -693,9 +693,18 @@ export const merchantWCP = {
 	},
 
 	wcpSettingsSaveChanges: async () => {
+		const saveSettingsButtonSelector = '.save-settings-section button';
+		const saveSettingsButton = await page.$( saveSettingsButtonSelector );
+		const buttonStatus = await (
+			await saveSettingsButton.getProperty( 'disabled' )
+		 ).jsonValue();
+		if ( buttonStatus === true ) {
+			return;
+		}
+
 		const snackbarSettingsSaved = '.components-snackbar';
 
-		await expect( page ).toClick( '.save-settings-section button' );
+		await expect( page ).toClick( saveSettingsButtonSelector );
 		await expect( page ).toMatchElement( snackbarSettingsSaved, {
 			text: 'Settings saved.',
 			timeout: 60000,


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

[The `WC - latest | wcpay - merchant` tests are failing on the release branch](https://github.com/Automattic/woocommerce-payments/actions/runs/11008661796/attempts/3), due to [the "Save changes" button being disabled if no changes have been made](https://github.com/Automattic/woocommerce-payments/pull/9386).
<img width="786" alt="Screenshot 2024-09-30 at 12 17 40 PM" src="https://github.com/user-attachments/assets/101cf58d-6de7-436a-bc2b-0fc62f719d2e">


Fixing the e2e tests to check if the "Save changes" button is disabled, before clicking it.

I ran the workflow here: https://github.com/Automattic/woocommerce-payments/actions/runs/11103399767/job/30845263496

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
