### PR TITLE
Rename deposits to Payouts in error messages

### DIFF
--- a/changelog/fix-9588-rename-payouts-error-messages
+++ b/changelog/fix-9588-rename-payouts-error-messages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Updated the payouts component error notices. User facing changelog will be on the feature branch.
+
+

--- a/client/data/deposits/resolvers.js
+++ b/client/data/deposits/resolvers.js
@@ -45,7 +45,7 @@ export function* getDeposit( id ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',
-			__( 'Error retrieving deposit.', 'woocommerce-payments' )
+			__( 'Error retrieving payout.', 'woocommerce-payments' )
 		);
 	}
 }
@@ -64,7 +64,7 @@ export function* getAllDepositsOverviews() {
 			'core/notices',
 			'createErrorNotice',
 			__(
-				"Error retrieving all deposits' overviews.",
+				"Error retrieving all payouts' overviews.",
 				'woocommerce-payments'
 			)
 		);
@@ -129,7 +129,7 @@ export function* getDeposits( query ) {
 		yield controls.dispatch(
 			'core/notices',
 			'createErrorNotice',
-			__( 'Error retrieving deposits.', 'woocommerce-payments' )
+			__( 'Error retrieving payouts.', 'woocommerce-payments' )
 		);
 		yield updateErrorForDepositQuery( query, null, e );
 	}


### PR DESCRIPTION
Fixes #9588

#### Changes proposed in this Pull Request
Updated the error messages in the Payouts Overview component.

<img width="517" alt="Pasted image 20241024181946" src="https://github.com/user-attachments/assets/5fc92b41-f145-4ced-ac38-6b99fa4ffa64">


#### Testing instructions
Simulate an error in the deposits APIs and validate the error messages.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
