### PR TITLE
Enable ECE Tracks Events when WooPay is disabled

### DIFF
--- a/changelog/fix-9784-ece-tracks-events
+++ b/changelog/fix-9784-ece-tracks-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix ECE Tracks events not triggering when WooPay is disabled.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -294,6 +294,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			return false;
 		}
 
+		$properties = apply_filters( 'wcpay_tracks_event_properties', $properties, $event_name );
+
 		if ( isset( $properties['record_event_data'] ) ) {
 			if ( isset( $properties['record_event_data']['is_admin_event'] ) ) {
 				$is_admin_event = $properties['record_event_data']['is_admin_event'];

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-display-handler.php
@@ -93,6 +93,8 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}
 
+		add_filter( 'wcpay_tracks_event_properties', [ $this, 'record_all_ece_tracks_events' ], 10, 2 );
+
 		if ( $this->is_pay_for_order_flow_supported() ) {
 			add_action( 'wp_enqueue_scripts', [ $this, 'add_pay_for_order_params_to_js_config' ], 5 );
 		}
@@ -217,5 +219,28 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			);
 		}
 		// phpcs:enable WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Record all ECE tracks events by adding the track_on_all_stores flag to the event.
+	 *
+	 * @param array  $properties Event properties.
+	 * @param string $event_name Event name.
+	 * @return array
+	 */
+	public function record_all_ece_tracks_events( $properties, $event_name ) {
+		$tracked_events_prefixes = [
+			'wcpay_applepay',
+			'wcpay_gpay',
+		];
+
+		foreach ( $tracked_events_prefixes as $prefix ) {
+			if ( strpos( $event_name, $prefix ) === 0 ) {
+				$properties['record_event_data']['track_on_all_stores'] = true;
+				break;
+			}
+		}
+
+		return $properties;
 	}
 }


### PR DESCRIPTION
Fixes #9784 

#### Changes proposed in this Pull Request

This PR addresses the issue where ECE Tracks Events are not being enabled when WooPay is disabled. By implementing this change, event tracking remains functional irrespective of the WooPay payment gateway’s status, ensuring consistent data collection and analytics.

#### Testing instructions

1. **Prepare Environment:**
   - Deploy this branch to a public-facing URL (Jurassic Ninja).
   - Ensure you are **not logged in as an administrator**.

2. **Disable WooPay:**
   - Navigate to **WooPayments Settings** and disable the **WooPay** payment method.

3. **Set Breakpoint:**
   - Open `class-woopay-tracker.php` and add a debugger breakpoint at line [327](https://github.com/Automattic/woocommerce-payments/blob/2aa31ee1810ce9a7a1076fa7cacfe300fb3d030d/includes/class-woopay-tracker.php#L327).

4. **Trigger Events and Verify Event Recording:**
   - Visit a page where the ECE button is present.
   - Ensure that the debugger hits the breakpoint for each ECE Tracks Event triggered.
   - Confirm that events like `wcpay_applepay_button_load` and `wcpay_gpay_button_load` are being recorded as expected.

5. **Verify that the issue existed:**
     - Deploy the `develop` branch to the same environment.
     - Perform the same actions to trigger ECE Tracks Events.
     - Verify that the breakpoint at line [327](https://github.com/Automattic/woocommerce-payments/blob/2aa31ee1810ce9a7a1076fa7cacfe300fb3d030d/includes/class-woopay-tracker.php#L327) is **not** hit, confirming that the issue is present in `develop` and fixed in this branch.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
