### PR TITLE
Vertically align the bnpl logos on legacy checkout payment method list.

### DIFF
--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -127,6 +127,8 @@
 					justify-self: end;
 					margin: 3px 0; // ensuring the images don't appear squished when all the payment methods are rendered next to each others, like in Elementor.
 					align-self: center;
+					grid-column: 2; // Be explicit that the image should be in the second column of the grid container.
+					grid-row: 1 / span 2; // Makes the image span two rows of the grid container.
 				}
 
 				.stripe-pmme-container {


### PR DESCRIPTION
Fixes #9488

#### Changes proposed in this Pull Request
As of writing this, this PR vertically aligns the bnpl icons with the method title and PMME text on the legacy checkout payment methods list.

Still determining if there are any other changes to be made in relation to this issue...

<img width="300" alt="388277631-ddf8b514-4ef8-4e51-ab1f-3c6b64d9414f" src="https://github.com/user-attachments/assets/e2f47b48-1d31-4fe0-b84f-045f4e24c6fd">


#### Testing instructions
*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
