### PR TITLE
Add WooPay clickwrap support

### DIFF
--- a/changelog/add-2253-clickwrap-terms-and-conditions
+++ b/changelog/add-2253-clickwrap-terms-and-conditions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Clickwrap terms and conditions support on WooPay

--- a/client/settings/express-checkout-settings/test/woopay-settings.test.js
+++ b/client/settings/express-checkout-settings/test/woopay-settings.test.js
@@ -149,7 +149,7 @@ describe( 'WooPaySettings', () => {
 		// confirm settings headings
 		expect(
 			screen.queryByRole( 'heading', {
-				name: 'Policies and custom text',
+				name: 'Checkout policies',
 			} )
 		).toBeInTheDocument();
 

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -255,7 +255,7 @@ const WooPaySettings = ( { section } ) => {
 					<div className="woopay-settings__custom-message-wrapper">
 						<h4>
 							{ __(
-								'Policies and custom text',
+								'Checkout policies',
 								'woocommerce-payments'
 							) }
 						</h4>

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -976,7 +976,7 @@ class WooPay_Session {
 			return;
 		}
 
-		$checkout_terms_block_index = array_search(
+		$inner_block_index = array_search(
 			$inner_block_name,
 			array_column(
 				$current_block['innerBlocks'],
@@ -985,10 +985,10 @@ class WooPay_Session {
 			true
 		);
 
-		if ( ! isset( $current_block['innerBlocks'][ $checkout_terms_block_index ] ) ) {
+		if ( ! isset( $current_block['innerBlocks'][ $inner_block_index ] ) ) {
 			return;
 		}
 
-		return $current_block['innerBlocks'][ $checkout_terms_block_index ];
+		return $current_block['innerBlocks'][ $inner_block_index ];
 	}
 }

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -898,9 +898,10 @@ class WooPay_Session {
 	 */
 	private static function get_option_fields_status() {
 		// Shortcode checkout options.
-		$company   = get_option( 'woocommerce_checkout_company_field', 'optional' );
-		$address_2 = get_option( 'woocommerce_checkout_address_2_field', 'optional' );
-		$phone     = get_option( 'woocommerce_checkout_phone_field', 'required' );
+		$company        = get_option( 'woocommerce_checkout_company_field', 'optional' );
+		$address_2      = get_option( 'woocommerce_checkout_address_2_field', 'optional' );
+		$phone          = get_option( 'woocommerce_checkout_phone_field', 'required' );
+		$terms_checkbox = ! empty( get_option( 'woocommerce_terms_page_id', null ) );
 
 		// Blocks checkout options. To get the blocks checkout options, we need
 		// to parse the checkout page content because the options are stored
@@ -910,9 +911,10 @@ class WooPay_Session {
 
 		if ( empty( $checkout_page ) ) {
 			return [
-				'company'   => $company,
-				'address_2' => $address_2,
-				'phone'     => $phone,
+				'company'        => $company,
+				'address_2'      => $address_2,
+				'phone'          => $phone,
+				'terms_checkbox' => $terms_checkbox,
 			];
 		}
 
@@ -947,12 +949,46 @@ class WooPay_Session {
 			if ( isset( $checkout_block_attrs['showPhoneField'] ) && false === $checkout_block_attrs['showPhoneField'] ) {
 				$phone = 'hidden';
 			}
+
+			$fields_block   = self::get_inner_block( $checkout_page_blocks[ $checkout_block_index ], 'woocommerce/checkout-fields-block' );
+			$terms_block    = self::get_inner_block( $fields_block, 'woocommerce/checkout-terms-block' );
+			$terms_checkbox = isset( $terms_block['attrs']['checkbox'] ) && $terms_block['attrs']['checkbox'];
 		}
 
 		return [
-			'company'   => $company,
-			'address_2' => $address_2,
-			'phone'     => $phone,
+			'company'        => $company,
+			'address_2'      => $address_2,
+			'phone'          => $phone,
+			'terms_checkbox' => $terms_checkbox,
 		];
+	}
+
+	/**
+	 * Searches for an inner block with the given name.
+	 *
+	 * @param array  $current_block A block that contains child blocks.
+	 * @param string $inner_block_name The name of a child block.
+	 * @return array|null
+	 */
+	private static function get_inner_block( $current_block, $inner_block_name ) {
+
+		if ( ! isset( $current_block['innerBlocks'] ) ) {
+			return;
+		}
+
+		$checkout_terms_block_index = array_search(
+			$inner_block_name,
+			array_column(
+				$current_block['innerBlocks'],
+				'blockName'
+			),
+			true
+		);
+
+		if ( ! isset( $current_block['innerBlocks'][ $checkout_terms_block_index ] ) ) {
+			return;
+		}
+
+		return $current_block['innerBlocks'][ $checkout_terms_block_index ];
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds support for Clickwrap terms and conditions (checkbox) on WooPay.

See testing instructions on https://github.com/Automattic/woopay/pull/3012

Fixes #10122

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
