### PR TITLE
fix: prevent multiple initializations of `WC_Payments`

### DIFF
--- a/changelog/fix-multiple-instances-of-wc-payments-in-tests
+++ b/changelog/fix-multiple-instances-of-wc-payments-in-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+fix: prevent multiple instances of WC_Payments_Apple_Pay_Registration

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -580,8 +580,12 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
-		self::$apple_pay_registration->init_hooks();
+		// in TeamCity tests, there might be multiple instances of WC_Payments initialized.
+		// This prevents the ApplePay-related hooks from being registered multiple times, which can cause issues.
+		if ( ! self::$apple_pay_registration ) {
+			self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
+			self::$apple_pay_registration->init_hooks();
+		}
 
 		$express_checkout_helper = new WC_Payments_Express_Checkout_Button_Helper( self::get_gateway(), self::$account );
 		self::set_express_checkout_helper( $express_checkout_helper );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -303,6 +303,12 @@ class WC_Payments {
 	 * Entry point to the initialization logic.
 	 */
 	public static function init() {
+		// in TeamCity tests, there might be multiple instances of WC_Payments initialized.
+		// This prevents the hooks from being registered multiple times, which can cause issues.
+		if ( defined( 'WCPAY_VERSION_NUMBER' ) ) {
+			return;
+		}
+
 		define( 'WCPAY_VERSION_NUMBER', self::get_plugin_headers()['Version'] );
 
 		include_once __DIR__ . '/class-wc-payments-utils.php';
@@ -580,12 +586,8 @@ class WC_Payments {
 		// To avoid register the same hooks twice.
 		wcpay_get_container()->get( \WCPay\Internal\Service\DuplicatePaymentPreventionService::class )->init_hooks();
 
-		// in TeamCity tests, there might be multiple instances of WC_Payments initialized.
-		// This prevents the ApplePay-related hooks from being registered multiple times, which can cause issues.
-		if ( ! self::$apple_pay_registration ) {
-			self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
-			self::$apple_pay_registration->init_hooks();
-		}
+		self::$apple_pay_registration = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
+		self::$apple_pay_registration->init_hooks();
 
 		$express_checkout_helper = new WC_Payments_Express_Checkout_Button_Helper( self::get_gateway(), self::$account );
 		self::set_express_checkout_helper( $express_checkout_helper );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Preventing multiple calls of `WC_Payments::init()` and preventing the registration of its hooks multiple times.
In combination with https://github.com/Automattic/woocommerce-payments/pull/9467 , this seems to be causing some issues in the TeamCity tests.
More specifically, there seem to be multiple instances of `WC_Payments` (and `WC_Payments_Apple_Pay_Registration`) initialized at the same time, which are affecting each other.

By adding this check on the `init()` method's body, we can ensure that the hooks are registered only once.

You can check the effect of these changes on TumblrPay tests on D162995-code - compare that with D162945-code

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I manually verified the basic functionality (checkout, enabled/disabled gateway, etc) on this site: https://simple-aurora.jurassic.ninja/shop/
But I also ran the e2e tests suite here: https://github.com/Automattic/woocommerce-payments/actions/runs/11159046111

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.