### PR TITLE
Fix WooPay user registration in classic checkout

### DIFF
--- a/changelog/fix-woopay-user-creation-in-shortcode-checkout
+++ b/changelog/fix-woopay-user-creation-in-shortcode-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooPay user registration via classic checkout

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -125,7 +125,10 @@ class WooPay_Utilities {
 			$session_data = WC()->session->get( WooPay_Session::WOOPAY_SESSION_KEY );
 		}
 
-		return ( isset( $_POST['save_user_in_woopay'] ) && filter_var( wp_unslash( $_POST['save_user_in_woopay'] ), FILTER_VALIDATE_BOOLEAN ) ) || ( isset( $session_data['save_user_in_woopay'] ) && filter_var( $session_data['save_user_in_woopay'], FILTER_VALIDATE_BOOLEAN ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		$save_user_in_woopay_post    = isset( $_POST['save_user_in_woopay'] ) && filter_var( wp_unslash( $_POST['save_user_in_woopay'] ), FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.Security.NonceVerification
+		$save_user_in_woopay_session = isset( $session_data['save_user_in_woopay'] ) && filter_var( $session_data['save_user_in_woopay'], FILTER_VALIDATE_BOOLEAN );
+
+		return $save_user_in_woopay_post || $save_user_in_woopay_session;
 	}
 
 	/**
@@ -170,7 +173,9 @@ class WooPay_Utilities {
 	public function get_woopay_phone() {
 		$session_data = WC()->session->get( WooPay_Session::WOOPAY_SESSION_KEY );
 
-		if ( ! empty( $session_data['woopay_user_phone_field']['full'] ) ) {
+		if ( ! empty( $_POST['woopay_user_phone_field']['full'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return wc_clean( wp_unslash( $_POST['woopay_user_phone_field']['full'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( ! empty( $session_data['woopay_user_phone_field']['full'] ) ) {
 			return $session_data['woopay_user_phone_field']['full'];
 		}
 
@@ -185,7 +190,9 @@ class WooPay_Utilities {
 	public function get_woopay_source_url() {
 		$session_data = WC()->session->get( WooPay_Session::WOOPAY_SESSION_KEY );
 
-		if ( ! empty( $session_data['woopay_source_url'] ) ) {
+		if ( ! empty( $_POST['woopay_source_url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return wc_clean( wp_unslash( $_POST['woopay_source_url'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( ! empty( $session_data['woopay_source_url'] ) ) {
 			return $session_data['woopay_source_url'];
 		}
 
@@ -200,7 +207,10 @@ class WooPay_Utilities {
 	public function get_woopay_is_blocks() {
 		$session_data = WC()->session->get( WooPay_Session::WOOPAY_SESSION_KEY );
 
-		return isset( $session_data['woopay_is_blocks'] ) && filter_var( $session_data['woopay_is_blocks'], FILTER_VALIDATE_BOOLEAN );
+		$woopay_is_blocks_post    = isset( $_POST['woopay_is_blocks'] ) && filter_var( wp_unslash( $_POST['woopay_is_blocks'] ), FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.Security.NonceVerification
+		$woopay_is_blocks_session = isset( $session_data['woopay_is_blocks'] ) && filter_var( $session_data['woopay_is_blocks'], FILTER_VALIDATE_BOOLEAN );
+
+		return $woopay_is_blocks_post || $woopay_is_blocks_session;
 	}
 
 	/**
@@ -211,7 +221,9 @@ class WooPay_Utilities {
 	public function get_woopay_viewport() {
 		$session_data = WC()->session->get( WooPay_Session::WOOPAY_SESSION_KEY );
 
-		if ( ! empty( $session_data['woopay_viewport'] ) ) {
+		if ( ! empty( $_POST['woopay_viewport'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return wc_clean( wp_unslash( $_POST['woopay_viewport'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( ! empty( $session_data['woopay_viewport'] ) ) {
 			return $session_data['woopay_viewport'];
 		}
 

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -125,7 +125,7 @@ class WooPay_Utilities {
 			$session_data = WC()->session->get( WooPay_Session::WOOPAY_SESSION_KEY );
 		}
 
-		return isset( $session_data['save_user_in_woopay'] ) && filter_var( $session_data['save_user_in_woopay'], FILTER_VALIDATE_BOOLEAN );
+		return ( isset( $_POST['save_user_in_woopay'] ) && filter_var( wp_unslash( $_POST['save_user_in_woopay'] ), FILTER_VALIDATE_BOOLEAN ) ) || ( isset( $session_data['save_user_in_woopay'] ) && filter_var( $session_data['save_user_in_woopay'], FILTER_VALIDATE_BOOLEAN ) ); // phpcs:ignore WordPress.Security.NonceVerification
 	}
 
 	/**

--- a/tests/unit/woopay/test-class-woopay-utilities.php
+++ b/tests/unit/woopay/test-class-woopay-utilities.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\WooPay\WooPay_Utilities;
+use WCPay\WooPay\WooPay_Session;
 
 /**
  * WooPay_Utilities unit tests.
@@ -178,27 +179,16 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test should_save_platform_customer.
+	 * WooPay user is saved to platform on classic checkout.
 	 *
 	 * @return void
 	 */
-	public function test_should_save_platform_customer() {
+	public function test_should_save_platform_customer_in_classic_checkout() {
 		$woopay_utilities = new WooPay_Utilities();
 
-		// Test with POST data set to save user in WooPay.
 		$_POST['save_user_in_woopay'] = 'true';
 		$this->assertTrue( $woopay_utilities->should_save_platform_customer() );
 		unset( $_POST['save_user_in_woopay'] );
-
-		// Test with session data set to save user in WooPay.
-		WC()->session = $this->createMock( 'WC_Session_Handler' );
-		WC()->session->method( 'has_session' )->willReturn( true );
-		WC()->session->method( 'get' )->with( WooPay_Session::WOOPAY_SESSION_KEY )->willReturn( [ 'save_user_in_woopay' => true ] );
-		$this->assertTrue( $woopay_utilities->should_save_platform_customer() );
-
-		// Test with neither POST nor session data set.
-		WC()->session->method( 'get' )->with( WooPay_Session::WOOPAY_SESSION_KEY )->willReturn( [] );
-		$this->assertFalse( $woopay_utilities->should_save_platform_customer() );
 	}
 
 	private function clean_up_should_enable_woopay_tests() {

--- a/tests/unit/woopay/test-class-woopay-utilities.php
+++ b/tests/unit/woopay/test-class-woopay-utilities.php
@@ -177,6 +177,30 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 		$this->clean_up_should_enable_woopay_tests();
 	}
 
+	/**
+	 * Test should_save_platform_customer.
+	 *
+	 * @return void
+	 */
+	public function test_should_save_platform_customer() {
+		$woopay_utilities = new WooPay_Utilities();
+
+		// Test with POST data set to save user in WooPay.
+		$_POST['save_user_in_woopay'] = 'true';
+		$this->assertTrue( $woopay_utilities->should_save_platform_customer() );
+		unset( $_POST['save_user_in_woopay'] );
+
+		// Test with session data set to save user in WooPay.
+		WC()->session = $this->createMock( 'WC_Session_Handler' );
+		WC()->session->method( 'has_session' )->willReturn( true );
+		WC()->session->method( 'get' )->with( WooPay_Session::WOOPAY_SESSION_KEY )->willReturn( [ 'save_user_in_woopay' => true ] );
+		$this->assertTrue( $woopay_utilities->should_save_platform_customer() );
+
+		// Test with neither POST nor session data set.
+		WC()->session->method( 'get' )->with( WooPay_Session::WOOPAY_SESSION_KEY )->willReturn( [] );
+		$this->assertFalse( $woopay_utilities->should_save_platform_customer() );
+	}
+
 	private function clean_up_should_enable_woopay_tests() {
 		remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 0 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9552

#### Changes proposed in this Pull Request
This re-introduces a check that was removed in https://github.com/Automattic/woocommerce-payments/pull/9464 to fix WooPay user registration when registering through the "Save my info" checkbox in the classic checkout page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test classic checkout**
1. Add a product to the cart.
2. Go to classic checkout page.
3. Enter a WooPay unregistered email address.
4. Check the "Securely save my information for 1-click checkout" checkbox.
5. Place the order.
6. Go to WooPay admin area.
7. Visit WooPay login page (`woopay.test/account/login`)
8. You should be able to login with the email used in step 2.

**(Regression) Test Blocks checkout**
Repeat the above tests, but in step 2, use blocks checkout.
 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
