### PR TITLE
Respect BNPL limits_per_currency (country, min, max)

### DIFF
--- a/changelog/fix-9456-bnpl-respect-limits-per-currency
+++ b/changelog/fix-9456-bnpl-respect-limits-per-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent dead space on product pages when no BNPL offers are available.

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -55,12 +55,11 @@ export const initializeBnplSiteMessaging = async () => {
 		isCart,
 		isCartBlock,
 		cartTotal,
-		minimumOrderAmount,
+		isBnplAvailable,
 	} = window.wcpayStripeSiteMessaging;
 
 	let amount;
 	let elementLocation = 'bnplProductPage';
-	const minOrderAmount = parseInt( minimumOrderAmount, 10 ) || 0;
 	const paymentMessageContainer = document.getElementById(
 		'payment-method-message'
 	);
@@ -71,7 +70,7 @@ export const initializeBnplSiteMessaging = async () => {
 	} else {
 		amount = parseInt( productVariations.base_product.amount, 10 ) || 0;
 
-		if ( amount < minOrderAmount ) {
+		if ( ! isBnplAvailable ) {
 			paymentMessageContainer.style.setProperty( 'display', 'none' );
 		}
 	}

--- a/client/product-details/index.js
+++ b/client/product-details/index.js
@@ -104,7 +104,7 @@ jQuery( async function ( $ ) {
 				'get_cart_total'
 			),
 			{
-				security: window.wcpayStripeSiteMessaging.nonce,
+				security: window.wcpayStripeSiteMessaging.nonce.get_cart_total,
 			}
 		);
 	};
@@ -116,7 +116,8 @@ jQuery( async function ( $ ) {
 				'check_bnpl_availability'
 			),
 			{
-				security: window.wcpayStripeSiteMessaging.nonce,
+				security:
+					window.wcpayStripeSiteMessaging.nonce.is_bnpl_available,
 				price: price,
 				currency: currency,
 				country: country,

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -138,7 +138,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			'isCartBlock'        => $is_cart_block,
 			'cartTotal'          => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
 			'minimumOrderAmount' => WC_Payments_Utils::get_cached_minimum_amount( $currency_code, true ),
-			'nonce'              => wp_create_nonce( 'wcpay-get-cart-total' ),
+			'nonce'              => wp_create_nonce( 'wcpay-bnpl-nonce' ),
 			'wcAjaxUrl'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 		];
 

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -126,20 +126,19 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		$country = empty( $billing_country ) ? $store_country : $billing_country;
 
 		$script_data = [
-			'productId'          => 'base_product',
-			'productVariations'  => $product_variations,
-			'country'            => $country,
-			'locale'             => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
-			'accountId'          => $this->account->get_stripe_account_id(),
-			'publishableKey'     => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
-			'paymentMethods'     => array_values( $bnpl_payment_methods ),
-			'currencyCode'       => $currency_code,
-			'isCart'             => is_cart(),
-			'isCartBlock'        => $is_cart_block,
-			'cartTotal'          => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
-			'minimumOrderAmount' => WC_Payments_Utils::get_cached_minimum_amount( $currency_code, true ),
-			'nonce'              => wp_create_nonce( 'wcpay-bnpl-nonce' ),
-			'wcAjaxUrl'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'productId'         => 'base_product',
+			'productVariations' => $product_variations,
+			'country'           => $country,
+			'locale'            => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
+			'accountId'         => $this->account->get_stripe_account_id(),
+			'publishableKey'    => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
+			'paymentMethods'    => array_values( $bnpl_payment_methods ),
+			'currencyCode'      => $currency_code,
+			'isCart'            => is_cart(),
+			'isCartBlock'       => $is_cart_block,
+			'cartTotal'         => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
+			'nonce'             => wp_create_nonce( 'wcpay-bnpl-nonce' ),
+			'wcAjaxUrl'         => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 		];
 
 		if ( $product ) {

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -90,6 +90,9 @@ class WC_Payments_Payment_Method_Messaging_Element {
 					'currency' => $currency_code,
 				],
 			];
+
+			$product_price = $product_variations['base_product']['amount'];
+
 			foreach ( $product->get_children() as $variation_id ) {
 				$variation = wc_get_product( $variation_id );
 				if ( $variation ) {
@@ -98,6 +101,8 @@ class WC_Payments_Payment_Method_Messaging_Element {
 						'amount'   => WC_Payments_Utils::prepare_amount( $price, $currency_code ),
 						'currency' => $currency_code,
 					];
+
+					$product_price = $product_variations['base_product']['amount'];
 				}
 			}
 		}
