### PR TITLE
chore: remove methods deprecated in 5.6.0

### DIFF
--- a/changelog/chore-remove-woopayments-dev-test-mode-calls
+++ b/changelog/chore-remove-woopayments-dev-test-mode-calls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+chore: remove deprecated is_in_dev_mode() and is_in_test_mode() methods

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4507,34 +4507,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return $this->duplicate_payment_methods_detection_service->find_duplicates();
 	}
 
-	// Start: Deprecated functions.
-
-	/**
-	 * Check the defined constant to determine the current plugin mode.
-	 *
-	 * @deprecated 5.6.0
-	 *
-	 * @return bool
-	 */
-	public function is_in_dev_mode() {
-		wc_deprecated_function( __FUNCTION__, '5.6.0', 'WC_Payments::mode()->is_dev()' );
-		return WC_Payments::mode()->is_dev();
-	}
-
-	/**
-	 * Returns whether test_mode or dev_mode is active for the gateway
-	 *
-	 * @deprecated 5.6.0
-	 *
-	 * @return boolean Test mode enabled if true, disabled if false
-	 */
-	public function is_in_test_mode() {
-		wc_deprecated_function( __FUNCTION__, '5.6.0', 'WC_Payments::mode()->is_test()' );
-		return WC_Payments::mode()->is_test();
-	}
-
-	// End: Deprecated functions.
-
 	/**
 	 * Determine whether redirection is needed for the non-card UPE payment method.
 	 *

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -3445,41 +3445,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * @expectedDeprecated is_in_dev_mode
-	 */
-	public function test_is_in_dev_mode() {
-		$mode = WC_Payments::mode();
-
-		$mode->dev();
-		$this->assertTrue( $this->card_gateway->is_in_dev_mode() );
-
-		$mode->live_mode_onboarding();
-		$this->assertFalse( $this->card_gateway->is_in_dev_mode() );
-
-		$mode->live();
-		$this->assertFalse( $this->card_gateway->is_in_dev_mode() );
-	}
-
-	/**
-	 * @expectedDeprecated is_in_test_mode
-	 */
-	public function test_is_in_test_mode() {
-		$mode = WC_Payments::mode();
-
-		$mode->dev();
-		$this->assertTrue( $this->card_gateway->is_in_test_mode() );
-
-		$mode->test_mode_onboarding();
-		$this->assertTrue( $this->card_gateway->is_in_test_mode() );
-
-		$mode->test();
-		$this->assertTrue( $this->card_gateway->is_in_test_mode() );
-
-		$mode->live();
-		$this->assertFalse( $this->card_gateway->is_in_test_mode() );
-	}
-
-	/**
 	 * Create a partial mock for WC_Payment_Gateway_WCPay class.
 	 *
 	 * @param array $methods                 Method names that need to be mocked.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Removing old deprecated functions.
These functions were marked as deprecated in 5.6.0, which was released in March 2023: https://github.com/Automattic/woocommerce-payments/releases/tag/5.6.0
I am also removing them from TumblrPay: D163963-code

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are no calls to these methods in the codebase.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.