### PR TITLE
Resolve compatibility issues with CustomSelectControl component styles for WordPress 6.7

### DIFF
--- a/changelog/fix-9636-custom-select-control-styling
+++ b/changelog/fix-9636-custom-select-control-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix compatibility issues with CustomSelectControl component styles for WordPress 6.7

--- a/client/components/custom-select-control/style.scss
+++ b/client/components/custom-select-control/style.scss
@@ -1,6 +1,7 @@
 .wcpay.components-custom-select-control {
 	font-size: 13px;
 	color: $gray-900;
+	position: relative;
 
 	.components-custom-select-control__label {
 		display: inline-block;
@@ -12,10 +13,20 @@
 		margin: 0;
 		line-height: initial;
 		box-shadow: inset 0 1px 0 #f0f0f0;
+		align-items: center;
+		cursor: default;
+		display: grid;
+		grid-template-columns: auto auto;
+		list-style-type: none;
 
 		&.is-highlighted {
 			background: $gray-0;
 		}
+	}
+
+	.components-custom-select-control__item
+		.components-custom-select-control__item-icon {
+		margin-left: auto;
 	}
 
 	button.components-custom-select-control__button {
@@ -53,9 +64,22 @@
 		}
 	}
 
+	.components-custom-select-control__menu[aria-hidden='true'] {
+		display: none;
+	}
+
 	.components-custom-select-control__menu {
 		margin: -1px 1px;
-		border-color: $gray-300;
+		background-color: #fff;
+		border: 1px solid $gray-300;
+		border-radius: 2px;
 		max-height: 300px;
+		min-width: 100%;
+		outline: none;
+		overflow: auto;
+		padding: 0;
+		position: absolute;
+		transition: none;
+		z-index: 1000000;
 	}
 }


### PR DESCRIPTION
Fixes #9636

#### Changes proposed in this Pull Request
This PR updates the styling for the `CustomSelectControl` component to ensure compatibility with WordPress 6.7. In this version, the component has been completely refactored, resulting in the removal of previous styles. This update reintroduces the necessary styles to maintain a consistent appearance and functionality within the new WordPress 6.7.

<img src="https://github.com/user-attachments/assets/e5fef729-f298-43d8-8084-6a0f62687a37" width="600"/>

#### Testing instructions
- Use [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin and update to WordPress 6.7-RC1.
- Start onboarding and navigate to KYC screen.
- Click on any dropdown and verify the stylings are correct. ( The dropdown is over the content below )

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
