### PR TITLE
Avoid PHP warning when checking for StoreAPI requests

### DIFF
--- a/changelog/fix-9661-avoid-php-warning
+++ b/changelog/fix-9661-avoid-php-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid PHP warnings for requests with an empty path.

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -1109,8 +1109,16 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_store_api_request_with_malformed_url() {
-		$_SERVER['REQUEST_URI'] = '///wp-json/wp/v2/users';
+		$_SERVER['REQUEST_URI'] = '///wp-json/wc/store/v1/checkout';
 
+		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
+	}
+
+	public function test_is_store_api_request_with_url_with_no_path() {
+		$_SERVER['REQUEST_URI'] = '?something';
+		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
+
+		$_SERVER['REQUEST_URI'] = '';
 		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
 	}
 


### PR DESCRIPTION
Fixes #9661 

#### Changes proposed in this Pull Request

We use `empty()` to include checking for falsy values, non-arrays, or non-existent array keys, thus avoiding any `Undefined array key` warnings.

#### Testing instructions

* The code changes make sense
* The PHP unit tests pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
