### PR TITLE
Fix broken e2e test (for 8.5.0 release) referring to `Deposit history`, should be `Payout history` after payouts rename

### DIFF
--- a/changelog/fix-e2e-test-8.5.0-release
+++ b/changelog/fix-e2e-test-8.5.0-release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update string in E2E test - `Deposit` to `Payout`
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-admin-deposits.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-admin-deposits.spec.js
@@ -16,7 +16,7 @@ describe( 'Admin deposits', () => {
 	it( 'page should load without any errors', async () => {
 		await merchantWCP.openDeposits();
 		await expect( page ).toMatchElement( 'h2', {
-			text: 'Deposit history',
+			text: 'Payout history',
 		} );
 		await takeScreenshot( 'merchant-admin-deposits' );
 	} );


### PR DESCRIPTION
Fixes #9695 

#### Changes proposed in this Pull Request

Update a string refering `Deposit` to `Payout` in e2e test config. 

#### Testing instructions

* Test should pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
