### PR TITLE
Rename 'deposit' to 'payout' on account connect / pre-onboarding page.

### DIFF
--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -37,7 +37,7 @@ export default {
 		),
 	paymentMethods: {
 		deposits: {
-			title: __( 'Deposits', 'woocommerce-payments' ),
+			title: __( 'Payouts', 'woocommerce-payments' ),
 			value: __( 'Automatic - Daily', 'woocommerce-payments' ),
 		},
 		capture: {
@@ -58,7 +58,7 @@ export default {
 		'woocommerce-payments'
 	),
 	usp3: __(
-		'Earn recurring revenue and get deposits into your bank account.',
+		'Earn recurring revenue and get payouts into your bank account.',
 		'woocommerce-payments'
 	),
 	sandboxMode: {
@@ -111,7 +111,7 @@ export default {
 				'woocommerce-payments'
 			),
 		},
-		button: __( 'enable deposits.', 'woocommerce-payments' ),
+		button: __( 'enable payouts.', 'woocommerce-payments' ),
 	},
 	infoModal: {
 		title: sprintf(
@@ -252,7 +252,7 @@ export default {
 	step2: {
 		heading: __( 'Provide a few business details', 'woocommerce-payments' ),
 		description: __(
-			'Next we’ll ask you to verify your business and payment details to enable deposits.',
+			'Next we’ll ask you to verify your business and payment details to enable payouts.',
 			'woocommerce-payments'
 		),
 	},

--- a/client/connect-account-page/test/__snapshots__/index.test.tsx.snap
+++ b/client/connect-account-page/test/__snapshots__/index.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
                 class="components-button is-link"
                 type="button"
               >
-                enable deposits.
+                enable payouts.
               </button>
             </div>
           </div>
@@ -133,7 +133,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
           >
             <div>
               <p>
-                Deposits
+                Payouts
               </p>
               <span>
                 Automatic - Daily
@@ -315,7 +315,7 @@ exports[`ConnectAccountPage should render correctly with WooPay eligible 1`] = `
                 class="components-button is-link"
                 type="button"
               >
-                enable deposits.
+                enable payouts.
               </button>
             </div>
           </div>
@@ -398,7 +398,7 @@ exports[`ConnectAccountPage should render correctly with WooPay eligible 1`] = `
           >
             <div>
               <p>
-                Deposits
+                Payouts
               </p>
               <span>
                 Automatic - Daily
@@ -542,7 +542,7 @@ exports[`ConnectAccountPage should render correctly with an incentive 1`] = `
                 class="components-button is-link"
                 type="button"
               >
-                enable deposits.
+                enable payouts.
               </button>
             </div>
           </div>
@@ -625,7 +625,7 @@ exports[`ConnectAccountPage should render correctly with an incentive 1`] = `
           >
             <div>
               <p>
-                Deposits
+                Payouts
               </p>
               <span>
                 Automatic - Daily

--- a/client/connect-account-page/test/info-notice-modal.test.tsx
+++ b/client/connect-account-page/test/info-notice-modal.test.tsx
@@ -27,7 +27,7 @@ describe( 'Connect Account Page – Info Notice Modal', () => {
 		render( <InfoNoticeModal /> );
 
 		const enableDeposits = screen.getByRole( 'button', {
-			name: /enable deposits./i,
+			name: /enable payouts./i,
 		} );
 		userEvent.click( enableDeposits );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9597.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Rename 'deposit' to 'payout' on account connect / pre-onboarding page.

note: I replace some other 'deposit' in the same file but I am not sure where they are displayed.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Imitate the state where WooPayments isn't onboarded yet. I use WCPay Dev to force the plugin to act as if disconnected from server.
* Observe the pre-onboarding page. wp-admin > Payments.
* Make sure 'deposit' is renamed to 'payout'.

<img width="770" alt="Screenshot 2024-10-31 at 20 37 16" src="https://github.com/user-attachments/assets/f261a5f5-6c41-4ab5-8229-9327dce22afa">


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
