### PR TITLE
Fix settings rendering on the Advanced Fraud Protection page

### DIFF
--- a/changelog/fix-9520-advanced-fraud-protection-settings
+++ b/changelog/fix-9520-advanced-fraud-protection-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix settings display on the advanced fraud protection page.

--- a/client/settings/fraud-protection/advanced-settings/allow-countries-notice.tsx
+++ b/client/settings/fraud-protection/advanced-settings/allow-countries-notice.tsx
@@ -45,7 +45,7 @@ interface AllowedCountriesNoticeProps {
 const AllowedCountriesNotice: React.FC< AllowedCountriesNoticeProps > = ( {
 	setting,
 } ) => {
-	const { protectionSettingsUI, protectionSettingsChanged } = useContext(
+	const { protectionSettingsUI } = useContext(
 		FraudPreventionSettingsContext
 	);
 	const [ isBlocking, setIsBlocking ] = useState(
@@ -53,7 +53,7 @@ const AllowedCountriesNotice: React.FC< AllowedCountriesNoticeProps > = ( {
 	);
 	useEffect( () => {
 		setIsBlocking( protectionSettingsUI[ setting ]?.block ?? false );
-	}, [ protectionSettingsUI, setting, protectionSettingsChanged ] );
+	}, [ protectionSettingsUI, setting ] );
 
 	const supportedCountriesType = getSupportedCountriesType();
 	const settingCountries = getSettingCountries();

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import React, {
-	useContext,
-	useEffect,
-	useState,
-	useMemo,
-	Dispatch,
-	SetStateAction,
-} from 'react';
+import React, { useContext, useMemo, Dispatch, SetStateAction } from 'react';
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 
@@ -36,7 +29,6 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 	const {
 		protectionSettingsUI,
 		setProtectionSettingsUI,
-		setProtectionSettingsChanged,
 		setIsDirty,
 	} = useContext( FraudPreventionSettingsContext );
 
@@ -48,39 +40,28 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 		[ protectionSettingsUI, setting ]
 	);
 
-	const minItemsTemp = parseInt( settingUI.min_items + '', 10 );
-	const maxItemsTemp = parseInt( settingUI.max_items + '', 10 );
+	const minItems = parseInt( settingUI?.min_items + '', 10 );
+	const maxItems = parseInt( settingUI?.max_items + '', 10 );
 
-	const [ minItemsCount, setMinItemsCount ] = useState(
-		isNaN( minItemsTemp ) ? '' : minItemsTemp
-	);
-	const [ maxItemsCount, setMaxItemsCount ] = useState(
-		isNaN( maxItemsTemp ) ? '' : maxItemsTemp
-	);
-
-	useEffect( () => {
-		settingUI.min_items = minItemsCount
-			? parseInt( minItemsCount + '', 10 )
-			: minItemsCount;
-		settingUI.max_items = maxItemsCount
-			? parseInt( maxItemsCount + '', 10 )
-			: maxItemsCount;
-		setProtectionSettingsUI( protectionSettingsUI );
-		setProtectionSettingsChanged( ( prev ) => ! prev );
-	}, [
-		settingUI,
-		minItemsCount,
-		maxItemsCount,
-		protectionSettingsUI,
-		setProtectionSettingsUI,
-		setProtectionSettingsChanged,
-	] );
+	const minItemsCount = isNaN( minItems ) ? '' : minItems;
+	const maxItemsCount = isNaN( maxItems ) ? '' : maxItems;
 
 	const isItemRangeEmpty =
 		! parseInt( minItemsCount + '', 10 ) &&
 		! parseInt( maxItemsCount + '', 10 );
 	const isMinGreaterThanMax =
 		parseInt( minItemsCount + '', 10 ) > parseInt( maxItemsCount + '', 10 );
+
+	const handleInputChange = ( name: string ) => ( val: string ) => {
+		setProtectionSettingsUI( ( settings ) => ( {
+			...settings,
+			[ setting ]: {
+				...settings[ setting ],
+				[ name ]: val ? parseInt( val + '', 10 ) : val,
+			},
+		} ) );
+		setIsDirty( true );
+	};
 
 	return (
 		<div className="fraud-protection-rule-toggle-children-container">
@@ -98,10 +79,7 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 						placeholder={ '0' }
 						value={ minItemsCount }
 						type="number"
-						onChange={ ( value ) => {
-							setMinItemsCount( value );
-							setIsDirty( true );
-						} }
+						onChange={ handleInputChange( 'min_items' ) }
 						onKeyDown={ ( e ) =>
 							/^[+-.,e]$/m.test( e.key ) && e.preventDefault()
 						}
@@ -125,10 +103,7 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 						placeholder={ '0' }
 						type="number"
 						value={ maxItemsCount }
-						onChange={ ( value ) => {
-							setMaxItemsCount( value );
-							setIsDirty( true );
-						} }
+						onChange={ handleInputChange( 'max_items' ) }
 						onKeyDown={ ( e ) =>
 							/^[+-.,e]$/m.test( e.key ) && e.preventDefault()
 						}

--- a/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import React, {
-	useContext,
-	useEffect,
-	useState,
-	useMemo,
-	SetStateAction,
-	Dispatch,
-} from 'react';
+import React, { useContext, useMemo, SetStateAction, Dispatch } from 'react';
 import { __ } from '@wordpress/i18n';
 import AmountInput from 'wcpay/components/amount-input';
 
@@ -55,7 +48,6 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 	const {
 		protectionSettingsUI,
 		setProtectionSettingsUI,
-		setProtectionSettingsChanged,
 		setIsDirty,
 	} = useContext( FraudPreventionSettingsContext );
 
@@ -67,25 +59,8 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 		[ protectionSettingsUI, setting ]
 	);
 
-	const minAmountTemp = parseFloat( settingUI.min_amount + '' );
-	const maxAmountTemp = parseFloat( settingUI.max_amount + '' );
-
-	const [ minAmount, setMinAmount ] = useState( minAmountTemp ?? '' );
-	const [ maxAmount, setMaxAmount ] = useState( maxAmountTemp ?? '' );
-
-	useEffect( () => {
-		settingUI.min_amount = minAmount ? parseFloat( minAmount + '' ) : null;
-		settingUI.max_amount = maxAmount ? parseFloat( maxAmount + '' ) : null;
-		setProtectionSettingsUI( protectionSettingsUI );
-		setProtectionSettingsChanged( ( prev ) => ! prev );
-	}, [
-		minAmount,
-		maxAmount,
-		protectionSettingsUI,
-		setProtectionSettingsUI,
-		setProtectionSettingsChanged,
-		settingUI,
-	] );
+	const minAmount = parseFloat( settingUI.min_amount + '' );
+	const maxAmount = parseFloat( settingUI.max_amount + '' );
 
 	const areInputsEmpty =
 		! getFloatValue( minAmount + '' ) && ! getFloatValue( maxAmount + '' );
@@ -95,6 +70,17 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 		getFloatValue( minAmount + '' ) > getFloatValue( maxAmount + '' );
 
 	const currencySymbol = getCurrencySymbol();
+
+	const handleAmountInputChange = ( name: string ) => ( val: string ) => {
+		setProtectionSettingsUI( ( settings ) => ( {
+			...settings,
+			[ setting ]: {
+				...settings[ setting ],
+				[ name ]: val ? parseFloat( val + '' ) : null,
+			},
+		} ) );
+		setIsDirty( true );
+	};
 
 	return (
 		<div className="fraud-protection-rule-toggle-children-container">
@@ -112,10 +98,7 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 						prefix={ currencySymbol }
 						placeholder={ '0.00' }
 						value={ minAmount.toString() }
-						onChange={ ( val ) => {
-							setMinAmount( Number( val ) );
-							setIsDirty( true );
-						} }
+						onChange={ handleAmountInputChange( 'min_amount' ) }
 						help={ __(
 							'Leave blank for no limit',
 							'woocommerce-payments'
@@ -134,10 +117,7 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 						prefix={ currencySymbol }
 						placeholder={ '0.00' }
 						value={ maxAmount.toString() }
-						onChange={ ( val ) => {
-							setMaxAmount( Number( val ) );
-							setIsDirty( true );
-						} }
+						onChange={ handleAmountInputChange( 'max_amount' ) }
 						help={ __(
 							'Leave blank for no limit',
 							'woocommerce-payments'

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/address-mismatch.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/address-mismatch.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Address mismatch card renders correctly when enabled 1`] = `
               >
                 <input
                   aria-describedby="inspector-toggle-control-1__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
                   type="checkbox"
@@ -265,6 +266,7 @@ exports[`Address mismatch card renders correctly when enabled and checked 1`] = 
               >
                 <input
                   aria-describedby="inspector-toggle-control-2__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
                   type="checkbox"

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/international-ip-address.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/international-ip-address.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`International IP address card renders correctly when enabled 1`] = `
               >
                 <input
                   aria-describedby="inspector-toggle-control-2__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
                   type="checkbox"
@@ -137,7 +138,7 @@ exports[`International IP address card renders correctly when enabled 1`] = `
                 data-wp-c16t="true"
                 data-wp-component="FlexItem"
               >
-                Orders from outside of the following countries will be blocked by the filter: 
+                Orders from outside of the following countries will be screened by the filter: 
                 <strong>
                   Canada, United States
                 </strong>
@@ -232,6 +233,7 @@ exports[`International IP address card renders correctly when enabled and checke
               >
                 <input
                   aria-describedby="inspector-toggle-control-3__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-3"
                   type="checkbox"
@@ -588,7 +590,7 @@ exports[`International IP address card renders correctly when woocommerce_allowe
                 data-wp-c16t="true"
                 data-wp-component="FlexItem"
               >
-                Orders from the following countries will be blocked by the filter: 
+                Orders from the following countries will be screened by the filter: 
                 <strong>
                   Canada, United States
                 </strong>
@@ -753,7 +755,7 @@ exports[`International IP address card renders correctly when woocommerce_allowe
                 data-wp-c16t="true"
                 data-wp-component="FlexItem"
               >
-                Orders from outside of the following countries will be blocked by the filter: 
+                Orders from outside of the following countries will be screened by the filter: 
                 <strong>
                   Canada, United States
                 </strong>

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/ip-address-mismatch.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/ip-address-mismatch.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`International billing address card renders correctly when enabled 1`] =
               >
                 <input
                   aria-describedby="inspector-toggle-control-1__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
                   type="checkbox"
@@ -289,6 +290,7 @@ exports[`International billing address card renders correctly when enabled and c
               >
                 <input
                   aria-describedby="inspector-toggle-control-2__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
                   type="checkbox"

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/order-items-threshold.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/order-items-threshold.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Order items threshold card renders correctly when enabled 1`] = `
               >
                 <input
                   aria-describedby="inspector-toggle-control-1__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
                   type="checkbox"
@@ -389,6 +390,7 @@ exports[`Order items threshold card renders correctly when enabled and checked 1
               >
                 <input
                   aria-describedby="inspector-toggle-control-2__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
                   type="checkbox"

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/purchase-price-threshold.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/purchase-price-threshold.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`Purchase price threshold card renders correctly when enabled 1`] = `
               >
                 <input
                   aria-describedby="inspector-toggle-control-1__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
                   type="checkbox"
@@ -391,6 +392,7 @@ exports[`Purchase price threshold card renders correctly when enabled and checke
               >
                 <input
                   aria-describedby="inspector-toggle-control-2__help"
+                  checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
                   type="checkbox"

--- a/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.tsx
@@ -32,8 +32,6 @@ describe( 'Address mismatch card', () => {
 	const contextValue = {
 		protectionSettingsUI: settings,
 		setProtectionSettingsUI: setSettings,
-		protectionSettingsChanged: false,
-		setProtectionSettingsChanged: jest.fn(),
 		setIsDirty: jest.fn(),
 	};
 	test( 'renders correctly', () => {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.tsx
@@ -40,8 +40,6 @@ describe( 'AVS mismatch card', () => {
 		const contextValue = {
 			protectionSettingsUI: settings,
 			setProtectionSettingsUI: setSettings,
-			protectionSettingsChanged: false,
-			setProtectionSettingsChanged: jest.fn(),
 			setIsDirty: jest.fn(),
 		};
 		const { container } = render(
@@ -69,8 +67,6 @@ describe( 'AVS mismatch card', () => {
 		const contextValue = {
 			protectionSettingsUI: settings,
 			setProtectionSettingsUI: setSettings,
-			protectionSettingsChanged: false,
-			setProtectionSettingsChanged: jest.fn(),
 			setIsDirty: jest.fn(),
 		};
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.tsx
@@ -40,8 +40,6 @@ describe( 'CVC verification card', () => {
 		const contextValue = {
 			protectionSettingsUI: settings,
 			setProtectionSettingsUI: setSettings,
-			protectionSettingsChanged: false,
-			setProtectionSettingsChanged: jest.fn(),
 			setIsDirty: jest.fn(),
 		};
 		const { container } = render(
@@ -72,8 +70,6 @@ describe( 'CVC verification card', () => {
 		const contextValue = {
 			protectionSettingsUI: settings,
 			setProtectionSettingsUI: setSettings,
-			protectionSettingsChanged: false,
-			setProtectionSettingsChanged: jest.fn(),
 			setIsDirty: jest.fn(),
 		};
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.tsx
@@ -41,8 +41,6 @@ describe( 'International IP address card', () => {
 	const contextValue = {
 		protectionSettingsUI: settings,
 		setProtectionSettingsUI: setSettings,
-		protectionSettingsChanged: false,
-		setProtectionSettingsChanged: jest.fn(),
 		isDirty: false,
 		setIsDirty: jest.fn(),
 	};

--- a/client/settings/fraud-protection/advanced-settings/cards/test/ip-address-mismatch.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/ip-address-mismatch.test.tsx
@@ -38,8 +38,6 @@ describe( 'International billing address card', () => {
 	const contextValue = {
 		protectionSettingsUI: settings,
 		setProtectionSettingsUI: setSettings,
-		protectionSettingsChanged: false,
-		setProtectionSettingsChanged: jest.fn(),
 		setIsDirty: jest.fn(),
 	};
 	global.wcSettings = {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.tsx
@@ -37,8 +37,6 @@ describe( 'Order items threshold card', () => {
 	const contextValue = {
 		protectionSettingsUI: settings,
 		setProtectionSettingsUI: setSettings,
-		protectionSettingsChanged: false,
-		setProtectionSettingsChanged: jest.fn(),
 		setIsDirty: jest.fn(),
 	};
 	test( 'renders correctly', () => {

--- a/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.tsx
@@ -65,8 +65,6 @@ describe( 'Purchase price threshold card', () => {
 	const contextValue = {
 		protectionSettingsUI: settings,
 		setProtectionSettingsUI: setSettings,
-		protectionSettingsChanged: false,
-		setProtectionSettingsChanged: jest.fn(),
 		setIsDirty: jest.fn(),
 	};
 	test( 'renders correctly', () => {

--- a/client/settings/fraud-protection/advanced-settings/context.ts
+++ b/client/settings/fraud-protection/advanced-settings/context.ts
@@ -7,8 +7,6 @@ import { FraudPreventionSettingsContextType } from '../interfaces';
 const FraudPreventionSettingsContext = createContext( {
 	protectionSettingsUI: {},
 	setProtectionSettingsUI: () => null,
-	protectionSettingsChanged: false,
-	setProtectionSettingsChanged: () => false,
 	setIsDirty: () => null,
 } as FraudPreventionSettingsContextType );
 

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -313,6 +313,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 
 	useEffect( confirmLeaveCallback, [
 		confirmLeaveCallback,
+		protectionSettingsUI,
 		advancedFraudProtectionSettings,
 	] );
 

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -122,10 +122,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 	const [ protectionSettingsUI, setProtectionSettingsUI ] = useState<
 		ProtectionSettingsUI
 	>( {} );
-	const [
-		protectionSettingsChanged,
-		setProtectionSettingsChanged,
-	] = useState( false );
 
 	useEffect( () => {
 		setProtectionSettingsUI(
@@ -317,7 +313,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 
 	useEffect( confirmLeaveCallback, [
 		confirmLeaveCallback,
-		protectionSettingsChanged,
 		advancedFraudProtectionSettings,
 	] );
 
@@ -342,8 +337,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			value={ {
 				protectionSettingsUI,
 				setProtectionSettingsUI,
-				protectionSettingsChanged,
-				setProtectionSettingsChanged,
 				setIsDirty,
 			} }
 		>

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          Orders from outside of the following countries will be blocked by the filter: 
+                          Orders from outside of the following countries will be screened by the filter: 
                           <strong>
                             Canada, United States
                           </strong>
@@ -1345,7 +1345,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be blocked by the filter: 
+                        Orders from outside of the following countries will be screened by the filter: 
                         <strong>
                           Canada, United States
                         </strong>
@@ -2119,7 +2119,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
     </div>
     <div>
       <div>
@@ -2415,7 +2415,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          Orders from outside of the following countries will be blocked by the filter: 
+                          Orders from outside of the following countries will be screened by the filter: 
                           <strong>
                             Canada, United States
                           </strong>
@@ -3277,7 +3277,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be blocked by the filter: 
+                        Orders from outside of the following countries will be screened by the filter: 
                         <strong>
                           Canada, United States
                         </strong>
@@ -3925,7 +3925,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
     </div>
     <div>
       <div
@@ -4186,7 +4186,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be blocked by the filter: 
+                        Orders from outside of the following countries will be screened by the filter: 
                         <strong>
                           Canada, United States
                         </strong>
@@ -5012,7 +5012,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                       data-wp-c16t="true"
                       data-wp-component="FlexItem"
                     >
-                      Orders from outside of the following countries will be blocked by the filter: 
+                      Orders from outside of the following countries will be screened by the filter: 
                       <strong>
                         Canada, United States
                       </strong>
@@ -5659,7 +5659,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
+                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
     </div>
     <div>
       <div>
@@ -5938,7 +5938,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          Orders from outside of the following countries will be blocked by the filter: 
+                          Orders from outside of the following countries will be screened by the filter: 
                           <strong>
                             Canada, United States
                           </strong>
@@ -6863,7 +6863,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be blocked by the filter: 
+                        Orders from outside of the following countries will be screened by the filter: 
                         <strong>
                           Canada, United States
                         </strong>

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/rule-toggle.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/rule-toggle.test.tsx.snap
@@ -219,6 +219,7 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
             >
               <input
                 aria-describedby="inspector-toggle-control-1__help"
+                checked=""
                 class="components-form-toggle__input"
                 id="inspector-toggle-control-1"
                 type="checkbox"
@@ -268,6 +269,7 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
           >
             <input
               aria-describedby="inspector-toggle-control-1__help"
+              checked=""
               class="components-form-toggle__input"
               id="inspector-toggle-control-1"
               type="checkbox"
@@ -398,6 +400,7 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
             >
               <input
                 aria-describedby="inspector-toggle-control-2__help"
+                checked=""
                 class="components-form-toggle__input"
                 id="inspector-toggle-control-2"
                 type="checkbox"
@@ -447,6 +450,7 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
           >
             <input
               aria-describedby="inspector-toggle-control-2__help"
+              checked=""
               class="components-form-toggle__input"
               id="inspector-toggle-control-2"
               type="checkbox"

--- a/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/allow-countries-notice.test.tsx
@@ -16,9 +16,7 @@ const mockContext = {
 			block: false,
 		},
 	},
-	protectionSettingsChanged: false,
 	setProtectionSettingsUI: jest.fn(),
-	setProtectionSettingsChanged: jest.fn(),
 	setIsDirty: jest.fn(),
 };
 

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -9,6 +9,7 @@ import { render } from '@testing-library/react';
  */
 import FraudProtectionRuleToggle from '../rule-toggle';
 import FraudPreventionSettingsContext from '../context';
+import userEvent from '@testing-library/user-event';
 
 declare const global: {
 	wcpaySettings: {
@@ -23,9 +24,7 @@ interface mockContext {
 			block: boolean;
 		};
 	};
-	protectionSettingsChanged: boolean;
 	setProtectionSettingsUI: jest.Mock;
-	setProtectionSettingsChanged: jest.Mock;
 	setIsDirty: jest.Mock;
 }
 
@@ -41,9 +40,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 				block: false,
 			},
 		},
-		protectionSettingsChanged: false,
 		setProtectionSettingsUI: jest.fn(),
-		setProtectionSettingsChanged: jest.fn(),
 		setIsDirty: jest.fn(),
 	};
 
@@ -55,9 +52,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 					block: false,
 				},
 			},
-			protectionSettingsChanged: false,
 			setProtectionSettingsUI: jest.fn(),
-			setProtectionSettingsChanged: jest.fn(),
 			setIsDirty: jest.fn(),
 		};
 	} );
@@ -134,7 +129,9 @@ describe( 'Fraud protection rule toggle tests', () => {
 		expect( container.getByLabelText( 'Test rule toggle' ) ).toBeChecked();
 		expect( container.queryByText( 'test content' ) ).toBeInTheDocument();
 	} );
-	test( 'sets the value correctly when enabled', () => {
+	test( 'calls the toggle enable function when clicking in the label', () => {
+		mockContext.protectionSettingsUI.test_rule.enabled = false;
+
 		const container = render(
 			<FraudPreventionSettingsContext.Provider value={ mockContext }>
 				<FraudProtectionRuleToggle
@@ -145,17 +142,10 @@ describe( 'Fraud protection rule toggle tests', () => {
 				</FraudProtectionRuleToggle>
 			</FraudPreventionSettingsContext.Provider>
 		);
+
 		const activationToggle = container.getByLabelText( 'Test rule toggle' );
-		expect(
-			mockContext.protectionSettingsUI.test_rule.enabled
-		).toBeFalsy();
-		activationToggle.click();
-		expect(
-			mockContext.protectionSettingsUI.test_rule.enabled
-		).toBeTruthy();
-		activationToggle.click();
-		expect(
-			mockContext.protectionSettingsUI.test_rule.enabled
-		).toBeFalsy();
+		userEvent.click( activationToggle );
+
+		expect( mockContext.setProtectionSettingsUI ).toHaveBeenCalled();
 	} );
 } );

--- a/client/settings/fraud-protection/interfaces.ts
+++ b/client/settings/fraud-protection/interfaces.ts
@@ -33,9 +33,7 @@ export type ProtectionSettingsUI = Record< string, FraudPreventionSettings >;
 
 export interface FraudPreventionSettingsContextType {
 	protectionSettingsUI: ProtectionSettingsUI;
-	setProtectionSettingsUI: ( settings: ProtectionSettingsUI ) => void;
-	protectionSettingsChanged: boolean;
-	setProtectionSettingsChanged: Dispatch< SetStateAction< boolean > >;
+	setProtectionSettingsUI: Dispatch< SetStateAction< ProtectionSettingsUI > >;
 	setIsDirty: Dispatch< SetStateAction< boolean > >;
 }
 


### PR DESCRIPTION
Fixes #9520 
Fixes #8747 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR aims to fix the Advanced Fraud Protection page that wasn't rendering the settings as expected, which also impacted the confirmation modal before leaving the page.

The approach used was to remove any code that was changing the `protectionSettingsUI` object directly and the global `useEffects`, to have specific `handleChange` functions for each form field. This makes the code simpler and adds immutability to the protection settings data.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before checking out to this branch:**
* Checkout to `develop` and also update it `git pull`
* Build your client `npm run start`
* Go to **Payments > Settings** and scroll to the **Fraud protection** section
* Check the **Advanced** option and click on its action button
* Scroll to the **Purchase Price Threshold** section and enable filtering
* Save the changes and refresh the page
* The **Purchase Price Threshold** section will be empty/unchecked
* Without changing anything in the form, try to navigate out of the page by clicking on any menu item
* You should receive a confirmation alert about unsaved changes

<img width="452" alt="Screenshot 2024-10-04 at 16 26 45" src="https://github.com/user-attachments/assets/d5a43364-c4d5-4fb5-bb32-7fd56922c7df">

**Test this branch**
* Checkout to this branch
* Build your client `npm run start`
* Go to **Payments > Settings** and scroll to the **Fraud protection** section
* Check the **Advanced** option and click on its action button
* Scroll to the **Purchase Price Threshold** section and enable filtering
  * If you had already saved in the previous test, this section should already be enabled
* Save the changes and refresh the page
* The **Purchase Price Threshold** section should still be enabled and have the values you added to it
* Without changing anything in the form, try to navigate out of the page by clicking on any menu item
* You **should not** receive a confirmation alert about unsaved changes
* Go back to the Advanced Fraud Protection page
* Change anything in the form and, without changing the changes, try to navigate out of the page again
* You **should** receive the confirmation alert about unsaved changes
* Undo the changes and try to navigate out of the page again
* You **should not** receive a confirmation alert about unsaved changes

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
