### PR TITLE
Stop enqueuing woopay-express-button.css to prevent 404 errors

### DIFF
--- a/changelog/as-fix-unnecessary-css-import
+++ b/changelog/as-fix-unnecessary-css-import
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Stop enqueuing woopay-express-button.css to prevent 404 errors

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -170,12 +170,6 @@ class WC_Payments_WooPay_Button_Handler {
 		}
 
 		WC_Payments::register_script_with_dependencies( 'WCPAY_WOOPAY_EXPRESS_BUTTON', 'dist/woopay-express-button' );
-		WC_Payments_Utils::enqueue_style(
-			'WCPAY_WOOPAY_EXPRESS_BUTTON',
-			plugins_url( 'dist/woopay-express-button.css', WCPAY_PLUGIN_FILE ),
-			[],
-			WC_Payments::get_file_version( 'dist/woopay-express-button.css' )
-		);
 
 		$wcpay_config = rawurlencode( wp_json_encode( WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() ) );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9406

#### Changes proposed in this Pull Request

The "404 Not found" request happens because an import to`express-checkout-buttons.scss` was added to `client/checkout/woopay/express-button/index.js`, which, through extraction in Webpack (via MiniCssExtractPlugin), generated the file `dist/woopay-express-button.css` (introduced [here](https://github.com/Automattic/woocommerce-payments/pull/6985/files#diff-badc16d7bb0e75c5925f0c59d73b426b664572914b7d28d6804a83f859ad2c10R14)). However, there is no longer a reference to given CSS file in the JS file, as it was removed in https://github.com/Automattic/woocommerce-payments/pull/9258.

This PR removes the lines that enqueue the `dist/woopay-express-button.css` file, preventing attempts to load a nonexistent file on the frontend.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to the `develop` branch.
* Ensure WooPay is enabled.
* Add a product to the cart.
* Visit the Checkout Block page.
* Notice there's a request to `https://yourdomain.tld/wp-content/plugins/woocommerce-payments/dist/woopay-express-button.css?ver=8.2.2
` which returns `404 Not Found`
* Switch to this branch `as-fix-unnecessary-css-import`
* Refresh the Checkout Block page.
* Note that the request to `/wp-content/plugins/woocommerce-payments/dist/woopay-express-button.css` is no longer made.
* Since the file was never present and no functional changes are being made, everything should continue to work as expected.


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
