### PR TITLE
Ignore Playwright setup errors for newer runner images

### DIFF
--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
       run : |
         echo "::group::Kill webserver running on port 8084"
-        sudo fuser -k -n tcp 8084
+        sudo fuser -k -n tcp 8084 || true
         echo "::endgroup::"
 
     # Prepare test environment


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

 WooPayments PW E2E tests are  failing due to the Ubuntu 24.04 image change. Particularly this step
```
- name: Kill mono-xsp4.service
      shell: bash
      run : |
        echo "::group::Kill webserver running on port 8084"
        sudo fuser -k -n tcp 8084
        echo "::endgroup::"
```

It looks like Mono is not included anymore, if we compare the list of included software between images: [24](https://github.com/actions/runner-images/blob/ubuntu24/20241006.1/images/ubuntu/Ubuntu2404-Readme.md) vs [22](https://github.com/actions/runner-images/blob/ubuntu22/20241006.1/images/ubuntu/Ubuntu2204-Readme.md)

#### Testing instructions

* Run PW E2E tests using this branch, they should pass. Verify that the runner image is set to 
```
Image: ubuntu-24.04
Version: 20241006.1.0
```

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
