### PR TITLE
Rename 'deposit' to 'payout' across doc urls

### DIFF
--- a/changelog/update-9587-doc-url-payout-rename
+++ b/changelog/update-9587-doc-url-payout-rename
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Update 'deposit' to 'payout' in URLs of WooPayments docs occuring across the codebase. Part of a larger renaming project.
+
+

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -198,7 +198,7 @@ const AccountBalances: React.FC = () => {
 												strong: <strong />,
 												learnMoreLink: (
 													<Link
-														href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/"
+														href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/"
 														target="_blank"
 														rel="noreferrer"
 														type="external"

--- a/client/components/account-balances/strings.ts
+++ b/client/components/account-balances/strings.ts
@@ -26,7 +26,7 @@ export const fundLabelStrings = {
 
 export const documentationUrls = {
 	depositSchedule:
-		'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/',
+		'https://woocommerce.com/document/woopayments/payouts/payout-schedule/',
 	negativeBalance:
 		'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/',
 };

--- a/client/components/account-balances/test/index.test.tsx
+++ b/client/components/account-balances/test/index.test.tsx
@@ -235,7 +235,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/'
+			'https://woocommerce.com/document/woopayments/payouts/payout-schedule/'
 		);
 	} );
 
@@ -293,7 +293,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getByRole( 'link' ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/'
+			'https://woocommerce.com/document/woopayments/payouts/payout-schedule/'
 		);
 	} );
 

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -37,7 +37,7 @@ export const SuspendedDepositNotice: React.FC = () => {
 					suspendLink: (
 						<Link
 							href={
-								'https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/'
+								'https://woocommerce.com/document/woopayments/payouts/why-payouts-suspended/'
 							}
 						/>
 					),

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -96,7 +96,7 @@ export const NewAccountWaitingPeriodNotice: React.FC = () => (
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#new-accounts"
+						href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/#new-accounts"
 					/>
 				),
 			},
@@ -181,7 +181,7 @@ export const DepositMinimumBalanceNotice: React.FC< {
 						<a
 							target="_blank"
 							rel="noopener noreferrer"
-							href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#minimum-deposit-amounts"
+							href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/#minimum-payout-amounts"
 						/>
 					),
 				},
@@ -207,7 +207,7 @@ export const NoFundsAvailableForDepositNotice: React.FC = () => (
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#pending-funds"
+						href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/#pending-funds"
 					/>
 				),
 			},

--- a/client/components/deposits-overview/deposit-schedule.tsx
+++ b/client/components/deposits-overview/deposit-schedule.tsx
@@ -176,7 +176,7 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 									rel="external noopener noreferrer"
 									target="_blank"
 									href={
-										'https://woocommerce.com/document/woopayments/deposits/change-deposit-schedule/'
+										'https://woocommerce.com/document/woopayments/payouts/change-payout-schedule/'
 									}
 								/>
 							),

--- a/client/components/deposits-overview/deposit-schedule.tsx
+++ b/client/components/deposits-overview/deposit-schedule.tsx
@@ -136,7 +136,7 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 									rel="external noopener noreferrer"
 									target="_blank"
 									href={
-										'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#pending-period-chart'
+										'https://woocommerce.com/document/woopayments/payouts/payout-schedule/#pending-period-chart'
 									}
 								/>
 							),
