### PR TITLE
Omit Test Mode badge in the Change payment method form

### DIFF
--- a/changelog/fix-omit-test-mode-badge-in-change-payment-form
+++ b/changelog/fix-omit-test-mode-badge-in-change-payment-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Omit the test mode badge in the change payment method form for subscriptions.

--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -39,52 +39,55 @@
 		max-height: 24px !important;
 	}
 
-	li.payment_method_woocommerce_payments {
-		display: grid;
-		grid-template-columns: 0fr 0fr 1fr;
-		grid-template-rows: max-content;
-
-		> input[name='payment_method'] {
-			align-self: center;
-		}
-		> label {
-			grid-column: 3;
+	&.wc_payment_methods,
+	&.woocommerce-PaymentMethods {
+		li.payment_method_woocommerce_payments {
 			display: grid;
-			grid-template-columns: 0fr auto;
+			grid-template-columns: 0fr 0fr 1fr;
 			grid-template-rows: max-content;
-			grid-gap: 0;
-			margin-bottom: 0;
 
-			> .label-title-container {
-				grid-area: 1 / 2 / 2 / 3;
+			> input[name='payment_method'] {
+				align-self: center;
 			}
+			> label {
+				grid-column: 3;
+				display: grid;
+				grid-template-columns: 0fr auto;
+				grid-template-rows: max-content;
+				grid-gap: 0;
+				margin-bottom: 0;
 
-			.payment-method-title {
-				margin-right: 8px;
-			}
+				> .label-title-container {
+					grid-area: 1 / 2 / 2 / 3;
+				}
 
-			.test-mode.badge {
-				display: inline-block;
-				background-color: #fff2d7;
-				border-radius: 4px;
-				padding: 4px 6px;
-				font-size: 12px;
-				font-weight: 400;
-				line-height: 16px;
-				color: #4d3716;
-				vertical-align: middle;
-			}
+				.payment-method-title {
+					margin-right: 8px;
+				}
 
-			img {
-				float: none;
-				grid-area: 1 / 4 / 2 / 5;
-				align-self: baseline;
-				justify-self: end;
-				margin-left: 1em;
+				.test-mode.badge {
+					display: inline-block;
+					background-color: #fff2d7;
+					border-radius: 4px;
+					padding: 4px 6px;
+					font-size: 12px;
+					font-weight: 400;
+					line-height: 16px;
+					color: #4d3716;
+					vertical-align: middle;
+				}
+
+				img {
+					float: none;
+					grid-area: 1 / 4 / 2 / 5;
+					align-self: baseline;
+					justify-self: end;
+					margin-left: 1em;
+				}
 			}
-		}
-		> div.payment_box {
-			grid-area: 2 / 1 / 3 / 4;
+			> div.payment_box {
+				grid-area: 2 / 1 / 3 / 4;
+			}
 		}
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -580,7 +580,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function get_title() {
 		$title = parent::get_title();
 
-		if ( Payment_Method::CARD === $this->stripe_id && ( is_checkout() || is_add_payment_method_page() ) ) {
+		if (
+			Payment_Method::CARD === $this->stripe_id &&
+			( is_checkout() || is_add_payment_method_page() ) &&
+			! isset( $_GET['change_payment_method'] )  // phpcs:ignore WordPress.Security.NonceVerification
+		) {
 			if ( WC_Payments::mode()->is_test() ) {
 				$test_mode_badge = '<span class="test-mode badge">' . __( 'Test Mode', 'woocommerce-payments' ) . '</span>';
 			} else {


### PR DESCRIPTION
Fixes #9616

Related to #9495

#### Changes proposed in this Pull Request

In order to show the "Test mode" badge, we need to insert HTML into the payment method title when rendering the form. This isn't a problem for WooCommerce core since the contents of `get_title` are not escaped. See: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/checkout/payment-method.php#L26

However; WooCommerce Subscriptions recreates the code to render the form, but the plugin does escape the HTML, causing the HTML to be rendered as text. See: https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/templates/checkout/form-change-payment-method.php#L70C81-L70C119

#### Testing instructions

* Follow https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#change-subscription-payment-method-to-a-new-card up to the Change Payment Method page/form.

Before
![image](https://github.com/user-attachments/assets/2fd97e93-fae4-46da-995f-0cefca4f60ac)

After
![image](https://github.com/user-attachments/assets/21fab79f-000b-418d-8efb-f2ccaaa7406c)

* Go through the Testing Instructions in https://github.com/Automattic/woocommerce-payments/pull/9495 to make sure there are no regressions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
