### PR TITLE
Fix WooPay duplicated Save my info section

### DIFF
--- a/changelog/fix-woopay-duplicated-component
+++ b/changelog/fix-woopay-duplicated-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay duplicated Save my info section.

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -23,31 +23,38 @@ const renderSaveUserSection = () => {
 	);
 
 	if ( blocksCheckout.length ) {
-		const checkoutPageSaveUserContainer = document.createElement(
-			'fieldset'
+		let checkoutPageSaveUserContainer = document.querySelector(
+			'#remember-me'
 		);
-		const paymentOptions = document.getElementsByClassName(
-			'wp-block-woocommerce-checkout-payment-block'
-		)?.[ 0 ];
 
-		checkoutPageSaveUserContainer.className =
-			'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block wc-block-components-checkout-step ';
-		checkoutPageSaveUserContainer.id = 'remember-me';
+		if ( ! checkoutPageSaveUserContainer ) {
+			const paymentOptions = document.getElementsByClassName(
+				'wp-block-woocommerce-checkout-payment-block'
+			)?.[ 0 ];
 
-		if ( paymentOptions ) {
-			// Render right after the payment options block, as a sibling element.
-			paymentOptions.parentNode.insertBefore(
-				checkoutPageSaveUserContainer,
-				paymentOptions.nextSibling
+			checkoutPageSaveUserContainer = document.createElement(
+				'fieldset'
 			);
 
-			paymentOptions.classList.add( 'is-woopay' );
+			checkoutPageSaveUserContainer.className =
+				'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block wc-block-components-checkout-step ';
+			checkoutPageSaveUserContainer.id = 'remember-me';
 
-			ReactDOM.render(
-				<CheckoutPageSaveUser isBlocksCheckout={ true } />,
-				checkoutPageSaveUserContainer
-			);
+			if ( paymentOptions ) {
+				// Render right after the payment options block, as a sibling element.
+				paymentOptions.parentNode.insertBefore(
+					checkoutPageSaveUserContainer,
+					paymentOptions.nextSibling
+				);
+
+				paymentOptions.classList.add( 'is-woopay' );
+			}
 		}
+
+		ReactDOM.render(
+			<CheckoutPageSaveUser isBlocksCheckout={ true } />,
+			checkoutPageSaveUserContainer
+		);
 	} else {
 		const checkoutPageSaveUserContainer = document.createElement( 'div' );
 		checkoutPageSaveUserContainer.className =


### PR DESCRIPTION
Fixes #9410

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
This PR fixes the WooPay `Save my info` component being duplicated due to late ajax requests before the payment method component is fully rendered, it was being duplicated [here](https://github.com/Automattic/woocommerce-payments/blob/319de19d321d5802b94b5dadfeee480b8f7bd643/client/checkout/woopay/index.js#L89).

The issue mentions it's related to Stripe plugin but it happens even without the Stripe plugin installed.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can try to reproduce this bug without checking out to the branch:

* Add a product to the cart.
* Duplicate [this line](https://github.com/Automattic/woocommerce-payments/blob/319de19d321d5802b94b5dadfeee480b8f7bd643/client/checkout/woopay/index.js#L83).
* Access blocks checkout page.
* The WooPay `Save my info` component should be duplicated.

<img width="465" alt="Screenshot 2024-10-06 at 17 17 00" src="https://github.com/user-attachments/assets/f765e3d9-18d8-48d0-b925-198072bd8fe4">

* Checkout to this PR.
* The WooPay `Save my info` component should not duplicate anymore.

This PR fixes that by checking if the element where the component is mounted already exists on the `renderSaveUserSection` before creating a new element for it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
