### PR TITLE
fix: missing ECE is_product_page checks

### DIFF
--- a/changelog/fix-missing-ece-checks
+++ b/changelog/fix-missing-ece-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: missing ece is_product_page checks

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -320,7 +320,8 @@ export default class WCPayAPI {
 			{
 				security: getExpressCheckoutConfig( 'nonce' )?.update_shipping,
 				shipping_method: [ shippingOption.id ],
-				is_product_page: getExpressCheckoutConfig( 'is_product_page' ),
+				is_product_page:
+					getExpressCheckoutConfig( 'button_context' ) === 'product',
 			}
 		);
 	}
@@ -381,7 +382,8 @@ export default class WCPayAPI {
 			getExpressCheckoutAjaxURL( 'ece_get_shipping_options' ),
 			{
 				security: getExpressCheckoutConfig( 'nonce' )?.shipping,
-				is_product_page: getExpressCheckoutConfig( 'is_product_page' ),
+				is_product_page:
+					getExpressCheckoutConfig( 'button_context' ) === 'product',
 				...shippingAddress,
 			}
 		);

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -611,7 +611,10 @@ jQuery( ( $ ) => {
 	};
 
 	// We don't need to initialize ECE on the checkout page now because it will be initialized by updated_checkout event.
-	if ( getExpressCheckoutData( 'button_context' ) !== 'checkout' ) {
+	if (
+		getExpressCheckoutData( 'button_context' ) !== 'checkout' ||
+		getExpressCheckoutData( 'button_context' ) === 'pay_for_order'
+	) {
 		wcpayECE.init();
 	}
 

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -25,6 +25,7 @@ import {
 	shippingRateChangeHandler,
 } from './event-handlers';
 import expressCheckoutButtonUi from './button-ui';
+import { getExpressCheckoutConfig } from 'wcpay/utils/express-checkout';
 
 jQuery( ( $ ) => {
 	// Don't load if blocks checkout is being loaded.
@@ -566,7 +567,9 @@ jQuery( ( $ ) => {
 					displayItems,
 					order,
 				} );
-			} else if ( wcpayExpressCheckoutParams.is_product_page ) {
+			} else if (
+				getExpressCheckoutConfig( 'button_context' ) === 'product'
+			) {
 				wcpayECE.startExpressCheckoutElement( {
 					mode: 'payment',
 					total: getExpressCheckoutData( 'product' )?.total.amount,
@@ -610,7 +613,7 @@ jQuery( ( $ ) => {
 
 	// We don't need to initialize ECE on the checkout page now because it will be initialized by updated_checkout event.
 	if (
-		! wcpayExpressCheckoutParams.is_checkout_page ||
+		! getExpressCheckoutData( 'button_context' ) === 'checkout' ||
 		getExpressCheckoutData( 'button_context' ) === 'pay_for_order'
 	) {
 		wcpayECE.init();

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -25,7 +25,6 @@ import {
 	shippingRateChangeHandler,
 } from './event-handlers';
 import expressCheckoutButtonUi from './button-ui';
-import { getExpressCheckoutConfig } from 'wcpay/utils/express-checkout';
 
 jQuery( ( $ ) => {
 	// Don't load if blocks checkout is being loaded.
@@ -568,7 +567,7 @@ jQuery( ( $ ) => {
 					order,
 				} );
 			} else if (
-				getExpressCheckoutConfig( 'button_context' ) === 'product'
+				getExpressCheckoutData( 'button_context' ) === 'product'
 			) {
 				wcpayECE.startExpressCheckoutElement( {
 					mode: 'payment',
@@ -613,7 +612,7 @@ jQuery( ( $ ) => {
 
 	// We don't need to initialize ECE on the checkout page now because it will be initialized by updated_checkout event.
 	if (
-		! getExpressCheckoutData( 'button_context' ) === 'checkout' ||
+		getExpressCheckoutData( 'button_context' ) !== 'checkout' ||
 		getExpressCheckoutData( 'button_context' ) === 'pay_for_order'
 	) {
 		wcpayECE.init();


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Missed from https://github.com/Automattic/woocommerce-payments/pull/9745

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
