### PR TITLE
Hide duplicate payment method warnings when Stripe gateway is disabled

### DIFF
--- a/changelog/fix-9271-hide-stripe-duplicates-warning-when-disabled
+++ b/changelog/fix-9271-hide-stripe-duplicates-warning-when-disabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Small change affecting Stripe Gateway settings notices
+
+

--- a/includes/class-duplicates-detection-service.php
+++ b/includes/class-duplicates-detection-service.php
@@ -78,6 +78,8 @@ class Duplicates_Detection_Service {
 		$keywords         = [ 'credit_card', 'creditcard', 'cc', 'card' ];
 		$special_keywords = [ 'woocommerce_payments', 'stripe' ];
 
+		$gateways = $this->get_enabled_gateways();
+
 		foreach ( $this->get_enabled_gateways() as $gateway ) {
 			if ( $this->gateway_contains_keyword( $gateway->id, $keywords ) || in_array( $gateway->id, $special_keywords, true ) ) {
 				$this->gateways_qualified_by_duplicates_detector[ CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID ][] = $gateway->id;
@@ -136,18 +138,12 @@ class Duplicates_Detection_Service {
 		];
 
 		foreach ( $this->get_registered_gateways() as $gateway ) {
-			// Stripe gateway can enable PRBs while being disabled as well, hence no need to check for enabled status.
-			if ( 'stripe' === $gateway->id && 'yes' === $gateway->get_option( 'payment_request' ) ) {
-				$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
-				continue;
-			}
-
 			if ( 'yes' === $gateway->enabled ) {
 				foreach ( $keywords as $keyword ) {
 					if ( strpos( $gateway->id, $keyword ) !== false ) {
 						$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
 						break;
-					} elseif ( 'yes' === $gateway->get_option( 'payment_request' ) && 'woocommerce_payments' === $gateway->id ) {
+					} elseif ( 'yes' === $gateway->get_option( 'payment_request' ) ) {
 						$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
 						break;
 					} elseif ( 'yes' === $gateway->get_option( 'express_checkout_enabled' ) ) {

--- a/includes/class-duplicates-detection-service.php
+++ b/includes/class-duplicates-detection-service.php
@@ -78,8 +78,6 @@ class Duplicates_Detection_Service {
 		$keywords         = [ 'credit_card', 'creditcard', 'cc', 'card' ];
 		$special_keywords = [ 'woocommerce_payments', 'stripe' ];
 
-		$gateways = $this->get_enabled_gateways();
-
 		foreach ( $this->get_enabled_gateways() as $gateway ) {
 			if ( $this->gateway_contains_keyword( $gateway->id, $keywords ) || in_array( $gateway->id, $special_keywords, true ) ) {
 				$this->gateways_qualified_by_duplicates_detector[ CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID ][] = $gateway->id;


### PR DESCRIPTION
Fixes #9271 

When another payment gateway enables a payment method that is already enabled in WooPayments, we display a warning.

<img width="681" alt="Screenshot 2024-11-01 at 2 09 21 PM" src="https://github.com/user-attachments/assets/9a7bc4d8-7d9d-4055-acb1-66eed48a9205">

&nbsp;
As mentioned in #9271, when WooCommerce Stripe Gateway has PRBs enabled, yet the gateway is disabled, the duplicate payment method warning is still displayed. It shouldn't be, since PRBs from WooCommerce Stripe Gateway are not displayed when the gateway is disabled.

#### Changes proposed in this Pull Request
The issue is caused by [these WooCommerce Stripe Gateway specific checks](https://github.com/Automattic/woocommerce-payments/blob/19f1f26d6774c88d9de8bf30eeccf6b9cdbc5ce1/includes/class-duplicates-detection-service.php#L140-L143). After discussing with @timur27, these checks which skip checking if WooCommerce Stripe Gateway is enabled aren't needed. We can remove them and rely on the `'yes' === $gateway->enabled` to ensure we're not displaying duplicate payment method notices for disabled gateways.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install, configure, and enable [WooCommerce Stripe](https://github.com/woocommerce/woocommerce-gateway-stripe)
* Enable Apple/Google Pay in both WooCommerce Stripe and WooPayments
* Verify that duplicate payment method notices appear in the WooPayments payment method settings
* Disable WooCommmerce Stripe at **WooCommerce > Settings > Payments > All Payment Methods**
* Verify that duplicate payment method notices no longer appear in the WooPayments payment method settings

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
