### PR TITLE
Use @stripe/connect-js/pure

### DIFF
--- a/changelog/fix-stripe-connect-breaks-underscore
+++ b/changelog/fix-stripe-connect-breaks-underscore
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Change the way we load an external lib to avoid issues with underscore.
+
+

--- a/client/onboarding/steps/embedded-kyc.tsx
+++ b/client/onboarding/steps/embedded-kyc.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
 	loadConnectAndInitialize,
 	StripeConnectInstance,
-} from '@stripe/connect-js';
+} from '@stripe/connect-js/pure';
 import {
 	ConnectAccountOnboarding,
 	ConnectComponentsProvider,

--- a/client/onboarding/steps/test/embedded-onboarding.tsx
+++ b/client/onboarding/steps/test/embedded-onboarding.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import { loadConnectAndInitialize } from '@stripe/connect-js';
+import { loadConnectAndInitialize } from '@stripe/connect-js/pure';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import { loadConnectAndInitialize } from '@stripe/connect-js';
 import EmbeddedKyc from '../embedded-kyc';
 
 jest.mock( '@wordpress/api-fetch' );
-jest.mock( '@stripe/connect-js', () => ( {
+jest.mock( '@stripe/connect-js/pure', () => ( {
 	loadConnectAndInitialize: jest.fn(),
 } ) );
 


### PR DESCRIPTION
Fixed #9675
Fixes https://github.com/woocommerce/google-listings-and-ads/issues/2652

#### Changes proposed in this Pull Request
Import `loadConnectAndInitialize` from `@stripe/connect-js/pure` instead of `@stripe/connect-js`, to ensure `https://connect-js.stripe.com/v1.0/connect.js` script is only loaded when needed. Otherwise, it can cause issues with other WC plugins using `underscore`.

The pure version loads the script when `loadConnectAndInitialize` is called, while the non-pure version loads it as soon as the JS code gets loaded. And as the code using it is part of the WooPayments `index.js` bundle, just by having the plugin enabled we were loading it.

#### Testing instructions

**Embedded components**
- Start a new onboarding from the connect page
- After specifying Planned revenue `more than 100 M` and time to go live `more than 6m` you should see an embedded onboarding component.

**Lodash/Underscore**
- Run `npm run start`
- Switch to `trunk` and go to a WC admin page.
- Run `console.log(_)` on the browser console.
- Clicking the log message should open the source file and point to `lodash`.
- Switch to `fix/stripe-connect-breaks-underscore` and go to a WC admin page.
- Run `console.log(_)` on the browser console.
- Clicking the log message should open the source file and point to `underscore`.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
