### PR TITLE
chore: port ece changes into tokenized ece

### DIFF
--- a/changelog/chore-port-ece-changes-into-tokenized-ece
+++ b/changelog/chore-port-ece-changes-into-tokenized-ece
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: port ece changes into tokenized ece
+
+

--- a/client/tokenized-express-checkout/button-ui.js
+++ b/client/tokenized-express-checkout/button-ui.js
@@ -1,0 +1,49 @@
+/* global jQuery */
+
+let $expressCheckoutSeparator = null;
+let $wcpayExpressCheckoutContainer = null;
+let expressCheckoutElementId = null;
+
+const expressCheckoutButtonUi = {
+	init: ( { elementId, $separator } ) => {
+		expressCheckoutElementId = elementId;
+		$wcpayExpressCheckoutContainer = jQuery( expressCheckoutElementId );
+		$expressCheckoutSeparator = $separator;
+	},
+
+	getButtonSeparator: () => {
+		return $expressCheckoutSeparator;
+	},
+
+	blockButton: () => {
+		// check if element isn't already blocked before calling block() to avoid blinking overlay issues
+		// blockUI.isBlocked is either undefined or 0 when element is not blocked
+		if ( $wcpayExpressCheckoutContainer.data( 'blockUI.isBlocked' ) ) {
+			return;
+		}
+
+		$wcpayExpressCheckoutContainer.block( { message: null } );
+	},
+
+	unblockButton: () => {
+		expressCheckoutButtonUi.showContainer();
+		$wcpayExpressCheckoutContainer.unblock();
+	},
+
+	renderButton: ( eceButton ) => {
+		if ( $wcpayExpressCheckoutContainer?.length ) {
+			expressCheckoutButtonUi.showContainer();
+			eceButton.mount( expressCheckoutElementId );
+		}
+	},
+
+	hideContainer: () => {
+		$wcpayExpressCheckoutContainer.hide();
+	},
+
+	showContainer: () => {
+		$wcpayExpressCheckoutContainer.show();
+	},
+};
+
+export default expressCheckoutButtonUi;

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -12,7 +12,8 @@ import {
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
 	normalizeLineItems,
-} from './utils/index';
+	displayLoginConfirmation,
+} from './utils';
 import {
 	onAbortPaymentHandler,
 	onCancelHandler,
@@ -23,7 +24,7 @@ import {
 	shippingAddressChangeHandler,
 	shippingRateChangeHandler,
 } from './event-handlers';
-import { displayLoginConfirmation } from './utils';
+import expressCheckoutButtonUi from './button-ui';
 
 jQuery( ( $ ) => {
 	// Don't load if blocks checkout is being loaded.
@@ -55,6 +56,11 @@ jQuery( ( $ ) => {
 			} );
 		}
 	);
+
+	expressCheckoutButtonUi.init( {
+		elementId: '#wcpay-express-checkout-element',
+		$separator: jQuery( '#wcpay-express-checkout-button-separator' ),
+	} );
 
 	let wcPayECEError = '';
 	const defaultErrorMessage = __(
@@ -243,7 +249,7 @@ jQuery( ( $ ) => {
 				getExpressCheckoutButtonStyleSettings()
 			);
 
-			wcpayECE.renderButton( eceButton );
+			expressCheckoutButtonUi.renderButton( eceButton );
 
 			eceButton.on( 'loaderror', () => {
 				wcPayECEError = __(
@@ -251,7 +257,7 @@ jQuery( ( $ ) => {
 					'woocommerce-payments'
 				);
 				if ( ! document.getElementById( 'wcpay-woopay-button' ) ) {
-					wcpayECE?.getButtonSeparator()?.hide();
+					expressCheckoutButtonUi.getButtonSeparator().hide();
 				}
 			} );
 
@@ -349,8 +355,8 @@ jQuery( ( $ ) => {
 						onReadyParams.availablePaymentMethods
 					).filter( Boolean ).length
 				) {
-					wcpayECE.show();
-					wcpayECE.getButtonSeparator().show();
+					expressCheckoutButtonUi.showContainer();
+					expressCheckoutButtonUi.getButtonSeparator().show();
 				}
 			} );
 
@@ -437,7 +443,7 @@ jQuery( ( $ ) => {
 			$( document.body )
 				.off( 'woocommerce_variation_has_changed' )
 				.on( 'woocommerce_variation_has_changed', () => {
-					wcpayECE.blockExpressCheckoutButton();
+					expressCheckoutButtonUi.blockButton();
 
 					$.when( wcpayECE.getSelectedProductData() )
 						.then( ( response ) => {
@@ -465,10 +471,11 @@ jQuery( ( $ ) => {
 							}
 						} )
 						.catch( () => {
-							wcpayECE.hide();
+							expressCheckoutButtonUi.hideContainer();
+							expressCheckoutButtonUi.getButtonSeparator().hide();
 						} )
 						.always( () => {
-							wcpayECE.unblockExpressCheckoutButton();
+							expressCheckoutButtonUi.unblockButton();
 						} );
 				} );
 
@@ -478,7 +485,7 @@ jQuery( ( $ ) => {
 					'input',
 					'.qty',
 					debounce( () => {
-						wcpayECE.blockExpressCheckoutButton();
+						expressCheckoutButtonUi.blockButton();
 						wcPayECEError = '';
 
 						$.when( wcpayECE.getSelectedProductData() )
@@ -511,7 +518,7 @@ jQuery( ( $ ) => {
 								}
 							)
 							.always( function () {
-								wcpayECE.unblockExpressCheckoutButton();
+								expressCheckoutButtonUi.unblockButton();
 							} );
 					}, 250 )
 				);
@@ -524,48 +531,6 @@ jQuery( ( $ ) => {
 			wcpayExpressCheckoutParams.product.displayItems =
 				response.displayItems;
 			wcpayECE.init();
-		},
-
-		blockExpressCheckoutButton: () => {
-			// check if element isn't already blocked before calling block() to avoid blinking overlay issues
-			// blockUI.isBlocked is either undefined or 0 when element is not blocked
-			if (
-				$( '#wcpay-express-checkout-element' ).data(
-					'blockUI.isBlocked'
-				)
-			) {
-				return;
-			}
-
-			$( '#wcpay-express-checkout-element' ).block( { message: null } );
-		},
-
-		unblockExpressCheckoutButton: () => {
-			wcpayECE.show();
-			$( '#wcpay-express-checkout-element' ).unblock();
-		},
-
-		getElements: () => {
-			return $( '#wcpay-express-checkout-element' );
-		},
-
-		getButtonSeparator: () => {
-			return $( '#wcpay-express-checkout-button-separator' );
-		},
-
-		show: () => {
-			wcpayECE.getElements().show();
-		},
-
-		hide: () => {
-			wcpayECE.getElements().hide();
-			wcpayECE.getButtonSeparator().hide();
-		},
-
-		renderButton: ( eceButton ) => {
-			if ( $( '#wcpay-express-checkout-element' ).length ) {
-				eceButton.mount( '#wcpay-express-checkout-element' );
-			}
 		},
 
 		productHasDepositOption() {
@@ -590,7 +555,8 @@ jQuery( ( $ ) => {
 				} = wcpayECEPayForOrderParams;
 
 				if ( total === 0 ) {
-					wcpayECE.hide();
+					expressCheckoutButtonUi.hideContainer();
+					expressCheckoutButtonUi.getButtonSeparator().hide();
 					return;
 				}
 
@@ -625,7 +591,8 @@ jQuery( ( $ ) => {
 				// cart details.
 				api.expressCheckoutECEGetCartDetails().then( ( cart ) => {
 					if ( cart.total.amount === 0 ) {
-						wcpayECE.hide();
+						expressCheckoutButtonUi.hideContainer();
+						expressCheckoutButtonUi.getButtonSeparator().hide();
 					} else {
 						wcpayECE.startExpressCheckoutElement( {
 							mode: 'payment',

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -412,18 +412,6 @@ jQuery( ( $ ) => {
 			return api.expressCheckoutECEGetSelectedProductData( data );
 		},
 
-		/**
-		 * Creates Stripe Express Checkout Element.
-		 *
-		 * @param {Object} elements       Stripe elements instance.
-		 * @param {Object} options 		  Options for creating the Express Checkout Element.
-		 *
-		 * @return {Object} Stripe Express Checkout Element.
-		 */
-		createButton: ( elements, options ) => {
-			return elements.create( 'expressCheckout', options );
-		},
-
 		attachProductPageEventListeners: ( elements ) => {
 			// WooCommerce Deposits support.
 			// Trigger the "woocommerce_variation_has_changed" event when the deposit option is changed.

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -244,8 +244,8 @@ jQuery( ( $ ) => {
 				locale: getExpressCheckoutData( 'stripe' )?.locale ?? 'en',
 			} );
 
-			const eceButton = wcpayECE.createButton(
-				elements,
+			const eceButton = elements.create(
+				'expressCheckout',
 				getExpressCheckoutButtonStyleSettings()
 			);
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When I implemented https://github.com/Automattic/woocommerce-payments/pull/9744 , I forgot to port the same changes into the `client/tokenized-express-checkout` directory 🤦 

This PR implements the exact same changes from #9744 into the `client/tokenized-express-checkout` directory.

Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
