### PR TITLE
Fix WooPay button preview in plugin settings.

### DIFF
--- a/changelog/fix-9537-woopay-button-size-preview
+++ b/changelog/fix-9537-woopay-button-size-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay button preview in plugin settings.

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -71,7 +71,8 @@ export const WoopayExpressCheckoutButton = ( {
 		borderRadius = buttonAttributes.borderRadius || borderRadius;
 	}
 
-	const buttonSize = buttonSizeMap.get( buttonHeight );
+	const buttonSize =
+		buttonSizeMap.get( buttonHeight?.toString() ) || 'medium';
 
 	const buttonText =
 		ButtonTypeTextMap[ buttonType || 'default' ] ??
@@ -361,6 +362,8 @@ export const WoopayExpressCheckoutButton = ( {
 			window.removeEventListener( 'pageshow', handlePageShow );
 		};
 	}, [] );
+
+	console.log( buttonSize );
 
 	return (
 		<button

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -363,8 +363,6 @@ export const WoopayExpressCheckoutButton = ( {
 		};
 	}, [] );
 
-	console.log( buttonSize );
-
 	return (
 		<button
 			ref={ buttonRef }

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -68,7 +68,7 @@ export const WoopayExpressCheckoutButton = ( {
 	// If we are on the checkout block, we receive button attributes which overwrite the extension specific settings
 	if ( typeof buttonAttributes !== 'undefined' ) {
 		buttonHeight = buttonAttributes.height || buttonHeight;
-		borderRadius = buttonAttributes.borderRadius || borderRadius;
+		borderRadius = buttonAttributes.borderRadius ?? borderRadius;
 	}
 
 	const buttonSize =

--- a/client/settings/express-checkout-settings/payment-request-button-preview.js
+++ b/client/settings/express-checkout-settings/payment-request-button-preview.js
@@ -43,7 +43,10 @@ const WooPayButtonPreview = ( { size, buttonType, theme, radius } ) => (
 				buttonSizeToPxMap[ size ] || buttonSizeToPxMap.medium
 			}px`,
 			size,
-			radius,
+		} }
+		buttonAttributes={ {
+			height: buttonSizeToPxMap[ size ] || buttonSizeToPxMap.medium,
+			borderRadius: radius,
 		} }
 	/>
 );


### PR DESCRIPTION
Fixes #9537 

#### Changes proposed in this Pull Request

Fixes the issue where changing the express checkout button size does not update the WooPay button size in the preview. 

https://github.com/user-attachments/assets/8d418080-2470-44b7-a150-7fa5f55c311d

#### Testing instructions


1. **Reproduce the Issue on `develop`**
   - Visit the issue: [WooCommerce Payments Issue #9537](https://github.com/Automattic/woocommerce-payments/issues/9537).
   - Follow the steps described to confirm you can reproduce the issue on the `develop` branch.

2. **Switch to the Branch `fix/9537-woopay-button-size-preview`**
   - Build the project:
     ```bash
     npm install
     npm run build
     ```

3. **Verify the Issue is Resolved**
   - Repeat the reproduction steps from the issue.
   - Confirm that the issue no longer occurs on this branch, and check for any new, unintended behaviors.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
