### PR TITLE
Fix WooPay auto enable for new accounts

### DIFF
--- a/changelog/fix-9548-woopay-auto-enable
+++ b/changelog/fix-9548-woopay-auto-enable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Auto-enabled WooPay for new accounts.

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -211,9 +211,6 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 			$account_session['locale'] = get_user_locale();
 		}
 
-		// Set the onboarding in progress option.
-		$this->onboarding_service->set_embedded_kyc_in_progress();
-
 		return rest_ensure_response( $account_session );
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1900,7 +1900,8 @@ class WC_Payments_Account {
 
 			// Clean up any existing onboarding state.
 			delete_transient( self::ONBOARDING_STATE_TRANSIENT );
-			delete_option( self::EMBEDDED_KYC_IN_PROGRESS_OPTION );
+			// Clear the embedded KYC in progress option, since the onboarding flow is now complete.
+			$this->onboarding_service->clear_embedded_kyc_in_progress();
 
 			return add_query_arg(
 				[ 'wcpay-connection-success' => '1' ],

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -28,6 +28,7 @@ class WC_Payments_Account {
 	const ONBOARDING_DISABLED_TRANSIENT                         = 'wcpay_on_boarding_disabled';
 	const ONBOARDING_STARTED_TRANSIENT                          = 'wcpay_on_boarding_started';
 	const ONBOARDING_STATE_TRANSIENT                            = 'wcpay_stripe_onboarding_state';
+	const WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT                   = 'woopay_enabled_by_default';
 	const EMBEDDED_KYC_IN_PROGRESS_OPTION                       = 'wcpay_onboarding_embedded_kyc_in_progress';
 	const ERROR_MESSAGE_TRANSIENT                               = 'wcpay_error_message';
 	const INSTANT_DEPOSITS_REMINDER_ACTION                      = 'wcpay_instant_deposit_reminder';
@@ -1607,7 +1608,7 @@ class WC_Payments_Account {
 		delete_transient( self::ONBOARDING_STATE_TRANSIENT );
 		delete_transient( self::ONBOARDING_STARTED_TRANSIENT );
 		delete_option( self::EMBEDDED_KYC_IN_PROGRESS_OPTION );
-		delete_transient( 'woopay_enabled_by_default' );
+		delete_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT );
 
 		// Clear the cache to avoid stale data.
 		$this->clear_cache();
@@ -1909,7 +1910,7 @@ class WC_Payments_Account {
 
 		// We have an account that needs to be verified (has a URL to redirect the merchant to).
 		// Store the relevant onboarding data.
-		set_transient( 'woopay_enabled_by_default', isset( $onboarding_data['woopay_enabled_by_default'] ) ?? false, DAY_IN_SECONDS );
+		set_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT, filter_var( $onboarding_data['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN ), DAY_IN_SECONDS );
 		// Save the onboarding state for a day.
 		// This is used to verify the state when finalizing the onboarding and connecting the account.
 		// On finalizing the onboarding, the transient gets deleted.
@@ -1926,9 +1927,9 @@ class WC_Payments_Account {
 			return;
 		}
 
-		if ( get_transient( 'woopay_enabled_by_default' ) ) {
+		if ( get_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT ) ) {
 			WC_Payments::get_gateway()->update_is_woopay_enabled( true );
-			delete_transient( 'woopay_enabled_by_default' );
+			delete_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT );
 		}
 	}
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -434,7 +434,7 @@ class WC_Payments_Onboarding_Service {
 	 * @return bool True if embedded KYC is in progress, false otherwise.
 	 */
 	public function is_embedded_kyc_in_progress(): bool {
-		return in_array( get_option( WC_Payments_Account::EMBEDDED_KYC_IN_PROGRESS_OPTION, 'no' ), [ 'yes', '1' ], true );
+		return filter_var( get_option( WC_Payments_Account::EMBEDDED_KYC_IN_PROGRESS_OPTION, 'no' ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -193,6 +193,9 @@ class WC_Payments_Onboarding_Service {
 			return [];
 		}
 
+		// Set the embedded KYC in progress flag.
+		$this->set_embedded_kyc_in_progress();
+
 		// Remember if we should enable WooPay by default.
 		set_transient(
 			WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT,

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -160,12 +160,13 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * @return array Session data.
 	 *
-	 * @throws API_Exception
+	 * @throws API_Exception|Exception
 	 */
 	public function create_embedded_kyc_session( array $self_assessment_data, bool $progressive = false ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
 			return [];
 		}
+
 		$setup_mode = WC_Payments::mode()->is_live() ? 'live' : 'test';
 
 		// Make sure the onboarding test mode DB flag is set.
@@ -240,7 +241,7 @@ class WC_Payments_Onboarding_Service {
 			throw new API_Exception( __( 'Failed to finalize onboarding session.', 'woocommerce-payments' ), 'wcpay-onboarding-finalize-error', 400 );
 		}
 
-		// Clear the onboarding in progress option, since the onboarding flow is now complete.
+		// Clear the embedded KYC in progress option, since the onboarding flow is now complete.
 		$this->clear_embedded_kyc_in_progress();
 
 		return [
@@ -332,7 +333,7 @@ class WC_Payments_Onboarding_Service {
 	}
 
 	/**
-	 * Get account data for onboarding from self assestment data.
+	 * Get account data for onboarding from self assessment data.
 	 *
 	 * @param string $setup_mode Setup mode.
 	 * @param array  $self_assessment_data Self assessment data.

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -193,6 +193,13 @@ class WC_Payments_Onboarding_Service {
 			return [];
 		}
 
+		// Remember if we should enable WooPay by default.
+		set_transient(
+			WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT,
+			filter_var( $account_session['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+			DAY_IN_SECONDS
+		);
+
 		return [
 			'clientSecret'   => $account_session['client_secret'] ?? '',
 			'expiresAt'      => $account_session['expires_at'] ?? 0,

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -158,10 +158,6 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 				$kyc_session
 			);
 
-		$this->mock_onboarding_service
-			->expects( $this->once() )
-			->method( 'set_embedded_kyc_in_progress' );
-
 		$request = new WP_REST_Request( 'GET' );
 		$request->set_query_params(
 			[


### PR DESCRIPTION
Fixes #9548 
Fixes #9535 

#### Changes proposed in this Pull Request

WooPay is again auto-enabled for new accounts if our platform instructs us to.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new JN site with WooCommerce, WooPayments using this PR's live branch and WCPay Dev Tools (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce-payments=fix/9548-woopay-auto-enable))
1. Go to `WooCommerce`, skip the profiler and set your store's location to US.
1. Go to `Payments` and make sure you see the top sandbox notice. Click on "Connect your store".
![Screenshot 2024-10-10 at 17 25 57](https://github.com/user-attachments/assets/46fa4420-3937-4fca-9dcc-d041cc0d316c)
1. Connect your site to your WPCOM account, go through the WooPayments MOX, and onboard a new account.
1. Once redirected to `Payments > Overview`, make sure your account's "Payments" status is enabled (at least). 
1. Go to `Payments > Settings `and make sure WooPay is enabled:
![Screenshot 2024-10-10 at 17 31 54](https://github.com/user-attachments/assets/d621df73-fb10-44f7-8cbe-fe697067d7cc)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