@@ -118,26 +123,34 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			WC_Payments::get_file_version( 'dist/product-details.css' ),
 		);
 
+		$country = empty( $billing_country ) ? $store_country : $billing_country;
+
+		$script_data = [
+			'productId'          => 'base_product',
+			'productVariations'  => $product_variations,
+			'country'            => $country,
+			'locale'             => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
+			'accountId'          => $this->account->get_stripe_account_id(),
+			'publishableKey'     => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
+			'paymentMethods'     => array_values( $bnpl_payment_methods ),
+			'currencyCode'       => $currency_code,
+			'isCart'             => is_cart(),
+			'isCartBlock'        => $is_cart_block,
+			'cartTotal'          => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
+			'minimumOrderAmount' => WC_Payments_Utils::get_cached_minimum_amount( $currency_code, true ),
+			'nonce'              => wp_create_nonce( 'wcpay-get-cart-total' ),
+			'wcAjaxUrl'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+		];
+
+		if ( $product ) {
+			$script_data['isBnplAvailable'] = WC_Payments_Utils::is_any_bnpl_method_available( array_values( $bnpl_payment_methods ), $country, $currency_code, $product_price );
+		}
+
 		// Create script tag with config.
 		wp_localize_script(
 			'WCPAY_PRODUCT_DETAILS',
 			'wcpayStripeSiteMessaging',
-			[
-				'productId'          => 'base_product',
-				'productVariations'  => $product_variations,
-				'country'            => empty( $billing_country ) ? $store_country : $billing_country,
-				'locale'             => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
-				'accountId'          => $this->account->get_stripe_account_id(),
-				'publishableKey'     => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
-				'paymentMethods'     => array_values( $bnpl_payment_methods ),
-				'currencyCode'       => $currency_code,
-				'isCart'             => is_cart(),
-				'isCartBlock'        => $is_cart_block,
-				'cartTotal'          => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
-				'minimumOrderAmount' => WC_Payments_Utils::get_cached_minimum_amount( $currency_code, true ),
-				'nonce'              => wp_create_nonce( 'wcpay-get-cart-total' ),
-				'wcAjaxUrl'          => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-			]
+			$script_data
 		);
 
 		// Ensure wcpayConfig is available in the page.

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -137,7 +137,10 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			'isCart'            => is_cart(),
 			'isCartBlock'       => $is_cart_block,
 			'cartTotal'         => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
-			'nonce'             => wp_create_nonce( 'wcpay-bnpl-nonce' ),
+			'nonce'             => [
+				'get_cart_total'    => wp_create_nonce( 'wcpay-get-cart-total' ),
+				'is_bnpl_available' => wp_create_nonce( 'wcpay-is-bnpl-available' ),
+			],
 			'wcAjaxUrl'         => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 		];
 

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -107,7 +107,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			}
 		}
 
