### PR TITLE
Rename 'deposit' to 'payout'  in onboarding tasklist

### DIFF
--- a/changelog/update-9581-rename-deposit-onboarding-tasklist
+++ b/changelog/update-9581-rename-deposit-onboarding-tasklist
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Rename 'deposit' to 'payout' within the onboarding tasklist section. The change is a part of a larger project of doing this rename across the codebase.
+
+

--- a/client/overview/task-list/strings.tsx
+++ b/client/overview/task-list/strings.tsx
@@ -305,7 +305,7 @@ export default {
 					}
 				);
 			},
-			action_label: __( 'Set up deposits', 'woocommerce-payments' ),
+			action_label: __( 'Set up payouts', 'woocommerce-payments' ),
 		},
 		no_payment_30_days: {
 			title: __(
@@ -327,7 +327,7 @@ export default {
 		},
 		after_payment: {
 			title: __(
-				'Verify your bank account to start receiving deposits',
+				'Verify your bank account to start receiving payouts',
 				'woocommerce-payments'
 			),
 			description: ( dueDate: string ): React.ReactElement => {
@@ -345,13 +345,13 @@ export default {
 				);
 			},
 			action_label: __(
-				'Start receiving deposits',
+				'Start receiving payouts',
 				'woocommerce-payments'
 			),
 		},
 		balance_rising: {
 			title: __(
-				'Verify your bank account to start receiving deposits',
+				'Verify your bank account to start receiving payouts',
 				'woocommerce-payments'
 			),
 			description: ( dueDate: string ): React.ReactElement => {
@@ -369,7 +369,7 @@ export default {
 				);
 			},
 			action_label: __(
-				'Start receiving deposits',
+				'Start receiving payouts',
 				'woocommerce-payments'
 			),
 		},
@@ -389,7 +389,7 @@ export default {
 					}
 				);
 			},
-			action_label: __( 'Set up deposits', 'woocommerce-payments' ),
+			action_label: __( 'Set up payouts', 'woocommerce-payments' ),
 		},
 		threshold_reached: {
 			title: __(
@@ -400,7 +400,7 @@ export default {
 				return createInterpolateElement(
 					sprintf(
 						__(
-							'<strong>You have reached the deposit threshold of $5,000.00. Please verify your bank account now to reactivate payments.</strong> Your customers can no longer make purchases on your store until your account is verified.',
+							'<strong>You have reached the payout threshold of $5,000.00. Please verify your bank account now to reactivate payments.</strong> Your customers can no longer make purchases on your store until your account is verified.',
 							'woocommerce-payments'
 						),
 						dueDate

--- a/client/overview/task-list/tasks/test/po-tasks.tsx
+++ b/client/overview/task-list/tasks/test/po-tasks.tsx
@@ -100,7 +100,7 @@ describe( 'getVerifyBankAccountTask()', () => {
 				completed: false,
 				expanded: true,
 				isDismissable: false,
-				actionLabel: 'Set up deposits',
+				actionLabel: 'Set up payouts',
 				showActionButton: true,
 				visible: true,
 				time: '2 minutes',
@@ -154,12 +154,12 @@ describe( 'getVerifyBankAccountTask()', () => {
 		expect( getVerifyBankAccountTask() ).toEqual(
 			expect.objectContaining( {
 				key: 'verify-bank-details-po',
-				title: 'Verify your bank account to start receiving deposits',
+				title: 'Verify your bank account to start receiving payouts',
 				level: 3,
 				completed: false,
 				expanded: true,
 				showActionButton: true,
-				actionLabel: 'Start receiving deposits',
+				actionLabel: 'Start receiving payouts',
 				visible: true,
 				time: '2 minutes',
 			} )
@@ -182,14 +182,14 @@ describe( 'getVerifyBankAccountTask()', () => {
 		expect( getVerifyBankAccountTask() ).toEqual(
 			expect.objectContaining( {
 				key: 'verify-bank-details-po',
-				title: 'Verify your bank account to start receiving deposits',
+				title: 'Verify your bank account to start receiving payouts',
 				level: 2,
 				completed: false,
 				visible: true,
 				expanded: true,
 				isDismissable: false,
 				showActionButton: true,
-				actionLabel: 'Start receiving deposits',
+				actionLabel: 'Start receiving payouts',
 				time: '2 minutes',
 			} )
 		);
@@ -211,12 +211,12 @@ describe( 'getVerifyBankAccountTask()', () => {
 		expect( getVerifyBankAccountTask() ).toEqual(
 			expect.objectContaining( {
 				key: 'verify-bank-details-po',
-				title: 'Verify your bank account to start receiving deposits',
+				title: 'Verify your bank account to start receiving payouts',
 				level: 2,
 				completed: false,
 				expanded: true,
 				isDismissable: false,
-				actionLabel: 'Start receiving deposits',
+				actionLabel: 'Start receiving payouts',
 				showActionButton: true,
 				visible: true,
 				time: '2 minutes',
@@ -246,7 +246,7 @@ describe( 'getVerifyBankAccountTask()', () => {
 				expanded: true,
 				isDismissable: false,
 				showActionButton: true,
-				actionLabel: 'Set up deposits',
+				actionLabel: 'Set up payouts',
 				visible: true,
 				time: '2 minutes',
 			} )
@@ -275,7 +275,7 @@ describe( 'getVerifyBankAccountTask()', () => {
 				expanded: true,
 				isDismissable: false,
 				showActionButton: true,
-				actionLabel: 'Set up deposits',
+				actionLabel: 'Set up payouts',
 				visible: true,
 				time: '2 minutes',
 			} )

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -43,7 +43,7 @@ export const getUpdateBusinessDetailsTask = (
 		accountDetailsUpdateByDescription = sprintf(
 			/* translators: %s - formatted requirements current deadline (date) */
 			__(
-				'Update by %s to avoid a disruption in deposits.',
+				'Update by %s to avoid a disruption in payouts.',
 				'woocommerce-payments'
 			),
 			dateI18n(

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -447,7 +447,7 @@ describe( 'getTasks()', () => {
 					completed: false,
 					level: 3,
 					title:
-						'Verify your bank account to start receiving deposits',
+						'Verify your bank account to start receiving payouts',
 				} ),
 			] )
 		);
@@ -549,7 +549,7 @@ describe( 'taskSort()', () => {
 				key: 'verify-bank-details-po',
 				completed: false,
 				level: 3,
-				title: 'Verify your bank account to start receiving deposits',
+				title: 'Verify your bank account to start receiving payouts',
 			} )
 		);
 	} );


### PR DESCRIPTION
Fixes #9581 

#### Changes proposed in this Pull Request
The PR renames 'deposit' to 'payout' across various places on the onboarding tasklist. 


#### Testing instructions

The changes are simple string replacements. Please review the code to check for any spelling mistake or any other visible errors. Make sure automated tests pass. 


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
