### PR TITLE
Payments Overview – rename deposits to payouts

### DIFF
--- a/client/components/account-balances/balance-tooltip.tsx
+++ b/client/components/account-balances/balance-tooltip.tsx
@@ -36,7 +36,7 @@ export const TotalBalanceTooltip: React.FC< TotalBalanceTooltipProps > = ( {
 					<>
 						{ interpolateComponents( {
 							mixedString: __(
-								'{{bold}}Total balance{{/bold}} combines both pending funds (transactions under processing) and available funds (ready for deposit). {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+								'{{bold}}Total balance{{/bold}} combines both pending funds (transactions under processing) and available funds (ready for payout). {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 								'woocommerce-payments'
 							),
 							components: {
@@ -105,7 +105,7 @@ export const AvailableBalanceTooltip: React.FC< AvailableBalanceTooltipProps > =
 					<p>
 						{ interpolateComponents( {
 							mixedString: __(
-								'{{bold}}Available funds{{/bold}} have completed processing and are ready to be deposited into your bank account. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+								'{{bold}}Available funds{{/bold}} have completed processing and are ready to be dispatched to your bank account. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 								'woocommerce-payments'
 							),
 							components: {

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -154,9 +154,8 @@ const AccountBalances: React.FC = () => {
 							>
 								{ sprintf(
 									__(
-										/* translators: %$1$s: Available instant deposit amount, %2$s: Instant deposit fee percentage */
-										/* 'Instantly deposit %1$s and get funds in your bank account in 30 mins for a %2$s%% fee.' */
-										'Get %1$s via instant deposit. Funds are typically in your bank account within 30 mins. Fee: %2$s%%.',
+										/* translators: %$1$s: Available instant payout amount, %2$s: Instant payout fee percentage */
+										'Get %1$s via instant payout. Funds are typically in your bank account within 30 mins. Fee: %2$s%%.',
 										'woocommerce-payments'
 									),
 									formatCurrency(
@@ -179,17 +178,17 @@ const AccountBalances: React.FC = () => {
 								<ClickTooltip
 									buttonIcon={ <HelpOutlineIcon /> }
 									buttonLabel={ __(
-										'Learn more about instant deposit',
+										'Learn more about instant payouts',
 										'woocommerce-payments'
 									) }
 									content={
-										/* 'With instant deposit you can receive requested funds in your bank account within 30 mins for a 1.5% fee. Learn more' */
+										/* 'With instant payout you can receive requested funds in your bank account within 30 mins for a 1.5% fee. Learn more' */
 
 										interpolateComponents( {
 											mixedString: sprintf(
 												__(
-													/* translators: %s: Instant deposit fee percentage */
-													'With {{strong}}instant deposit{{/strong}} you can receive requested funds in your bank account within 30 mins for a %s%% fee. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+													/* translators: %s: Instant payout fee percentage */
+													'With {{strong}}instant payout{{/strong}} you can receive requested funds in your bank account within 30 mins for a %s%% fee. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 													'woocommerce-payments'
 												),
 												selectedOverview.instantBalance

--- a/client/components/account-balances/test/index.test.tsx
+++ b/client/components/account-balances/test/index.test.tsx
@@ -231,7 +231,7 @@ describe( 'AccountBalances', () => {
 		} );
 		fireEvent.click( tooltipButton );
 		const tooltip = screen.getByRole( 'tooltip', {
-			name: /Available funds have completed processing and are ready to be deposited into your bank account./,
+			name: /Available funds have completed processing and are ready to be dispatched to your bank account./,
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
@@ -289,7 +289,7 @@ describe( 'AccountBalances', () => {
 		} );
 		fireEvent.click( tooltipButton );
 		const tooltip = screen.getByRole( 'tooltip', {
-			name: /Total balance combines both pending funds \(transactions under processing\) and available funds \(ready for deposit\)\./,
+			name: /Total balance combines both pending funds \(transactions under processing\) and available funds \(ready for payout\)\./,
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',

--- a/client/components/account-status/account-tools/strings.tsx
+++ b/client/components/account-status/account-tools/strings.tsx
@@ -17,7 +17,7 @@ export default {
 				'woocommerce-payments'
 		  )
 		: __(
-				'Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
+				'Payments and payouts are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
 				'woocommerce-payments'
 		  ),
 	reset: __( 'Reset account', 'woocommerce-payments' ),

--- a/client/components/account-status/account-tools/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-status/account-tools/test/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`AccountTools should render in test/sandbox mode onboarding 1`] = `
       Account Tools
     </h4>
     <p>
-      Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
+      Payments and payouts are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
     </p>
     <div
       class="account-tools__actions"

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -112,7 +112,7 @@ const AccountStatusDetails = ( props ) => {
 				/>
 			</AccountStatusItem>
 			<AccountStatusItem
-				label={ __( 'Deposits:', 'woocommerce-payments' ) }
+				label={ __( 'Payouts:', 'woocommerce-payments' ) }
 			>
 				<DepositsStatus
 					status={ accountStatus.deposits?.status }

--- a/client/components/account-status/status-chip.js
+++ b/client/components/account-status/status-chip.js
@@ -34,7 +34,7 @@ const StatusChip = ( props ) => {
 		description = __( 'Pending', 'woocommerce-payments' );
 		type = 'light';
 		tooltip = __(
-			'Deposits are pending while Stripe verifies details on your account.',
+			'Payouts are pending while Stripe verifies details on your account.',
 			'woocommerce-payments'
 		);
 	} else if ( accountStatus === 'restricted_partially' ) {

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -86,7 +86,7 @@ exports[`AccountStatus does not render edit details when no account link 1`] = `
             data-wp-c16t="true"
             data-wp-component="FlexItem"
           >
-            Deposits:
+            Payouts:
           </div>
           <div
             class="components-flex-item components-flex-block item-value css-14wzr73-View-Item-sx-Base-block em57xhy0"
@@ -254,7 +254,7 @@ exports[`AccountStatus renders account tools 1`] = `
             data-wp-c16t="true"
             data-wp-component="FlexItem"
           >
-            Deposits:
+            Payouts:
           </div>
           <div
             class="components-flex-item components-flex-block item-value css-14wzr73-View-Item-sx-Base-block em57xhy0"
@@ -295,7 +295,7 @@ exports[`AccountStatus renders account tools 1`] = `
             Account Tools
           </h4>
           <p>
-            Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
+            Payments and payouts are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
           </p>
           <div
             class="account-tools__actions"
@@ -490,7 +490,7 @@ exports[`AccountStatus renders normal status 1`] = `
             data-wp-c16t="true"
             data-wp-component="FlexItem"
           >
-            Deposits:
+            Payouts:
           </div>
           <div
             class="components-flex-item components-flex-block item-value css-14wzr73-View-Item-sx-Base-block em57xhy0"

--- a/client/components/deposits-overview/deposit-schedule.tsx
+++ b/client/components/deposits-overview/deposit-schedule.tsx
@@ -119,7 +119,7 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 	const nextDepositHelpContent = (
 		<>
 			{ __(
-				'Deposits are initiated based on the following criteria:',
+				'Payouts are initiated based on the following criteria:',
 				'woocommerce-payments'
 			) }
 			<ul>
@@ -166,7 +166,7 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 				<li>
 					{ interpolateComponents( {
 						mixedString: __(
-							'Your {{link}}deposit schedule{{/link}} settings',
+							'Your {{link}}payout schedule{{/link}} settings',
 							'woocommerce-payments'
 						),
 						components: {
@@ -193,7 +193,7 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 			<ClickTooltip
 				content={ nextDepositHelpContent }
 				buttonIcon={ <HelpOutlineIcon /> }
-				buttonLabel={ 'Deposit schedule tooltip' }
+				buttonLabel={ 'Payout schedule tooltip' }
 			/>
 		</>
 	);

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -98,7 +98,7 @@ const DepositsOverview: React.FC = () => {
 		return (
 			<Card className="wcpay-deposits-overview">
 				<CardHeader>
-					{ __( 'Deposits', 'woocommerce-payments' ) }
+					{ __( 'Payouts', 'woocommerce-payments' ) }
 				</CardHeader>
 
 				<CardBody className="wcpay-deposits-overview__schedule__container">
@@ -132,9 +132,7 @@ const DepositsOverview: React.FC = () => {
 
 	return (
 		<Card className="wcpay-deposits-overview">
-			<CardHeader>
-				{ __( 'Deposits', 'woocommerce-payments' ) }
-			</CardHeader>
+			<CardHeader>{ __( 'Payouts', 'woocommerce-payments' ) }</CardHeader>
 
 			{ /* Deposit schedule message */ }
 			{ isDepositsUnrestricted && !! account && hasScheduledDeposits && (
@@ -190,7 +188,7 @@ const DepositsOverview: React.FC = () => {
 				<>
 					<CardBody className="wcpay-deposits-overview__heading">
 						<span className="wcpay-deposits-overview__heading__title">
-							{ __( 'Deposit history', 'woocommerce-payments' ) }
+							{ __( 'Payout history', 'woocommerce-payments' ) }
 						</span>
 					</CardBody>
 					<RecentDepositsList deposits={ deposits } />
@@ -205,7 +203,7 @@ const DepositsOverview: React.FC = () => {
 							onClick={ navigateToDepositsHistory }
 						>
 							{ __(
-								'View full deposits history',
+								'View full payout history',
 								'woocommerce-payments'
 							) }
 						</Button>
@@ -228,7 +226,7 @@ const DepositsOverview: React.FC = () => {
 							}
 						>
 							{ __(
-								'Change deposit schedule',
+								'Change payout schedule',
 								'woocommerce-payments'
 							) }
 						</Button>

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -93,7 +93,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
         data-wp-c16t="true"
         data-wp-component="CardHeader"
       >
-        Deposits
+        Payouts
       </div>
       <div
         class="components-card__body components-card-body wcpay-deposits-overview__schedule__container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
@@ -113,7 +113,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
             class="wcpay-tooltip__content-wrapper"
           >
             <div
-              aria-label="Deposit schedule tooltip"
+              aria-label="Payout schedule tooltip"
               role="button"
               tabindex="0"
             >
@@ -190,7 +190,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
         <span
           class="wcpay-deposits-overview__heading__title"
         >
-          Deposit history
+          Payout history
         </span>
       </div>
       <div
@@ -344,13 +344,13 @@ exports[`Deposits Overview information Component Renders 1`] = `
           class="components-button is-secondary"
           type="button"
         >
-          View full deposits history
+          View full payout history
         </button>
         <a
           class="components-button is-tertiary"
           href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#deposit-schedule"
         >
-          Change deposit schedule
+          Change payout schedule
         </a>
       </div>
     </div>

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -257,8 +257,8 @@ describe( 'Deposits Overview information', () => {
 
 		const { container, getByText } = render( <DepositsOverview /> );
 		// Check that the button and link is rendered.
-		getByText( 'View full deposits history' );
-		getByText( 'Change deposit schedule' );
+		getByText( 'View full payout history' );
+		getByText( 'Change payout schedule' );
 		expect( container ).toMatchSnapshot();
 	} );
 
@@ -321,7 +321,7 @@ describe( 'Deposits Overview information', () => {
 		getByText( /Your deposits are temporarily suspended/ );
 
 		// Check that the buttons are rendered as expected.
-		getByText( 'View full deposits history' );
+		getByText( 'View full payout history' );
 		// This one is not rendered when deposits are blocked.
 		expect( queryByText( 'Change deposit schedule' ) ).toBeFalsy();
 	} );

--- a/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
@@ -82,7 +82,7 @@ const SetupLivePaymentsModal: React.FC< Props > = ( {
 				) }
 				<Icon icon={ currencyDollar } />
 				{ __(
-					'We will need your banking details in order to process any deposits to you.',
+					'We will need your banking details in order to process any payouts to you.',
 					'woocommerce-payments'
 				) }
 			</div>


### PR DESCRIPTION
Fixes #9526 , #9586 , #9575, #9576

> [!IMPORTANT]  
> This PR is to be merged into feature branch `feature/deposits-payouts-rename`

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Project thread TBD – Rename Deposits to Payouts

This PR changes "Deposits/Deposit/Deposited" to "Payouts/Payout/Dispatched" on the Payments overview screen UI.


- [x] Deposits onboarding checklist items
- [x] Deposits overview / recent deposits list card
	- Notices are being updated in #9532, out of scope of this PR
- [x] Balances card tooltip(s)
- [x] Instant deposit notice in balances card
- [x] Account details deposits status check
- [x] Next deposit summary and tooltip


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Deposits onboarding checklist items – visit WC Home in wp admin and click the **Set up real payments on your store** task to view a modal. Ensure the word `deposits` is no more 💣

	<img src="https://github.com/user-attachments/assets/23e7f7d1-6d6f-4287-9bf0-7ac0ca9ea237" width="300" />
	<img src="https://github.com/user-attachments/assets/f3bc4c79-7d11-4e9a-90ab-f9de1bc55f6a" width="300" />

* Navigate to Payments → Overview and observe the following changes:
	-  Deposits overview / recent deposits list card

		<img src="https://github.com/user-attachments/assets/e4f1dd53-0112-4259-8b4d-dd7ad3cfe835" width="300" />

		- Notices are being updated in #9532, out of scope of this PR

	* Balances card tooltips

		<img src="https://github.com/user-attachments/assets/b9f4fd30-d6f2-4a4f-8fbe-11ff83ac7d84" width="300" />
		<img src="https://github.com/user-attachments/assets/c84fa7e3-c734-4806-b896-0150451dd2aa" width="300" />

	- Instant deposit notice in balances card

		<img src="https://github.com/user-attachments/assets/4ddeb7c2-1d05-4207-99aa-41f904bd231e" width="300" />

	- Account details deposits status check

		<img src="https://github.com/user-attachments/assets/9981db53-b142-46d5-a47d-593dc4f851d6" width="300" />

	- Next deposit summary and tooltip

		<img src="https://github.com/user-attachments/assets/b118ff68-ca7f-45f4-a6f5-2139850bea32" width="300" />



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. **N/A - changelog will be included in feature branch release**
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A - minor text changes only** 

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
