### PR TITLE
Rename deposit to payout in account messaging.

### DIFF
--- a/changelog/fix-payout-rename-account-errors
+++ b/changelog/fix-payout-rename-account-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Renamed deposit to Payout in account error messages. Main changelog will be added on feature branch.
+
+

--- a/client/components/account-status/account-tools/strings.tsx
+++ b/client/components/account-status/account-tools/strings.tsx
@@ -17,7 +17,7 @@ export default {
 				'woocommerce-payments'
 		  )
 		: __(
-				'Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
+				'Payments and payouts are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
 				'woocommerce-payments'
 		  ),
 	reset: __( 'Reset account', 'woocommerce-payments' ),

--- a/client/components/account-status/account-tools/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-status/account-tools/test/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`AccountTools should render in test/sandbox mode onboarding 1`] = `
       Account Tools
     </h4>
     <p>
-      Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
+      Payments and payouts are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
     </p>
     <div
       class="account-tools__actions"

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -295,7 +295,7 @@ exports[`AccountStatus renders account tools 1`] = `
             Account Tools
           </h4>
           <p>
-            Payments and deposits are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
+            Payments and payouts are disabled until account setup is completed. If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.
           </p>
           <div
             class="account-tools__actions"

--- a/client/overview/modal/update-business-details/strings.tsx
+++ b/client/overview/modal/update-business-details/strings.tsx
@@ -14,7 +14,7 @@ export default {
 	),
 
 	restrictedDescription: __(
-		'Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.',
+		'Payments and payouts are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.',
 		'woocommerce-payments'
 	),
 

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -50,7 +50,7 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+          Payments and payouts are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
         </p>
         <div
           class="components-notice is-warning"
@@ -248,7 +248,7 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+          Payments and payouts are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
         </p>
         <div
           class="components-notice is-warning"

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -70,14 +70,14 @@ export const getUpdateBusinessDetailsTask = (
 			accountDetailsTaskDescription =
 				/* translators: <a> - dashboard login URL */
 				__(
-					'Payments and deposits are disabled for this account until setup is completed.',
+					'Payments and payouts are disabled for this account until setup is completed.',
 					'woocommerce-payments'
 				);
 		} else {
 			accountDetailsTaskDescription =
 				/* translators: <a> - dashboard login URL */
 				__(
-					'Payments and deposits are disabled for this account until missing business information is updated.',
+					'Payments and payouts are disabled for this account until missing business information is updated.',
 					'woocommerce-payments'
 				);
 		}


### PR DESCRIPTION
Fixes #9574, #9580

#### Changes proposed in this Pull Request
In various account error messages, the text "Payments and deposits are disabled...." is used, which has been changed to "Payments and payouts are disabled...."

**Example fix screenshot:**
<img width="758" alt="image" src="https://github.com/user-attachments/assets/29e91b61-a46e-4621-b116-a875be333afd">


#### Testing instructions
- Can be verified using code review OR
- Replicate the respective account error and validate the message

-------------------
N/A
- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
