### PR TITLE
Rename Deposit to Payout in TOS modal

### DIFF
--- a/changelog/fix-9573-rename-payout-tos-modal
+++ b/changelog/fix-9573-rename-payout-tos-modal
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Rename Deposit to Payout in TOS modal. Changelog to be included in featture branch
+
+

--- a/client/tos/modal/index.js
+++ b/client/tos/modal/index.js
@@ -102,7 +102,7 @@ const DisableModalUI = ( { onDisable, onCancel, isBusy, hasError } ) => {
 			__(
 				'By declining our {{link}}Terms of Service{{/link}},' +
 					' you’ll no longer be able to capture credit card payments using %s.' +
-					' Your previous transaction and deposit data will still be available.',
+					' Your previous transaction and payout data will still be available.',
 				'woocommerce-payments'
 			),
 			'WooPayments'

--- a/client/tos/modal/test/__snapshots__/index.js.snap
+++ b/client/tos/modal/test/__snapshots__/index.js.snap
@@ -103,7 +103,7 @@ exports[`ToS modal should render disable plugin modal on decline 1`] = `
         >
           Terms of Service
         </a>
-        , you’ll no longer be able to capture credit card payments using WooPayments. Your previous transaction and deposit data will still be available.
+        , you’ll no longer be able to capture credit card payments using WooPayments. Your previous transaction and payout data will still be available.
       </div>
       <div
         class="woocommerce-payments__tos-footer"


### PR DESCRIPTION
Fixes #9573

#### Changes proposed in this Pull Request
Rename deposit to payout in the TOS disable message.

#### Testing instructions
* On server, remove/edit the row for the account from `wcpay_tos_agreements`
* On client, use WCPay Dev Tools to force update the server stripe cache and refresh the Payments screen
* A modal will be shown for accepting the Terms of Service. Click on Decline
* Another modal is displayed with the message 'Your previous transaction and payout data will still be available.' which was earlier 'Your previous transaction and deposit data will still be available.'

-------------------

N/A -
- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
