### PR TITLE
Migrate WizardTaskItem and CollapsibleBody components to TS for improve code safety and clarity

### DIFF
--- a/client/additional-methods-setup/wizard/collapsible-body.tsx
+++ b/client/additional-methods-setup/wizard/collapsible-body.tsx
@@ -10,7 +10,10 @@ import classNames from 'classnames';
 import WizardTaskContext from './task/context';
 import './collapsible-body.scss';
 
-const CollapsibleBody = ( { className = '', ...restProps } ) => {
+const CollapsibleBody: React.FC< React.HTMLAttributes< HTMLDivElement > > = ( {
+	className,
+	...restProps
+} ) => {
 	const { isActive } = useContext( WizardTaskContext );
 
 	return (

--- a/client/additional-methods-setup/wizard/task-item.tsx
+++ b/client/additional-methods-setup/wizard/task-item.tsx
@@ -8,15 +8,21 @@ import { Icon, check } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import WizardTaskContext from '../../additional-methods-setup/wizard/task/context';
+import WizardTaskContext from './task/context';
 import './task-item.scss';
 
-const WizardTaskItem = ( {
+interface WizardTaskItemProps {
+	children: React.ReactNode;
+	title: string;
+	index: number;
+	className?: string;
+}
+
+const WizardTaskItem: React.FC< WizardTaskItemProps > = ( {
 	children,
 	title,
 	index,
-	visibleDescription,
-	className = '',
+	className,
 } ) => {
 	const { isCompleted, isActive } = useContext( WizardTaskContext );
 
@@ -32,7 +38,7 @@ const WizardTaskItem = ( {
 				className="wcpay-wizard-task__headline"
 				// tabindex with value `-1` is necessary to programmatically set the focus
 				// on an element that is not interactive.
-				tabIndex="-1"
+				tabIndex={ -1 }
 			>
 				<div className="wcpay-wizard-task__icon-wrapper">
 					<div className="wcpay-wizard-task__icon-text">
@@ -45,16 +51,6 @@ const WizardTaskItem = ( {
 				</div>
 				<span className="wcpay-wizard-task__title">{ title }</span>
 			</div>
-			{ visibleDescription && ! isActive && (
-				<span
-					className={ classNames(
-						'wcpay-wizard-task__visible-description-element',
-						'is-muted-color'
-					) }
-				>
-					{ visibleDescription }
-				</span>
-			) }
 			<div className="wcpay-wizard-task__body">{ children }</div>
 		</li>
 	);

--- a/client/multi-currency-setup/wizard/task-item.tsx
+++ b/client/multi-currency-setup/wizard/task-item.tsx
@@ -8,10 +8,24 @@ import { Icon, check } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import WizardTaskContext from './task/context';
+import WizardTaskContext from '../../additional-methods-setup/wizard/task/context';
 import './task-item.scss';
 
-const WizardTaskItem = ( { children, title, index, className = '' } ) => {
+interface WizardTaskItemProps {
+	children: React.ReactNode;
+	title: string;
+	index: number;
+	visibleDescription: string;
+	className?: string;
+}
+
+const WizardTaskItem: React.FC< WizardTaskItemProps > = ( {
+	children,
+	title,
+	index,
+	visibleDescription,
+	className,
+} ) => {
 	const { isCompleted, isActive } = useContext( WizardTaskContext );
 
 	return (
@@ -26,7 +40,7 @@ const WizardTaskItem = ( { children, title, index, className = '' } ) => {
 				className="wcpay-wizard-task__headline"
 				// tabindex with value `-1` is necessary to programmatically set the focus
 				// on an element that is not interactive.
-				tabIndex="-1"
+				tabIndex={ -1 }
 			>
 				<div className="wcpay-wizard-task__icon-wrapper">
 					<div className="wcpay-wizard-task__icon-text">
@@ -39,6 +53,16 @@ const WizardTaskItem = ( { children, title, index, className = '' } ) => {
 				</div>
 				<span className="wcpay-wizard-task__title">{ title }</span>
 			</div>
+			{ visibleDescription && ! isActive && (
+				<span
+					className={ classNames(
+						'wcpay-wizard-task__visible-description-element',
+						'is-muted-color'
+					) }
+				>
+					{ visibleDescription }
+				</span>
+			) }
 			<div className="wcpay-wizard-task__body">{ children }</div>
 		</li>
 	);


### PR DESCRIPTION
Based on PR #9157 as an additional change to be considered.

#### Changes proposed in this Pull Request

This PR is an optional additional change to PR #9157, migrating the WizardTaskItem and CollapsibleBody components from JS to TypeScript to allow explicit prop type declarations,  improving code safety and clarity.

* Each component has been renamed to `.tsx`
* An appropriate TS `interface` has been added to each, explicitly declaring the types
* `tabIndex` corrected to a `number` rather than `string` (highlighted by TS)
* The default `className = ''` string has been removed, reverting to `undefined` which more straightforwardly represents the intended "empty" value, although not a concern either way.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure linters, TypeScript, code checks are all green ✅ and happy.

**Note** I've tested this with the VAT download task list following the instructions from #8974 and confirm that the wizard renders correctly.

<details>
<summary>Test instructions followed</summary>


> Note you'll need to test this with a store with [account country that supports tax docs](https://github.com/Automattic/woocommerce-payments-server/blob/8f6bdc2195cd0a99abf888300b292795e7d294c7/server/wp-content/rest-api-plugins/endpoints/wcpay/utils/class-vat-utils.php#L19). Ideally, test with different accounts to see UI for different countries. Tip: if you set `wcpay_accounts[].deleted` to a date in the past, you can onboard a new account. Or switch between accounts by setting wcpay_accounts[].deleted=NULL` on the account you want to use.
> 
> 1. Set up tax docs so you have a document to view at `Payments > Documents`. Fake one up with this CLI command:
>    - `wp wcpay add_document_for_account [account_id] vat_invoice --mode=test --period_from="2024-04-01 00:00:00" --period_to="2024-04-30 23:59:59"`
>    - Or can use `wp wcpay backfill_merchant_vat_invoices`
> 1. If you've added VAT id / tax information previously, clear it out so you can see the modal: 
>    - Delete `company_vat_submitted` `company_vat_number` `company_name` `company_address` from  `wcpay_account_meta` table.
>    - Side note:
>        - https://github.com/Automattic/woocommerce-payments-server/issues/5915
> 1. Go to `Payments > Documents`. 
> 1. Click `Download` for a tax doc row.
> 1. See modal.
> 1. Test adding valid and invalid tax info.
> 1. Test downloading the generated tax doc – confirm the merchant details are correct.

</details>

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **Existing tests should pass**
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
