### PR TITLE
Add risk level information to the Fraud & Risk meta box

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -155,11 +155,89 @@
 	padding-top: 2px;
 }
 
+/* WCPay Fraud Risk Level meta box */
+.wcpay-fraud-risk-level {
+	border-bottom: 1px solid #ddd;
+	padding: 8px 12px;
+}
+
+.wcpay-fraud-risk-level > p {
+	margin: 0;
+}
+
+.wcpay-fraud-risk-level__title {
+	font-weight: 600;
+}
+
+.wcpay-fraud-risk-level__bar {
+	display: grid;
+	gap: 4px;
+	grid-template-columns: 50% auto;
+	margin: 6px 0 8px;
+}
+
+.wcpay-fraud-risk-level__bar::after,
+.wcpay-fraud-risk-level__bar::before {
+	background-color: #bbb;
+	content: '';
+	border-radius: 4px;
+	height: 4px;
+}
+
+.wcpay-fraud-risk-level--normal .wcpay-fraud-risk-level__title {
+	color: #008a20;
+}
+
+.wcpay-fraud-risk-level--normal .wcpay-fraud-risk-level__bar {
+	grid-template-columns: 15% auto;
+}
+
+.wcpay-fraud-risk-level--normal .wcpay-fraud-risk-level__bar::before {
+	background-color: #008a20;
+}
+
+.wcpay-fraud-risk-level--elevated .wcpay-fraud-risk-level__title {
+	color: #b16202;
+}
+
+.wcpay-fraud-risk-level--elevated .wcpay-fraud-risk-level__bar {
+	grid-template-columns: 60% auto;
+}
+
+.wcpay-fraud-risk-level--elevated .wcpay-fraud-risk-level__bar::before {
+	background-color: #b16202;
+}
+
+.wcpay-fraud-risk-level--highest .wcpay-fraud-risk-level__bar::before {
+	background-color: #b32d2e;
+}
+
+.wcpay-fraud-risk-level--highest .wcpay-fraud-risk-level__bar {
+	grid-template-columns: 100% auto;
+}
+
+.wcpay-fraud-risk-level--highest .wcpay-fraud-risk-level__bar::before {
+	background-color: #b32d2e;
+}
+
+/* WCPay Fraud Risk Action meta box */
+#wcpay-order-fraud-and-risk-meta-box div.inside {
+	margin-top: 0;
+	padding: 0;
+}
+
+.wcpay-fraud-risk-action {
+	padding: 8px 12px 12px;
+}
+
+.wcpay-fraud-risk-action > p {
+	margin: 0 0 6px;
+}
+
 .wcpay-fraud-risk-meta-allow,
 .wcpay-fraud-risk-meta-review,
 .wcpay-fraud-risk-meta-blocked {
 	font-weight: 600;
-	font-size: 14px;
 }
 
 .wcpay-fraud-risk-meta-allow img {
@@ -181,4 +259,8 @@
 
 .wcpay-fraud-risk-meta-blocked {
 	color: #b32d2e;
+}
+
+.wcpay-fraud-risk-meta-link {
+	margin-top: 10px;
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -234,6 +234,10 @@
 	margin: 0 0 6px;
 }
 
+.wcpay-fraud-risk-action > p:last-child {
+	margin-bottom: 0;
+}
+
 .wcpay-fraud-risk-meta-allow,
 .wcpay-fraud-risk-meta-review,
 .wcpay-fraud-risk-meta-blocked {
@@ -259,8 +263,4 @@
 
 .wcpay-fraud-risk-meta-blocked {
 	color: #b32d2e;
-}
-
-.wcpay-fraud-risk-meta-link {
-	margin-top: 10px;
 }

--- a/changelog/add-1225-flag-elevated-risk-transactions
+++ b/changelog/add-1225-flag-elevated-risk-transactions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add risk level information to the fraud and risk box on the order details page.

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -96,7 +96,7 @@ class WC_Payments_Admin_Settings {
 	/**
 	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
 	 *
-	 * @param array $query_args Optional additonal query args to append to the URL.
+	 * @param array $query_args Optional additional query args to append to the URL.
 	 *
 	 * @return string URL of the configuration screen for this gateway
 	 */

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -96,9 +96,11 @@ class WC_Payments_Admin_Settings {
 	/**
 	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
 	 *
+	 * @param array $query_args Optional additonal query args to append to the URL.
+	 *
 	 * @return string URL of the configuration screen for this gateway
 	 */
-	public static function get_settings_url() {
-		return admin_url( add_query_arg( self::$settings_url_params, 'admin.php' ) ); // nosemgrep: audit.php.wp.security.xss.query-arg -- constant string is passed in.
+	public static function get_settings_url( $query_args = [] ) {
+		return admin_url( add_query_arg( array_merge( self::$settings_url_params, $query_args ), 'admin.php' ) ); // nosemgrep: audit.php.wp.security.xss.query-arg -- constant string is passed in.
 	}
 }

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -105,8 +105,9 @@ class Order_Fraud_And_Risk_Meta_Box {
 			'no_action_taken' => __( 'No action taken', 'woocommerce-payments' ),
 		];
 
-		$risk_filters_callout = __( 'Adjust risk filters', 'woocommerce-payments' );
-		$risk_filters_url     = WC_Payments_Admin_Settings::get_settings_url( [ 'anchor' => '%23fp-settings' ] );
+		$risk_filters_callout          = __( 'Adjust risk filters', 'woocommerce-payments' );
+		$risk_filters_url              = WC_Payments_Admin_Settings::get_settings_url( [ 'anchor' => '%23fp-settings' ] );
+		$show_adjust_risk_filters_link = true;
 
 		$this->maybe_print_risk_level_block( $risk_level );
 
@@ -122,12 +123,13 @@ class Order_Fraud_And_Risk_Meta_Box {
 				$description     = __( 'The payment for this order was blocked by your risk filtering. There is no pending authorization, and the order can be cancelled to reduce any held stock.', 'woocommerce-payments' );
 				$callout         = __( 'View more details', 'woocommerce-payments' );
 				$transaction_url = $this->compose_transaction_url_with_tracking( $order->get_id(), '', Rule::FRAUD_OUTCOME_BLOCK );
-				echo '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . esc_url( $icons['red_shield']['url'] ) . '" alt="' . esc_html( $icons['red_shield']['alt'] ) . '"> ' . esc_html( $statuses['blocked'] ) . '</p><p>' . esc_html( $description ) . '</p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
+				echo '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . esc_url( $icons['red_shield']['url'] ) . '" alt="' . esc_html( $icons['red_shield']['alt'] ) . '"> ' . esc_html( $statuses['blocked'] ) . '</p><p>' . esc_html( $description ) . '</p><p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a></p>';
 				break;
 
 			case Fraud_Meta_Box_Type::NOT_CARD:
 			case Fraud_Meta_Box_Type::NOT_WCPAY:
-				$payment_method_title = $order->get_payment_method_title();
+				$payment_method_title          = $order->get_payment_method_title();
+				$show_adjust_risk_filters_link = false;
 
 				if ( ! empty( $payment_method_title ) && 'Popular payment methods' !== $payment_method_title ) {
 					$description = sprintf(
@@ -147,7 +149,7 @@ class Order_Fraud_And_Risk_Meta_Box {
 				$callout     = __( 'Learn more', 'woocommerce-payments' );
 				$callout_url = 'https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/';
 				$callout_url = add_query_arg( 'status_is', 'fraud-meta-box-not-wcpay-learn-more', $callout_url );
-				echo '<p>' . esc_html( $description ) . '</p><a href="' . esc_url( $callout_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
+				echo '<p>' . esc_html( $description ) . '</p><p><a href="' . esc_url( $callout_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a></p>';
 				break;
 
 			case Fraud_Meta_Box_Type::PAYMENT_STARTED:
@@ -159,7 +161,7 @@ class Order_Fraud_And_Risk_Meta_Box {
 				$description     = __( 'The payment for this order was held for review by your risk filtering. You can review the details and determine whether to approve or block the payment.', 'woocommerce-payments' );
 				$callout         = __( 'Review payment', 'woocommerce-payments' );
 				$transaction_url = $this->compose_transaction_url_with_tracking( $intent_id, $charge_id, Rule::FRAUD_OUTCOME_REVIEW );
-				echo '<p class="wcpay-fraud-risk-meta-review"><img src="' . esc_url( $icons['orange_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
+				echo '<p class="wcpay-fraud-risk-meta-review"><img src="' . esc_url( $icons['orange_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a></p>';
 				break;
 
 			case Fraud_Meta_Box_Type::REVIEW_ALLOWED:
@@ -171,21 +173,21 @@ class Order_Fraud_And_Risk_Meta_Box {
 				$description     = __( 'This transaction was held for review by your risk filters, and the charge was manually blocked after review.', 'woocommerce-payments' );
 				$callout         = __( 'Review payment', 'woocommerce-payments' );
 				$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
-				echo '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . esc_url( $icons['red_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
+				echo '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . esc_url( $icons['red_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a></p>';
 				break;
 
 			case Fraud_Meta_Box_Type::REVIEW_EXPIRED:
 				$description     = __( 'The payment for this order was held for review by your risk filtering. The authorization for the charge appears to have expired.', 'woocommerce-payments' );
 				$callout         = __( 'Review payment', 'woocommerce-payments' );
 				$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
-				echo '<p class="wcpay-fraud-risk-meta-review"><img src="' . esc_url( $icons['orange_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
+				echo '<p class="wcpay-fraud-risk-meta-review"><img src="' . esc_url( $icons['orange_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a></p>';
 				break;
 
 			case Fraud_Meta_Box_Type::REVIEW_FAILED:
 				$description     = __( 'The payment for this order was held for review by your risk filtering. The authorization for the charge appears to have failed.', 'woocommerce-payments' );
 				$callout         = __( 'Review payment', 'woocommerce-payments' );
 				$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
-				echo '<p class="wcpay-fraud-risk-meta-review"><img src="' . esc_url( $icons['orange_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a>';
+				echo '<p class="wcpay-fraud-risk-meta-review"><img src="' . esc_url( $icons['orange_shield']['url'] ) . '" alt="' . esc_html( $icons['orange_shield']['alt'] ) . '"> ' . esc_html( $statuses['held_for_review'] ) . '</p><p>' . esc_html( $description ) . '</p><p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $callout ) . '</a></p>';
 				break;
 
 			case Fraud_Meta_Box_Type::TERMINAL_PAYMENT:
@@ -203,7 +205,10 @@ class Order_Fraud_And_Risk_Meta_Box {
 				break;
 		}
 
-		echo '<a class="wcpay-fraud-risk-meta-link" href="' . esc_url( $risk_filters_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $risk_filters_callout ) . '</a>';
+		if ( $show_adjust_risk_filters_link ) {
+			echo '<p><a href="' . esc_url( $risk_filters_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $risk_filters_callout ) . '</a></p>';
+		}
+
 		echo '</div>';
 	}
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -54,7 +54,7 @@ class Order_Fraud_And_Risk_Meta_Box {
 		// Get the order edit screen to be able to add the meta box to.
 		$wc_screen_id = \wc_get_page_screen_id( 'shop-order' );
 
-		add_meta_box( 'wcpay_order_fraud_and_risk_meta_box', __( 'Fraud &amp; Risk', 'woocommerce-payments' ), [ $this, 'display_order_fraud_and_risk_meta_box_message' ], $wc_screen_id, 'side', 'default' );
+		add_meta_box( 'wcpay-order-fraud-and-risk-meta-box', __( 'Fraud &amp; Risk', 'woocommerce-payments' ), [ $this, 'display_order_fraud_and_risk_meta_box_message' ], $wc_screen_id, 'side', 'default' );
 	}
 
 	/**

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -95,7 +95,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			],
 			'Fraud_Meta_Box_Type_REVIEW'           => [
 				'meta_box_type'   => Fraud_Meta_Box_Type::REVIEW,
-				'expected_output' => '<p class="wcpay-fraud-risk-meta-review"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>The payment for this order was held for review by your risk filtering. You can review the details and determine whether to approve or block the payment.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock&#038;status_is=review&#038;type_is=meta_box" target="_blank" rel="noopener noreferrer">Review payment</a>',
+				'expected_output' => '<p class="wcpay-fraud-risk-meta-review"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>The payment for this order was held for review by your risk filtering. You can review the details and determine whether to approve or block the payment.</p><p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock&#038;status_is=review&#038;type_is=meta_box" target="_blank" rel="noopener noreferrer">Review payment</a></p>',
 			],
 			'Fraud_Meta_Box_Type_REVIEW_ALLOWED'   => [
 				'meta_box_type'   => Fraud_Meta_Box_Type::REVIEW_ALLOWED,
@@ -103,15 +103,15 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			],
 			'Fraud_Meta_Box_Type_REVIEW_BLOCKED'   => [
 				'meta_box_type'   => Fraud_Meta_Box_Type::REVIEW_BLOCKED,
-				'expected_output' => '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-red.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>This transaction was held for review by your risk filters, and the charge was manually blocked after review.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Review payment</a>',
+				'expected_output' => '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-red.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>This transaction was held for review by your risk filters, and the charge was manually blocked after review.</p><p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Review payment</a></p>',
 			],
 			'Fraud_Meta_Box_Type_REVIEW_EXPIRED'   => [
 				'meta_box_type'   => Fraud_Meta_Box_Type::REVIEW_EXPIRED,
-				'expected_output' => '<p class="wcpay-fraud-risk-meta-review"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>The payment for this order was held for review by your risk filtering. The authorization for the charge appears to have expired.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Review payment</a>',
+				'expected_output' => '<p class="wcpay-fraud-risk-meta-review"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>The payment for this order was held for review by your risk filtering. The authorization for the charge appears to have expired.</p><p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Review payment</a></p>',
 			],
 			'Fraud_Meta_Box_Type_REVIEW_FAILED'    => [
 				'meta_box_type'   => Fraud_Meta_Box_Type::REVIEW_FAILED,
-				'expected_output' => '<p class="wcpay-fraud-risk-meta-review"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>The payment for this order was held for review by your risk filtering. The authorization for the charge appears to have failed.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Review payment</a>',
+				'expected_output' => '<p class="wcpay-fraud-risk-meta-review"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Held for review</p><p>The payment for this order was held for review by your risk filtering. The authorization for the charge appears to have failed.</p><p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Review payment</a></p>',
 			],
 			'Fraud_Meta_Box_Type_TERMINAL_PAYMENT' => [
 				'meta_box_type'   => Fraud_Meta_Box_Type::TERMINAL_PAYMENT,
@@ -171,7 +171,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-red.svg', WCPAY_PLUGIN_FILE ) . '" alt="Red shield outline"> Blocked</p><p>The payment for this order was blocked by your risk filtering. There is no pending authorization, and the order can be cancelled to reduce any held stock.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=' . $this->order->get_id() . '&#038;status_is=block&#038;type_is=meta_box" target="_blank" rel="noopener noreferrer">View more details</a>' ) );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-red.svg', WCPAY_PLUGIN_FILE ) . '" alt="Red shield outline"> Blocked</p><p>The payment for this order was blocked by your risk filtering. There is no pending authorization, and the order can be cancelled to reduce any held stock.</p><p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=' . $this->order->get_id() . '&#038;status_is=block&#038;type_is=meta_box" target="_blank" rel="noopener noreferrer">View more details</a></p>' ) );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( $expected_output ) );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( $expected_output, false ) );
 	}
 
 	public function display_order_fraud_and_risk_meta_box_message_not_card_provider() {
@@ -218,17 +218,17 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			'simulate legacy UPE Popular payment methods' => [
 				'payment_method_id'    => 'woocommerce_payments',
 				'payment_method_title' => 'Popular payment methods',
-				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
+				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments.</p><p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a></p>',
 			],
 			'simulate legacy UPE Bancontact'              => [
 				'payment_method_id'    => 'woocommerce_payments',
 				'payment_method_title' => 'Bancontact',
-				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
+				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a></p>',
 			],
 			'simulate split UPE Bancontact'               => [
 				'payment_method_id'    => 'woocommerce_payments_bancontact',
 				'payment_method_title' => 'Bancontact',
-				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>',
+				'expected_output'      => '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Bancontact.</p><p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a></p>',
 			],
 		];
 	}
@@ -263,7 +263,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Direct bank transfer.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>' ) );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Direct bank transfer.</p><p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a></p>', false ) );
 	}
 
 	public function test_display_order_fraud_and_risk_meta_box_message_default() {
@@ -432,10 +432,14 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		return $output;
 	}
 
-	private function compose_fraud_and_risk_actions_block( $content ) {
+	private function compose_fraud_and_risk_actions_block( $content, $show_adjust_risk_filters_link = true ) {
 		$output  = '<div class="wcpay-fraud-risk-action">';
 		$output .= $content;
-		$output .= '<a class="wcpay-fraud-risk-meta-link" href="http://example.org/wp-admin/admin.php?page=wc-settings&#038;tab=checkout&#038;section=woocommerce_payments&#038;anchor=%23fp-settings" target="_blank" rel="noopener noreferrer">Adjust risk filters</a>';
+
+		if ( $show_adjust_risk_filters_link ) {
+			$output .= '<p><a href="http://example.org/wp-admin/admin.php?page=wc-settings&#038;tab=checkout&#038;section=woocommerce_payments&#038;anchor=%23fp-settings" target="_blank" rel="noopener noreferrer">Adjust risk filters</a></p>';
+		}
+
 		$output .= '</div>';
 
 		return $output;

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -71,6 +71,11 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->method( 'get_fraud_meta_box_type_for_order' )
 			->willReturn( $meta_box_type );
 
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
 		// Act: Call the method to display the meta box.
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
@@ -129,6 +134,10 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'get_fraud_meta_box_type_for_order' );
 
+		$this->mock_order_service
+			->expects( $this->never() )
+			->method( 'get_charge_risk_level_for_order' );
+
 		// Act: Call the method to display the meta box.
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( 'fake_order' );
 
@@ -152,6 +161,11 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_fraud_meta_box_type_for_order' )
 			->willReturn( Fraud_Meta_Box_Type::BLOCK );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
 
 		// Act: Call the method to display the meta box.
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
@@ -181,6 +195,11 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_fraud_meta_box_type_for_order' )
 			->willReturn( Fraud_Meta_Box_Type::NOT_CARD );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
 
 		// Arrange: Update the order's payment method.
 		$this->order->set_payment_method( $payment_method_id );
@@ -231,6 +250,11 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->method( 'get_fraud_meta_box_type_for_order' )
 			->willReturn( '' );
 
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
 		// Arrange: Update the order's payment method.
 		$this->order->set_payment_method( 'bacs' );
 		$this->order->save();
@@ -259,11 +283,153 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->method( 'get_fraud_meta_box_type_for_order' )
 			->willReturn( '' );
 
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
 		// Act: Call the method to display the meta box.
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
 		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p>Risk filtering through WooPayments was not found on this order, it may have been created while filtering was not enabled.</p>' ) );
+	}
+
+	public function test_display_risk_level_normal_in_order_fraud_and_risk_meta_box() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( 'normal' );
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure the expected string has been output.
+		$risk_level_block   = $this->compose_fraud_and_risk_level_block( 'normal', 'Normal', 'This payment shows a lower than normal risk of fraudulent activity.' );
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $risk_level_block . $risk_actions_block );
+	}
+
+	public function test_display_risk_level_elevated_in_order_fraud_and_risk_meta_box() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( 'elevated' );
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure the expected string has been output.
+		$risk_level_block   = $this->compose_fraud_and_risk_level_block( 'elevated', 'Elevated', 'This order has a moderate risk of being fraudulent. We suggest contacting the customer to confirm their details before fulfilling it.' );
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $risk_level_block . $risk_actions_block );
+	}
+
+	public function test_display_risk_level_highest_in_order_fraud_and_risk_meta_box() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( 'highest' );
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure the expected string has been output.
+		$risk_level_block   = $this->compose_fraud_and_risk_level_block( 'highest', 'High', 'This order has a high risk of being fraudulent. We suggest contacting the customer to confirm their details before fulfilling it.' );
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $risk_level_block . $risk_actions_block );
+	}
+
+	public function test_do_not_display_risk_level_in_order_fraud_and_risk_meta_box_with_invalid_risk_level() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( 'unknown' );
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure the expected string has been output.
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $risk_actions_block );
+	}
+
+	private function compose_fraud_and_risk_level_block( $risk_level, $title, $description ) {
+		$output  = '<div class="wcpay-fraud-risk-level wcpay-fraud-risk-level--' . $risk_level . '">';
+		$output .= '<p class="wcpay-fraud-risk-level__title">' . $title . '</p>';
+		$output .= '<div class="wcpay-fraud-risk-level__bar"></div>';
+		$output .= '<p>' . $description . '</p>';
+		$output .= '</div>';
+
+		return $output;
 	}
 
 	private function compose_fraud_and_risk_actions_block( $content ) {

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -12,7 +12,6 @@ use WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box;
  * Fraud_Prevention_Service_Test unit tests.
  */
 class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
-
 	/**
 	 * Test WC_Order object.
 	 *
@@ -76,7 +75,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( $expected_output );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( $expected_output ) );
 	}
 
 	public function display_order_fraud_and_risk_meta_box_message_provider() {
@@ -158,7 +157,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-red.svg', WCPAY_PLUGIN_FILE ) . '" alt="Red shield outline"> Blocked</p><p>The payment for this order was blocked by your risk filtering. There is no pending authorization, and the order can be cancelled to reduce any held stock.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=' . $this->order->get_id() . '&#038;status_is=block&#038;type_is=meta_box" target="_blank" rel="noopener noreferrer">View more details</a>' );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-blocked"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-red.svg', WCPAY_PLUGIN_FILE ) . '" alt="Red shield outline"> Blocked</p><p>The payment for this order was blocked by your risk filtering. There is no pending authorization, and the order can be cancelled to reduce any held stock.</p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=/payments/transactions/details&#038;id=' . $this->order->get_id() . '&#038;status_is=block&#038;type_is=meta_box" target="_blank" rel="noopener noreferrer">View more details</a>' ) );
 	}
 
 	/**
@@ -192,7 +191,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( $expected_output );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( $expected_output ) );
 	}
 
 	public function display_order_fraud_and_risk_meta_box_message_not_card_provider() {
@@ -240,7 +239,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Direct bank transfer.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>' );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p>Risk filtering is only available for orders processed using credit cards with WooPayments. This order was processed with Direct bank transfer.</p><a href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/?status_is=fraud-meta-box-not-wcpay-learn-more" target="_blank" rel="noopener noreferrer">Learn more</a>' ) );
 	}
 
 	public function test_display_order_fraud_and_risk_meta_box_message_default() {
@@ -264,6 +263,15 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
 		// Assert: Check to make sure the expected string has been output.
-		$this->expectOutputString( '<p>Risk filtering through WooPayments was not found on this order, it may have been created while filtering was not enabled.</p>' );
+		$this->expectOutputString( $this->compose_fraud_and_risk_actions_block( '<p>Risk filtering through WooPayments was not found on this order, it may have been created while filtering was not enabled.</p>' ) );
+	}
+
+	private function compose_fraud_and_risk_actions_block( $content ) {
+		$output  = '<div class="wcpay-fraud-risk-action">';
+		$output .= $content;
+		$output .= '<a class="wcpay-fraud-risk-meta-link" href="http://example.org/wp-admin/admin.php?page=wc-settings&#038;tab=checkout&#038;section=woocommerce_payments&#038;anchor=%23fp-settings" target="_blank" rel="noopener noreferrer">Adjust risk filters</a>';
+		$output .= '</div>';
+
+		return $output;
 	}
 }


### PR DESCRIPTION
Fixes #1225

#### Changes proposed in this Pull Request

This PR aims to add the risk level information to the Fraud & Risk meta box on the order details page. The risk level information provides more information and clarity around the possible risk of the order.

Besides that, an "Adjust risk filters" link was added to the block, allowing merchants to go to the risk filter configuration in an easier way.

| Scenario | Meta box |
|--------|--------|
| Processed with another payment method | ![Screenshot 2024-10-02 at 12 03 31](https://github.com/user-attachments/assets/7e53503c-62ea-47e2-a603-a294e4d6c28f) |
| Order created while Fraud and Risk was disabled | ![Screenshot 2024-10-02 at 11 42 32](https://github.com/user-attachments/assets/f3b6bfb1-170e-45e9-a5a4-4358d4e31042) |
| Order created before this PR | ![Screenshot 2024-10-02 at 11 42 03](https://github.com/user-attachments/assets/b043d5d7-9c9a-4205-a023-a9354d811bfb) |
| Normal risk level | ![Screenshot 2024-10-02 at 11 43 02](https://github.com/user-attachments/assets/05bf80fa-9424-44eb-b8f2-32635d5849a4) |
| Elevated risk level | ![Screenshot 2024-10-02 at 11 41 49](https://github.com/user-attachments/assets/a92ff53c-3a49-4c9e-86a6-9b972e7e850c) | 
| Blocked order | ![Screenshot 2024-10-02 at 11 41 26](https://github.com/user-attachments/assets/2a8ca51f-6763-483f-a957-5c7aa909d3a7) |

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Unit tests should be passing
* Run `npm run listen`
* On your shop, buy a product using the `4242424242424242` card
* Check the latest order and confirm that the "Fraud & Risk" meta box looks like:

![Screenshot 2024-10-02 at 11 43 02](https://github.com/user-attachments/assets/05bf80fa-9424-44eb-b8f2-32635d5849a4)

* On your shop, buy a product using the `4000000000009235` card
* Check the latest order and confirm that the "Fraud & Risk" meta box looks like:

![Screenshot 2024-10-02 at 11 41 49](https://github.com/user-attachments/assets/a92ff53c-3a49-4c9e-86a6-9b972e7e850c)

* On your shop, buy a product using a different payment method (Cash on delivery etc)
* Check the latest order and confirm that the "Fraud & Risk" meta box looks like:

![Screenshot 2024-10-02 at 12 03 31](https://github.com/user-attachments/assets/7e53503c-62ea-47e2-a603-a294e4d6c28f)

* Update your Fraud protection settings
* On your shop, buy a product using the `4242424242424242` card and make sure it gets blocked by your rules
* Check the latest order and confirm that the "Fraud & Risk" meta box looks like:

![Screenshot 2024-10-02 at 11 41 26](https://github.com/user-attachments/assets/2a8ca51f-6763-483f-a957-5c7aa909d3a7)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
