### PR TITLE
Show "Download" label on documents list view table

### DIFF
--- a/changelog/fix-7014-documents-list-view-table-download-label
+++ b/changelog/fix-7014-documents-list-view-table-download-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add the missing "Download" column heading label and toggle menu option to the Payments → Documents list view table.

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -55,7 +55,7 @@ const getColumns = (): Column[] =>
 		},
 		{
 			key: 'download',
-			label: '',
+			label: __( 'Download', 'woocommerce-payments' ),
 			screenReaderLabel: __( 'Download', 'woocommerce-payments' ),
 			isLeftAligned: false,
 			isNumeric: true,

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -197,7 +197,8 @@ export const DocumentsList = (): JSX.Element => {
 				value: getDocumentUrl( document.document_id ),
 				display: (
 					<Button
-						isLink
+						className="documents-list__download-button"
+						variant="link"
 						onClick={ () =>
 							downloadDocument(
 								document.document_id,

--- a/client/documents/list/style.scss
+++ b/client/documents/list/style.scss
@@ -17,6 +17,11 @@ $space-header-item: 12px;
 	}
 }
 
+// Adjusting the "Download"padding to match the column header alignment
+button.components-button.documents-list__download-button {
+	padding: 3px;
+}
+
 /**
  * Sourced from https://github.com/woocommerce/woocommerce-admin/blob/ec36a00b77b5c0e313985a5a64c88aaec9eb154e/client/analytics/components/report-table/style.scss.
  * Depending on the wc-admin version, these styles are not loaded if not using the analytics report components, so they need to be included here.

--- a/client/documents/list/test/__snapshots__/index.tsx.snap
+++ b/client/documents/list/test/__snapshots__/index.tsx.snap
@@ -202,7 +202,9 @@ exports[`Documents list renders correctly 1`] = `
                   >
                     <span
                       aria-hidden="true"
-                    />
+                    >
+                      Download
+                    </span>
                     <span
                       class="screen-reader-text"
                     >
@@ -231,7 +233,7 @@ exports[`Documents list renders correctly 1`] = `
                     class="woocommerce-table__item is-numeric"
                   >
                     <button
-                      class="components-button is-link"
+                      class="components-button documents-list__download-button is-link"
                       type="button"
                     >
                       Download
@@ -259,7 +261,7 @@ exports[`Documents list renders correctly 1`] = `
                     class="woocommerce-table__item is-numeric"
                   >
                     <button
-                      class="components-button is-link"
+                      class="components-button documents-list__download-button is-link"
                       type="button"
                     >
                       Download
@@ -515,7 +517,9 @@ exports[`Documents list renders table summary only when the documents summary da
                   >
                     <span
                       aria-hidden="true"
-                    />
+                    >
+                      Download
+                    </span>
                     <span
                       class="screen-reader-text"
                     >
@@ -544,7 +548,7 @@ exports[`Documents list renders table summary only when the documents summary da
                     class="woocommerce-table__item is-numeric"
                   >
                     <button
-                      class="components-button is-link"
+                      class="components-button documents-list__download-button is-link"
                       type="button"
                     >
                       Download
@@ -572,7 +576,7 @@ exports[`Documents list renders table summary only when the documents summary da
                     class="woocommerce-table__item is-numeric"
                   >
                     <button
-                      class="components-button is-link"
+                      class="components-button documents-list__download-button is-link"
                       type="button"
                     >
                       Download


### PR DESCRIPTION
Fixes #7014

#### Changes proposed in this Pull Request

Adds the missing "Download" column heading label and toggle menu option to the Payments → Documents list view table.

I've also:
* adjusted the padding of the "Download" buttons to align with the new column heading
* replaced the deprecated `isLink` Button component prop with `variant="link"` on the download button


**Before/After gifs**

Document list view table:
![table](https://github.com/user-attachments/assets/4df4bd99-1959-44c0-976c-05fb2a18031b)

Document list view table toggle menu:
![toggle](https://github.com/user-attachments/assets/6844a335-5864-40b4-9d90-745eafb6d8a6)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pre-requisite: ensure you have VAT tax documents and can see Payments → Documents
* Navigate to Payments → Documents
* Ensure you can see the "Download" column label
* Open the three dots menu and ensure the menu includes a "Download" toggle
* Check on mobile viewpots

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : **Minor change, release testing not required**
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **N/A**
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
