### PR TITLE
Fix E2E tests by disabling AppArmor restrictions

### DIFF
--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -76,3 +76,11 @@ runs:
         echo "::group::Setup E2E test environment"
         npm run test:e2e-setup
         echo "::endgroup::"
+
+    # Disable restrictions that prevent chromium from running properly. See: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+    - name: Disable AppArmor User Namespace Restrictions
+      shell: bash
+      run: |
+        echo "::group::Disable AppArmor User Namespace Restrictions"
+        sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
+        echo "::endgroup::"


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

The recent switch to Ubuntu 24 as the default runner image also broke the E2E tests, particularly when we try to run Chromium. Here's [the error](https://github.com/Automattic/woocommerce-payments/actions/runs/11365266818/job/31613077082) we get: 

```
Error: Jest: Got error running globalSetup - /home/runner/work/woocommerce-payments/woocommerce-payments/node_modules/jest-environment-puppeteer/setup.js, reason: Failed to launch the browser process!
[14172:14172:1016/121230.110584:FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

This is a known issue with Ubuntu 23+, and here's documentation about it: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E tests run manually for this branch don't fail when trying to run Chromium.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
