### PR TITLE
Prevent payment method deletion in local environment when using Stripe production account

### DIFF
--- a/changelog/fix-5384-prevent-pm-detach-on-prod-when-user-is-deleted-on-localhost
+++ b/changelog/fix-5384-prevent-pm-detach-on-prod-when-user-is-deleted-on-localhost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevented detaching payment methods from live Stripe accounts when working in non-production environments.


### PR DESCRIPTION
Fixes #5384 

#### Changes proposed in this Pull Request

This PR introduces a safeguard for scenarios where, for example, you clone a production environment or a live version of a WordPress site to your local environment for testing. In such cases, there is a potential risk of deleting a customer or payment method locally, which could trigger the detachment of the payment method from the live Stripe account.

To prevent this, this PR adds a check that ensures the payment method will not be detached if:
- The user is on the admin page
- A live or production Stripe account is being used
- The WordPress environment is not set to production

This means that if you delete a customer or payment method locally from the admin page using a live Stripe account, this safeguard will prevent it from affecting the live environment.

This update is particularly useful for developers testing live versions of their websites locally, helping them avoid unintended issues with attached payment methods.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the reproduction steps outlined in the linked issue, but in the final step, ensure the payment method is not detached. This PR introduces checks across various environments and test settings, so feel free to explore different configurations. For example, you can hardcode the `WC_Payments::mode()->is_live()` function to return specific values for testing. Additionally, you can modify the `WP_ENVIRONMENT_TYPE` constant to simulate different environments as needed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
