### PR TITLE
Update cache key for composer dependencies

### DIFF
--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ./vendor
-        key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+        key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
 
     # Cache node dependencies
     - name: Cache node dependencies

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/composer/
-        key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
 
     - name: "Set up PHP"
       uses: ./.github/actions/setup-php

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
       - name: "Set up PHP"
         uses: ./.github/actions/setup-php

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
       - uses: shivammathur/setup-php@v2
         with:
@@ -54,7 +54,7 @@ jobs:
           coverage: none
       # run CI checks
       - run: bash bin/run-ci-tests.bash
-  
+
   generate-wc-compat-beta-matrix:
     name: "Generate the matrix for compatibility-woocommerce-beta dynamically"
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/i18n-weekly-release.yml
+++ b/.github/workflows/i18n-weekly-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       - uses: actions/cache@v4
         with:
           path: ~/.npm/
@@ -33,7 +33,7 @@ jobs:
         run: |
           npm ci
           npm run build
-          
+
           if [[ ! -f woocommerce-payments.zip ]]; then
             echo "Failed to create release zip"
             exit 1

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       - uses: actions/cache@v4
         with:
           path: ~/.npm/

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       # setup PHP, but without debug extensions for reasonable performance
       - name: "Set up PHP"
         uses: ./.github/actions/setup-php
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/changelog/gh-actions-e2e-optimize-composer-cache
+++ b/changelog/gh-actions-e2e-optimize-composer-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Updates gh actions cache-key for composer dependencies.
+
+


### PR DESCRIPTION
Fixes #9478

#### Changes proposed in this Pull Request

* Updates the cache key for composer dependencies to include hash of both `composer.json` & `composer.lock`.
* This prevents cache issues while running tests on GitHub actions, if only `composer.json` was updated.

#### Testing instructions

* Confirm that you can see the cache key in the format `Linux-composer-<composer.json-hash>-<composer.lock-hash>` in the GitHub actions logs. Previously it was `Linux-composer-<composer.lock-hash>`.
* Confirm that tests are not failing.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
