### PR TITLE
fix: E_DEPRECATED on BNPL empty PMME

### DIFF
--- a/changelog/fix-deprecated-message-on-empty-pmme
+++ b/changelog/fix-deprecated-message-on-empty-pmme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+fix: E_DEPRECATED on BNPL empty PMME

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1887,7 +1887,7 @@ class WC_Payments {
 		if ( ! $is_subscription ) {
 			require_once __DIR__ . '/class-wc-payments-payment-method-messaging-element.php';
 			$stripe_site_messaging = new WC_Payments_Payment_Method_Messaging_Element( self::$account, self::$card_gateway );
-			echo wp_kses( $stripe_site_messaging->init(), 'post' );
+			echo wp_kses( $stripe_site_messaging->init() ?? '', 'post' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Seeing the following message on the block-based cart:
<img width="841" alt="Screenshot 2024-11-08 at 6 09 32 PM" src="https://github.com/user-attachments/assets/b5281521-97c4-4497-bfef-a63bdeb5855d">

> Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /Users/xxx/Sites/wcpay/wp-includes/kses.php on line 1805

Fixing its source.


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Don't add a product to the cart
- Ensure you have WC Subscriptions enabled
- Ensure you have BNPL methods enabled in the WooPayments settings
- Navigate to the block-based cart
- The deprecated error should no longer appear

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
