### PR TITLE
Ensure dispute urls in order notes are encoded correctly

### DIFF
--- a/changelog/fix-7399
+++ b/changelog/fix-7399
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Ensure dispute urls in order notes are urlencoded
+
+

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1657,12 +1657,13 @@ class WC_Payments_Order_Service {
 				/* translators: %1: the disputed amount and currency; %2: the dispute reason; %3 the deadline date for responding to dispute */
 				__( 'Payment has been disputed for %1$s with reason "%2$s". <a>Response due by %3$s</a>.', 'woocommerce-payments' ),
 				[
-					'a' => '<a href="' . $dispute_url . '" target="_blank" rel="noopener noreferrer">',
+					'a' => '<a href="%4$s" target="_blank" rel="noopener noreferrer">',
 				]
 			),
 			$amount,
 			$reason,
-			$due_by
+			$due_by,
+			$dispute_url
 		);
 	}
 
@@ -1681,10 +1682,11 @@ class WC_Payments_Order_Service {
 				/* translators: %1: the dispute status */
 				__( 'Payment dispute has been closed with status %1$s. See <a>dispute overview</a> for more details.', 'woocommerce-payments' ),
 				[
-					'a' => '<a href="' . $dispute_url . '" target="_blank" rel="noopener noreferrer">',
+					'a' => '<a href="%2$s" target="_blank" rel="noopener noreferrer">',
 				]
 			),
-			$status
+			$status,
+			$dispute_url
 		);
 	}
 
@@ -1747,7 +1749,7 @@ class WC_Payments_Order_Service {
 		return add_query_arg(
 			[
 				'page' => 'wc-admin',
-				'path' => '/payments/transactions/details',
+				'path' => rawurlencode( '/payments/transactions/details' ),
 				'id'   => $charge_id,
 			],
 			admin_url( 'admin.php' )

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -856,7 +856,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( $amount, $notes[0]->content );
 		$this->assertStringContainsString( 'Product not received', $notes[0]->content );
 		$this->assertStringContainsString( $deadline, $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=ch_123" target="_blank" rel="noopener noreferrer">Response due by', $notes[0]->content );
+		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" target="_blank" rel="noopener noreferrer">Response due by', $notes[0]->content );
 
 		// Assert: Check that order status change note was added.
 		$this->assertStringContainsString( 'Pending payment to On hold', $notes[1]->content );
@@ -910,7 +910,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'Pending payment to Completed', $notes[1]->content );
 		$this->assertStringContainsString( 'Payment dispute has been closed with status won', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=ch_123" target="_blank" rel="noopener noreferrer">dispute overview', $notes[0]->content );
+		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" target="_blank" rel="noopener noreferrer">dispute overview', $notes[0]->content );
 
 		// Assert: Applying the same data multiple times does not cause duplicate actions.
 		$this->order_service->mark_payment_dispute_closed( $this->order, $charge_id, $status );
@@ -938,7 +938,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'On hold to Refunded', $notes[1]->content );
 		$this->assertStringContainsString( 'Payment dispute has been closed with status lost', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=ch_123" target="_blank" rel="noopener noreferrer">dispute overview', $notes[0]->content );
+		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" target="_blank" rel="noopener noreferrer">dispute overview', $notes[0]->content );
 
 		// Assert: Check for created refund, and the amount is correct.
 		$refunds = $this->order->get_refunds();


### PR DESCRIPTION
Fixes #7399

#### Changes proposed in this Pull Request

URLs to disputes in order notes are rendered incorrectly. Any `/` characters inside the query string should be encoded as `%2F`

```html
<a href="https://woo.test/wp-admin/admin.php?page=wc-admin&path=/payments/transactions/details&id=pi_3QKsaDQtab9RariT0e2C6i39" target="_blank" rel="noopener noreferrer">pi_3QKsaDQtab9RariT0e2C6i39</a>
```

This PR ensures that the `path` attribute in the query string is URL-encoded correctly.


#### Implementation Notes

Passing a correctly encoded URL to `WC_Payments_Utils::esc_interpolated_html()` alters the URL to replace `%2F` with `0.000000`. 

```html
<a href="https://woo.test/wp-admin/admin.php?page=wc-admin&path=0.000000payments0.000000transactions2024.000000details&id=ch_3QNQOSQtab9RariT1x7pIdpK" target="_blank" rel="noopener noreferrer">Response due by 2024-11-30</a>
```

I looked at the possibility of updating this function but couldn't see where it was going wrong. I reviewed the code and found that links to disputes and [transactions](https://github.com/Automattic/woocommerce-payments/issues/9789) (issue created) are the only cases where this is affected.

Surprisingly, the WP function `add_query_arg` doesn’t sanitize or encode the provided values.

I was going to use `urlencode` but phpcs recommends `rawurlencode` instead.


#### Testing instructions

* Purchase a product using a dispute test card such as `4000000000000259`
* Visit the WC Order page, confirm that the note is rendering the link correctly
* View the raw order note in the database column wp_comments.comment_content to confirm.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
