### PR TITLE
Ensure the BNPL PMME doesn't appear on carts with subscriptions

### DIFF
--- a/changelog/fix-no-bnpl-subscriptions
+++ b/changelog/fix-no-bnpl-subscriptions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Small fix for BNPL messaging element.
+
+

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -107,11 +107,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			}
 		}
 
-		if ( is_cart() ) {
-			$enabled_upe_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
-		} else {
-			$enabled_upe_payment_methods = $this->gateway->get_upe_enabled_payment_method_ids();
-		}
+		$enabled_upe_payment_methods = $this->gateway->get_upe_enabled_payment_method_ids();
 		// Filter non BNPL out of the list of payment methods.
 		$bnpl_payment_methods = array_intersect( $enabled_upe_payment_methods, Payment_Method::BNPL_PAYMENT_METHODS );
 

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -107,7 +107,11 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			}
 		}
 
-		$enabled_upe_payment_methods = $this->gateway->get_upe_enabled_payment_method_ids();
+		if ( is_cart() ) {
+			$enabled_upe_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
+		} else {
+			$enabled_upe_payment_methods = $this->gateway->get_upe_enabled_payment_method_ids();
+		}
 		// Filter non BNPL out of the list of payment methods.
 		$bnpl_payment_methods = array_intersect( $enabled_upe_payment_methods, Payment_Method::BNPL_PAYMENT_METHODS );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1880,10 +1880,11 @@ class WC_Payments {
 		$are_subscriptions_enabled = class_exists( 'WC_Subscriptions' ) || class_exists( 'WC_Subscriptions_Core_Plugin' );
 		if ( $are_subscriptions_enabled ) {
 				global $product;
-				$is_subscription = $product && WC_Subscriptions_Product::is_subscription( $product );
+				$is_subscription            = $product && WC_Subscriptions_Product::is_subscription( $product );
+				$cart_contains_subscription = is_cart() && WC_Subscriptions_Cart::cart_contains_subscription();
 		}
 
-		if ( ! $is_subscription ) {
+		if ( ! $is_subscription && ! $cart_contains_subscription ) {
 			require_once __DIR__ . '/class-wc-payments-payment-method-messaging-element.php';
 			$stripe_site_messaging = new WC_Payments_Payment_Method_Messaging_Element( self::$account, self::$card_gateway );
 			echo wp_kses( $stripe_site_messaging->init() ?? '', 'post' );


### PR DESCRIPTION
Fixes #9772 

#### Changes proposed in this Pull Request

In an effort to fix [an issue on PDPs](https://github.com/Automattic/woocommerce-payments/pull/9626#pullrequestreview-2407990115), I made a change that caused the PMME to appear on the cart page when subscription products are in the cart. In fact, the cart page should indeed use `get_payment_method_ids_enabled_at_checkout()` which is a filtered list of enabled payment methods. The PDP still needs all enabled payment methods however, to solve the issue mentioned above. This PR adds adds some branching to ensure both page have the list of BNPL payment methods it needs.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable BNPL methods.
2. Add a subscription product to the cart.
3. Visit the classic cart. The PMME should not appear.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
