### PR TITLE
Ensure Stripe is loaded correctly when checking payment method availability

### DIFF
--- a/changelog/fix-9518-apple-pay-button-on-blocks-checkout
+++ b/changelog/fix-9518-apple-pay-button-on-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Load Stripe with merchant account's key when checking payment method availability.

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -42,7 +42,7 @@ export const checkPaymentMethodIsAvailable = memoize(
 
 		root.render(
 			<Elements
-				stripe={ api.loadStripe() }
+				stripe={ api.loadStripe( true ) }
 				options={ {
 					mode: 'payment',
 					paymentMethodCreation: 'manual',


### PR DESCRIPTION
Fixes #9518.

#### Changes proposed in this Pull Request

This changes how the Stripe is loaded when we're checking whether the ECE payment method is available. ApplePay was returning as unavailable as Stripe was not being loaded with the merchant's account key, passing `true` toggles that.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**

1. Install the latest WooCommerce version.
2. Ensure WooPay is enabled.
3. Add a Blocks checkout page, if needed.
4. Ensure your site is publicly available over HTTPS.

**Confirm issue: ApplePay is not displayed on checkout Blocks**

You may try to test this with your local environment, but this may depend on whether you have verified your public domain on Stripe. If you can't confirm the issue locally, spin up a JN site and checks whether ApplePay is displayed in the checkout Blocks.

**Test: Ensure ApplePay loads correctly on checkout Blocks**

If you were able to test this locally you can just switch to this branch and build the assets: `npm run build:client` to check the fix. Otherwise, you'll need to build a package (`npm run build:release`) and upload in the JN site you created.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
