### PR TITLE
fix: imports of tokenized ECE referring to wrong path

### DIFF
--- a/changelog/fix-tokenized-express-checkout-relative-imports
+++ b/changelog/fix-tokenized-express-checkout-relative-imports
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: fix: tokenized ECE referring to non-tokenized ECE imports
+
+

--- a/client/express-checkout/utils/index.ts
+++ b/client/express-checkout/utils/index.ts
@@ -111,7 +111,9 @@ export const getExpressCheckoutData = <
 ) => {
 	if ( typeof window.wcpayExpressCheckoutParams !== 'undefined' ) {
 		return window.wcpayExpressCheckoutParams[ key ] ?? null;
-	} else if ( typeof window.wc?.wcSettings !== 'undefined' ) {
+	}
+
+	if ( typeof window.wc?.wcSettings !== 'undefined' ) {
 		return window.wc.wcSettings.getSetting( 'ece_data' )?.[ key ] ?? null;
 	}
 

--- a/client/express-checkout/utils/test/index.ts
+++ b/client/express-checkout/utils/test/index.ts
@@ -5,7 +5,7 @@ import {
 	WCPayExpressCheckoutParams,
 	getErrorMessageFromNotice,
 	getExpressCheckoutData,
-} from '../index';
+} from '..';
 
 describe( 'Express checkout utils', () => {
 	test( 'getExpressCheckoutData returns null for missing option', () => {

--- a/client/tokenized-express-checkout/blocks/components/express-checkout-container.js
+++ b/client/tokenized-express-checkout/blocks/components/express-checkout-container.js
@@ -11,7 +11,7 @@ import ExpressCheckoutComponent from './express-checkout-component';
 import {
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutData,
-} from 'wcpay/express-checkout/utils';
+} from '../../utils';
 import '../express-checkout-element.scss';
 
 const ExpressCheckoutContainer = ( props ) => {

--- a/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
@@ -11,7 +11,7 @@ import {
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
 	normalizeLineItems,
-} from 'wcpay/express-checkout/utils';
+} from '../../utils';
 import {
 	onAbortPaymentHandler,
 	onCancelHandler,
@@ -19,7 +19,7 @@ import {
 	onCompletePaymentHandler,
 	onConfirmHandler,
 	onReadyHandler,
-} from 'wcpay/express-checkout/event-handlers';
+} from '../../event-handlers';
 
 export const useExpressCheckout = ( {
 	api,

--- a/client/tokenized-express-checkout/utils/index.ts
+++ b/client/tokenized-express-checkout/utils/index.ts
@@ -1,108 +1,9 @@
 /**
  * Internal dependencies
  */
+import { WCPayExpressCheckoutParams } from 'wcpay/express-checkout/utils';
 export * from './normalize';
 import { getDefaultBorderRadius } from 'wcpay/utils/express-checkout';
-
-interface MyWindow extends Window {
-	wcpayExpressCheckoutParams: WCPayExpressCheckoutParams;
-}
-
-declare let window: MyWindow;
-
-/**
- * An /incomplete/ representation of the data that is loaded into the frontend for the Express Checkout.
- */
-export interface WCPayExpressCheckoutParams {
-	ajax_url: string;
-
-	/**
-	 * Express Checkout Button style configuration.
-	 */
-	button: {
-		type: string;
-		theme: string;
-		height: string;
-		locale: string;
-		branded_type: string;
-		radius: number;
-	};
-
-	/**
-	 * Indicates in which context the button is being displayed.
-	 */
-	button_context: 'checkout' | 'cart' | 'product' | 'pay_for_order';
-	checkout: {
-		country_code: string;
-		currency_code: string;
-		needs_payer_phone: boolean;
-		needs_shipping: boolean;
-	};
-
-	/**
-	 * Indicaters whether the page has a Cart or Checkout Block on it.
-	 */
-	has_block: boolean;
-
-	/**
-	 * True if we're on the checkout page.
-	 */
-	is_checkout_page: boolean;
-
-	/**
-	 * True if we're on a product page.
-	 */
-	is_product_page: boolean;
-
-	/**
-	 * True if we're on the pay for order page.
-	 */
-	is_pay_for_order_page: boolean;
-	nonce: {
-		add_to_cart: string;
-		checkout: string;
-		empty_cart: string;
-		get_cart_details: string;
-		get_selected_product_data: string;
-		pay_for_order: string;
-		platform_tracker: string;
-		shipping: string;
-		update_shipping: string;
-	};
-
-	/**
-	 * Product specific options.
-	 */
-	product: {
-		needs_shipping: boolean;
-		currency: string;
-		shippingOptions: {
-			id: string;
-			label: string;
-			detail: string;
-			amount: number;
-		};
-	};
-
-	/**
-	 * Settings for the user authentication dialog and redirection.
-	 */
-	login_confirmation: { message: string; redirect_url: string } | false;
-
-	stripe: {
-		accountId: string;
-		locale: string;
-		publishableKey: string;
-	};
-	total_label: string;
-	wc_ajax_url: string;
-}
-
-declare global {
-	interface Window {
-		wcpayExpressCheckoutParams?: WCPayExpressCheckoutParams;
-	}
-}
 
 export const getExpressCheckoutData = <
 	K extends keyof WCPayExpressCheckoutParams
@@ -111,7 +12,9 @@ export const getExpressCheckoutData = <
 ) => {
 	if ( typeof window.wcpayExpressCheckoutParams !== 'undefined' ) {
 		return window.wcpayExpressCheckoutParams[ key ] ?? null;
-	} else if ( typeof window.wc?.wcSettings !== 'undefined' ) {
+	}
+
+	if ( typeof window.wc?.wcSettings !== 'undefined' ) {
 		return window.wc.wcSettings.getSetting( 'ece_data' )?.[ key ] ?? null;
 	}
 

--- a/client/tokenized-express-checkout/utils/test/index.ts
+++ b/client/tokenized-express-checkout/utils/test/index.ts
@@ -1,11 +1,8 @@
 /**
  * Internal dependencies
  */
-import {
-	WCPayExpressCheckoutParams,
-	getErrorMessageFromNotice,
-	getExpressCheckoutData,
-} from '../index';
+import { WCPayExpressCheckoutParams } from 'wcpay/express-checkout/utils';
+import { getErrorMessageFromNotice, getExpressCheckoutData } from '..';
 
 describe( 'Express checkout utils', () => {
 	test( 'getExpressCheckoutData returns null for missing option', () => {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

While copying the ECE implementation into the `client/tokenized-express-checkout` directory ( https://github.com/Automattic/woocommerce-payments/pull/9730 ), I didn't make adjustments to the import paths.
Some of the import paths are absolute, so the files inside `client/tokenized-express-checkout` are importing from `client/express-checkout` - which we don't want.
Ideally `client/express-checkout` and `client/tokenized-express-checkout` should be self-contained.

The only place I didn't make changes is to the import of `WCPayExpressCheckoutParams`, which is a TS type that should be declared only once (otherwise TS is going to yell at us).

For the rest, I assured that the files inside `client/tokenized-express-checkout` didn't import from `client/express-checkout`.

I am keeping the relative imports because al the files will be moved in the `express-checkout` directory, after the refactor is completed.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No change in functionality introduced - this is just an import reference being adjusted.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
