### PR TITLE
Fix single product page view tracks.

### DIFF
--- a/changelog/9550-fix-single-product-page-view-tracks
+++ b/changelog/9550-fix-single-product-page-view-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed single product page view tracks when BNPL and PRB payment methods are inactive.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -622,12 +622,22 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 
 		WC_Payments::register_script_with_dependencies( 'wcpay-frontend-tracks', 'dist/frontend-tracks' );
 
-		wp_enqueue_script( 'wcpay-frontend-tracks' );
+		// Define wcpayConfig before the frontend tracks script if it hasn't been defined yet.
+		$wcpay_config = rawurlencode( wp_json_encode( WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() ) );
+		wp_add_inline_script(
+			'wcpay-frontend-tracks',
+			"
+			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
+			",
+			'before'
+		);
 
 		wp_localize_script(
 			'wcpay-frontend-tracks',
 			'wcPayFrontendTracks',
 			$frontent_tracks
 		);
+
+		wp_enqueue_script( 'wcpay-frontend-tracks' );
 	}
 }


### PR DESCRIPTION
Fixes #9550

#### Changes proposed in this Pull Request
When a merchant did not have any BNPL or express checkout payment methods active in their store, visiting the single product page resulted in a 404 `POST` request to `null`. The frontend tracks script assumes that the `wcpayConfig` object will always be available on the single product page and that's not the case. It looks like this bug was exposed after #9467 was merged. Before that fix, BNPL and PMME scripts (which included adding `wcpayConfig` to the single product page) were being loaded even if they were not enabled.

This PR fixes this by defining `wcpayConfig` inline before the `frontend-tracks` script if it hasn't already been defined.

#### Testing instructions
* Disable all BNPL payment methods.
* Disable Apple Pay/Google Pay, and WooPay.
* Load a single product page and see a `404` request to `store-url.com/product/product-name/null` in the console.
* Apply this PR.
* Load a single product page and see a `200` request to `admin-ajax.php` with the `product_page_view` as the `tracksEventName` in the request payload.
* Enable a BNPL payment method.
* Enable Apple Pay/Google Pay, and WooPay.
* Load a single product page and see a `200` request to `admin-ajax.php` with the `product_page_view` as the `tracksEventName` in the request payload.
* 
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
