### PR TITLE
Register Expresss Checkout block only when enabled in the settings

### DIFF
--- a/changelog/fix-express-checkout-block-registering
+++ b/changelog/fix-express-checkout-block-registering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Register Expresss Checkout block only when enabled in the settings

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -157,15 +157,17 @@ if ( getUPEConfig( 'isWooPayEnabled' ) ) {
 	}
 }
 
-if ( getUPEConfig( 'isTokenizedCartPrbEnabled' ) ) {
-	registerExpressPaymentMethod(
-		tokenizedCartPaymentRequestPaymentMethod( api )
-	);
-} else if ( getUPEConfig( 'isExpressCheckoutElementEnabled' ) ) {
-	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
-	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
-} else {
-	registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
+if ( getUPEConfig( 'isPaymentRequestEnabled' ) ) {
+	if ( getUPEConfig( 'isTokenizedCartPrbEnabled' ) ) {
+		registerExpressPaymentMethod(
+			tokenizedCartPaymentRequestPaymentMethod( api )
+		);
+	} else if ( getUPEConfig( 'isExpressCheckoutElementEnabled' ) ) {
+		registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
+		registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
+	} else {
+		registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
+	}
 }
 window.addEventListener( 'load', () => {
 	enqueueFraudScripts( getUPEConfig( 'fraudServices' ) );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -895,6 +895,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Checks if the setting to show the payment request buttons is enabled.
+	 *
+	 * @return bool Whether the setting to show the payment request buttons is enabled or not.
+	 */
+	public function is_payment_request_enabled() {
+		return 'yes' === $this->get_option( 'payment_request' );
+	}
+
+	/**
 	 * Check if account is eligible for card present.
 	 *
 	 * @return bool

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -193,6 +193,7 @@ class WC_Payments_Checkout {
 			'isPreview'                         => is_preview(),
 			'isSavedCardsEnabled'               => $this->gateway->is_saved_cards_enabled(),
 			'isExpressCheckoutElementEnabled'   => WC_Payments_Features::is_stripe_ece_enabled(),
+			'isPaymentRequestEnabled'           => $this->gateway->is_payment_request_enabled(),
 			'isTokenizedCartPrbEnabled'         => WC_Payments_Features::is_tokenized_cart_prb_enabled(),
 			'isWooPayEnabled'                   => $this->woopay_util->should_enable_woopay( $this->gateway ) && $this->woopay_util->should_enable_woopay_on_cart_or_checkout(),
 			'isWoopayExpressCheckoutEnabled'    => $this->woopay_util->is_woopay_express_checkout_enabled(),


### PR DESCRIPTION
Fixes #9444

#### Changes proposed in this Pull Request

The Google & Apple Pay buttons were displayed in editor even when the payment method is disabled in WooPayments settings because they were always registered. This PR adds a check before registering them.

#### Testing instructions

1. In wp-admin, go to WooCommerce > Settings > Payments > WooPayments page
1. Disable Apple / Google Pay
1. Open the checkout page in the editor
1. See that the Apple & Google pay buttons are still rendered in the editor when using `develop`
1. Checkout this branch and ensure they are not rendered anymore
1. Enable Apple / Google Pay and ensurethey are rendered
1. Smoke test to ensure everything still work as exptected

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
