### PR TITLE
npm script to update e2e-pw screenshots / snapshots

### DIFF
--- a/changelog/update-npm-readme-update-e2e-pw-snapshots
+++ b/changelog/update-npm-readme-update-e2e-pw-snapshots
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not user-facing.
+
+

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:e2e-dev": "NODE_CONFIG_DIR='tests/e2e/config' JEST_PUPPETEER_CONFIG='tests/e2e/config/jest-puppeteer.config.js' wp-scripts test-e2e --config tests/e2e/config/jest.config.js --puppeteer-interactive",
     "test:e2e-performance": "NODE_CONFIG_DIR='tests/e2e/config' wp-scripts test-e2e --config tests/e2e/config/jest.performance.config.js",
     "test:e2e-pw": "./tests/e2e-pw/test-e2e-pw.sh",
+    "test:e2e-pw-update-snapshots": "rm -rf tests/e2e-pw/specs/merchant/__snapshots__/ && npm run test:e2e-pw --update-snapshots",
     "test:e2e-pw-ui": "./tests/e2e-pw/test-e2e-pw-ui.sh",
     "test:e2e-pw-ci": "npx playwright test --config=tests/e2e-pw/playwright.config.ts --grep-invert @todo",
     "test:update-snapshots": "npm run test:js -- --updateSnapshot",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:e2e-dev": "NODE_CONFIG_DIR='tests/e2e/config' JEST_PUPPETEER_CONFIG='tests/e2e/config/jest-puppeteer.config.js' wp-scripts test-e2e --config tests/e2e/config/jest.config.js --puppeteer-interactive",
     "test:e2e-performance": "NODE_CONFIG_DIR='tests/e2e/config' wp-scripts test-e2e --config tests/e2e/config/jest.performance.config.js",
     "test:e2e-pw": "./tests/e2e-pw/test-e2e-pw.sh",
-    "test:e2e-pw-update-snapshots": "npm run test:e2e-pw --update-snapshots",
+    "test:e2e-pw-update-snapshots": "npm run test:e2e-pw -- --update-snapshots",
     "test:e2e-pw-ui": "./tests/e2e-pw/test-e2e-pw-ui.sh",
     "test:e2e-pw-ci": "npx playwright test --config=tests/e2e-pw/playwright.config.ts --grep-invert @todo",
     "test:update-snapshots": "npm run test:js -- --updateSnapshot",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:e2e-dev": "NODE_CONFIG_DIR='tests/e2e/config' JEST_PUPPETEER_CONFIG='tests/e2e/config/jest-puppeteer.config.js' wp-scripts test-e2e --config tests/e2e/config/jest.config.js --puppeteer-interactive",
     "test:e2e-performance": "NODE_CONFIG_DIR='tests/e2e/config' wp-scripts test-e2e --config tests/e2e/config/jest.performance.config.js",
     "test:e2e-pw": "./tests/e2e-pw/test-e2e-pw.sh",
-    "test:e2e-pw-update-snapshots": "rm -rf tests/e2e-pw/specs/merchant/__snapshots__/ && npm run test:e2e-pw --update-snapshots",
+    "test:e2e-pw-update-snapshots": "npm run test:e2e-pw --update-snapshots",
     "test:e2e-pw-ui": "./tests/e2e-pw/test-e2e-pw-ui.sh",
     "test:e2e-pw-ci": "npx playwright test --config=tests/e2e-pw/playwright.config.ts --grep-invert @todo",
     "test:update-snapshots": "npm run test:js -- --updateSnapshot",

--- a/tests/e2e-pw/README.md
+++ b/tests/e2e-pw/README.md
@@ -17,7 +17,7 @@ See [tests/e2e/README.md](/tests/e2e/README.md) for detailed e2e environment set
 -   `npm run test:e2e-pw` headless run from within a linux docker container.
 -   `npm run test:e2e-pw-ui` runs tests in interactive UI mode from within a linux docker container – recommended for authoring tests and re-running failed tests.
 -   `npm run test:e2e-pw keyword` runs tests only with a specific keyword in the file name, e.g. `dispute` or `checkout`.
--   `npm run test:e2e-pw --update-snapshots` updates snapshots.
+-   `npm run test:e2e-pw --update-snapshots` updates snapshots but the existing snapshot file needs to be deleted first.
 
 ## FAQs
 

--- a/tests/e2e-pw/README.md
+++ b/tests/e2e-pw/README.md
@@ -17,7 +17,7 @@ See [tests/e2e/README.md](/tests/e2e/README.md) for detailed e2e environment set
 -   `npm run test:e2e-pw` headless run from within a linux docker container.
 -   `npm run test:e2e-pw-ui` runs tests in interactive UI mode from within a linux docker container – recommended for authoring tests and re-running failed tests.
 -   `npm run test:e2e-pw keyword` runs tests only with a specific keyword in the file name, e.g. `dispute` or `checkout`.
--   `npm run test:e2e-pw --update-snapshots` updates snapshots but the existing snapshot file needs to be deleted first.
+-   `npm run test:e2e-pw --update-snapshots` updates snapshots. Make sure you delete the the existing snapshot / screenshot file you want to update before running this command.
 
 ## FAQs
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9596.

#### Changes proposed in this Pull Request

There is already one to update snapshot for unit tests: `npm run test:update-snapshots`.
However, I couldn't find one for Playwright e2e tests, so I added one: `npm run test:e2e-pw-update-snapshots`.

ps: the test fails the screenshot comparison if you make huge UI change (maybe to the point where the screenshot dimension should be different) but if it's just a text change, it passes, which unexpected for me, but it's out of the scope of this PR.

#### Testing instructions

* Try to change a UI in one of the pages tested in one of the Playwright e2e tests, for example, change this [line](https://github.com/Automattic/woocommerce-payments/blob/f0e96e3e1edce9e1421a30282d6db2205e607a8d/client/deposits/filters/config.js#L33) to true. This will show the currency filter which was hidden.
* Build client: `npm run build:client`.
* Run `npm run test:e2e-pw merchant-admin-deposits` which will run this [test](https://github.com/Automattic/woocommerce-payments/blob/f0e96e3e1edce9e1421a30282d6db2205e607a8d/tests/e2e-pw/specs/merchant/merchant-admin-deposits.spec.ts).
* Confirm that the test fails because it sees some differences between the [current screenshot](https://github.com/Automattic/woocommerce-payments/blob/f0e96e3e1edce9e1421a30282d6db2205e607a8d/tests/e2e-pw/specs/merchant/__snapshots__/merchant-admin-deposits.spec.ts/Merchant-deposits-Select-deposits-list-advanced-filters-1.png) and the changed UI.
* Delete [current screenshot](https://github.com/Automattic/woocommerce-payments/blob/f0e96e3e1edce9e1421a30282d6db2205e607a8d/tests/e2e-pw/specs/merchant/__snapshots__/merchant-admin-deposits.spec.ts/Merchant-deposits-Select-deposits-list-advanced-filters-1.png).
* Run `npm run test:e2e-pw-update-snapshots` to update the screenshot. Deleting it first is essential. Otherwise, the screenshot won't get updated. I got the hint from this [comment](https://github.com/microsoft/playwright/issues/19597#issuecomment-1359601841). @Jinksi believes it's a bug though.
* Confirm that a new screenshot with the changed UI is generated.
* Run `npm run test:e2e-pw merchant-admin-deposits` again and confirm it passes this time.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
