### PR TITLE
Update Playwright README with correct instructions for updating snapshots

### DIFF
--- a/changelog/fix-9562-readme-correction-playwright-update-snapshots
+++ b/changelog/fix-9562-readme-correction-playwright-update-snapshots
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update Playwright README with correct instructions for updating snapshots – not user-facing.
+
+

--- a/tests/e2e-pw/README.md
+++ b/tests/e2e-pw/README.md
@@ -17,7 +17,7 @@ See [tests/e2e/README.md](/tests/e2e/README.md) for detailed e2e environment set
 -   `npm run test:e2e-pw` headless run from within a linux docker container.
 -   `npm run test:e2e-pw-ui` runs tests in interactive UI mode from within a linux docker container – recommended for authoring tests and re-running failed tests.
 -   `npm run test:e2e-pw keyword` runs tests only with a specific keyword in the file name, e.g. `dispute` or `checkout`.
--   `npm run test:e2e-pw --update-snapshots` updates snapshots.
+-   `npm run test:e2e-pw -- --update-snapshots` updates snapshots. This can be combined with a keyword to update a specific set of snapshots, e.g. `npm run test:e2e-pw -- --update-snapshots deposits`.
 
 ## FAQs
 


### PR DESCRIPTION
Fixes #9562

#### Changes proposed in this Pull Request
This PR updates the Playwright README file to correct the instructions for updating visual comparison snapshots. This correction includes placing `--` before `--update-snapshots` when running `npm run test:e2e-pw` to ensure that the arg is passed through to the playwright command.


```diff
--   `npm run test:e2e-pw --update-snapshots` updates snapshots.
+-   `npm run test:e2e-pw -- --update-snapshots` updates snapshots. This can be combined with a keyword to update a specific set of snapshots, e.g. `npm run test:e2e-pw -- --update-snapshots deposits`.
```

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure your local e2e dev env is running (`npm run test:e2e-setup`)
* Make a significant change to the merchant admin deposits test so that the visual comparison snapshot fails
	* In [tests/e2e-pw/specs/merchant/merchant-admin-deposits.spec.ts > Select deposits list advanced filters](https://github.com/Automattic/woocommerce-payments/blob/e93d699e837560aa07deb4db61c97dac2e8e6b42/tests/e2e-pw/specs/merchant/merchant-admin-deposits.spec.ts#L28), remove the bulk of the test steps so that the advanced filters are not active
		* <img width="400" alt="image" src="https://github.com/user-attachments/assets/69af3aa8-d9eb-492f-868b-e81a0fcedee8">
	* Run `npm run test:e2e-pw deposits` – this should fail due to a failed visual snapshot comparison 🔴
* Run the command `npm run test:e2e-pw --update-snapshots deposits` and notice that the snapshot is not regenerated and the command fails 🔴
	* Snapshot file found in `tests/e2e-pw/specs/merchant/__snapshots__/merchant-admin-deposits.spec.ts/`
* Run the correct command `npm run test:e2e-pw -- --update-snapshots deposits` and notice that the snapshot is regenerated and the command passes 🟢 
* Ensure that the update to the README in this PR accurately reflects the correct procedure.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A**
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
