### PR TITLE
Handle IPP failure webhooks

### DIFF
--- a/changelog/add-ipp-missing-failure-webhooks
+++ b/changelog/add-ipp-missing-failure-webhooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved issue with terminal payments in the payment intent failed webhook processing.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -414,6 +414,7 @@ class WC_Payments_Webhook_Processing_Service {
 
 		$actionable_methods = [
 			Payment_Method::CARD,
+			Payment_Method::CARD_PRESENT,
 			Payment_Method::US_BANK_ACCOUNT,
 			Payment_Method::BECS,
 		];
@@ -423,12 +424,14 @@ class WC_Payments_Webhook_Processing_Service {
 		}
 
 		// Get the order and make sure it is an order and the payment methods match.
-		$order             = $this->get_order_from_event_body_intent_id( $event_body );
+		$order             = $this->get_order_from_event_body( $event_body );
 		$payment_method_id = $payment_method['id'] ?? null;
 
-		if ( ! $order
-			|| empty( $payment_method_id )
-			|| $payment_method_id !== $order->get_meta( '_payment_method_id' ) ) {
+		if ( ! $order || empty( $payment_method_id ) ) {
+			return;
+		}
+
+		if ( Payment_Method::CARD_PRESENT !== $payment_method_type && $payment_method_id !== $order->get_meta( '_payment_method_id' ) ) {
 			return;
 		}
 
@@ -452,7 +455,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$event_object  = $this->read_webhook_property( $event_data, 'object' );
 		$intent_id     = $this->read_webhook_property( $event_object, 'id' );
 		$currency      = $this->read_webhook_property( $event_object, 'currency' );
-		$order         = $this->get_order_from_event_body_intent_id( $event_body );
+		$order         = $this->get_order_from_event_body( $event_body );
 		$intent_status = $this->read_webhook_property( $event_object, 'status' );
 		$event_charges = $this->read_webhook_property( $event_object, 'charges' );
 		$charges_data  = $this->read_webhook_property( $event_charges, 'data' );
@@ -704,7 +707,7 @@ class WC_Payments_Webhook_Processing_Service {
 	}
 
 	/**
-	 * Gets the order related to the event intent id.
+	 * Gets the order related to the event.
 	 *
 	 * @param array $event_body The event that triggered the webhook.
 	 *
@@ -713,7 +716,7 @@ class WC_Payments_Webhook_Processing_Service {
 	 *
 	 * @return boolean|WC_Order|WC_Order_Refund
 	 */
-	private function get_order_from_event_body_intent_id( $event_body ) {
+	private function get_order_from_event_body( $event_body ) {
 		$event_data   = $this->read_webhook_property( $event_body, 'data' );
 		$event_object = $this->read_webhook_property( $event_data, 'object' );
 		$intent_id    = $this->read_webhook_property( $event_object, 'id' );
@@ -725,10 +728,16 @@ class WC_Payments_Webhook_Processing_Service {
 			// Retrieving order with order_id in case intent_id was not properly set.
 			Logger::debug( 'intent_id not found, using order_id to retrieve order' );
 			$metadata = $this->read_webhook_property( $event_object, 'metadata' );
+			$order_id = $metadata['order_id'] ?? null;
+			// If metadata order id is null, try to read from the charges metadata.
+			if ( null === $order_id ) {
+				$charges  = $this->read_webhook_property( $event_object, 'charges' );
+				$charge   = $charges[0] ?? [];
+				$order_id = $charge['metadata']['order_id'] ?? null;
+			}
 
-			if ( isset( $metadata['order_id'] ) ) {
-				$order_id = $metadata['order_id'];
-				$order    = $this->wcpay_db->order_from_order_id( $order_id );
+			if ( $order_id ) {
+				$order = $this->wcpay_db->order_from_order_id( $order_id );
 			} elseif ( ! empty( $event_object['invoice'] ) ) {
 				// If the payment intent contains an invoice it is a WCPay Subscription-related intent and will be handled by the `invoice.paid` event.
 				return false;


### PR DESCRIPTION
Fixes #9220

#### Changes proposed in this Pull Request

These changes were already reviewed and approved in https://github.com/Automattic/woocommerce-payments/pull/9198, but we had to revert it due to an undesired side effect in the app https://github.com/Automattic/woocommerce-payments/pull/9229.

We intend to reapply the fix as per this conversation: https://woomobilep2.wordpress.com/2024/08/13/addressing-inconsistencies-in-ipp-payment-failure-handling/#comment-13525

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please refer to the testing instructions in the linked PR

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
