### PR TITLE
Use tax inclusive amounts in PMME calculations to match displayed prices

### DIFF
--- a/changelog/fix-9553-use-tax-inclusive-prices-pmme
+++ b/changelog/fix-9553-use-tax-inclusive-prices-pmme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+The amounts used by the PMMEs will match the displayed price of the product regardless of the tax settings.

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -60,11 +60,16 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		$product_variations = [];
 
 		if ( $product ) {
+			/*
+			 * If the product price is tax exclusive but we are displaying tax inclusive amounts in the product page,
+			 * we need to do the same here and send tax inclusive amounts to the PMME.
+			 */
 			$price_needs_tax    = (
 				wc_tax_enabled() &&
 				! wc_prices_include_tax() &&
-				! WC()->cart->get_customer()->get_is_vat_exempt() &&
-				$product->is_taxable()
+				$product->is_taxable() &&
+				get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
+				! WC()->customer->get_is_vat_exempt()
 			);
 			$price              = $price_needs_tax ? wc_get_price_including_tax( $product ) : $product->get_price();
 			$product_variations = [

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -67,7 +67,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 				if (
 					wc_prices_include_tax() &&
 					(
-						get_option( 'woocommerce_tax_display_shop' ) === 'excl' ||
+						get_option( 'woocommerce_tax_display_shop' ) !== 'incl' ||
 						WC()->customer->get_is_vat_exempt()
 					)
 				) {

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -60,17 +60,27 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		$product_variations = [];
 
 		if ( $product ) {
+			$price_needs_tax    = (
+				wc_tax_enabled() &&
+				! wc_prices_include_tax() &&
+				! WC()->cart->get_customer()->get_is_vat_exempt() &&
+				$product->is_taxable()
+			);
+			$price              = $price_needs_tax ? wc_get_price_including_tax( $product ) : $product->get_price();
 			$product_variations = [
 				'base_product' => [
-					'amount'   => WC_Payments_Utils::prepare_amount( $product->get_price(), $currency_code ),
+					'amount'   => WC_Payments_Utils::prepare_amount( $price, $currency_code ),
 					'currency' => $currency_code,
 				],
 			];
 			foreach ( $product->get_children() as $variation_id ) {
 				$variation = wc_get_product( $variation_id );
 				if ( $variation ) {
+					$price                               = $price_needs_tax
+						? wc_get_price_including_tax( $variation )
+						: $variation->get_price();
 					$product_variations[ $variation_id ] = [
-						'amount'   => WC_Payments_Utils::prepare_amount( $variation->get_price(), $currency_code ),
+						'amount'   => WC_Payments_Utils::prepare_amount( $price, $currency_code ),
 						'currency' => $currency_code,
 					];
 				}


### PR DESCRIPTION
Fixes #9553

#### Changes proposed in this Pull Request



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable taxes and set a standard tax rate in your store (e.g. 20%)
* In the Tax settings select "No, I will enter prices exclusive of tax" and set "Display prices in the shop" to "Including Tax".
* Enable Klarna, Afterpay, and/or Affirm.
* Go to a product page.

**Before**
The amount used for the PMME calculation doesn't match the display price
![image](https://github.com/user-attachments/assets/3e11b45d-6235-4b73-abe5-a7fae75b4659)

**After**
The amount used for the PMME calculation matches the display price
![image](https://github.com/user-attachments/assets/8ff4c80b-394d-4e7a-b479-d6391e792f6c)

#### Other Scenarios

* If the product is not taxable or the customer is VAT exempt, the displayed price will be tax exclusive, and the PMME calculation should use that amount.
* If you enter tax exclusive prices and show tax exclusive prices in shop, that price should be used in the PMME calculation: 
![image](https://github.com/user-attachments/assets/974ca756-924f-477f-985a-0d7fe88fb8cd)
* Similarly, if you enter Tax Inclusive prices but choose to display tax exclusive prices in shop, the amounts should also match (For this example I had to increase the price of the product otherwise the PMME didn't show up):
![image](https://github.com/user-attachments/assets/ab353b25-c3f5-42f6-8bbf-f0a5060b8f48)

#### Regression testing
* When taxes are disabled or the product is not taxable, the calculations should always use the raw price.
* The calculations should remain unchanged for both Cart and Checkout, and they should always match the total.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply): N/A

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
