### PR TITLE
Fix PMME appearance in checkout

### DIFF
--- a/changelog/fix-pmme-appearance-checkout
+++ b/changelog/fix-pmme-appearance-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PMME appearance in checkout

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -77,8 +77,6 @@ const api = new WCPayAPI(
 	request
 );
 
-const stripeAppearance = getUPEConfig( 'wcBlocksUPEAppearance' );
-
 Object.entries( enabledPaymentMethodsConfig )
 	.filter( ( [ upeName ] ) => upeName !== 'link' )
 	.forEach( ( [ upeName, upeConfig ] ) => {
@@ -114,7 +112,6 @@ Object.entries( enabledPaymentMethodsConfig )
 					api={ api }
 					upeConfig={ upeConfig }
 					upeName={ upeName }
-					stripeAppearance={ stripeAppearance }
 					upeAppearanceTheme={ upeAppearanceTheme }
 				/>
 			),

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -36,7 +36,7 @@ const PaymentElements = ( { api, ...props } ) => {
 	useEffect( () => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance( 'blocks_checkout', false, true );
+			let upeAppearance = getAppearance( 'blocks_checkout', false );
 			upeAppearance = await api.saveUPEAppearance(
 				upeAppearance,
 				'blocks_checkout'

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -204,7 +204,8 @@ jQuery( function ( $ ) {
 								decimalPlaces:
 									cartData?.totals?.currency_minor_unit,
 								country: currentCountry,
-							}
+							},
+							'shortcode_checkout'
 						);
 					}
 				}

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -453,10 +453,11 @@ export async function mountStripePaymentElement(
 export async function mountStripePaymentMethodMessagingElement(
 	api,
 	domElement,
-	cartData
+	cartData,
+	location
 ) {
 	const paymentMethodType = domElement.dataset.paymentMethodType;
-	const appearance = await initializeAppearance( api );
+	const appearance = await initializeAppearance( api, location );
 
 	try {
 		const paymentMethodMessagingElement = api


### PR DESCRIPTION
Fixes #9522

#### Changes proposed in this Pull Request

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/efdaa542-a628-4f66-af16-378d13bbea17) | ![image](https://github.com/user-attachments/assets/2d404d3b-10fb-4081-9d4f-a583bb97dfe5) |
| ![image](https://github.com/user-attachments/assets/43f4f938-e9fa-40a2-a53e-209f54c35da9) | ![image](https://github.com/user-attachments/assets/bdd483d9-e196-4a5d-9ec0-82e96863f805) |


#### Testing instructions

1. Comment [these lines](https://github.com/Automattic/woocommerce-payments/blob/447eb9b446e7583928d1d6fa23c4403d5221d757/includes/class-wc-payments-checkout.php#L227-L233) to prevent the appearance object from caching
1. Change your background to a dark color and your text color to a light one.
2. The instruction above should be enough for the shortcode checkout, but for the blocks checkout you need to edit its page and enable Dark Mode inputs.
    ![image](https://github.com/user-attachments/assets/0a5d4b81-e4b6-487c-a2e3-a52c46b2bbd4)
4. Add something to your cart
5. Go to the checkout
6. The PMME on the label should be correctly styled on this branch but broken in `develop`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
