### PR TITLE
Make experiment Payments task onboarding flow treatment final

### DIFF
--- a/changelog/update-9540-payment-task-onboarding-flow
+++ b/changelog/update-9540-payment-task-onboarding-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Payments task onboarding flows skip the Connect page.

--- a/client/overview/task-list/tasks.tsx
+++ b/client/overview/task-list/tasks.tsx
@@ -89,7 +89,9 @@ export const getTasks = ( {
 		! isPoInProgress;
 
 	const isGoLiveTaskVisible =
-		isInTestModeOnboarding( false ) && showGoLiveTask;
+		wcpaySettings.isAccountConnected &&
+		isInTestModeOnboarding( false ) &&
+		showGoLiveTask;
 
 	return [
 		isUpdateDetailsTaskVisible &&

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -767,12 +767,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string Connection URL.
 	 */
 	public function get_connection_url() {
-		$account_data = $this->account->get_cached_account_data();
-
-		// The onboarding is finished if account_id is set. `Set up` will be shown instead of `Connect`.
-		if ( isset( $account_data['account_id'] ) ) {
+		// If we have an account, `Set up` will be shown instead of `Connect`.
+		if ( $this->is_connected() ) {
 			return '';
 		}
+
+		// Note: Payments Task is not a very accurate from value, but it is the best we can do, for now.
 		return html_entity_decode( WC_Payments_Account::get_connect_url( WC_Payments_Onboarding_Service::FROM_WCADMIN_PAYMENTS_TASK ) );
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -958,11 +958,8 @@ class WC_Payments_Account {
 		$from = WC_Payments_Onboarding_Service::get_from();
 
 		// If the user came from the core Payments task list item,
-		// we run an experiment to skip the Connect page
-		// and go directly to the Jetpack connection flow and/or onboarding wizard.
-		if ( WC_Payments_Onboarding_Service::FROM_WCADMIN_PAYMENTS_TASK === $from
-			&& WC_Payments_Utils::is_in_core_payments_task_onboarding_flow_treatment_mode() ) {
-
+		// skip the Connect page and go directly to the Jetpack connection flow and/or onboarding wizard.
+		if ( WC_Payments_Onboarding_Service::FROM_WCADMIN_PAYMENTS_TASK === $from ) {
 			// We use a connect link to allow our logic to determine what comes next:
 			// the Jetpack connection setup and/or onboarding wizard (MOX).
 			$this->redirect_service->redirect_to_wcpay_connect(
@@ -1344,14 +1341,6 @@ class WC_Payments_Account {
 					],
 					true
 				)
-				/**
-				 * We are running an experiment to skip the Connect page for Payments Task flows.
-				 * Only redirect to the Connect page if the user is not in the experiment's treatment mode.
-				 *
-				 * @see self::maybe_redirect_from_connect_page()
-				 */
-				|| ( WC_Payments_Onboarding_Service::FROM_WCADMIN_PAYMENTS_TASK === $from
-					&& ! WC_Payments_Utils::is_in_core_payments_task_onboarding_flow_treatment_mode() )
 				// This is a weird case, but it is best to handle it.
 				|| ( WC_Payments_Onboarding_Service::FROM_ONBOARDING_WIZARD === $from && ! $this->has_working_jetpack_connection() )
 			) {

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -911,25 +911,6 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Check to see if the current user is in Core Payments task onboarding flow experiment treatment mode.
-	 *
-	 * @return bool
-	 */
-	public static function is_in_core_payments_task_onboarding_flow_treatment_mode(): bool {
-		if ( ! isset( $_COOKIE['tk_ai'] ) ) {
-			return false;
-		}
-
-		$abtest = new \WCPay\Experimental_Abtest(
-			sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ),
-			'woocommerce',
-			'yes' === get_option( 'woocommerce_allow_tracking', 'no' )
-		);
-
-		return 'treatment' === $abtest->get_variation( 'woopayments_core_payments_task_onboarding_flow_2024_v1' );
-	}
-
-	/**
 	 * Helper function to check whether to show default new onboarding flow or as an exception disable it (if specific constant is set) .
 	 *
 	 * @return boolean

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -431,7 +431,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 				false,
 				true,
 				false,
-				'connect_page',
+				'start_jetpack_connection',
 			],
 			'From Woo Payments task - Jetpack connection, Stripe not connected' => [
 				WC_Payments_Onboarding_Service::FROM_WCADMIN_PAYMENTS_TASK,
@@ -439,7 +439,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 				true,
 				false,
 				false,
-				'connect_page',
+				'onboarding_wizard',
 			],
 			'From Woo Payments task - Jetpack connection, Stripe connected' => [
 				WC_Payments_Onboarding_Service::FROM_WCADMIN_PAYMENTS_TASK,


### PR DESCRIPTION
Fixes #9540 

#### Changes proposed in this Pull Request

All onboardings originating from the WooCommerce payments task(s) skip the WooPayments Connect page and go directly to the MOX for live account onboarding. If there isn't a site WPCOM/Jetpack connection, go to the WPCOM/Jetpack connection and then redirect to the MOX.

#### Testing instructions - WooCommerce 9.3.x

1. Create a new Jurassic Ninja site with latest WooCommerce and _without_ WooPayments (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce))
1. Go through the WooCommerce core profiler by clicking on the `WooCommerce` main menu item (if it doesn't start automatically), skip it by clicking "Skip guided setup" in the upper right corner, and select 'US' as your store's location
1. Go to `Plugins` and **install** WooPayments from either a locally built zip of this PR's branch or you can download it from here: [woocommerce-payments.zip](https://github.com/user-attachments/files/17309752/woocommerce-payments.zip). Don't activate WooPayments.
1. Go to the `Payments` main menu item and dismiss the incentive by clicking on "No thanks", then on "Just dismiss WooPayments" in the modal.
1. Go to `WooCommerce > Home` and click on the "Get paid with WooPayments" task. 
1. After WooPayments is activated, you  will be redirected to set up your site's WPCOM/Jetpack connection - accept your connection.
1. After you've connected your site to WPCOM you should be redirected straight into the WooPayments MOX:
![Screenshot 2024-10-09 at 17 27 55](https://github.com/user-attachments/assets/50c6e4e7-89b3-43b0-9f93-2f0fb359614a)
1. Exit the MOX by clicking on "Cancel" in the upper right corner
1. Go to `Plugins` and deactivate WooPayments
1. Go to `Plugins > Add new`, search from "stripe" and install and activate the [WooCommerce Stripe Payment Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/) extension 
1. Go to `WooCommerce > Settings > Payments` and click on "Finish setup" for the Stripe payment gateway. Then click on "Create or connect a test account instead" to set up the gateway - finish the Stripe KYC.
1. Go to `WooCommerce > Home` and you should see a "Get paid" task that is completed (striked out).
1. In the "Things to do next" task list you should see a "Set up additional payments options" task. Click on it and you should see the Payments task page with WooPayments at the top.
![Screenshot 2024-10-09 at 17 35 37](https://github.com/user-attachments/assets/da248818-6ff6-4cc7-88c5-cfb9e6b35425)
1. Click on "Get started" and you should see the installation/activation stepper:
![Screenshot 2024-10-09 at 17 36 33](https://github.com/user-attachments/assets/4e79852e-2541-4849-923b-1a400a437295)
1. Click on "Connect" and you should be redirected to the MOX.


#### Testing instructions - WooCommerce trunk

1. Create a new Jurassic Ninja site with just WooCommerce using the latest `trunk` (here is a [direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce=trunk))
1. Go through the WooCommerce core profiler by clicking on the "WooCommerce" main menu item (if it doesn't start automatically) and select 'US' as your store's location
1. Go to `Plugins` and **install** WooPayments from either a locally built zip of this PR's branch or you can download it from here: [woocommerce-payments.zip](https://github.com/user-attachments/files/17309752/woocommerce-payments.zip). Don't activate WooPayments.
1. Go to the `Payments` main menu item and dismiss the incentive by clicking on "No thanks", then on "Just dismiss WooPayments" in the modal.
1. Go to `WooCommerce > Home` and click on the "Get paid with WooPayments" task. 
1. You should see the install/activation stepper
![Screenshot 2024-10-09 at 17 49 24](https://github.com/user-attachments/assets/4279e704-968c-4733-a6a8-2f1ebaa33076)
1. Click on "Connect" and you should be redirected to the WPCOM/Jetpack connection setup flow - accept your connection.
1. After you've connected your site to WPCOM you should be redirected straight into the WooPayments MOX:
![Screenshot 2024-10-09 at 17 27 55](https://github.com/user-attachments/assets/50c6e4e7-89b3-43b0-9f93-2f0fb359614a)
1. Exit the MOX by clicking on "Cancel" in the upper right corner
1. Go to `Plugins` and **deactivate** WooPayments
1. Go to the Payments main menu item and then click on "Get started" for WooPayments:
![Screenshot 2024-10-09 at 17 52 43](https://github.com/user-attachments/assets/3068694a-9e40-47d7-a258-f6d5978fa727)
1. You should see the install/activation stepper
![Screenshot 2024-10-09 at 17 49 24](https://github.com/user-attachments/assets/4279e704-968c-4733-a6a8-2f1ebaa33076)
1. Click on "Connect" and you should be redirected to the MOX.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
