### PR TITLE
Rename 'deposit' to 'payout' in 'Overview' section modals for progressive onboarding

### DIFF
--- a/changelog/update-9578-79-rename-deposit-overview-modal
+++ b/changelog/update-9578-79-rename-deposit-overview-modal
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Rename 'deposit' to 'payout' in modals within 'Overview' section. PR is a part of a larger renaming project.
+
+

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -82,7 +82,7 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 			</h1>
 			<h2 className="wcpay-progressive-onboarding-eligibility-modal__subheading">
 				{ __(
-					'Start selling now and fast track the setup process, or continue the process to set up deposits with WooPayments.',
+					'Start selling now and fast track the setup process, or continue the process to set up payouts with WooPayments.',
 					'woocommerce-payments'
 				) }
 			</h2>
@@ -120,14 +120,14 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 						{ __( 'Flexible process', 'woocommerce-payments' ) }
 					</h3>
 					{ __(
-						'You have a $5,000 balance limit or 30 days from your first transaction to verify and set up deposits in your account.',
+						'You have a $5,000 balance limit or 30 days from your first transaction to verify and set up payouts in your account.',
 						'woocommerce-payments'
 					) }
 				</div>
 			</div>
 			<div className="wcpay-progressive-onboarding-eligibility-modal__footer">
 				<Button variant="secondary" onClick={ handleSetup }>
-					{ __( 'Start receiving deposits', 'woocommerce-payments' ) }
+					{ __( 'Start receiving payouts', 'woocommerce-payments' ) }
 				</Button>
 				<Button variant="primary" onClick={ handlePaymentsOnly }>
 					{ __( 'Start selling', 'woocommerce-payments' ) }

--- a/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
@@ -83,7 +83,7 @@ describe( 'Progressive Onboarding Eligibility Modal', () => {
 
 		user.click(
 			screen.getByRole( 'button', {
-				name: 'Start receiving deposits',
+				name: 'Start receiving payouts',
 			} )
 		);
 

--- a/client/overview/modal/reset-account/strings.tsx
+++ b/client/overview/modal/reset-account/strings.tsx
@@ -13,7 +13,7 @@ export default {
 	title: __( 'Reset account', 'woocommerce-payments' ),
 	description: isInTestModeOnboarding()
 		? __(
-				'In sandbox mode, you can reset your account and onboard again at any time. Please note that all current WooPayments account details, test transactions, and deposits history will be lost.',
+				'In sandbox mode, you can reset your account and onboard again at any time. Please note that all current WooPayments account details, test transactions, and payouts history will be lost.',
 				'woocommerce-payments'
 		  )
 		: __(

--- a/client/overview/modal/update-business-details/strings.tsx
+++ b/client/overview/modal/update-business-details/strings.tsx
@@ -19,7 +19,7 @@ export default {
 	),
 
 	restrictedSoonDescription: __(
-		'Additional information is required to verify your business. Update by %s to avoid a disruption in deposits.',
+		'Additional information is required to verify your business. Update by %s to avoid a disruption in payouts.',
 		'woocommerce-payments'
 	),
 

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -149,7 +149,7 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Additional information is required to verify your business. Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
+          Additional information is required to verify your business. Update by 7pm Dec 31, 2021 to avoid a disruption in payouts.
         </p>
         <div
           class="components-notice is-warning"


### PR DESCRIPTION
Fixes #9578 , #9579

#### Changes proposed in this Pull Request

The PR renames all occurences of 'deposit' to 'payout' within the 'Overview' section. This is a part of a larger project to do this rename throughout the WooPayments codebase. 

#### Testing instructions

* Set `showProgressiveOnboardingEligibilityModal` to `true`  [on this line](https://github.com/Automattic/woocommerce-payments/blob/ad8941b548bbd261531e27b93e7e787acc10602e/client/overview/index.js#L111) . You should then see a modal as below on the overview page:

<img src="https://github.com/user-attachments/assets/8970ac1f-a1b6-4070-afee-ea27478e2777" width="500px" />

* Reset account modal - Within `Overview` page, `Account details` section, click the reset button. You should see the text changed to `payouts` as below:

<img src="https://github.com/user-attachments/assets/ac917160-24c5-4ded-973b-7915be5324a0" width="500px" />

 * The PR also changes text within the `UpdateBusinessDetailsModal` . I have so far found it difficult to simulate the situation in which the modal gets shown.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.