### PR TITLE
Darken the color of links within click tooltips to improve color contrast and readability

### DIFF
--- a/changelog/fix-9559-tooltip-link-color-contrast
+++ b/changelog/fix-9559-tooltip-link-color-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the color of links within tooltips to improve color contrast and improve readability.

--- a/changelog/fix-9559-tooltip-link-color-contrast
+++ b/changelog/fix-9559-tooltip-link-color-contrast
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix the color of links within tooltips to improve color contrast and improve readability.
+Fix the color contrast of links within tooltips to improve readability.

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -50,11 +50,13 @@
 	&__tooltip {
 		position: relative;
 
+		// Default tooltip styles have a dark background and light text.
 		color: $white;
 		background-color: $gray-900;
 		padding: 10px;
 		text-align: center;
 
+		// Links inside default tooltips should have a light color against the dark background.
 		a {
 			color: var( --wp-admin-theme-color-background-25, $wp-blue-5 );
 			text-decoration: underline;
@@ -72,15 +74,20 @@
 		}
 
 		&__tooltip {
-			// Specific styles for the click tooltip variant.
+			// Click tooltips have a light background and dark text.
 			position: relative;
 			padding: 12px;
 			color: $gray-900;
 			text-align: left;
 			border-radius: 2px;
 			border: 1px solid $gray-400;
-			background: $white;
+			background-color: $white;
 			box-shadow: 0 2px 6px 0 rgba( 0, 0, 0, 0.05 );
+
+			// Links inside click tooltips should have a dark color against the light background.
+			a {
+				color: var( --wp-admin-theme-color, $gutenberg-blue );
+			}
 
 			&::after {
 				// Remove the arrow from the click tooltip variant.


### PR DESCRIPTION
Fixes #9559

#### Changes proposed in this Pull Request

This PR fixes the color contrast of links within tooltips to improve readability.

**Before/after**
<div style="display: flex;">

<img src="https://github.com/user-attachments/assets/7a45aa8f-737c-4aa4-a46d-64a2a95c4448" width="45%"  />

<img src="https://github.com/user-attachments/assets/9f485b68-da6b-45e5-9d8b-de082a9c7eeb" width="45%" />

</div>



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the following pages and ensure that tooltips are rendered with appropriate color contrast.
	1. Payments → Deposits list schedule notice
	2. Payments → Overview (account balances, deposit card)
	3. Payments → Settings (colors should remain unchanged)
	4. Payments → Transactions list (Future Deposit tooltip)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **Not currently, but we should consider visual regression testing**
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