-		$enabled_upe_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
+		$enabled_upe_payment_methods = $this->gateway->get_upe_enabled_payment_method_ids();
 		// Filter non BNPL out of the list of payment methods.
 		$bnpl_payment_methods = array_intersect( $enabled_upe_payment_methods, Payment_Method::BNPL_PAYMENT_METHODS );
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -775,49 +775,49 @@ class WC_Payments_Utils {
 				return [
 					Currency_Code::UNITED_STATES_DOLLAR => [
 						Country_Code::UNITED_STATES => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 1000000,
-						], // Represents USD 0 - 10,000 USD.
+						], // Represents USD 1 - 10,000 USD.
 					],
 					Currency_Code::POUND_STERLING       => [
 						Country_Code::UNITED_KINGDOM => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 1150000,
-						], // Represents GBP 0 - 11,500 GBP.
+						], // Represents GBP 1 - 11,500 GBP.
 					],
 					Currency_Code::EURO                 => [
 						Country_Code::AUSTRIA     => [
-							'min' => 1,
+							'min' => 100,
 							'max' => 1000000,
 						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::BELGIUM     => [
-							'min' => 1,
+							'min' => 100,
 							'max' => 1000000,
 						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::GERMANY     => [
-							'min' => 1,
+							'min' => 100,
 							'max' => 1000000,
 						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::NETHERLANDS => [
-							'min' => 1,
+							'min' => 100,
 							'max' => 1500000,
 						], // Represents EUR 1 - 15,000 EUR.
 						Country_Code::FINLAND     => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 1000000,
-						], // Represents EUR 0 - 10,000 EUR.
+						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::SPAIN       => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 1000000,
-						], // Represents EUR 0 - 10,000 EUR.
+						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::IRELAND     => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 400000,
-						], // Represents EUR 0 - 4,000 EUR.
+						], // Represents EUR 1 - 4,000 EUR.
 						Country_Code::ITALY       => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 1000000,
