### PR TITLE
chore: rename tokenized prb flag to ece

### DIFF
--- a/changelog/chore-rename-tokenized-prb-flag-to-tokenized-ece
+++ b/changelog/chore-rename-tokenized-prb-flag-to-tokenized-ece
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: rename tokenized prb flag to ece
+
+

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -160,7 +160,7 @@ if ( getUPEConfig( 'isWooPayEnabled' ) ) {
 }
 
 if ( getUPEConfig( 'isPaymentRequestEnabled' ) ) {
-	if ( getUPEConfig( 'isTokenizedCartPrbEnabled' ) ) {
+	if ( getUPEConfig( 'isTokenizedCartEceEnabled' ) ) {
 		registerExpressPaymentMethod(
 			tokenizedCartPaymentRequestPaymentMethod( api )
 		);

--- a/client/tokenized-payment-request/button-ui.js
+++ b/client/tokenized-payment-request/button-ui.js
@@ -9,7 +9,7 @@ const paymentRequestButtonUi = {
 
 	getElements: () => {
 		return jQuery(
-			'.wcpay-payment-request-wrapper,#wcpay-payment-request-button-separator'
+			'.wcpay-payment-request-wrapper,#wcpay-express-checkout-button-separator'
 		);
 	},
 

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -73,7 +73,7 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 
 		$script_dependencies = [ 'stripe' ];
 
-		if ( WC_Payments_Features::is_tokenized_cart_prb_enabled() && ( is_cart() || is_checkout() || is_product() || has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) ) {
+		if ( WC_Payments_Features::is_tokenized_cart_ece_enabled() && ( is_cart() || is_checkout() || is_product() || has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) ) {
 			$script_dependencies[] = 'WCPAY_PAYMENT_REQUEST';
 		}
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -191,7 +191,7 @@ class WC_Payments_Checkout {
 			'isPreview'                         => is_preview(),
 			'isSavedCardsEnabled'               => $this->gateway->is_saved_cards_enabled(),
 			'isPaymentRequestEnabled'           => $this->gateway->is_payment_request_enabled(),
-			'isTokenizedCartPrbEnabled'         => WC_Payments_Features::is_tokenized_cart_prb_enabled(),
+			'isTokenizedCartEceEnabled'         => WC_Payments_Features::is_tokenized_cart_ece_enabled(),
 			'isWooPayEnabled'                   => $this->woopay_util->should_enable_woopay( $this->gateway ) && $this->woopay_util->should_enable_woopay_on_cart_or_checkout(),
 			'isWoopayExpressCheckoutEnabled'    => $this->woopay_util->is_woopay_express_checkout_enabled(),
 			'isWoopayFirstPartyAuthEnabled'     => $this->woopay_util->is_woopay_first_party_auth_enabled(),

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -28,7 +28,7 @@ class WC_Payments_Features {
 	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME      = '_wcpay_feature_woopay_direct_checkout';
 	const AUTH_AND_CAPTURE_FLAG_NAME            = '_wcpay_feature_auth_and_capture';
 	const DISPUTE_ISSUER_EVIDENCE               = '_wcpay_feature_dispute_issuer_evidence';
-	const TOKENIZED_CART_PRB_FLAG_NAME          = '_wcpay_feature_tokenized_cart_prb';
+	const TOKENIZED_CART_ECE_FLAG_NAME          = '_wcpay_feature_tokenized_cart_ece';
 	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME     = '_wcpay_feature_payment_overview_widget';
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME = '_wcpay_feature_woopay_global_theme_support';
 
@@ -48,8 +48,8 @@ class WC_Payments_Features {
 	 *
 	 * @return bool
 	 */
-	public static function is_tokenized_cart_prb_enabled(): bool {
-		return '1' === get_option( self::TOKENIZED_CART_PRB_FLAG_NAME, '0' );
+	public static function is_tokenized_cart_ece_enabled(): bool {
+		return '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '0' );
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -70,7 +70,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return;
 		}
 
-		if ( ! WC_Payments_Features::is_tokenized_cart_prb_enabled() ) {
+		if ( ! WC_Payments_Features::is_tokenized_cart_ece_enabled() ) {
 			return;
 		}
 
@@ -855,7 +855,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			'is_checkout_page'   => $this->express_checkout_helper->is_checkout(),
 		];
 
-		if ( WC_Payments_Features::is_tokenized_cart_prb_enabled() ) {
+		if ( WC_Payments_Features::is_tokenized_cart_ece_enabled() ) {
 			WC_Payments::register_script_with_dependencies(
 				'WCPAY_PAYMENT_REQUEST',
 				'dist/tokenized-payment-request',

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -116,10 +116,9 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	 * @return void
 	 */
 	public function display_express_checkout_separator_if_necessary( $separator_starts_hidden = false ) {
-		$html_id = WC_Payments_Features::is_tokenized_cart_prb_enabled() ? 'wcpay-payment-request-button-separator' : 'wcpay-express-checkout-button-separator';
 		if ( $this->express_checkout_helper->is_checkout() ) {
 			?>
-			<p id="<?php echo esc_attr( $html_id ); ?>" style="margin-top:1.5em;text-align:center;<?php echo $separator_starts_hidden ? 'display:none;' : ''; ?>">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
+			<p id="wcpay-express-checkout-button-separator" style="margin-top:1.5em;text-align:center;<?php echo $separator_starts_hidden ? 'display:none;' : ''; ?>">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
 			<?php
 		}
 	}
@@ -145,7 +144,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 				$this->platform_checkout_button_handler->display_woopay_button_html();
 			}
 
-			if ( WC_Payments_Features::is_tokenized_cart_prb_enabled() ) {
+			if ( WC_Payments_Features::is_tokenized_cart_ece_enabled() ) {
 				$this->payment_request_button_handler->display_payment_request_button_html();
 			} else {
 				$this->express_checkout_button_handler->display_express_checkout_button_html();

--- a/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
@@ -258,7 +258,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler_Test extends WCPAY_Uni
 
 		$this->assertStringContainsString( 'wcpay-woopay-button', ob_get_contents() );
 		$this->assertStringContainsString( 'wcpay-express-checkout-element', ob_get_contents() );
-		$this->assertStringNotContainsString( 'wcpay-payment-request-button-separator', ob_get_contents() );
+		$this->assertStringNotContainsString( 'wcpay-express-checkout-button-separator', ob_get_contents() );
 		ob_end_clean();
 	}
 
@@ -299,7 +299,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler_Test extends WCPAY_Uni
 		$this->express_checkout_button_display_handler->display_express_checkout_buttons();
 
 		$this->assertStringContainsString( 'wcpay-woopay-button', ob_get_contents() );
-		$this->assertStringNotContainsString( 'wcpay-payment-request-button-separator', ob_get_contents() );
+		$this->assertStringNotContainsString( 'wcpay-express-checkout-button-separator', ob_get_contents() );
 		ob_end_clean();
 	}
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -154,7 +154,7 @@ function wcpay_init() {
 	 * Check https://github.com/Automattic/woocommerce-payments/issues/4759
 	 */
 	\WCPay\WooPay\WooPay_Session::init();
-	if ( WC_Payments_Features::is_tokenized_cart_prb_enabled() ) {
+	if ( WC_Payments_Features::is_tokenized_cart_ece_enabled() ) {
 		( new WC_Payments_Payment_Request_Session() )->init();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9720

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Part of pbIwZe-2ur-p2 - renaming the "Tokenized Cart PRB" to "Tokenized Cart ECE" feature flag.

The purpose of this PR is iterative, just to rename the flag, without caring for the actual feature.
The work to convert the feature to use the ECE will come later.

The dev tools will also be updated.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No change in functionality - this is just renaming a feature flag for a feature that is not live.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.