### PR TITLE
Add new tracking events and update Stripe connect library

### DIFF
--- a/changelog/dev-readd-tracking-event
+++ b/changelog/dev-readd-tracking-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improvements to events during onboarding flow.

--- a/client/onboarding/steps/embedded-kyc.tsx
+++ b/client/onboarding/steps/embedded-kyc.tsx
@@ -25,6 +25,10 @@ import {
 	isPoEligible,
 } from 'wcpay/onboarding/utils';
 import { getConnectUrl, getOverviewUrl } from 'wcpay/utils';
+import {
+	trackEmbeddedStepChange,
+	trackRedirected,
+} from 'wcpay/onboarding/tracking';
 
 interface Props {
 	continueKyc?: boolean;
@@ -57,6 +61,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 				isEligible
 			);
 			if ( accountSession && accountSession.clientSecret ) {
+				trackRedirected( isEligible, true );
 				return accountSession; // Return the full account session object
 			}
 
@@ -139,6 +144,10 @@ const EmbeddedKyc: React.FC< Props > = ( {
 		locale,
 	] );
 
+	const handleStepChange = ( step: string ) => {
+		trackEmbeddedStepChange( step );
+	};
+
 	const handleOnExit = async () => {
 		const urlParams = new URLSearchParams( window.location.search );
 		const urlSource =
@@ -192,6 +201,9 @@ const EmbeddedKyc: React.FC< Props > = ( {
 							)
 						}
 						onExit={ handleOnExit }
+						onStepChange={ ( stepChange ) =>
+							handleStepChange( stepChange.step )
+						}
 						collectionOptions={ {
 							fields: collectPayoutRequirements
 								? 'eventually_due'

--- a/client/onboarding/tracking.ts
+++ b/client/onboarding/tracking.ts
@@ -46,11 +46,32 @@ export const trackStepCompleted = ( step: string ): void => {
 	trackedSteps.add( step );
 };
 
-export const trackRedirected = ( isPoEligible: boolean ): void => {
+export const trackRedirected = (
+	isPoEligible: boolean,
+	isEmbedded = false
+): void => {
 	const urlParams = new URLSearchParams( window.location.search );
 
 	recordEvent( 'wcpay_onboarding_flow_redirected', {
 		is_po_eligible: isPoEligible,
+		is_embedded_onboarding: isEmbedded,
+		elapsed: elapsed( startTime ),
+		source:
+			urlParams.get( 'source' )?.replace( /[^\w-]+/g, '' ) || 'unknown',
+	} );
+};
+
+/**
+ * Track a change in the embedded onboarding step.
+ *
+ * @param step The current step in the embedded onboarding flow. See:
+ * https://docs.stripe.com/connect/supported-embedded-components/account-onboarding#step-values
+ */
+export const trackEmbeddedStepChange = ( step: string ): void => {
+	const urlParams = new URLSearchParams( window.location.search );
+
+	recordEvent( 'wcpay_onboarding_flow_embedded_step_change', {
+		step: step,
 		elapsed: elapsed( startTime ),
 		source:
 			urlParams.get( 'source' )?.replace( /[^\w-]+/g, '' ) || 'unknown',

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -60,6 +60,7 @@ export type Event =
 	| 'wcpay_onboarding_flow_reset'
 	| 'wcpay_onboarding_flow_eligibility_modal_closed'
 	| 'wcpay_onboarding_flow_setup_live_payments'
+	| 'wcpay_onboarding_flow_embedded_step_change'
 	| 'wcpay_overview_balances_currency_tab_click'
 	| 'wcpay_overview_deposits_view_history_click'
 	| 'wcpay_overview_deposits_change_schedule_click'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
       "dependencies": {
         "@automattic/interpolate-components": "1.2.1",
         "@fingerprintjs/fingerprintjs": "3.4.1",
-        "@stripe/connect-js": "3.3.12",
-        "@stripe/react-connect-js": "3.3.13",
+        "@stripe/connect-js": "3.3.16",
+        "@stripe/react-connect-js": "3.3.17",
         "@stripe/react-stripe-js": "2.5.1",
         "@stripe/stripe-js": "1.15.1",
         "@woocommerce/explat": "2.3.0",
@@ -9158,16 +9158,16 @@
       }
     },
     "node_modules/@stripe/connect-js": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@stripe/connect-js/-/connect-js-3.3.12.tgz",
-      "integrity": "sha512-hXbgvGq9Lb6BYgsb8lcbjL76Yqsxr0yAj6T9ZFTfUK0O4otI5GSEWum9do9rf/E5OfYy6fR1FG/77Jve2w1o6Q=="
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/@stripe/connect-js/-/connect-js-3.3.16.tgz",
+      "integrity": "sha512-lMUKJJaDl6qzjp+czNn+N6wMwFXwLawmB2jNNgds8SeR+bXCVCXevzJ8dfF92KfmexKg++hBYagF9e99sEMBJQ=="
     },
     "node_modules/@stripe/react-connect-js": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@stripe/react-connect-js/-/react-connect-js-3.3.13.tgz",
-      "integrity": "sha512-kMxYjeQUcl/ixu/mSeX5QGIr/MuP+YxFSEBdb8j6w+tbK82tmcjyFDgoQTQwVXNqUV6jI66Kks3XcfpPRfeiJA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/@stripe/react-connect-js/-/react-connect-js-3.3.17.tgz",
+      "integrity": "sha512-uxCh6ACcSWS/t0kBeqvvRieBI9pRxh2rPxt6NpjrTg3Ft1ZDleUfg9OAjkfoOT3Ta+FTomouA19l2ju7If2h5A==",
       "peerDependencies": {
-        "@stripe/connect-js": ">=3.3.11",
+        "@stripe/connect-js": ">=3.3.16",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
   "dependencies": {
     "@automattic/interpolate-components": "1.2.1",
     "@fingerprintjs/fingerprintjs": "3.4.1",
-    "@stripe/connect-js": "3.3.12",
-    "@stripe/react-connect-js": "3.3.13",
+    "@stripe/connect-js": "3.3.16",
+    "@stripe/react-connect-js": "3.3.17",
     "@stripe/react-stripe-js": "2.5.1",
     "@stripe/stripe-js": "1.15.1",
     "@woocommerce/explat": "2.3.0",


### PR DESCRIPTION
Fixes #9608

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

* Update the Stripe react libraries for connect JS to support the `onStepChange` event
* Add a new event, `wcpay_onboarding_flow_embedded_step_change`
* Re-add the `wcpay_onboarding_flow_redirected` which was lost in the change from external KYC to embedded KYC.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test, you can either use the Tracks Vigilante extension (locally), or test using a Jurassic Ninja site and wait for the events to show up in [Tracks Live View](https://mc.a8c.com/tracks/live/).

* Clear any previous accounts on your site.
* Start a new onboarding.
* Complete the onboarding.
* Check the events that have been logged. You should see the normal events (e.g. onboarding started, onboarding complete). You should also see the `wcpay_onboarding_flow_redirected`, which should happen when the embedded KYC page loads. You will also see `wcpay_onboarding_flow_embedded_step_change` events which occur when changing step on the embdedded KYC. They will have a `step` parameter which should contain a string indicating the current step on the KYC.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