-						], // Represents EUR 0 - 10,000 EUR.
+						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::FRANCE      => [
 							'min' => 3500,
 							'max' => 400000,
@@ -831,15 +831,15 @@ class WC_Payments_Utils {
 					],
 					Currency_Code::NORWEGIAN_KRONE      => [
 						Country_Code::NORWAY => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 100000000,
-						], // Represents NOK 0 - 1,000,000 NOK.
+						], // Represents NOK 1 - 1,000,000 NOK.
 					],
 					Currency_Code::SWEDISH_KRONA        => [
 						Country_Code::SWEDEN => [
-							'min' => 0,
+							'min' => 100,
 							'max' => 15000000,
-						], // Represents SEK 0 - 150,000 SEK.
+						], // Represents SEK 1 - 150,000 SEK.
 					],
 				];
 			default:

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -716,65 +716,9 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Retrieves Stripe minimum order value authorized per currency.
-	 * The values are based on Stripe's recommendations.
-	 * See https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts.
-	 *
-	 * @param string $currency The currency.
-	 *
-	 * @return int The minimum amount.
-	 */
-	public static function get_stripe_minimum_amount( $currency ) {
-		switch ( $currency ) {
-			case 'AED':
-			case 'MYR':
-			case 'PLN':
-			case 'RON':
-				$minimum_amount = 200;
-				break;
-			case 'BGN':
-				$minimum_amount = 100;
-				break;
-			case 'CZK':
-				$minimum_amount = 1500;
-				break;
-			case 'DKK':
-				$minimum_amount = 250;
-				break;
-			case 'GBP':
-				$minimum_amount = 30;
-				break;
-			case 'HKD':
-				$minimum_amount = 400;
-				break;
-			case 'HUF':
-				$minimum_amount = 17500;
-				break;
-			case 'JPY':
-				$minimum_amount = 5000;
-				break;
-			case 'MXN':
-			case 'THB':
-				$minimum_amount = 1000;
-				break;
-			case 'NOK':
-			case 'SEK':
-				$minimum_amount = 300;
-				break;
-			default:
-				$minimum_amount = 50;
-				break;
-		}
-
-		self::cache_minimum_amount( $currency, $minimum_amount );
-
-		return $minimum_amount;
-	}
-
-	/**
 	 * Get the BNPL limits per currency for a specific payment method.
 	 *
-	 * @param string $payment_method The payment method name ('affirm', 'afterpay', or 'klarna').
+	 * @param string $payment_method The payment method name ('affirm', 'afterpay_clearpay', or 'klarna').
 	 * @return array The BNPL limits per currency for the specified payment method.
 	 */
 	public static function get_bnpl_limits_per_currency( $payment_method ) {
@@ -945,20 +889,12 @@ class WC_Payments_Utils {
 	 * Checks if there is a minimum amount required for transactions in a given currency.
 	 *
 	 * @param string $currency The currency to check for.
-	 * @param bool   $fallback_to_local_list Whether to fallback to the local Stripe list if the cached value is not available.
 	 *
 	 * @return int|null Either the minimum amount, or `null` if not available.
 	 */
-	public static function get_cached_minimum_amount( $currency, $fallback_to_local_list = false ) {
+	public static function get_cached_minimum_amount( $currency ) {
 		$cached = get_transient( 'wcpay_minimum_amount_' . strtolower( $currency ) );
-
-		if ( (int) $cached ) {
-			return (int) $cached;
-		} elseif ( $fallback_to_local_list ) {
-			return self::get_stripe_minimum_amount( $currency );
-		}
-
-		return null;
+		return (int) $cached ? (int) $cached : null;
 	}
 
 	/**

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -782,8 +782,8 @@ class WC_Payments_Utils {
 					Currency_Code::POUND_STERLING       => [
 						Country_Code::UNITED_KINGDOM => [
 							'min' => 100,
-							'max' => 1150000,
-						], // Represents GBP 1 - 11,500 GBP.
+							'max' => 500000,
+						], // Represents GBP 1 - 5,000 GBP.
 					],
 					Currency_Code::EURO                 => [
 						Country_Code::AUSTRIA     => [
@@ -819,9 +819,9 @@ class WC_Payments_Utils {
 							'max' => 400000,
 						], // Represents EUR 1 - 4,000 EUR.
 						Country_Code::FRANCE      => [
-							'min' => 3500,
+							'min' => 100,
 							'max' => 400000,
-						], // Represents EUR 35 - 4000 EUR.
+						], // Represents EUR 1 - 4,000 EUR.
 					],
 					Currency_Code::DANISH_KRONE         => [
 						Country_Code::DENMARK => [

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -800,8 +800,8 @@ class WC_Payments_Utils {
 						], // Represents EUR 1 - 10,000 EUR.
 						Country_Code::NETHERLANDS => [
 							'min' => 100,
-							'max' => 1500000,
-						], // Represents EUR 1 - 15,000 EUR.
+							'max' => 500000,
+						], // Represents EUR 1 - 5,000 EUR.
 						Country_Code::FINLAND     => [
 							'min' => 100,
 							'max' => 1000000,
@@ -816,30 +816,30 @@ class WC_Payments_Utils {
 						], // Represents EUR 1 - 4,000 EUR.
 						Country_Code::ITALY       => [
 							'min' => 100,
-							'max' => 1000000,
-						], // Represents EUR 1 - 10,000 EUR.
+							'max' => 400000,
+						], // Represents EUR 1 - 4,000 EUR.
 						Country_Code::FRANCE      => [
 							'min' => 3500,
 							'max' => 400000,
-						], // Represents EUR 35 - 400 EUR.
+						], // Represents EUR 35 - 4000 EUR.
 					],
 					Currency_Code::DANISH_KRONE         => [
 						Country_Code::DENMARK => [
 							'min' => 100,
-							'max' => 100000000,
-						], // Represents DKK 1 - 1,000,000 DKK.
+							'max' => 10000000,
+						], // Represents DKK 1 - 100,000 DKK.
 					],
 					Currency_Code::NORWEGIAN_KRONE      => [
 						Country_Code::NORWAY => [
 							'min' => 100,
-							'max' => 100000000,
-						], // Represents NOK 1 - 1,000,000 NOK.
+							'max' => 10000000,
+						], // Represents NOK 1 - 100,000 NOK.
 					],
 					Currency_Code::SWEDISH_KRONA        => [
 						Country_Code::SWEDEN => [
 							'min' => 100,
-							'max' => 15000000,
-						], // Represents SEK 1 - 150,000 SEK.
+							'max' => 10000000,
+						], // Represents SEK 1 - 100,000 SEK.
 					],
 				];
 			default:

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -618,6 +618,7 @@ class WC_Payments {
 				add_action( 'woocommerce_proceed_to_checkout', [ __CLASS__, 'load_stripe_bnpl_site_messaging' ], 5 );
 				add_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after', [ __CLASS__, 'load_stripe_bnpl_site_messaging' ] );
 				add_action( 'wc_ajax_wcpay_get_cart_total', [ __CLASS__, 'ajax_get_cart_total' ] );
+				add_action( 'wc_ajax_wcpay_check_bnpl_availability', [ __CLASS__, 'ajax_check_bnpl_availability' ] );
 			}
 		}
 
@@ -1713,7 +1714,7 @@ class WC_Payments {
 	 * Get cart total.
 	 */
 	public static function ajax_get_cart_total() {
-		check_ajax_referer( 'wcpay-get-cart-total', 'security' );
+		check_ajax_referer( 'wcpay-bnpl-nonce', 'security' );
 
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
@@ -1729,6 +1730,26 @@ class WC_Payments {
 		$currency_code = get_woocommerce_currency();
 
 		wp_send_json( [ 'total' => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ) ] );
+	}
+
+	/**
+	 * Check if BNPL is available for the given price, currency, and country.
+	 */
+	public static function ajax_check_bnpl_availability() {
+		check_ajax_referer( 'wcpay-bnpl-nonce', 'security' );
+
+		$price    = floatval( $_POST['price'] );
+		$currency = sanitize_text_field( wp_unslash( $_POST['currency'] ) );
+		$country  = sanitize_text_field( wp_unslash( $_POST['country'] ) );
+
+		$enabled_bnpl_payment_methods = array_intersect(
+			Payment_Method::BNPL_PAYMENT_METHODS,
+			self::get_gateway()->get_upe_enabled_payment_method_ids()
+		);
+
+		$is_available = WC_Payments_Utils::is_any_bnpl_method_available( $enabled_bnpl_payment_methods, $country, $currency, $price );
+
+		wp_send_json_success( [ 'is_available' => $is_available ] );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1714,7 +1714,7 @@ class WC_Payments {
 	 * Get cart total.
 	 */
 	public static function ajax_get_cart_total() {
-		check_ajax_referer( 'wcpay-bnpl-nonce', 'security' );
+		check_ajax_referer( 'wcpay-get-cart-total', 'security' );
 
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
@@ -1736,7 +1736,7 @@ class WC_Payments {
 	 * Check if BNPL is available for the given price, currency, and country.
 	 */
 	public static function ajax_check_bnpl_availability() {
-		check_ajax_referer( 'wcpay-bnpl-nonce', 'security' );
+		check_ajax_referer( 'wcpay-is-bnpl-available', 'security' );
 
 		$price    = floatval( $_POST['price'] );
 		$currency = sanitize_text_field( wp_unslash( $_POST['currency'] ) );

--- a/includes/payment-methods/class-affirm-payment-method.php
+++ b/includes/payment-methods/class-affirm-payment-method.php
@@ -35,20 +35,7 @@ class Affirm_Payment_Method extends UPE_Payment_Method {
 		$this->dark_icon_url                = plugins_url( 'assets/images/payment-methods/affirm-logo-dark.svg', WCPAY_PLUGIN_FILE );
 		$this->currencies                   = [ Currency_Code::UNITED_STATES_DOLLAR, Currency_Code::CANADIAN_DOLLAR ];
 		$this->accept_only_domestic_payment = true;
-		$this->limits_per_currency          = [
-			Currency_Code::CANADIAN_DOLLAR      => [
-				Country_Code::CANADA => [
-					'min' => 5000,
-					'max' => 3000000,
-				], // Represents CAD 50 - 30,000 CAD.
-			],
-			Currency_Code::UNITED_STATES_DOLLAR => [
-				Country_Code::UNITED_STATES => [
-					'min' => 5000,
-					'max' => 3000000,
-				], // Represents USD 50 - 30,000 USD.
-			],
-		];
+		$this->limits_per_currency          = WC_Payments_Utils::get_bnpl_limits_per_currency( self::PAYMENT_METHOD_STRIPE_ID );
 		$this->countries                    = [ Country_Code::UNITED_STATES, Country_Code::CANADA ];
 	}
 

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -34,38 +34,7 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 		$this->currencies                   = [ Currency_Code::UNITED_STATES_DOLLAR, Currency_Code::CANADIAN_DOLLAR, Currency_Code::AUSTRALIAN_DOLLAR, Currency_Code::NEW_ZEALAND_DOLLAR, Currency_Code::POUND_STERLING ];
 		$this->countries                    = [ Country_Code::UNITED_STATES, Country_Code::CANADA, Country_Code::AUSTRALIA, Country_Code::NEW_ZEALAND, Country_Code::UNITED_KINGDOM ];
 		$this->accept_only_domestic_payment = true;
-		$this->limits_per_currency          = [
-			Currency_Code::AUSTRALIAN_DOLLAR    => [
-				Country_Code::AUSTRALIA => [
-					'min' => 100,
-					'max' => 200000,
-				], // Represents AUD 1 - 2,000 AUD.
-			],
-			Currency_Code::CANADIAN_DOLLAR      => [
-				Country_Code::CANADA => [
-					'min' => 100,
-					'max' => 200000,
-				], // Represents CAD 1 - 2,000 CAD.
-			],
-			Currency_Code::NEW_ZEALAND_DOLLAR   => [
-				Country_Code::NEW_ZEALAND => [
-					'min' => 100,
-					'max' => 200000,
-				], // Represents NZD 1 - 2,000 NZD.
-			],
-			Currency_Code::POUND_STERLING       => [
-				Country_Code::UNITED_KINGDOM => [
-					'min' => 100,
-					'max' => 120000,
-				], // Represents GBP 1 - 1,200 GBP.
-			],
-			Currency_Code::UNITED_STATES_DOLLAR => [
-				Country_Code::UNITED_STATES => [
-					'min' => 100,
-					'max' => 400000,
-				], // Represents USD 1 - 4,000 USD.
-			],
-		];
+		$this->limits_per_currency          = WC_Payments_Utils::get_bnpl_limits_per_currency( self::PAYMENT_METHOD_STRIPE_ID );
 	}
 
 	/**

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -34,76 +34,7 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 		$this->currencies                   = [ Currency_Code::UNITED_STATES_DOLLAR, Currency_Code::POUND_STERLING, Currency_Code::EURO, Currency_Code::DANISH_KRONE, Currency_Code::NORWEGIAN_KRONE, Currency_Code::SWEDISH_KRONA ];
 		$this->accept_only_domestic_payment = true;
 		$this->countries                    = [ Country_Code::UNITED_STATES, Country_Code::UNITED_KINGDOM, Country_Code::AUSTRIA, Country_Code::GERMANY, Country_Code::NETHERLANDS, Country_Code::BELGIUM, Country_Code::SPAIN, Country_Code::ITALY, Country_Code::IRELAND, Country_Code::DENMARK, Country_Code::FINLAND, Country_Code::NORWAY, Country_Code::SWEDEN, Country_Code::FRANCE ];
-		$this->limits_per_currency          = [
-			Currency_Code::UNITED_STATES_DOLLAR => [
-				Country_Code::UNITED_STATES => [
-					'min' => 0,
-					'max' => 1000000,
-				],
-			],
-			Currency_Code::POUND_STERLING       => [
-				Country_Code::UNITED_KINGDOM => [
-					'min' => 0,
-					'max' => 1150000,
-				],
-			],
-			Currency_Code::EURO                 => [
-				Country_Code::AUSTRIA     => [
-					'min' => 1,
-					'max' => 1000000,
-				],
-				Country_Code::BELGIUM     => [
-					'min' => 1,
-					'max' => 1000000,
-				],
-				Country_Code::GERMANY     => [
-					'min' => 1,
-					'max' => 1000000,
-				],
-				Country_Code::NETHERLANDS => [
-					'min' => 1,
-					'max' => 1500000,
-				],
-				Country_Code::FINLAND     => [
-					'min' => 0,
-					'max' => 1000000,
-				],
-				Country_Code::SPAIN       => [
-					'min' => 0,
-					'max' => 1000000,
-				],
-				Country_Code::IRELAND     => [
-					'min' => 0,
-					'max' => 400000,
-				],
-				Country_Code::ITALY       => [
-					'min' => 0,
-					'max' => 1000000,
-				],
-				Country_Code::FRANCE      => [
-					'min' => 3500,
-					'max' => 400000,
-				],
-			],
-			Currency_Code::DANISH_KRONE         => [
-				Country_Code::DENMARK => [
-					'min' => 100,
-					'max' => 100000000,
-				],
-			],
-			Currency_Code::NORWEGIAN_KRONE      => [
-				Country_Code::NORWAY => [
-					'min' => 0,
-					'max' => 100000000,
-				],
-			],
-			Currency_Code::SWEDISH_KRONA        => [
-				Country_Code::SWEDEN => [
-					'min' => 0,
-					'max' => 15000000,
-				],
-			],
-		];
+		$this->limits_per_currency          = WC_Payments_Utils::get_bnpl_limits_per_currency( self::PAYMENT_METHOD_STRIPE_ID );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9456 

#### Changes proposed in this Pull Request

As described in #9456, when there is no BNPL offer on PDPs, the PMME is displaying a skeleton loader which resolves to an empty space. This PR solves that by predicting whether the PMME will render any payment methods. If not, the PMME is hidden, with no skeleton displayed and no dead space below the product price. An [earlier PR](https://github.com/Automattic/woocommerce-payments/pull/9355) attempted to solve this for minimum price limits only, but rather than the BNPL minimums, the overall Stripe charge limits were used, which differ from BNPL minimums. To solve this, I've aggregated all `$limits_per_currency` arrays into a function that is used to determine whether any offers will be available. The result is surfaced on the front end via the `wcpayStripeSiteMessaging.isBnplAvailable`.

This also ensures that the PMME visibility is toggled when product quantity or variation changes result in price changes that affect payment method visibility. This done listening for changes to quantity or variation, then sending a request to get the BNPL availability. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Enable all BNPL payment methods
2. Ensure your billing country matches the country in your Stripe merchant account
3. Test the following scenarios: 

**No BNPL offers**
1. Create a product with a price of 20 cents. 
2. Visit the product and check that no skeleton loader or dead space appear below the product price.

**Quantity Updates**
1. On the same 20 cent product, increase the quantity to 5 or more
2. The PMME should appear.
3. Decrease the quantity to 1. The PMME should smoothly disappear with no dead space apparent.

Further tests can be perform using the conditions in the unit test [here](https://github.com/Automattic/woocommerce-payments/compare/fix/9456-bnpl-respect-limits-per-currency?expand=1#diff-f2dfed80507c5b96fde36d3f57be2fb1310a8bd3c8f141297c3e4e4c8bd2ae63R1116).

**Before**
![Screen Capture on 2024-10-24 at 16-47-08](https://github.com/user-attachments/assets/34911781-8421-414e-bae4-7bf02a369a7b)

**After**
![image](https://github.com/user-attachments/assets/03bd3dad-ce8a-4a89-a357-a5303e16587b)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
