### PR TITLE
Use official `phpmyadmin` Docker Hub container image

### DIFF
--- a/changelog/dev-use-official-docker-hub-phpmyadmin-image
+++ b/changelog/dev-use-official-docker-hub-phpmyadmin-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use official `phpmyadmin` Docker Hub container image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - ./docker/data:/var/lib/mysql
   phpMyAdmin:
     container_name: woocommerce_payments_phpmyadmin
-    image: phpmyadmin/phpmyadmin:latest
+    image: phpmyadmin:latest
     ports:
       - "8083:80"
     env_file:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

 - [`phpmyadmin`](https://hub.docker.com/_/phpmyadmin) is now part of the official Docker Hub repository and should be used instead of [`phpmyadmin/phpmyadmin`](https://hub.docker.com/r/phpmyadmin/phpmyadmin). Moreover, architectures like arm64 are not available for the latter.

#### Testing instructions

 - Rebuild local setup with `npm run up`
 - PHPMyAdmin should be available on the port 8083

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
