### PR TITLE
Add unit tests for disputed order notices of WP Admin

### DIFF
--- a/changelog/dev-add-unit-tests-for-diputed-order-notice
+++ b/changelog/dev-add-unit-tests-for-diputed-order-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add Jest tests for the disputed order notices

--- a/client/components/disputed-order-notice/test/__snapshots__/index.test.js.snap
+++ b/client/components/disputed-order-notice/test/__snapshots__/index.test.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DisputedOrderNoticeHandler renders regular dispute notice 1`] = `
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
+  >
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <strong>
+            This order has a payment dispute for $10.00 for the reason 'Transaction unauthorized'. 
+          </strong>
+           
+          Please respond before Oct 28, 2023.
+          <div
+            class="components-flex wcpay-inline-notice__content__actions css-azptjn-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
+          >
+            <button
+              class="components-button wcpay-inline-notice__action"
+              type="button"
+            >
+              Respond now
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DisputedOrderNoticeHandler renders urgent dispute notice 1`] = `
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-error-notice components-notice is-error"
+  >
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <strong>
+            Please resolve the dispute on this order of $10.00 labeled 'Transaction unauthorized' by Oct 28, 2023.
+          </strong>
+           
+          (Last day today)
+          <div
+            class="components-flex wcpay-inline-notice__content__actions css-azptjn-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
+          >
+            <button
+              class="components-button wcpay-inline-notice__action"
+              type="button"
+            >
+              Respond today
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/client/components/disputed-order-notice/test/index.test.js
+++ b/client/components/disputed-order-notice/test/index.test.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import DisputedOrderNoticeHandler from '../index';
+import { useCharge } from 'wcpay/data';
+
+jest.mock( 'wcpay/data', () => ( {
+	useCharge: jest.fn(),
+} ) );
+
+jest.mock( 'tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'DisputedOrderNoticeHandler', () => {
+	const mockCharge = {
+		dispute: {
+			status: 'needs_response',
+			reason: 'fraudulent',
+			amount: 1000,
+			currency: 'USD',
+			evidence_details: {
+				due_by: 1698500219,
+			},
+		},
+	};
+
+	beforeEach( () => {
+		window.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+		};
+		useCharge.mockReturnValue( { data: mockCharge } );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders urgent dispute notice', () => {
+		const fixedDate = new Date( '2023-10-28T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		const { container } = render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+		const disputeMessages = screen.getAllByText(
+			/Please resolve the dispute on this order of/
+		);
+		expect( disputeMessages[ 0 ] ).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent(
+			'Respond today'
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders regular dispute notice', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		const { container } = render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+		const disputeMessages = screen.getAllByText( /Please respond before/ );
+		expect( disputeMessages[ 0 ] ).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent(
+			'Respond now'
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'does not render notice if no dispute', () => {
+		useCharge.mockReturnValue( { data: {} } );
+		const { container } = render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'does not render notice if dispute is not awaiting response', () => {
+		mockCharge.dispute.status = 'won';
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+		expect(
+			screen.queryByText( /Please resolve the dispute on this order of/ )
+		).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes #6567

I’m adding these basic tests for the disputed order notices, to minimize the risk of regression errors when modifying date and time formats in https://github.com/Automattic/woocommerce-payments/pull/9635.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add Jest tests for the disputed order notices

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
