### PR TITLE
Rendering Test Model badge only for Credit Card

### DIFF
--- a/changelog/fix-test-mode-badge-credit-card
+++ b/changelog/fix-test-mode-badge-credit-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rendering Test Model badge only for Credit Card

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -44,7 +44,7 @@ export default ( {
 				<span className="payment-method-label__label">
 					{ upeConfig.title }
 				</span>
-				{ isTestMode && isCreditCard && (
+				{ isCreditCard && isTestMode && (
 					<span className="test-mode badge">
 						{ __( 'Test Mode', 'woocommerce-payments' ) }
 					</span>

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -36,13 +36,15 @@ export default ( {
 		window.wcBlocksCheckoutData?.storeCountry ||
 		'US';
 
+	const isCreditCard = upeName === 'card';
+
 	return (
 		<>
 			<div className="payment-method-label">
 				<span className="payment-method-label__label">
 					{ upeConfig.title }
 				</span>
-				{ isTestMode && (
+				{ isTestMode && isCreditCard && (
 					<span className="test-mode badge">
 						{ __( 'Test Mode', 'woocommerce-payments' ) }
 					</span>


### PR DESCRIPTION
Fixes #9513

#### Changes proposed in this Pull Request

In #9483 we added the Test mode badge to all Payment Method labels, but the the design was to add it only to the Credit Card payment method. This PR fixes that.

<img width="503" alt="image" src="https://github.com/user-attachments/assets/f72c2c9b-4544-4f62-bc3f-6e646dc1d242">

#### Testing instructions

* Checkout this branch, go to the blocks checkout and make sure the test mode label is only rendered for credit card

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
