### PR TITLE
Payouts:  Rename 'deposit' to 'payout' in transaction details timeline

### DIFF
--- a/changelog/update-9564-transaction-timeline-deposit-to-payout-rename
+++ b/changelog/update-9564-transaction-timeline-deposit-to-payout-rename
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Part of a larger change to change 'deposit' to 'payout'. This PR specificially changes it for the transaction details timeline.
+
+

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -54,14 +54,14 @@ const getStatusChangeTimelineItem = ( event, status ) => {
 };
 
 /**
- * Creates a timeline item about a deposit
+ * Creates a timeline item about a payout
  *
- * @param {Object} event An event affecting the deposit
+ * @param {Object} event An event affecting the payout
  * @param {string} formattedAmount Formatted amount string
  * @param {boolean} isPositive Whether the amount will be added or deducted
  * @param {Array} body Any extra subitems that should be included as item body
  *
- * @return {Object} Deposit timeline item
+ * @return {Object} Payout timeline item
  */
 const getDepositTimelineItem = (
 	event,
@@ -73,14 +73,14 @@ const getDepositTimelineItem = (
 	if ( event.deposit ) {
 		headline = sprintf(
 			isPositive
-				? // translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
+				? // translators: %1$s - formatted amount, %2$s - payout arrival date, <a> - link to the payout
 				  __(
-						'%1$s was added to your <a>%2$s deposit</a>.',
+						'%1$s was added to your <a>%2$s payout</a>.',
 						'woocommerce-payments'
 				  )
-				: // translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
+				: // translators: %1$s - formatted amount, %2$s - payout arrival date, <a> - link to the payout
 				  __(
-						'%1$s was deducted from your <a>%2$s deposit</a>.',
+						'%1$s was deducted from your <a>%2$s payout</a>.',
 						'woocommerce-payments'
 				  ),
 			formattedAmount,
@@ -104,12 +104,12 @@ const getDepositTimelineItem = (
 			isPositive
 				? // translators: %s - formatted amount
 				  __(
-						'%s will be added to a future deposit.',
+						'%s will be added to a future payout.',
 						'woocommerce-payments'
 				  )
 				: // translators: %s - formatted amount
 				  __(
-						'%s will be deducted from a future deposit.',
+						'%s will be deducted from a future payout.',
 						'woocommerce-payments'
 				  ),
 			formattedAmount
@@ -127,19 +127,19 @@ const getDepositTimelineItem = (
 /**
  * Creates a timeline item about a financing paydown
  *
- * @param {Object} event An event affecting the deposit
+ * @param {Object} event An event affecting the payout
  * @param {string} formattedAmount Formatted amount string
  * @param {Array} body Any extra subitems that should be included as item body
  *
- * @return {Object} Deposit timeline item
+ * @return {Object} Payout timeline item
  */
 const getFinancingPaydownTimelineItem = ( event, formattedAmount, body ) => {
 	let headline = '';
 	if ( event.deposit ) {
 		headline = sprintf(
-			// translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
+			// translators: %1$s - formatted amount, %2$s - payout arrival date, <a> - link to the payout
 			__(
-				'%1$s was subtracted from your <a>%2$s deposit</a>.',
+				'%1$s was subtracted from your <a>%2$s payout</a>.',
 				'woocommerce-payments'
 			),
 			formattedAmount,
@@ -162,7 +162,7 @@ const getFinancingPaydownTimelineItem = ( event, formattedAmount, body ) => {
 	} else {
 		headline = sprintf(
 			__(
-				'%s will be subtracted from a future deposit.',
+				'%s will be subtracted from a future payout.',
 				'woocommerce-payments'
 			),
 			formattedAmount
@@ -245,7 +245,7 @@ const formatNetString = ( event ) => {
 export const composeNetString = ( event ) => {
 	return sprintf(
 		/* translators: %s is a monetary amount */
-		__( 'Net deposit: %s', 'woocommerce-payments' ),
+		__( 'Net payout: %s', 'woocommerce-payments' ),
 		formatNetString( event )
 	);
 };

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -183,7 +183,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                           data-link-type="wc-admin"
                           href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
                         >
-                          Apr 5, 2020 deposit
+                          Apr 5, 2020 payout
                         </a>
                         .
                       </span>
@@ -309,7 +309,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                         </g>
                       </svg>
                       <span>
-                        $100.00 will be deducted from a future deposit.
+                        $100.00 will be deducted from a future payout.
                       </span>
                     </div>
                     <span
@@ -441,7 +441,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                         </g>
                       </svg>
                       <span>
-                        $50.00 will be deducted from a future deposit.
+                        $50.00 will be deducted from a future payout.
                       </span>
                     </div>
                     <span
@@ -663,7 +663,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                         </g>
                       </svg>
                       <span>
-                        $110.00 will be deducted from a future deposit.
+                        $110.00 will be deducted from a future payout.
                       </span>
                     </div>
                     <span
@@ -793,7 +793,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                           data-link-type="wc-admin"
                           href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
                         >
-                          Apr 2, 2020 deposit
+                          Apr 2, 2020 payout
                         </a>
                         .
                       </span>
@@ -852,7 +852,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                     </span>
                     <span />
                     <span>
-                      Net deposit: $59.50
+                      Net payout: $59.50
                     </span>
                   </div>
                 </li>
@@ -1441,7 +1441,7 @@ exports[`PaymentDetailsTimeline renders subscription fee correctly 1`] = `
                         </g>
                       </svg>
                       <span>
-                        $0.66 will be added to a future deposit.
+                        $0.66 will be added to a future payout.
                       </span>
                     </div>
                     <span
@@ -1511,7 +1511,7 @@ exports[`PaymentDetailsTimeline renders subscription fee correctly 1`] = `
                       </ul>
                     </span>
                     <span>
-                      Net deposit: $0.66
+                      Net payout: $0.66
                     </span>
                   </div>
                 </li>

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -16,7 +16,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events with fe
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -27,7 +27,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events with fe
       "1.00 EUR → 1.19944 USD: $21.59 USD",
       "Fee (2.9% + $0.30): -$0.62",
       undefined,
-      "Net deposit: $20.97 USD",
+      "Net payout: $20.97 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of €18.00 EUR was successfully charged.",
@@ -54,7 +54,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events without
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -65,7 +65,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events without
       "1.00 EUR → 1.19944 USD: $21.59 USD",
       "Fee: €0.52",
       undefined,
-      "Net deposit: $20.97 USD",
+      "Net payout: $20.97 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of €18.00 EUR was successfully charged.",
@@ -91,7 +91,7 @@ exports[`mapTimelineEvents Multi-Currency events formats dispute_needs_response 
       "Fee: $15.00",
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "$36.60 USD will be deducted from a future deposit.",
+    "headline": "$36.60 USD will be deducted from a future payout.",
     "icon": <MinusIcon />,
   },
   {
@@ -124,7 +124,7 @@ exports[`mapTimelineEvents Multi-Currency events formats dispute_won events 1`] 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
-        Apr 5, 2020 deposit
+        Apr 5, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -152,7 +152,7 @@ exports[`mapTimelineEvents Multi-Currency events formats full_refund events 1`] 
   {
     "body": [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "21,64 $ USD will be deducted from a future deposit.",
+    "headline": "21,64 $ USD will be deducted from a future payout.",
     "icon": <MinusIcon />,
   },
   {
@@ -180,7 +180,7 @@ exports[`mapTimelineEvents Multi-Currency events formats partial_refund events 1
   {
     "body": [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "6,00 $ USD will be deducted from a future deposit.",
+    "headline": "6,00 $ USD will be deducted from a future payout.",
     "icon": <MinusIcon />,
   },
   {
@@ -376,7 +376,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -414,7 +414,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
         </li>
          
       </ul>,
-      "Net deposit: $59.50 USD",
+      "Net payout: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -441,7 +441,7 @@ exports[`mapTimelineEvents single currency events formats captured events with j
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -452,7 +452,7 @@ exports[`mapTimelineEvents single currency events formats captured events with j
       undefined,
       "Base fee (1.95% + $0.15): -$3.50",
       undefined,
-      "Net deposit: $59.50 USD",
+      "Net payout: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -479,7 +479,7 @@ exports[`mapTimelineEvents single currency events formats captured events withou
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -490,7 +490,7 @@ exports[`mapTimelineEvents single currency events formats captured events withou
       undefined,
       "Fee: $3.50",
       undefined,
-      "Net deposit: $59.50 USD",
+      "Net payout: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -535,7 +535,7 @@ exports[`mapTimelineEvents single currency events formats dispute_needs_response
       "Fee: $15.00",
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "$110.00 USD will be deducted from a future deposit.",
+    "headline": "$110.00 USD will be deducted from a future payout.",
     "icon": <MinusIcon />,
   },
   {
@@ -568,7 +568,7 @@ exports[`mapTimelineEvents single currency events formats dispute_won events 1`]
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
-        Apr 5, 2020 deposit
+        Apr 5, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -599,7 +599,7 @@ exports[`mapTimelineEvents single currency events formats financing paydown even
       </React.Fragment>,
     ],
     "date": 2022-02-01T12:04:04.000Z,
-    "headline": "$110.00 will be subtracted from a future deposit.",
+    "headline": "$110.00 will be subtracted from a future payout.",
     "icon": <MinusIcon />,
   },
 ]
@@ -616,7 +616,7 @@ exports[`mapTimelineEvents single currency events formats full_refund events 1`]
   {
     "body": [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "$100.00 USD will be deducted from a future deposit.",
+    "headline": "$100.00 USD will be deducted from a future payout.",
     "icon": <MinusIcon />,
   },
   {
@@ -644,7 +644,7 @@ exports[`mapTimelineEvents single currency events formats partial_refund events 
   {
     "body": [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "$50.00 USD will be deducted from a future deposit.",
+    "headline": "$50.00 USD will be deducted from a future payout.",
     "icon": <MinusIcon />,
   },
   {
@@ -677,7 +677,7 @@ exports[`mapTimelineEvents single currency events in person payments - tap to pa
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -699,7 +699,7 @@ exports[`mapTimelineEvents single currency events in person payments - tap to pa
         </li>
          
       </ul>,
-      "Net deposit: $19.19 USD",
+      "Net payout: $19.19 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $19.80 USD was successfully charged.",
@@ -726,7 +726,7 @@ exports[`mapTimelineEvents single currency events should not render fee breakup 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
-        Apr 2, 2020 deposit
+        Apr 2, 2020 payout
       </Link>
       .
     </React.Fragment>,
@@ -737,7 +737,7 @@ exports[`mapTimelineEvents single currency events should not render fee breakup 
       undefined,
       "Fee (1.95% + $0.15): -$3.50",
       undefined,
-      "Net deposit: $59.50 USD",
+      "Net payout: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",

--- a/includes/class-wc-payments-captured-event-note.php
+++ b/includes/class-wc-payments-captured-event-note.php
@@ -194,7 +194,7 @@ class WC_Payments_Captured_Event_Note {
 		// Format and return the net string.
 		return sprintf(
 			/* translators: %s is a monetary amount */
-			__( 'Net deposit: %s', 'woocommerce-payments' ),
+			__( 'Net payout: %s', 'woocommerce-payments' ),
 			WC_Payments_Utils::format_explicit_currency( $net, $currency )
 		);
 	}

--- a/tests/fixtures/captured-payments/discount.json
+++ b/tests/fixtures/captured-payments/discount.json
@@ -67,6 +67,6 @@
         "fixed": "Fixed fee: -$0.30"
       }
     },
-    "netString": "Net deposit: $105.48 USD"
+    "netString": "Net payout: $105.48 USD"
   }
 }

--- a/tests/fixtures/captured-payments/foreign-card.json
+++ b/tests/fixtures/captured-payments/foreign-card.json
@@ -55,6 +55,6 @@
       "additional-international": "International card fee: 1%",
       "additional-fx": "Foreign exchange fee: 1%"
     },
-    "netString": "Net deposit: $95.47 USD"
+    "netString": "Net payout: $95.47 USD"
   }
 }

--- a/tests/fixtures/captured-payments/fx-decimal.json
+++ b/tests/fixtures/captured-payments/fx-decimal.json
@@ -47,6 +47,6 @@
       "base": "Base fee: 2.9% + $0.30",
       "additional-fx": "Foreign exchange fee: 1%"
     },
-    "netString": "Net deposit: $100.65 USD"
+    "netString": "Net payout: $100.65 USD"
   }
 }

--- a/tests/fixtures/captured-payments/fx-foreign-card.json
+++ b/tests/fixtures/captured-payments/fx-foreign-card.json
@@ -47,6 +47,6 @@
       "base": "Base fee: 2.9% + $0.30",
       "additional-international": "International card fee: 1%"
     },
-    "netString": "Net deposit: $96.80 USD"
+    "netString": "Net payout: $96.80 USD"
   }
 }

--- a/tests/fixtures/captured-payments/fx-partial-capture.json
+++ b/tests/fixtures/captured-payments/fx-partial-capture.json
@@ -64,6 +64,6 @@
         "fixed": "Fixed fee: -$0.03"
       }
     },
-    "netString": "Net deposit: $16.79 USD"
+    "netString": "Net payout: $16.79 USD"
   }
 }

--- a/tests/fixtures/captured-payments/fx-with-capped-fee.json
+++ b/tests/fixtures/captured-payments/fx-with-capped-fee.json
@@ -57,6 +57,6 @@
       "additional-international": "International card fee: 1.5%",
       "additional-fx": "Foreign exchange fee: 1%"
     },
-    "netString": "Net deposit: $971.04 USD"
+    "netString": "Net payout: $971.04 USD"
   }
 }

--- a/tests/fixtures/captured-payments/fx.json
+++ b/tests/fixtures/captured-payments/fx.json
@@ -48,6 +48,6 @@
       "base": "Base fee: 2.9% + $0.30",
       "additional-fx": "Foreign exchange fee: 1%"
     },
-    "netString": "Net deposit: $95.84 USD"
+    "netString": "Net payout: $95.84 USD"
   }
 }

