### PR TITLE
Converting text color rgba to hex to prevent Stripe warning

### DIFF
--- a/changelog/fix-convert-rgba-text-color
+++ b/changelog/fix-convert-rgba-text-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Converting text color rgba to hex to prevent Stripe warning

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -8,6 +8,7 @@ import {
 	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
+	maybeConvertRGBAtoRGB,
 } from './utils.js';
 
 export const appearanceSelectors = {
@@ -379,9 +380,11 @@ export const getFieldStyles = (
 	for ( let i = 0; i < styles.length; i++ ) {
 		const camelCase = dashedToCamelCase( styles[ i ] );
 		if ( validProperties.includes( camelCase ) ) {
-			filteredStyles[ camelCase ] = styles.getPropertyValue(
-				styles[ i ]
-			);
+			let propertyValue = styles.getPropertyValue( styles[ i ] );
+			if ( camelCase === 'color' ) {
+				propertyValue = maybeConvertRGBAtoRGB( propertyValue );
+			}
+			filteredStyles[ camelCase ] = propertyValue;
 		}
 	}
 

--- a/client/checkout/upe-styles/test/utils.js
+++ b/client/checkout/upe-styles/test/utils.js
@@ -111,4 +111,30 @@ describe( 'UPE Utilities to generate UPE styles', () => {
 		expect( upeUtils.isColorLight( darkGrey ) ).toEqual( false );
 		expect( upeUtils.isColorLight( lightGrey ) ).toEqual( true );
 	} );
+
+	test( 'maybeConvertRGBAtoRGB returns valid colors', () => {
+		const hex = '#ffffff';
+		const color = 'red';
+		const rgb = 'rgb(1, 2, 3)';
+		const rgbNoSpaces = 'rgb(1,2,3)';
+		const rgba = 'rgba(1, 2, 3, 1)';
+		const rgbaNoSpaces = 'rgba(1,2,3,1)';
+		const shadow = 'rgb(1,2,3) 0px 1px 1px 0px';
+		const shadowTransparent = 'rgba(1,2,3,1) 0px 1px 1px 0px';
+		const pixel = '0px';
+
+		expect( upeUtils.maybeConvertRGBAtoRGB( hex ) ).toEqual( hex );
+		expect( upeUtils.maybeConvertRGBAtoRGB( color ) ).toEqual( color );
+		expect( upeUtils.maybeConvertRGBAtoRGB( rgb ) ).toEqual( rgb );
+		expect( upeUtils.maybeConvertRGBAtoRGB( rgbNoSpaces ) ).toEqual(
+			rgbNoSpaces
+		);
+		expect( upeUtils.maybeConvertRGBAtoRGB( rgba ) ).toEqual( rgb );
+		expect( upeUtils.maybeConvertRGBAtoRGB( rgbaNoSpaces ) ).toEqual( rgb );
+		expect( upeUtils.maybeConvertRGBAtoRGB( shadow ) ).toEqual( shadow );
+		expect( upeUtils.maybeConvertRGBAtoRGB( shadowTransparent ) ).toEqual(
+			shadowTransparent
+		);
+		expect( upeUtils.maybeConvertRGBAtoRGB( pixel ) ).toEqual( pixel );
+	} );
 } );

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -138,3 +138,23 @@ export const getBackgroundColor = ( selectors ) => {
 export const isColorLight = ( color ) => {
 	return tinycolor( color ).getBrightness() > 125;
 };
+
+/**
+ * Converts rgba to rgb format, since Stripe Appearances API does not accept rgba format for text color.
+ *
+ * @param {string} color CSS color value.
+ * @return {string} Accepted CSS color value.
+ */
+export const maybeConvertRGBAtoRGB = ( color ) => {
+	const colorParts = color.match(
+		/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0?(\.\d+)?|1?(\.0+)?)\s*\)$/
+	);
+	if ( colorParts ) {
+		const alpha = colorParts[ 4 ] || 1;
+		const newColorParts = colorParts.slice( 1, 4 ).map( ( part ) => {
+			return Math.round( part * alpha + 255 * ( 1 - alpha ) );
+		} );
+		color = `rgb(${ newColorParts.join( ', ' ) })`;
+	}
+	return color;
+};


### PR DESCRIPTION
Fixes #9502

#### Changes proposed in this Pull Request

This PR reintroduces the `maybeConvertRGBAtoRGB` function removed in #9453 to prevent warnings from Stripe about text-color not support rgba values.

<img width="510" alt="image" src="https://github.com/user-attachments/assets/87a3c824-6b8a-4b36-ae7b-c161e129d955">

#### Testing instructions

##### Trigger the warnings first

1. In `develop`, make sure the text color from your inputs is rgba:
    ```css
    * {
      color: rgba(255, 255, 255, 0.5) !important;
    }
    ```
1. Go to the checkout, render the credit card form and ensure you see warnings from stripe about the rgba in the console.

##### Ensure warnigns are gone

1. Checkout this branch.
1. Go to the checkout, render the credit card form and ensure there are no warnings from stripe about the rgba in the console.

##### Regression testing

1. Run testing steps from #9453 to ensure it is not broken by this change.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
