### PR TITLE
Add unit test for Capital Loans page of WP Admin

### DIFF
--- a/changelog/dev-add-unit-tests-for-capital-list
+++ b/changelog/dev-add-unit-tests-for-capital-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add unit tests for the Capital Loans page component.

--- a/client/capital/test/__snapshots__/index.test.tsx.snap
+++ b/client/capital/test/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,496 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CapitalPage renders the TableCard component with loan data 1`] = `
+<div>
+  <div
+    class=" woocommerce-payments-page"
+  >
+    <div
+      class="wcpay-banner-notice is-warning"
+    >
+      <div
+        class="wcpay-banner-notice__content"
+      >
+        Viewing test loans. To view live loans, disable test mode in 
+        <a
+          href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+        >
+          WooPayments settings
+        </a>
+        .
+      </div>
+    </div>
+    <div
+      class="components-surface components-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+      data-wp-c16t="true"
+      data-wp-component="Card"
+    >
+      <div
+        class="css-mgwsf4-View-Content em57xhy0"
+      >
+        <div
+          class="components-flex components-card__header components-card-header wcpay-loan-summary-header css-1g5oj2q-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="CardHeader"
+        >
+          <div
+            class="components-flex-item css-mw3lhz-View-Item-sx-Base em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="FlexItem"
+          >
+            Active loan overview
+          </div>
+          <div
+            class="components-flex-item css-mw3lhz-View-Item-sx-Base em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="FlexItem"
+          />
+        </div>
+        <div
+          class="components-card__body components-card-body wcpay-loan-summary-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="CardBody"
+        >
+          <div
+            class="components-flex wcpay-loan-summary-row css-s9rxun-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
+          >
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                Total repaid
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                <span
+                  class="is-big"
+                >
+                  $0.00
+                </span>
+                 of $1,100.00
+              </div>
+            </div>
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                Repaid this period (until Dec 27, 2024)
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                <span
+                  class="is-big"
+                >
+                  $0.00
+                </span>
+                 of $122.23 minimum
+              </div>
+            </div>
+          </div>
+          <div
+            class="components-flex wcpay-loan-summary-row is-bottom-row css-s9rxun-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
+          >
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                Loan disbursed
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                Oct 21, 2024
+              </div>
+            </div>
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                Loan amount
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                $1,000.00
+              </div>
+            </div>
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                Fixed fee
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                $100.00
+              </div>
+            </div>
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                Withhold rate
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                15
+                %
+              </div>
+            </div>
+            <div
+              class="components-flex-item components-flex-block wcpay-loan-summary-block css-14wzr73-View-Item-sx-Base-block em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="FlexBlock"
+            >
+              <div
+                class="wcpay-loan-summary-block__title"
+              >
+                First paydown
+              </div>
+              <div
+                class="wcpay-loan-summary-block__value"
+              >
+                Oct 28, 2024
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Elevation"
+      />
+      <div
+        aria-hidden="true"
+        class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Elevation"
+      />
+    </div>
+    <div
+      class="components-surface components-card woocommerce-table wcpay-loans-list css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+      data-wp-c16t="true"
+      data-wp-component="Card"
+    >
+      <div
+        class="css-mgwsf4-View-Content em57xhy0"
+      >
+        <div
+          class="components-flex components-card__header components-card-header css-1g5oj2q-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="CardHeader"
+        >
+          <h2
+            class="components-truncate components-text css-1s1vggh-View-Text-sx-Base em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Text"
+          >
+            All loans
+          </h2>
+          <div
+            class="woocommerce-table__actions"
+          />
+        </div>
+        <div
+          class="components-card__body components-card-body css-1i4jx7i-View-Body-borderRadius em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="CardBody"
+        >
+          <div
+            aria-labelledby="caption-0"
+            class="woocommerce-table__table"
+            role="group"
+          >
+            <table>
+              <caption
+                class="woocommerce-table__caption screen-reader-text"
+                id="caption-0"
+              >
+                All loans
+              </caption>
+              <tbody>
+                <tr>
+                  <th
+                    class="woocommerce-table__header is-left-aligned is-sorted"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      Disbursed
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Disbursed
+                    </span>
+                  </th>
+                  <th
+                    class="woocommerce-table__header is-center-aligned is-left-aligned"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      Status
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Status
+                    </span>
+                  </th>
+                  <th
+                    class="woocommerce-table__header is-numeric"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      Amount
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Amount
+                    </span>
+                  </th>
+                  <th
+                    class="woocommerce-table__header is-numeric"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      Fixed fee
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Fixed fee
+                    </span>
+                  </th>
+                  <th
+                    class="woocommerce-table__header is-numeric"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      Withhold rate
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Withhold rate
+                    </span>
+                  </th>
+                  <th
+                    class="woocommerce-table__header is-numeric"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      First paydown
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      First paydown
+                    </span>
+                  </th>
+                </tr>
+                <tr>
+                  <th
+                    class="woocommerce-table__item is-left-aligned is-sorted"
+                    scope="row"
+                  >
+                    <a
+                      class="woocommerce-table__clickable-cell"
+                      data-link-type="wc-admin"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      tabindex="-1"
+                    >
+                      Oct 28, 2024
+                    </a>
+                  </th>
+                  <td
+                    class="woocommerce-table__item is-center-aligned is-left-aligned"
+                  >
+                    <a
+                      class="woocommerce-table__clickable-cell"
+                      data-link-type="wc-admin"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="chip chip-warning"
+                      >
+                        Active
+                      </span>
+                    </a>
+                  </td>
+                  <td
+                    class="woocommerce-table__item is-numeric"
+                  >
+                    <a
+                      class="woocommerce-table__clickable-cell"
+                      data-link-type="wc-admin"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      tabindex="-1"
+                    >
+                      $1,000.00
+                    </a>
+                  </td>
+                  <td
+                    class="woocommerce-table__item is-numeric"
+                  >
+                    <a
+                      class="woocommerce-table__clickable-cell"
+                      data-link-type="wc-admin"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      tabindex="-1"
+                    >
+                      $100.00
+                    </a>
+                  </td>
+                  <td
+                    class="woocommerce-table__item is-numeric"
+                  >
+                    <a
+                      class="woocommerce-table__clickable-cell"
+                      data-link-type="wc-admin"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      tabindex="-1"
+                    >
+                      15%
+                    </a>
+                  </td>
+                  <td
+                    class="woocommerce-table__item is-numeric"
+                  >
+                    <a
+                      class="woocommerce-table__clickable-cell"
+                      data-link-type="wc-admin"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      tabindex="-1"
+                    >
+                      -
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          class="components-flex components-card__footer components-card-footer css-142znvl-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-medium em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="CardFooter"
+        >
+          <ul
+            class="woocommerce-table__summary"
+            role="complementary"
+          >
+            <li
+              class="woocommerce-table__summary-item"
+            >
+              <span
+                class="woocommerce-table__summary-value"
+              >
+                1
+              </span>
+              <span
+                class="woocommerce-table__summary-label"
+              >
+                loan
+              </span>
+            </li>
+            <li
+              class="woocommerce-table__summary-item"
+            >
+              <span
+                class="woocommerce-table__summary-value"
+              >
+                $1,000.00
+              </span>
+              <span
+                class="woocommerce-table__summary-label"
+              >
+                total
+              </span>
+            </li>
+            <li
+              class="woocommerce-table__summary-item"
+            >
+              <span
+                class="woocommerce-table__summary-value"
+              >
+                $100.00
+              </span>
+              <span
+                class="woocommerce-table__summary-label"
+              >
+                fixed fees
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        class="components-elevation css-15t1t3g-View-Elevation-sx-Base-elevationClassName em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Elevation"
+      />
+      <div
+        aria-hidden="true"
+        class="components-elevation css-15t1t3g-View-Elevation-sx-Base-elevationClassName em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Elevation"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/client/capital/test/index.test.tsx
+++ b/client/capital/test/index.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { useActiveLoanSummary, useLoans } from 'wcpay/data';
+import CapitalPage from '../index';
+
+// Mock the useLoans hook
+jest.mock( 'wcpay/data', () => ( {
+	useLoans: jest.fn(),
+	useActiveLoanSummary: jest.fn(),
+} ) );
+
+declare const global: {
+	wcpaySettings: {
+		zeroDecimalCurrencies: string[];
+		testMode: boolean;
+		connect: {
+			country: string;
+		};
+		accountLoans: {
+			has_active_loan: boolean;
+		};
+	};
+};
+
+describe( 'CapitalPage', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			accountLoans: { has_active_loan: true },
+			testMode: true,
+		};
+	} );
+
+	it( 'renders the TableCard component with loan data', () => {
+		const loans = [
+			{
+				wcpay_capital_loan_id: 1,
+				stripe_account_id: 'acct_1QD3WwR45o7u2iE3',
+				stripe_offer_id: 'financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S',
+				stripe_loan_id: 'financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S',
+				amount: 100000,
+				currency: 'usd',
+				fee_amount: 10000,
+				withhold_rate: 0.15,
+				accepted_at: '2024-10-28 10:10:50',
+				paid_out_at: '2024-10-28 10:11:40',
+				first_paydown_at: null,
+				fully_paid_at: null,
+				deleted_at: null,
+			},
+		];
+		( useLoans as jest.Mock ).mockReturnValue( {
+			loans,
+			isLoading: false,
+		} );
+
+		( useActiveLoanSummary as jest.Mock ).mockReturnValue( {
+			summary: {
+				details: {
+					advance_amount: 100000,
+					advance_paid_out_at: 1729505500.7316985,
+					currency: 'usd',
+					current_repayment_interval: {
+						due_at: 1735294500,
+						paid_amount: 0,
+						remaining_amount: 12223,
+					},
+					fee_amount: 10000,
+					paid_amount: 0,
+					remaining_amount: 110000,
+					repayments_begin_at: 1730110500,
+					withhold_rate: 0.15,
+				},
+				isLoading: false,
+			},
+		} );
+
+		const { container } = render( <CapitalPage /> );
+
+		expect(
+			screen.getByRole( 'heading', { name: 'All loans' } )
+		).toBeInTheDocument();
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'shows loading state when loans are being fetched', () => {
+		( useLoans as jest.Mock ).mockReturnValue( {
+			loans: [],
+			isLoading: true,
+		} );
+
+		render( <CapitalPage /> );
+
+		expect(
+			screen.getByText( 'Your requested data is loading' )
+		).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes #6567

While working on [Issue #6567](https://github.com/Automattic/woocommerce-payments/issues/6567), I noticed that we lack unit tests to verify how the Capital Loans page is rendered. I’m adding these basic tests to minimize the risk of regression errors when modifying date and time formats in [this related PR](https://github.com/Automattic/woocommerce-payments/pull/9635).

#### Changes proposed in this Pull Request

* Add Jest tests for the Capital Loans page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Covered by unit test.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
