### PR TITLE
Rename 'deposit' to 'payout' in deposit details page

### DIFF
--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -103,8 +103,8 @@ export const DepositOverview: React.FC< DepositOverviewProps > = ( {
 	}
 
 	const depositDateLabel = deposit.automatic
-		? __( 'Deposit date', 'woocommerce-payments' )
-		: __( 'Instant deposit date', 'woocommerce-payments' );
+		? __( 'Payout date', 'woocommerce-payments' )
+		: __( 'Instant payout date', 'woocommerce-payments' );
 
 	const depositDateItem = (
 		<SummaryItem
@@ -138,14 +138,14 @@ export const DepositOverview: React.FC< DepositOverviewProps > = ( {
 				</Card>
 			) : (
 				<SummaryList
-					label={ __( 'Deposit overview', 'woocommerce-payments' ) }
+					label={ __( 'Payout overview', 'woocommerce-payments' ) }
 				>
 					{ () => [
 						depositDateItem,
 						<SummaryItem
 							key="depositAmount"
 							label={ __(
-								'Deposit amount',
+								'Payout amount',
 								'woocommerce-payments'
 							) }
 							value={ formatExplicitCurrency(
@@ -171,7 +171,7 @@ export const DepositOverview: React.FC< DepositOverviewProps > = ( {
 						<SummaryItem
 							key="netDepositAmount"
 							label={ __(
-								'Net deposit amount',
+								'Net payout amount',
 								'woocommerce-payments'
 							) }
 							value={ formatExplicitCurrency(
@@ -220,7 +220,7 @@ export const DepositDetails: React.FC< DepositDetailsProps > = ( {
 							<CardHeader>
 								<Text size={ 16 } weight={ 600 } as="h2">
 									{ __(
-										'Deposit transactions',
+										'Payout transactions',
 										'woocommerce-payments'
 									) }
 								</Text>
@@ -229,7 +229,7 @@ export const DepositDetails: React.FC< DepositDetailsProps > = ( {
 								{ interpolateComponents( {
 									/* Translators: {{learnMoreLink}} is a link element (<a/>). */
 									mixedString: __(
-										`We're unable to show transaction history on instant deposits. {{learnMoreLink}}Learn more{{/learnMoreLink}}`,
+										`We're unable to show transaction history on instant payouts. {{learnMoreLink}}Learn more{{/learnMoreLink}}`,
 										'woocommerce-payments'
 									),
 									components: {

--- a/client/deposits/details/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/details/test/__snapshots__/index.tsx.snap
@@ -23,7 +23,7 @@ exports[`Deposit overview renders automatic deposit correctly 1`] = `
               <div
                 class="woocommerce-summary__item-label"
               >
-                Deposit date: Jan 2, 2020
+                Payout date: Jan 2, 2020
               </div>
               <div
                 class="woocommerce-summary__item-data"
@@ -79,7 +79,7 @@ exports[`Deposit overview renders instant deposit correctly 1`] = `
   >
     <div
       aria-describedby="woocommerce-summary-helptext-1"
-      aria-label="Deposit overview"
+      aria-label="Payout overview"
       aria-orientation="horizontal"
       role="menu"
     >
@@ -101,7 +101,7 @@ exports[`Deposit overview renders instant deposit correctly 1`] = `
             <div
               class="woocommerce-summary__item-label"
             >
-              Instant deposit date: Jan 2, 2020
+              Instant payout date: Jan 2, 2020
             </div>
             <div
               class="woocommerce-summary__item-data"
@@ -135,7 +135,7 @@ exports[`Deposit overview renders instant deposit correctly 1`] = `
             <div
               class="woocommerce-summary__item-label"
             >
-              Deposit amount
+              Payout amount
             </div>
             <div
               class="woocommerce-summary__item-data"
@@ -179,7 +179,7 @@ exports[`Deposit overview renders instant deposit correctly 1`] = `
             <div
               class="woocommerce-summary__item-label"
             >
-              Net deposit amount
+              Net payout amount
             </div>
             <div
               class="woocommerce-summary__item-data"


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9561

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Rename 'deposit' to 'payout' in deposit details page.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

So I can control what is shown under the transaction list UI, I make this local change in `WC_REST_Payments_Transactions_Controller::get_transactions()`:

```php
		$to_return = [
			'data' => [
				[
					'transaction_id' => 'txn_abc',
					'type' => 'charge',
					'date' => '2024-09-18 23:11:20',
					'source' => 'visa',
					'source_identifier' => '4242',
					'customer_name' => 'customer',
					'customer_email' => 'email@email.email',
					'customer_country' => 'US',
					'amount' => 1000,
					'net' => 941,
					'fees' => 59,
					'currency' => 'usd',
					'risk_level' => 0,
					'charge_id' => 'ch_def',
					'deposit_id' => null,
					'available_on' => '2024-09-20 00:00:00',
					'exchange_rate' => 1,
					'customer_amount' => 1000,
					'customer_currency' => 'usd',
					'order_id' => 167,
					'amount_in_usd' => 1000,
					'source_device' => null,
					'channel' => null,
					'order' => [
						'number' => '123',
						'url' => 'https://web.site/wp-admin/post.php?post=123&action=edit',
						'customer_url' => 'admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=1'
					],
					'payment_intent_id' => 'pi_ghi'
				]
			]
		];
		return $to_return;
```

There are 3 states that affect the UI in deposit details page:

Testing automatic deposit
- Go to wp-admin > Payments > Payouts > click one of the payout

<img width="1525" alt="Screenshot 2024-10-27 at 07 10 43" src="https://github.com/user-attachments/assets/9646b5b4-c804-4ff8-b898-5d86ff8cc654">


Testing instant deposit

- Make local change on this [line](https://github.com/Automattic/woocommerce-payments/blob/63bdb45a228896ac704170debc6facb14e67db14/client/deposits/details/index.tsx#L104):
```diff
+       deposit.automatic = false;
```

<img width="1482" alt="Screenshot 2024-10-27 at 07 13 20" src="https://github.com/user-attachments/assets/6a4bace2-6e2b-42da-8b06-0cde0cdf9600">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