@@ -156,7 +156,7 @@ const DepositSchedule: React.FC< DepositScheduleProps > = ( {
 									rel="external noopener noreferrer"
 									target="_blank"
 									href={
-										'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#available-funds'
+										'https://woocommerce.com/document/woopayments/payouts/payout-schedule/#available-funds'
 									}
 								/>
 							),

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -414,7 +414,7 @@ exports[`Suspended Deposit Notice Renders Component Renders 1`] = `
           . 
           <a
             data-link-type="wc-admin"
-            href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+            href="https://woocommerce.com/document/woopayments/payouts/why-payouts-suspended/"
           >
             Learn more
           </a>

--- a/client/components/deposits-overview/test/index.tsx
+++ b/client/components/deposits-overview/test/index.tsx
@@ -438,7 +438,7 @@ describe( 'Deposits Overview information', () => {
 		} );
 		expect( getByRole( 'link', { name: /Why\?/ } ) ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#new-accounts'
+			'https://woocommerce.com/document/woopayments/payouts/payout-schedule/#new-accounts'
 		);
 	} );
 } );

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -63,7 +63,7 @@ const DepositsStatusSuspended: React.FC< DepositsStatusProps > = ( props ) => {
 	const { iconSize } = props;
 
 	const learnMoreHref =
-		'https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/';
+		'https://woocommerce.com/document/woopayments/payouts/why-payouts-suspended/';
 
 	const description = createInterpolateElement(
 		/* translators: <a> - suspended accounts FAQ URL */

--- a/client/components/deposits-status/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-status/test/__snapshots__/index.js.snap
@@ -20,7 +20,7 @@ exports[`DepositsStatus renders blocked status 1`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+      href="https://woocommerce.com/document/woopayments/payouts/why-payouts-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -51,7 +51,7 @@ exports[`DepositsStatus renders blocked status 2`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+      href="https://woocommerce.com/document/woopayments/payouts/why-payouts-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -174,7 +174,7 @@ exports[`DepositsStatus renders pending verification status 1`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/woopayments/deposits/why-deposits-suspended/"
+      href="https://woocommerce.com/document/woopayments/payouts/why-payouts-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -231,7 +231,7 @@ export const DepositDetails: React.FC< DepositDetailsProps > = ( {
 									),
 									components: {
 										learnMoreLink: (
-											<ExternalLink href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/#transactions" />
+											<ExternalLink href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/#transactions" />
 										),
 									},
 								} ) }

--- a/client/deposits/instant-payouts/modal.tsx
+++ b/client/deposits/instant-payouts/modal.tsx
@@ -29,7 +29,7 @@ const InstantPayoutModal: React.FC< InstantPayoutModalProps > = ( {
 	inProgress,
 } ) => {
 	const learnMoreHref =
-		'https://woocommerce.com/document/woopayments/deposits/instant-deposits/';
+		'https://woocommerce.com/document/woopayments/payouts/instant-payouts/';
 	const feePercentage = `${ percentage }%`;
 	const description = createInterpolateElement(
 		/* translators: %s: amount representing the fee percentage, <a>: instant payout doc URL */

--- a/client/deposits/instant-payouts/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/instant-payouts/test/__snapshots__/index.tsx.snap
@@ -57,7 +57,7 @@ exports[`Instant payout button and modal modal renders correctly 1`] = `
     <p>
       Need cash in a hurry? Instant payouts are available within 30 minutes for a nominal 1.5% service fee. 
       <a
-        href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/"
+        href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -168,7 +168,7 @@ const DepositsSchedule = () => {
 						learnMoreLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
 							<a
-								href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/"
+								href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/"
 								target="_blank"
 								rel="noreferrer noopener"
 							/>
@@ -191,7 +191,7 @@ const DepositsSchedule = () => {
 						learnMoreLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
 							<a
-								href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/"
+								href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/"
 								target="_blank"
 								rel="noreferrer noopener"
 							/>

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -94,7 +94,7 @@ const DepositsDescription = () => {
 					depositDelayDays
 				) }
 			</p>
-			<ExternalLink href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/">
+			<ExternalLink href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/">
 				{ __(
 					'Learn more about pending schedules',
 					'woocommerce-payments'

--- a/client/transactions/list/deposit.tsx
+++ b/client/transactions/list/deposit.tsx
@@ -52,7 +52,7 @@ const Deposit: React.FC< DepositProps > = ( { depositId, dateAvailable } ) => {
 					),
 					components: {
 						learnMoreLink: (
-							<ExternalLink href="https://woocommerce.com/document/woopayments/deposits/deposit-schedule/#pending-funds" />
+							<ExternalLink href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/#pending-funds" />
 						),
 					},
 				} ) }

--- a/docs/rest-api/source/includes/wp-api-v3/deposits.md
+++ b/docs/rest-api/source/includes/wp-api-v3/deposits.md
@@ -354,7 +354,7 @@ curl -X GET https://example.com/wp-json/wc/v3/payments/deposits/po_123abc \
 
 ## Submit an instant deposit
 
-Submit an instant deposit for a list of transactions. Only for eligible accounts. See [Instant Deposits with WooPayments](https://woocommerce.com/document/woopayments/deposits/instant-deposits/) for more information.
+Submit an instant deposit for a list of transactions. Only for eligible accounts. See [Instant Deposits with WooPayments](https://woocommerce.com/document/woopayments/payouts/instant-payouts/) for more information.
 
 ### HTTP request
 

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -41,7 +41,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 					__( "Get immediate access to your funds when you need them – including nights, weekends, and holidays. With %s' <a>Instant Deposits feature</a>, you're able to transfer your earnings to a debit card within minutes.", 'woocommerce-payments' ),
 					'WooPayments'
 				),
-				[ 'a' => '<a href="https://woocommerce.com/document/woopayments/deposits/instant-deposits/">' ]
+				[ 'a' => '<a href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/">' ]
 			)
 		);
 		$note->set_content_data( (object) [] );
@@ -51,7 +51,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Request an instant deposit', 'woocommerce-payments' ),
-			'https://woocommerce.com/document/woopayments/deposits/instant-deposits/#request-an-instant-deposit',
+			'https://woocommerce.com/document/woopayments/payouts/instant-payouts/#request-an-instant-payout',
 			'unactioned',
 			true
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ Features previously only available on your payment provider’s website are now 
 
 - View the details of [payments, refunds, and other transactions](https://woocommerce.com/document/woopayments/managing-money/).
 - View and respond to [disputes and chargebacks](https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/).
-- [Track deposits](https://woocommerce.com/document/woopayments/deposits/) into your bank account or debit card.
+- [Track payouts](https://woocommerce.com/document/woopayments/payouts/) into your bank account or debit card.
 
 **Pay as you go**
 


### PR DESCRIPTION
Fixes #9587 

#### Changes proposed in this Pull Request

The PR changes 'deposit' to 'payout' across various documentation URLs ( including anchor text ) 

URL's that have been changed are recorded on [this sheet](https://docs.google.com/spreadsheets/d/1A_ZarapBs3vNeLDjC1AAHh_13zZfd9X83vZixClmeH8/edit?gid=0#gid=0). 

( Thank you @aheckler  for the sheet with the links and references to the anchor text in the issue ) 

#### Testing instructions

It may not be practical to test the links on actual render. Please visually inspect the URLs and do a CMD + enter to check if they render correctly ( for a few links ).

All existing tests must pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
