### PR TITLE
chore: rename wrapper from payment-request to ECE

### DIFF
--- a/changelog/chore-payment-request-to-express-checkout-wrapper-name
+++ b/changelog/chore-payment-request-to-express-checkout-wrapper-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+chore: rename wrapper from payment-request to express-checkout

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -1,4 +1,4 @@
-.wcpay-payment-request-wrapper {
+.wcpay-express-checkout-wrapper {
 	margin-top: 1em;
 	width: 100%;
 	clear: both;
@@ -21,7 +21,7 @@
 }
 
 // This fixes width calculation issues inside the iframe for blocks and shortcode pages.
-.wcpay-payment-request-wrapper,
+.wcpay-express-checkout-wrapper,
 .wc-block-components-express-payment__event-buttons {
 	.StripeElement iframe {
 		max-width: unset;

--- a/client/tokenized-payment-request/button-ui.js
+++ b/client/tokenized-payment-request/button-ui.js
@@ -9,7 +9,7 @@ const paymentRequestButtonUi = {
 
 	getElements: () => {
 		return jQuery(
-			'.wcpay-payment-request-wrapper,#wcpay-express-checkout-button-separator'
+			'.wcpay-express-checkout-wrapper,#wcpay-express-checkout-button-separator'
 		);
 	},
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -138,7 +138,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 		$separator_starts_hidden = ! $should_show_woopay;
 		if ( $should_show_woopay || $should_show_payment_request || $should_show_express_checkout_button ) {
 			?>
-			<div class='wcpay-payment-request-wrapper' >
+			<div class='wcpay-express-checkout-wrapper' >
 			<?php
 			if ( ! $this->express_checkout_helper->is_pay_for_order_page() || $this->is_pay_for_order_flow_supported() ) {
 				$this->platform_checkout_button_handler->display_woopay_button_html();

--- a/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
+++ b/tests/unit/test-class-wc-payments-express-checkout-button-display-handler.php
@@ -278,7 +278,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler_Test extends WCPAY_Uni
 		ob_start();
 		$this->express_checkout_button_display_handler->display_express_checkout_buttons();
 
-		$this->assertStringNotContainsString( 'wcpay-payment-request-wrapper', ob_get_contents() );
+		$this->assertStringNotContainsString( 'wcpay-express-checkout-wrapper', ob_get_contents() );
 		ob_end_clean();
 	}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the wrapper on the ECE has the `payment-request` prefix.
Since "payment request" is the name of the older API implementation for GooglePay/ApplePay, I was thinking it would be nice to rename this wrapper as well.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- This change should provide no difference in functionality
- As a merchant, ensure you have GooglePay/ApplePay enabled in your settings for product pages, cart, checkout
- Go to a product page for a simple product
- The ECE button should be displayed
- The ECE button should also be displayed on Cart & Checkout pages

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
