### PR TITLE
Remove unnecessary WC table css overrides to fix WC Analytics styling and a11y issues

### DIFF
--- a/changelog/fix-9572-woococommerce-table-specificity
+++ b/changelog/fix-9572-woococommerce-table-specificity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unnecessary '.woocommerce-table' css overrides to fix WC Analytics styling and a11y issues

--- a/client/style.scss
+++ b/client/style.scss
@@ -20,14 +20,10 @@
 	}
 }
 
-.woocommerce-table {
-	letter-spacing: 0.012rem;
-	color: $studio-gray-60;
-
-	.woocommerce-table__summary {
-		border-radius: 0 0 3px 3px;
-	}
-
+/**
+* This styling is for all `<TableCard />` components found in WooPayments screens.
+*/
+.woocommerce-payments-page .woocommerce-table {
 	.woocommerce-table__item {
 		white-space: nowrap;
 	}

--- a/client/style.scss
+++ b/client/style.scss
@@ -21,7 +21,6 @@
 }
 
 .woocommerce-table {
-	font-weight: 300;
 	letter-spacing: 0.012rem;
 	color: $studio-gray-60;
 


### PR DESCRIPTION
Fixes #9572

## Changes proposed in this Pull Request

This PR removes unnecessary CSS overrides of the `.woocommerce-table` class that are causing style bugs on WC Analytics. The removed CSS overrides and increased specificity of styles in this PR fix the issue while having no/minimal impact on the rendered UI for WooPayments tables.

WooPayments should avoid using CSS overrides where possible, to remain consistent with WC UI, avoid style conflicts and reduce complexity/maintenance burden.

## Before/After 

> [!TIP]
> _**Before** is lighter text, **After** is bolder text_


#### Chromium (Arc browser 1.65.0) 

Transactions

![transactions](https://github.com/user-attachments/assets/25c22093-c282-4749-9abc-df4e44097c32)


Documents

![documents](https://github.com/user-attachments/assets/556d168e-6d39-4b0d-b52a-f022058f5c28)


Disputes

![disputes](https://github.com/user-attachments/assets/a50c1c26-2e51-4122-93fd-44573a06db7c)


Deposits

![deposits](https://github.com/user-attachments/assets/4ec700fa-23ea-4a9d-b756-4c0fb3a3df2a)


WC Analytics – no longer overriding styles

![analytics](https://github.com/user-attachments/assets/5fe3fabe-95cc-400a-a942-7e4bfa11dfb5)


### Safari iOS 18.0.1

> [!TIP]
> _**Before** is lighter text, **After** is bolder text_


Transactions
<img width="400" src="https://github.com/user-attachments/assets/a7c6e63d-0e58-4f70-8596-66d8e7b22265" />


WC Analytics – no longer overriding styles

<img width="400" src="https://github.com/user-attachments/assets/6f828735-cf3a-4259-afde-5a166519a3bc" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to _Analytics → Products_ or any other analytics table
	* Use browser-devtools to ensure the text within tables is not overridden by WooPayments styles, in particular `font-weight`
* Navigate to _Payments → Transactions_ or any other WooPayments table
	* Ensure the table is rendered well and the text is clear and readable – not too thin

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A - styling issue**
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
