### PR TITLE
Rename instant deposits to instant payouts

### DIFF
--- a/changelog/fix-9585-rename-instant-payouts
+++ b/changelog/fix-9585-rename-instant-payouts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Renamed instant deposit to instant payout. Main changelog will be part of feature branch
+
+

--- a/client/data/deposits/actions.js
+++ b/client/data/deposits/actions.js
@@ -112,7 +112,7 @@ export function* submitInstantDeposit( currency ) {
 		yield dispatch( 'core/notices' ).createSuccessNotice(
 			sprintf(
 				__(
-					'Instant deposit for %s in transit.',
+					'Instant payout for %s in transit.',
 					'woocommerce-payments'
 				),
 				formatCurrency( deposit.amount )
@@ -132,7 +132,7 @@ export function* submitInstantDeposit( currency ) {
 		);
 	} catch {
 		yield dispatch( 'core/notices' ).createErrorNotice(
-			__( 'Error creating instant deposit.', 'woocommerce-payments' )
+			__( 'Error creating instant payout.', 'woocommerce-payments' )
 		);
 	} finally {
 		yield dispatch( STORE_NAME ).finishResolution( 'getInstantDeposit', [

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -50,7 +50,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->set_source( 'woocommerce-payments' );
 		$note->add_action(
 			self::NOTE_NAME,
-			__( 'Request an instant deposit', 'woocommerce-payments' ),
+			__( 'Request an instant payout', 'woocommerce-payments' ),
 			'https://woocommerce.com/document/woopayments/deposits/instant-deposits/#request-an-instant-deposit',
 			'unactioned',
 			true

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -30,7 +30,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->set_title(
 			sprintf(
 				/* translators: %s: WooPayments */
-				__( 'You’re now eligible to receive Instant Deposits with %s', 'woocommerce-payments' ),
+				__( 'You’re now eligible to receive Instant Payouts with %s', 'woocommerce-payments' ),
 				'WooPayments'
 			)
 		);
@@ -38,7 +38,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 			WC_Payments_Utils::esc_interpolated_html(
 				sprintf(
 					/* translators: %s: WooPayments */
-					__( "Get immediate access to your funds when you need them – including nights, weekends, and holidays. With %s' <a>Instant Deposits feature</a>, you're able to transfer your earnings to a debit card within minutes.", 'woocommerce-payments' ),
+					__( "Get immediate access to your funds when you need them – including nights, weekends, and holidays. With %s' <a>Instant Payouts feature</a>, you're able to transfer your earnings to a debit card within minutes.", 'woocommerce-payments' ),
 					'WooPayments'
 				),
 				[ 'a' => '<a href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/">' ]


### PR DESCRIPTION
Fixes #9585 and some additional references. Some of the text referred in the issue are already fixed.

#### Changes proposed in this Pull Request
1. Instant Payout Eligibility note updated: <img width="656" alt="image" src="https://github.com/user-attachments/assets/d036789a-9328-4ee8-8181-acc42d179757">
2. Changes to error and success notices on submitting a request for instant payout


#### Testing instructions
- Enable instant payout by setting account `instant_deposits_eligible` to true on server.
- Check the instant payout eligibility order note.
- Review the changes to the notices on instant payout request success/failure OR test requesting instant payout on an eligibe account

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
