### PR TITLE
Fix duplicate saving of 3DS card entry after checkout

### DIFF
--- a/changelog/fix-saving-duplicate-3ds-cards
+++ b/changelog/fix-saving-duplicate-3ds-cards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicate saving of 3DS card entry after checkout

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -125,10 +125,10 @@ export default class WCPayAPI {
 	 * and displays the intent confirmation modal (if needed).
 	 *
 	 * @param {string} redirectUrl The redirect URL, returned from the server.
-	 * @param {string} paymentMethodToSave The ID of a Payment Method if it should be saved (optional).
+	 * @param {boolean} shouldSavePaymentMethod Whether the payment method should be saved.
 	 * @return {Promise<string>|boolean} A redirect URL on success, or `true` if no confirmation is needed.
 	 */
-	confirmIntent( redirectUrl, paymentMethodToSave ) {
+	confirmIntent( redirectUrl, shouldSavePaymentMethod = false ) {
 		const partials = redirectUrl.match(
 			/#wcpay-confirm-(pi|si):(.+):(.+):(.+)$/
 		);
@@ -219,7 +219,9 @@ export default class WCPayAPI {
 						// order status call works when a guest user creates an account during checkout.
 						_ajax_nonce: nonce,
 						intent_id: intentId,
-						payment_method_id: paymentMethodToSave || null,
+						should_save_payment_method: shouldSavePaymentMethod
+							? 'true'
+							: 'false',
 					} );
 
 					return [ ajaxCall, result.error ];

--- a/client/checkout/blocks/confirm-card-payment.js
+++ b/client/checkout/blocks/confirm-card-payment.js
@@ -13,12 +13,12 @@ export default async function confirmCardPayment(
 	emitResponse,
 	shouldSavePayment
 ) {
-	const { redirect, payment_method: paymentMethod } = paymentDetails;
+	const { redirect } = paymentDetails;
 
 	try {
 		const confirmationRequest = api.confirmIntent(
 			redirect,
-			shouldSavePayment ? paymentMethod : null
+			shouldSavePayment
 		);
 
 		// `true` means there is no intent to confirm.

--- a/client/checkout/classic/3ds-flow-handling.js
+++ b/client/checkout/classic/3ds-flow-handling.js
@@ -22,12 +22,9 @@ const cleanupURL = () => {
 };
 
 export const showAuthenticationModalIfRequired = ( api ) => {
-	const paymentMethodId = document.querySelector( '#wcpay-payment-method' )
-		?.value;
-
 	const confirmationRequest = api.confirmIntent(
 		window.location.href,
-		shouldSavePaymentPaymentMethod() ? paymentMethodId : null
+		shouldSavePaymentPaymentMethod()
 	);
 
 	// Boolean `true` means that there is nothing to confirm.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3608,7 +3608,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				wc_reduce_stock_levels( $order_id );
 				WC()->cart->empty_cart();
 
-				if ( ! empty( $payment_method_id ) ) {
+				$is_subscription            = function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order );
+				$should_save_payment_method = $is_subscription || ( isset( $_POST['should_save_payment_method'] ) && 'true' === $_POST['should_save_payment_method'] );
+				if ( $should_save_payment_method && ! empty( $payment_method_id ) ) {
 					try {
 						$token = $this->token_service->add_payment_method_to_user( $payment_method_id, wp_get_current_user() );
 						$this->add_token_to_order( $order, $token );


### PR DESCRIPTION
Fixes #8997

#### Changes proposed in this Pull Request

This PR updates the logic we use to save 3DS cards to avoid saving it everytime a saved 3DS card is used. Instead of only checking the presence of a payment method id from the intent, we now check if the Save payment method checkbox is checked or if it is a subscription purchase.

#### Testing instructions

##### Reproduce issue in `develop`

1. `git checkout develop`
1. Perform checkout, using the [always authenticate 3DS card](https://docs.stripe.com/testing#regulatory-cards) (`4000002760003184`), and save it
1. Checkout again but use the saved 3DS this time
1. Open the checkout page and you will see the saved 3DS entry is duplicated now
1. Remove these saved cards to start the next test fresh

##### Ensure this PR fixes the issue

1. `git checkout fix/saving-duplicate-3ds-cards`
1. Perform checkout, using the [always authenticate 3DS card](https://docs.stripe.com/testing#regulatory-cards) (`4000002760003184`), and save it
1. Checkout again but use the saved 3DS this time
1. Open the checkout page and there should not be a duplicate saved card entry
1. Remove these saved cards to start the next test fresh

##### Ensure subscriptions still work

This PR affects how we save cards and it might break subscriptions (more info in #8786). We are going to test it with a **different card** so 3DS authentication is not required on every renewal.

1. Buy a subscription using the [Authenticate unless set up 3DS card](https://docs.stripe.com/testing#regulatory-cards) (`4000002500003155`).
2. Ensure this card was saved to your account.
3. In the admin, Process a renewal for this subscription and ensure it is successful.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
