### PR TITLE
Set the transient for woopay_enabled_by_default for the new onboarding flow

### DIFF
--- a/changelog/fix-enable-woopay-by-default
+++ b/changelog/fix-enable-woopay-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set transient for woopay_enabled_by_default for the new onboarding flow

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -188,6 +188,9 @@ class WC_Payments_Onboarding_Service {
 				$actioned_notes,
 				$progressive
 			);
+
+			set_transient( 'woopay_enabled_by_default', isset( $account_session['woopay_enabled_by_default'] ) ?? false, DAY_IN_SECONDS );
+
 		} catch ( API_Exception $e ) {
 			// If we fail to create the session, return an empty array.
 			return [];
@@ -228,6 +231,11 @@ class WC_Payments_Onboarding_Service {
 
 		if ( ! $result || ! $success ) {
 			throw new API_Exception( __( 'Failed to finalize onboarding session.', 'woocommerce-payments' ), 'wcpay-onboarding-finalize-error', 400 );
+		}
+
+		if ( get_transient( 'woopay_enabled_by_default' ) ) {
+			\WC_Payments::get_gateway()->update_is_woopay_enabled( true );
+			delete_transient( 'woopay_enabled_by_default' );
 		}
 
 		// Clear the onboarding in progress option, since the onboarding flow is now complete.


### PR DESCRIPTION
Fixes #9535 

#### Changes proposed in this Pull Request
This PR sets the transient for `woopay_enabled_by_default` for the new onboarding flow.  The new onboarding flow redirects to the onboarding wizard [here](https://github.com/Automattic/woocommerce-payments/blob/3ea6923006374090e82f2df4d8a67e2134159b4f/includes/class-wc-payments-account.php#L1425), so we don't reach the original [init_stripe_onboarding](https://github.com/Automattic/woocommerce-payments/blob/3ea6923006374090e82f2df4d8a67e2134159b4f/includes/class-wc-payments-account.php#L1512) flow to [set the transient](https://github.com/Automattic/woocommerce-payments/blob/3ea6923006374090e82f2df4d8a67e2134159b4f/includes/class-wc-payments-account.php#L1923) for `woopay_enabled_by_default`.


#### Testing instructions
1. Create a new merchant site via JN or locally and do not proxy to the local wcpay-server
2. Go through the WooPayments onboarding
3. Go to WooCommerce ->Settings -> Payments -> WooPayments
4. Should see WooPay is enabled by default

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
