### PR TITLE
Fix uncaught TypeError when editing or previewing cart and checkout

### DIFF
--- a/changelog/fix-9657-uncaught-type-error
+++ b/changelog/fix-9657-uncaught-type-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix error on WooPay button on Blocks editing and previewing.

--- a/client/checkout/woopay/connect/woopay-connect.js
+++ b/client/checkout/woopay/connect/woopay-connect.js
@@ -22,7 +22,9 @@ class WoopayConnect {
 			getPostMessageTimeoutCallback: () => {},
 		};
 		this.removeMessageListener = this.attachMessageListener();
-		this.injectWooPayConnectIframe();
+		if ( this.shouldInjectConnectIframe() ) {
+			this.injectWooPayConnectIframe();
+		}
 	}
 
 	/**
@@ -60,6 +62,15 @@ class WoopayConnect {
 		if ( typeof this.removeMessageListener === 'function' ) {
 			this.removeMessageListener();
 		}
+	}
+
+	/**
+	 * Determines whether the WooPay Connect iframe should be injected.
+	 *
+	 * @return {boolean} Whether the WooPay Connect iframe should be injected.
+	 */
+	shouldInjectConnectIframe() {
+		return ! ( getConfig( 'isPreview' ) || getConfig( 'is_admin' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9657.

#### Changes proposed in this Pull Request

This fixes an uncaught `TypeError` that is triggered when editing or previewing cart and checkout Blocks pages when WooPay is enabled.

The error is triggered by [this block of code](https://github.com/Automattic/woocommerce-payments/blob/25db37e303f2a47664e88b2526457be567dd14d0/client/checkout/woopay/connect/woopay-connect-iframe.js#L46-L68) which tries to dispatch an event to WooPay. In fact, when editing and previewing pages we should avoid dispatch, inject or do anything that's supposed to trigger checkout flows, so this PR prevents the injection of the connect iframe.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**

1. Enable WooPay, if needed.
2. Enable the WooPay express checkout button in the cart and checkout pages, if needed.

**Reproduce the issue**

1. Switch to `develop`.
2. As a merchant, navigate to **Pages > All Pages** and edit either the Cart or Checkout (Blocks) page.
3. Open your dev tools console and note a `Uncaught TypeError: Cannot read properties of null (reading 'source')` error.

**Regression test: Ensure the connect iframe is successfully injected in live pages**

1. Switch to this branch.
2. Build the assets: `npm run build:client`.
3. As a shopper, navigate to the store, add a product to the cart and navigate to the cart Blocks page.
4. Open your dev tools console.
5. Run `document.querySelector('#woopay-connect-iframe-container')` and make sure it returns a valid `div`.
6. Navigate to checkout Blocks page.
7. Run `document.querySelector('#woopay-connect-iframe-container')` and make sure it returns a valid `div`.

**Test: Ensure no errors are logged in the console when editing or previewing those pages**

1. As a merchant, navigate to **Pages > All Pages** and edit both the Cart Blocks page.
2. Open your dev tools console and make sure you don't see a `Uncaught TypeError: Cannot read properties of null (reading 'source')` error.
3. Run `document.querySelector('#woopay-connect-iframe-container')` and make sure it returns `null`.
4. Preview the page.
<img width="405" alt="Screenshot 2024-10-31 at 16 46 08" src="https://github.com/user-attachments/assets/696ede78-a163-45e4-8837-5d42dcb6f966">

5. Open your dev tools console and make sure you don't see a `Uncaught TypeError: Cannot read properties of null (reading 'source')` error.
6. Run `document.querySelector('#woopay-connect-iframe-container')` and make sure it returns `null`.
7. Repeat this test for the Checkout Blocks page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
