### PR TITLE
Rename deposits to payouts on the settings screen

### DIFF
--- a/changelog/fix-9527-payouts-rename-settings
+++ b/changelog/fix-9527-payouts-rename-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Payouts rename: Settings page, part of a larger change

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -29,7 +29,7 @@ export const SuspendedDepositNotice: React.FC = () => {
 			{ interpolateComponents( {
 				/** translators: {{strong}}: placeholders are opening and closing strong tags. {{suspendLink}}: is a <a> link element */
 				mixedString: __(
-					'Your deposits are {{strong}}temporarily suspended{{/strong}}. {{suspendLink}}Learn more{{/suspendLink}}',
+					'Your payouts are {{strong}}temporarily suspended{{/strong}}. {{suspendLink}}Learn more{{/suspendLink}}',
 					'woocommerce-payments'
 				),
 				components: {
@@ -54,7 +54,7 @@ export const DepositIncludesLoanPayoutNotice: React.FC = () => (
 	<InlineNotice icon status="warning" isDismissible={ false }>
 		{ interpolateComponents( {
 			mixedString: __(
-				'This deposit will include funds from your WooCommerce Capital loan. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+				'This payout will include funds from your WooCommerce Capital loan. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 				'woocommerce-payments'
 			),
 			components: {
@@ -86,7 +86,7 @@ export const NewAccountWaitingPeriodNotice: React.FC = () => (
 	>
 		{ interpolateComponents( {
 			mixedString: __(
-				'Your first deposit is held for 7-14 days. {{whyLink}}Why?{{/whyLink}}',
+				'Your first payout is held for 7-14 days. {{whyLink}}Why?{{/whyLink}}',
 				'woocommerce-payments'
 			),
 			components: {
@@ -114,7 +114,7 @@ export const DepositTransitDaysNotice: React.FC = () => (
 		className="wcpay-deposit-transit-days-notice"
 	>
 		{ __(
-			'It may take 1-3 business days for deposits to reach your bank account.',
+			'It may take 1-3 business days for payouts to reach your bank account.',
 			'woocommerce-payments'
 		) }
 	</InlineNotice>
@@ -134,7 +134,7 @@ export const NegativeBalanceDepositsPausedNotice: React.FC = () => (
 			mixedString: sprintf(
 				/* translators: %s: WooPayments */
 				__(
-					'Deposits may be interrupted while your %s balance remains negative. {{whyLink}}Why?{{/whyLink}}',
+					'Payouts may be interrupted while your %s balance remains negative. {{whyLink}}Why?{{/whyLink}}',
 					'woocommerce-payments'
 				),
 				'WooPayments'
@@ -169,7 +169,7 @@ export const DepositMinimumBalanceNotice: React.FC< {
 				mixedString: sprintf(
 					/* translators: %s: a formatted currency amount, e.g. $5.00 USD */
 					__(
-						'Deposits are paused while your available funds balance remains below %s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+						'Payouts are paused while your available funds balance remains below %s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 						'woocommerce-payments'
 					),
 					minimumDepositAmountFormatted
@@ -197,7 +197,7 @@ export const NoFundsAvailableForDepositNotice: React.FC = () => (
 	<InlineNotice status="warning" icon isDismissible={ false }>
 		{ interpolateComponents( {
 			mixedString: __(
-				'You have no funds available to deposit. {{whyLink}}Why?{{/whyLink}}',
+				'You have no funds available. {{whyLink}}Why?{{/whyLink}}',
 				'woocommerce-payments'
 			),
 			components: {
@@ -240,7 +240,7 @@ export const DepositFailureNotice: React.FC< {
 		>
 			{ interpolateComponents( {
 				mixedString: __(
-					'Deposits are currently paused because a recent deposit failed. Please {{updateLink}}update your bank account details{{/updateLink}}.',
+					'Payouts are currently paused because a recent payout failed. Please {{updateLink}}update your bank account details{{/updateLink}}.',
 					'woocommerce-payments'
 				),
 				components: {

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -37,7 +37,7 @@ exports[`DepositFailureNotice Renders Renders DepositFailureNotice component cor
           data-wp-c16t="true"
           data-wp-component="FlexItem"
         >
-          Deposits are currently paused because a recent deposit failed. Please 
+          Payouts are currently paused because a recent payout failed. Please 
           <a
             class="components-external-link"
             href="https://example.com?from=WCPAY_PAYOUTS&source=wcpay-payout-failure-notice"
@@ -173,7 +173,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
                 data-wp-c16t="true"
                 data-wp-component="FlexItem"
               >
-                It may take 1-3 business days for deposits to reach your bank account.
+                It may take 1-3 business days for payouts to reach your bank account.
               </div>
             </div>
             <div
@@ -407,7 +407,7 @@ exports[`Suspended Deposit Notice Renders Component Renders 1`] = `
           data-wp-c16t="true"
           data-wp-component="FlexItem"
         >
-          Your deposits are 
+          Your payouts are 
           <strong>
             temporarily suspended
           </strong>

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -295,7 +295,7 @@ describe( 'Deposits Overview information', () => {
 			setSelectedCurrency: mockSetSelectedCurrency,
 		} );
 		const { getByText, queryByText } = render( <DepositsOverview /> );
-		getByText( /Your first deposit is held for/, {
+		getByText( /Your first payout is held for/, {
 			ignore: '.a11y-speak-region',
 		} );
 		expect( queryByText( 'Change deposit schedule' ) ).toBeFalsy();
@@ -318,7 +318,7 @@ describe( 'Deposits Overview information', () => {
 
 		const { getByText, queryByText } = render( <DepositsOverview /> );
 
-		getByText( /Your deposits are temporarily suspended/ );
+		getByText( /Your payouts are temporarily suspended/ );
 
 		// Check that the buttons are rendered as expected.
 		getByText( 'View full deposits history' );
@@ -386,7 +386,7 @@ describe( 'Deposits Overview information', () => {
 
 		expect(
 			queryByText(
-				'deposit will include funds from your WooCommerce Capital loan',
+				'payout will include funds from your WooCommerce Capital loan',
 				{
 					exact: false,
 					ignore: '.a11y-speak-region',
@@ -415,7 +415,7 @@ describe( 'Deposits Overview information', () => {
 		} );
 
 		const { queryByText } = render( <DepositsOverview /> );
-		expect( queryByText( /Your first deposit is held for/ ) ).toBeFalsy();
+		expect( queryByText( /Your first payout is held for/ ) ).toBeFalsy();
 	} );
 
 	test( 'Confirm new account waiting period notice shows if within waiting period', () => {
@@ -433,7 +433,7 @@ describe( 'Deposits Overview information', () => {
 		} );
 
 		const { getByText, getByRole } = render( <DepositsOverview /> );
-		getByText( /Your first deposit is held for/, {
+		getByText( /Your first payout is held for/, {
 			ignore: '.a11y-speak-region',
 		} );
 		expect( getByRole( 'link', { name: /Why\?/ } ) ).toHaveAttribute(
@@ -565,7 +565,7 @@ describe( 'DepositFailureNotice Renders', () => {
 		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
-				/Deposits are currently paused because a recent deposit failed./,
+				/Payouts are currently paused because a recent payout failed./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -604,7 +604,7 @@ describe( 'DepositFailureNotice Renders', () => {
 		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
-				/Deposits are currently paused because a recent deposit failed./,
+				/Payouts are currently paused because a recent payout failed./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -643,7 +643,7 @@ describe( 'DepositFailureNotice Renders', () => {
 		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
-				/Deposits are currently paused because a recent deposit failed./,
+				/Payouts are currently paused because a recent payout failed./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -668,7 +668,7 @@ describe( 'Paused Deposit notice Renders', () => {
 		} );
 
 		const { getByText } = render( <DepositsOverview /> );
-		getByText( /Deposits may be interrupted/, {
+		getByText( /Payouts may be interrupted/, {
 			ignore: '.a11y-speak-region',
 		} );
 	} );
@@ -682,7 +682,7 @@ describe( 'Paused Deposit notice Renders', () => {
 		mockDepositOverviews( [ accountOverview ] );
 
 		const { queryByText } = render( <DepositsOverview /> );
-		expect( queryByText( /Deposits may be interrupted/ ) ).toBeFalsy();
+		expect( queryByText( /Payouts may be interrupted/ ) ).toBeFalsy();
 	} );
 	test( 'When available balance is negative', () => {
 		const accountOverview = createMockNewAccountOverview(
@@ -694,7 +694,7 @@ describe( 'Paused Deposit notice Renders', () => {
 		mockDepositOverviews( [ accountOverview ] );
 
 		const { queryByText } = render( <DepositsOverview /> );
-		expect( queryByText( /Deposits may be interrupted/ ) ).toBeFalsy();
+		expect( queryByText( /Payouts may be interrupted/ ) ).toBeFalsy();
 	} );
 } );
 
@@ -723,7 +723,7 @@ describe( 'Minimum Deposit Amount Notice', () => {
 
 		const { getByText } = render( <DepositsOverview /> );
 		getByText(
-			/Deposits are paused while your available funds balance remains below €5.00/,
+			/Payouts are paused while your available funds balance remains below €5.00/,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -743,7 +743,7 @@ describe( 'Minimum Deposit Amount Notice', () => {
 		const { queryByText } = render( <DepositsOverview /> );
 		expect(
 			queryByText(
-				/Deposits are paused while your available funds balance remains below/
+				/Payouts are paused while your available funds balance remains below/
 			)
 		).toBeFalsy();
 	} );

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -131,17 +131,17 @@ const CustomizeDepositSchedule = () => {
 			<p className="help-text">
 				{ depositScheduleInterval === 'monthly' &&
 					__(
-						'Deposits scheduled on a weekend will be sent on the next business day.',
+						'Payouts scheduled on a weekend will be sent on the next business day.',
 						'woocommerce-payments'
 					) }
 				{ depositScheduleInterval === 'weekly' &&
 					__(
-						'Deposits that fall on a holiday will initiate on the next business day.',
+						'Payouts that fall on a holiday will initiate on the next business day.',
 						'woocommerce-payments'
 					) }
 				{ depositScheduleInterval === 'daily' &&
 					__(
-						'Deposits will occur every business day.',
+						'Payouts will occur every business day.',
 						'woocommerce-payments'
 					) }
 			</p>
@@ -161,7 +161,7 @@ const DepositsSchedule = () => {
 			<InlineNotice status="warning" isDismissible={ false } icon>
 				{ interpolateComponents( {
 					mixedString: __(
-						'Deposit scheduling is currently unavailable for your store. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+						'Payout scheduling is currently unavailable for your store. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 						'woocommerce-payments'
 					),
 					components: {
@@ -183,8 +183,8 @@ const DepositsSchedule = () => {
 			<InlineNotice status="warning" isDismissible={ false } icon>
 				{ interpolateComponents( {
 					mixedString: __(
-						'Your first deposit will be held for 7-14 days. ' +
-							'Deposit scheduling will be available after this period. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+						'Your first payout will be held for 7-14 days. ' +
+							'Payout scheduling will be available after this period. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 						'woocommerce-payments'
 					),
 					components: {
@@ -220,13 +220,13 @@ const Deposits = () => {
 	return (
 		<Card className="deposits">
 			<CardBody>
-				<h4>{ __( 'Deposit schedule', 'woocommerce-payments' ) }</h4>
+				<h4>{ __( 'Payout schedule', 'woocommerce-payments' ) }</h4>
 
 				<DepositsSchedule />
 
 				<div className="deposits__bank-information">
 					<h4>
-						{ __( 'Deposit bank account', 'woocommerce-payments' ) }
+						{ __( 'Payout bank account', 'woocommerce-payments' ) }
 					</h4>
 					{ hasErroredExternalAccount ? (
 						<DepositFailureNotice
@@ -235,7 +235,7 @@ const Deposits = () => {
 					) : (
 						<p className="deposits__bank-information-help">
 							{ __(
-								'Manage and update your deposit account information to receive payments and deposits.',
+								'Manage and update your payout account information to receive payments and payouts.',
 								'woocommerce-payments'
 							) }{ ' ' }
 							{ accountLink && (

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -235,7 +235,7 @@ const Deposits = () => {
 					) : (
 						<p className="deposits__bank-information-help">
 							{ __(
-								'Manage and update your payout account information to receive payments and payouts.',
+								'Manage and update your bank account information to receive payouts.',
 								'woocommerce-payments'
 							) }{ ' ' }
 							{ accountLink && (

--- a/client/settings/deposits/test/index.test.js
+++ b/client/settings/deposits/test/index.test.js
@@ -108,7 +108,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Deposit scheduling is currently unavailable for your store/,
+			/Payout scheduling is currently unavailable for your store/,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -128,7 +128,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Deposit scheduling is currently unavailable for your store/,
+			/Payout scheduling is currently unavailable for your store/,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -146,7 +146,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Deposit scheduling is currently unavailable for your store/,
+			/Payout scheduling is currently unavailable for your store/,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -165,7 +165,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Your first deposit will be held for/,
+			/Your first payout will be held for/,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -184,7 +184,7 @@ describe( 'Deposits', () => {
 		);
 
 		expect(
-			screen.queryByText( /Your first deposit will be held for/, {
+			screen.queryByText( /Your first payout will be held for/, {
 				ignore: '.a11y-speak-region',
 			} )
 		).toBeFalsy();
@@ -285,7 +285,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Deposits are currently paused because a recent deposit failed./,
+			/Payouts are currently paused because a recent payout failed./,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -294,7 +294,7 @@ describe( 'Deposits', () => {
 
 		expect(
 			screen.queryByText(
-				/Manage and update your deposit account information to receive payments and deposits./,
+				/Manage and update your payout account information to receive payments and payouts./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -311,7 +311,7 @@ describe( 'Deposits', () => {
 
 		expect(
 			screen.queryByText(
-				/Deposits are currently paused because a recent deposit failed./,
+				/Payouts are currently paused because a recent payout failed./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -319,7 +319,7 @@ describe( 'Deposits', () => {
 		).toBeFalsy();
 
 		const depositsMessage = screen.getByText(
-			/Manage and update your deposit account information to receive payments and deposits./,
+			/Manage and update your payout account information to receive payments and payouts./,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -352,7 +352,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Deposits are currently paused because a recent deposit failed./,
+			/Payouts are currently paused because a recent payout failed./,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -361,7 +361,7 @@ describe( 'Deposits', () => {
 
 		expect(
 			screen.queryByText(
-				/Manage and update your deposit account information to receive payments and deposits./,
+				/Manage and update your payout account information to receive payments and payouts./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -395,7 +395,7 @@ describe( 'Deposits', () => {
 
 		expect(
 			screen.queryByText(
-				/Deposits are currently paused because a recent deposit failed./,
+				/Payouts are currently paused because a recent payout failed./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -403,7 +403,7 @@ describe( 'Deposits', () => {
 		).toBeFalsy();
 
 		const depositsMessage = screen.getByText(
-			/Manage and update your deposit account information to receive payments and deposits./,
+			/Manage and update your payout account information to receive payments and payouts./,
 			{
 				ignore: '.a11y-speak-region',
 			}

--- a/client/settings/deposits/test/index.test.js
+++ b/client/settings/deposits/test/index.test.js
@@ -294,7 +294,7 @@ describe( 'Deposits', () => {
 
 		expect(
 			screen.queryByText(
-				/Manage and update your payout account information to receive payments and payouts./,
+				/Manage and update your bank account information to receive payouts./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -319,7 +319,7 @@ describe( 'Deposits', () => {
 		).toBeFalsy();
 
 		const depositsMessage = screen.getByText(
-			/Manage and update your payout account information to receive payments and payouts./,
+			/Manage and update your bank account information to receive payouts./,
 			{
 				ignore: '.a11y-speak-region',
 			}
@@ -361,7 +361,7 @@ describe( 'Deposits', () => {
 
 		expect(
 			screen.queryByText(
-				/Manage and update your payout account information to receive payments and payouts./,
+				/Manage and update your bank account information to receive payouts./,
 				{
 					ignore: '.a11y-speak-region',
 				}
@@ -403,7 +403,7 @@ describe( 'Deposits', () => {
 		).toBeFalsy();
 
 		const depositsMessage = screen.getByText(
-			/Manage and update your payout account information to receive payments and payouts./,
+			/Manage and update your bank account information to receive payouts./,
 			{
 				ignore: '.a11y-speak-region',
 			}

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -88,7 +88,7 @@ const DepositsDescription = () => {
 			<p>
 				{ sprintf(
 					__(
-						'Funds are available to be dispatched %s business days after they’re received.',
+						'Funds are available for payout %s business days after they’re received.',
 						'woocommerce-payments'
 					),
 					depositDelayDays

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -84,11 +84,11 @@ const DepositsDescription = () => {
 
 	return (
 		<>
-			<h2>{ __( 'Deposits', 'woocommerce-payments' ) }</h2>
+			<h2>{ __( 'Payouts', 'woocommerce-payments' ) }</h2>
 			<p>
 				{ sprintf(
 					__(
-						'Funds are available for deposit %s business days after they’re received.',
+						'Funds are available to be dispatched %s business days after they’re received.',
 						'woocommerce-payments'
 					),
 					depositDelayDays


### PR DESCRIPTION
Fixes #9527 

#### Changes proposed in this Pull Request

Rename "Deposits" to "payouts on the settings screen and notices.

This PR updates all instances of "Deposits" to "payouts" on the settings screen

<img width="1076" alt="Screenshot 2024-10-09 at 10 38 30 AM" src="https://github.com/user-attachments/assets/8520ca89-5619-4038-8abf-e7be1b6f3068">

and all the "deposit" notices.

<img width="654" alt="image" src="https://github.com/user-attachments/assets/caf8d539-f336-4f96-a795-b951a2de31af">


#### Testing instructions

* Visit Payments > Settings
* Check the UI, including changing the deposit schedule.
* Test various error states.

Rather than testing various error states, I injected all deposit notices onto a page to review.

```
<hr/>

 <h3>Notices Tests</h3>
 
  <DepositFailureNotice updateAccountLink={'#'}/>
  <SuspendedDepositNotice/>
  <DepositIncludesLoanPayoutNotice/>
  <NewAccountWaitingPeriodNotice/>
  <DepositTransitDaysNotice/>
  <NegativeBalanceDepositsPausedNotice/>
  <DepositMinimumBalanceNotice minimumDepositAmountFormatted={'77.32'}/>
  <NoFundsAvailableForDepositNotice/>

<hr/>
```


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
