### PR TITLE
Fix: BNPL payment methods should work when available in the Pay For Order page

### DIFF
--- a/changelog/fix-8254-bnpl-pay-for-order
+++ b/changelog/fix-8254-bnpl-pay-for-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+BNPL methods now work properly in Pay for Order when they are available. Default values are also provided when available.

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -192,6 +192,16 @@ function createStripePaymentMethod(
 		};
 	}
 
+	if (
+		getUPEConfig( 'isOrderPay' ) &&
+		[ 'afterpay_clearpay', 'affirm' ].includes( paymentMethodType ) &&
+		params?.billing_details?.address &&
+		! params.billing_details.address.line1
+	) {
+		// These payment methods don't accept an address object with partial information.
+		delete params.billing_details.address;
+	}
+
 	return api
 		.getStripeForUPE( paymentMethodType )
 		.createPaymentMethod( { elements, params: params } );

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -122,6 +122,41 @@ function submitForm( jQueryForm ) {
 }
 
 /**
+ * Validates the contents of the address fields based on the requirements from BNPL payment methods.
+ *
+ * @param {Object} params The parameters to be sent to `createPaymentMethod`.
+ * @param {string} paymentMethodType The type of Stripe payment method to create.
+ * @return {boolean} True, if there are missing address fields. False, if the validation passes or is not applicable.
+ */
+function isMissingRequiredAddressFieldsForBNPL( params, paymentMethodType ) {
+	if ( [ 'afterpay_clearpay', 'affirm' ].includes( paymentMethodType ) ) {
+		return false;
+	}
+	const address = params?.billing_details?.address;
+
+	if ( ! address ) {
+		return false;
+	}
+
+	const requiredAddressFields =
+		paymentMethodType === 'affirm'
+			? [ 'line1', 'state', 'city', 'postal_code', 'country' ] // Line2 is not required.
+			: [ 'line1', 'postal_code', 'country' ]; // City and State are not required in Afterpay.
+
+	for ( const field of requiredAddressFields ) {
+		if (
+			address[ field ] === '' ||
+			address[ field ] === null ||
+			typeof address[ field ] === 'undefined'
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Creates a Stripe payment method by calling the Stripe API's createPaymentMethod with the provided elements
  * and billing details. The billing details are obtained from various form elements on the page.
  *
@@ -144,7 +179,7 @@ function createStripePaymentMethod(
 			billing_details: {
 				name: wcpayCustomerData.name || undefined,
 				email: wcpayCustomerData.email,
-				address: {
+				address: wcpayCustomerData.address || {
 					country: wcpayCustomerData.billing_country,
 				},
 			},
@@ -194,11 +229,9 @@ function createStripePaymentMethod(
 
 	if (
 		getUPEConfig( 'isOrderPay' ) &&
-		[ 'afterpay_clearpay', 'affirm' ].includes( paymentMethodType ) &&
-		params?.billing_details?.address &&
-		! params.billing_details.address.line1
+		isMissingRequiredAddressFieldsForBNPL( params, paymentMethodType )
 	) {
-		// These payment methods don't accept an address object with partial information.
+		// These payment methods don't accept an address object with partial information, so we just remove the object entirely.
 		delete params.billing_details.address;
 	}
 

--- a/client/checkout/utils/test/upe.test.js
+++ b/client/checkout/utils/test/upe.test.js
@@ -284,6 +284,8 @@ describe( 'UPE checkout utils', () => {
 			if ( checkboxElement ) {
 				checkboxElement.remove();
 			}
+
+			delete window.wcpayCustomerData;
 		} );
 
 		it( 'should not provide terms when cart does not contain subscriptions and the saving checkbox is unchecked', () => {
@@ -353,6 +355,34 @@ describe( 'UPE checkout utils', () => {
 			const upeSettings = getUpeSettings();
 
 			expect( upeSettings.terms.card ).toEqual( 'always' );
+		} );
+
+		it( 'should define defaultValues when wcpayCustomerData is present', () => {
+			window.wcpayCustomerData = {
+				name: 'Test Person',
+				email: 'test@example.com',
+				billing_country: 'US',
+			};
+
+			const upeSettings = getUpeSettings();
+
+			expect( upeSettings.defaultValues ).toEqual( {
+				billingDetails: {
+					name: 'Test Person',
+					email: 'test@example.com',
+					address: {
+						country: 'US',
+					},
+				},
+			} );
+		} );
+
+		it( 'should not define defaultValues if wcpayCustomerData is not present', () => {
+			window.wcpayCustomerData = null;
+
+			const upeSettings = getUpeSettings();
+
+			expect( upeSettings.defaultValues ).toBeUndefined();
 		} );
 
 		function createCheckboxElementWhich( isChecked ) {

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -119,6 +119,18 @@ export const getUpeSettings = () => {
 		};
 	}
 
+	if ( window.wcpayCustomerData ) {
+		upeSettings.defaultValues = {
+			billingDetails: {
+				name: window.wcpayCustomerData.name,
+				email: window.wcpayCustomerData.email,
+				address: {
+					country: window.wcpayCustomerData.billing_country,
+				},
+			},
+		};
+	}
+
 	return upeSettings;
 };
 

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -531,6 +531,7 @@ class WC_Payments_Customer_Service {
 		$firstname       = '';
 		$lastname        = '';
 		$billing_country = '';
+		$address         = null;
 
 		if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$order_id = absint( $wp->query_vars['order-pay'] );
@@ -541,6 +542,14 @@ class WC_Payments_Customer_Service {
 				$lastname        = $order->get_billing_last_name();
 				$user_email      = $order->get_billing_email();
 				$billing_country = $order->get_billing_country();
+				$address         = [
+					'city'        => $order->get_billing_city(),
+					'country'     => $order->get_billing_country(),
+					'line1'       => $order->get_billing_address_1(),
+					'line2'       => $order->get_billing_address_2(),
+					'postal_code' => $order->get_billing_postcode(),
+					'state'       => $order->get_billing_state(),
+				];
 			}
 		}
 
@@ -560,6 +569,7 @@ class WC_Payments_Customer_Service {
 			'name'            => $firstname . ' ' . $lastname,
 			'email'           => $user_email,
 			'billing_country' => $billing_country,
+			'address'         => $address,
 		];
 	}
 }

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -177,19 +177,21 @@ abstract class UPE_Payment_Method {
 				$order = is_a( $order, 'WC_Order' ) ? $order : null;
 			}
 
+			$currency = get_woocommerce_currency();
 			if ( $order ) {
 				$currency = $order->get_currency();
-			} else {
-				$currency = get_woocommerce_currency();
 			}
+
 			// If the currency limits are not defined, we allow the PM for now (gateway has similar validation for limits).
-			// Additionally, we don't engage with limits verification in no-checkout context (cart is not available or empty).
-			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) ) {
-				if ( $order ) {
-					$amount = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
-				} else {
-					$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
-				}
+			$total = null;
+			if ( $order ) {
+				$total = $order->get_total();
+			} elseif ( isset( WC()->cart ) ) {
+				$total = WC()->cart->get_total( '' );
+			}
+
+			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) && ! empty( $total ) ) {
+				$amount = WC_Payments_Utils::prepare_amount( $total, $currency );
 
 				if ( $amount > 0 ) {
 					$range = null;

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -171,11 +171,26 @@ abstract class UPE_Payment_Method {
 
 		// This part ensures that when payment limits for the currency declared, those will be respected (e.g. BNPLs).
 		if ( [] !== $this->limits_per_currency ) {
-			$currency = get_woocommerce_currency();
+			$order = null;
+			if ( is_wc_endpoint_url( 'order-pay' ) ) {
+				$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
+				$order = is_a( $order, 'WC_Order' ) ? $order : null;
+			}
+
+			if ( $order ) {
+				$currency = $order->get_currency();
+			} else {
+				$currency = get_woocommerce_currency();
+			}
 			// If the currency limits are not defined, we allow the PM for now (gateway has similar validation for limits).
 			// Additionally, we don't engage with limits verification in no-checkout context (cart is not available or empty).
 			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) ) {
-				$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
+				if ( $order ) {
+					$amount = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
+				} else {
+					$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
+				}
+
 				if ( $amount > 0 ) {
 					$range = null;
 					if ( isset( $this->limits_per_currency[ $currency ][ $account_country ] ) ) {


### PR DESCRIPTION
Fixes #8254

#### Changes proposed in this Pull Request

- Make sure the `wcpayCustomerData` global variable is properly rendered. A couple issues related to this were fixed:
  - The `payment_fields()` code was running before the `wcpay-upe-checkout` script was registered, so when `wp_localize_script` ran, nothing was added to the page. This problem was solved for the `wcpay_upe_config` variable by adding a callback to `wp_footer` but the same fix wasn't applied to `wcpayCustomerData`. This PR should make both work consistently.
  - When multiple Payment Methods were enabled, the callbacks to localize the scripts were queued multiple times. This was unnecessary given that the variables always had the same names, so the values were overridden. To prevent rendering unnecessary data, I'm using a workaround using a dummy action to verify if the callback already run once.
- Pass default values to the payment elements when available. 
- `is_enabled_at_checkout` was updated so it checks the order data instead of the cart data to determine availability

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a US WooPayments account.
* Enable Affirm, AfterPay/ClearPay, and Klarna.
* In WP Admin, create an order, make sure to include customer details as Name, Email, and Country (must be US). Add a product of at least 50 USD (which is Affirm's minimum amount).
* Copy the **Customer payment page** URL.
* As a customer, go to the Customer payment page.

**Before (using develop)**
BNPL payment methods showed up but nothing was rendered when selected. (Verify for all BNPL methods)
![image](https://github.com/user-attachments/assets/2b31a7f8-8d26-42f2-806b-a18f9a2ddaf0)

Clicking **Pay for Order** results in an error.
![image](https://github.com/user-attachments/assets/306d12a9-d006-4afc-a6de-5dc94e16fd08)

**After (Using this branch)**
The contents of the BNPL methods is properly rendered, customer information is prefilled based on the data filled for the order.
![image](https://github.com/user-attachments/assets/bd9d30dc-96eb-430b-a22a-23d802055cac)

Submitting the order should result in a successful payment. Test this for all BNPL methods (Klarna, Afterpay/Clearpay, and Affirm).

**Testing payment method availability**
* In WP Admin, update the Billing information of the pending order to another country.
* If you reload the Pay for Order page, the BNPL methods should no longer show up.
![image](https://github.com/user-attachments/assets/4dfee3f2-e4d8-4a71-ab51-867adc9adc2b)

* In WP Admin, restore the billing country to US but change the line items so the total is less than 50 USD.
* Reload the pay for order page, Affirm should not be displayed:
![image](https://github.com/user-attachments/assets/8969bf88-b6bd-40aa-8050-716783319205)

# Regression Testing

* Make sure that Credit Cards (with and without 3DS) continue to work as expected in the pay for order flow.
* Test the Add Payment Method flow to make sure cards can still be added.
* Test the Classic Checkout and Blocks Checkout flow to make sure BNPL and Card payments still work as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