--- a/tests/fixtures/captured-payments/jpy-payment.json
+++ b/tests/fixtures/captured-payments/jpy-payment.json
@@ -59,6 +59,6 @@
 			"additional-international": "International card fee: 2%",
 			"additional-fx": "Foreign exchange fee: 2%"
 		},
-		"netString": "Net deposit: ¥4,507 JPY"
+		"netString": "Net payout: ¥4,507 JPY"
 	}
 }

--- a/tests/fixtures/captured-payments/only-base-fee.json
+++ b/tests/fixtures/captured-payments/only-base-fee.json
@@ -35,6 +35,6 @@
   },
   "expectation": {
     "feeString": "Base fee (2.9% + $0.30): -$0.74",
-    "netString": "Net deposit: $14.26 USD"
+    "netString": "Net payout: $14.26 USD"
   }
 }

--- a/tests/fixtures/captured-payments/partial-capture.json
+++ b/tests/fixtures/captured-payments/partial-capture.json
@@ -38,6 +38,6 @@
   },
   "expectation": {
     "feeString": "Base fee (2.9% + $0.30): -$0.82",
-    "netString": "Net deposit: $17.18 USD"
+    "netString": "Net payout: $17.18 USD"
   }
 }

--- a/tests/fixtures/captured-payments/subscription.json
+++ b/tests/fixtures/captured-payments/subscription.json
@@ -56,6 +56,6 @@
       "additional-fx": "Foreign exchange fee: 1%",
       "additional-wcpay-subscription": "Subscription transaction fee: 1%"
     },
-    "netString": "Net deposit: $52.87 USD"
+    "netString": "Net payout: $52.87 USD"
   }
 }


### PR DESCRIPTION
Fixes #9564 

#### Changes proposed in this Pull Request

The PR renames `deposit` to `payout` in the Timeline box messages that appear in the Transaction details page. 

#### Testing instructions

* Checkout this branch and rebuild assets
* Make sure your site has a few transactions including a refund transaction
* Browse to `Payments > Transactions` and click various transactions including the refund transaction
* Note that in all messages within the `Timeline` card, you should see `payout` instead of `deposit` 

#### Screenshots

![image](https://github.com/user-attachments/assets/3ac7c0ac-de79-4853-8d4e-639479fd3256)

--------

![image](https://github.com/user-attachments/assets/27b373c7-991e-4324-a359-158a8d19dba9)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
