### PR TITLE
feat: add filter to override rich payment method label

### DIFF
--- a/changelog/feat-add-gateway-label-filter-override
+++ b/changelog/feat-add-gateway-label-filter-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+feat: add `wcpay_checkout_use_plain_method_label` filter to allow themes or merchants to force the "plain" WooPayments label on shortcode checkout.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -580,6 +580,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function get_title() {
 		$title = parent::get_title();
 
+		/**
+		 * Allows themes or other plugins to override whether the "rich" payment method label
+		 * (normally displayed on shortcode checkout/my account/pay-for-order pages) will be used.
+		 *
+		 * @since 8.6.0
+		 *
+		 * @param $use_plain_method_label boolean Whether the "plain" payment method label will be displayed.
+		 */
+		if ( apply_filters( 'wcpay_checkout_use_plain_method_label', false ) ) {
+			return $title;
+		}
+
 		if (
 			( is_checkout() || is_add_payment_method_page() ) &&
 			! isset( $_GET['change_payment_method'] )  // phpcs:ignore WordPress.Security.NonceVerification


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed here: https://github.com/Automattic/woocommerce-payments/pull/9647#issuecomment-2490796584

The "Test mode" label that we originally introduced in 8.4.0 can have some incompatibilities with themes or existing pages.
[We already fixed some incompatibility](https://github.com/Automattic/woocommerce-payments/issues/9616) with the "change payment method" page for subscriptions.
But I think a bigger revision might be needed.
Adding these styles via the `get_title()` method on the main gateway seems to be problematic for some themes ( p1731488040924719/1731451895.464649-slack-CU6SYV31A | https://github.com/Automattic/woocommerce-payments/pull/9647#issuecomment-2490956335 ).
We now found that it could also affect email templates: https://github.com/Automattic/woocommerce-payments/issues/9779

For now, we can add a filter for merchants to tap into.

I'm also tempted to add an `is_ajax()` check on the `get_title()` method, just to fix the email address.
But for now, let's move forward with _at least_ having a filter.

This filter doesn't alter the block checkout, which doesn't suffer of this issue.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure WooPayments is set in "Test mode"
- Add a non-free product to the cart
- Go to the shortcode checkout
- Select the "Credit card / debit card" payment method from WooPayments
- The "Test mode" label should be present next to the "Credit card / debit card" label
- Via plugin like Code Snippets ( https://wordpress.org/plugins/code-snippets/ ) , add the following filter:
```php
add_filter( 'wcpay_checkout_use_plain_method_label', '__return_true' );
```
- Now, refresh the shortcode checkout page
- The "Test mode" label should no longer be visible, and the plain label should be displayed instead
- The Stripe PMME should no longer be visible next to the label on the BNPL methods
<img width="1078" alt="Screenshot 2024-11-21 at 4 42 28 PM" src="https://github.com/user-attachments/assets/b8d5dc35-2e8c-4dbe-a4a7-43ff90e63c4e">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.