### PR TITLE
Rename anchor link to the deposit schedule section of the payments settings

### DIFF
--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -217,7 +217,7 @@ const DepositsOverview: React.FC = () => {
 									page: 'wc-settings',
 									tab: 'checkout',
 									section: 'woocommerce_payments',
-								} ) + '#deposit-schedule'
+								} ) + '#payout-schedule'
 							}
 							onClick={ () =>
 								recordEvent(

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -348,7 +348,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
         </button>
         <a
           class="components-button is-tertiary"
-          href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#deposit-schedule"
+          href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#payout-schedule"
         >
           Change payout schedule
         </a>

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -242,7 +242,7 @@ const SettingsManager = () => {
 				</LoadableSettingsSection>
 			</SettingsSection>
 			<SettingsSection description={ DepositsDescription } id="deposits">
-				<div id={ 'deposit-schedule' }>
+				<div id="payout-schedule">
 					<LoadableSettingsSection numLines={ 20 }>
 						<ErrorBoundary>
 							<Deposits />


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9598

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Most of plugin URL renames have been done in https://github.com/Automattic/woocommerce-payments/pull/9530.

This PR covers this one bit mentioned in https://github.com/Automattic/woocommerce-payments/pull/9530#pullrequestreview-2384549331 where there is an achor link to the deposit schedule section of the payment settings page.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open payments overview page: wp-admin > Payments.
* Click on the 'Change payout schedule' button.
* Confirm that the link is `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#payout-schedule` and it brings you to the deposit schedule section of the payment settings page.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
