### PR TITLE
fix: remove 'test mode' badge from shortcode checkout

### DIFF
--- a/changelog/fix-remove-shortcode-test-mode-badge-from-label
+++ b/changelog/fix-remove-shortcode-test-mode-badge-from-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: remove "test mode" badge from shortcode checkout.

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -169,43 +169,55 @@ jQuery( function ( $ ) {
 
 	async function injectStripePMMEContainers() {
 		const bnplMethods = [ 'affirm', 'afterpay_clearpay', 'klarna' ];
+		const labelBase = 'payment_method_woocommerce_payments_';
 		const paymentMethods = getUPEConfig( 'paymentMethodsConfig' );
 		const paymentMethodsKeys = Object.keys( paymentMethods );
 		const cartData = await api.pmmeGetCartData();
 
 		for ( const method of paymentMethodsKeys ) {
 			if ( bnplMethods.includes( method ) ) {
+				const targetLabel = document.querySelector(
+					`label[for="${ labelBase }${ method }"]`
+				);
 				const containerID = `stripe-pmme-container-${ method }`;
-				const container = document.getElementById( containerID );
 
-				if ( ! container ) {
-					continue;
+				if ( document.getElementById( containerID ) ) {
+					document.getElementById( containerID ).innerHTML = '';
 				}
 
-				container.innerHTML = '';
-				container.dataset.paymentMethodType = method;
+				if ( targetLabel ) {
+					let container = document.getElementById( containerID );
+					if ( ! container ) {
+						container = document.createElement( 'span' );
+						container.id = containerID;
+						container.dataset.paymentMethodType = method;
+						container.classList.add( 'stripe-pmme-container' );
+						targetLabel.appendChild( container );
+					}
 
-				const currentCountry =
-					cartData?.billing_address?.country ||
-					getUPEConfig( 'storeCountry' );
-				if (
-					paymentMethods[ method ]?.countries.length === 0 ||
-					paymentMethods[ method ]?.countries?.includes(
-						currentCountry
-					)
-				) {
-					await mountStripePaymentMethodMessagingElement(
-						api,
-						container,
-						{
-							amount: cartData?.totals?.total_price,
-							currency: cartData?.totals?.currency_code,
-							decimalPlaces:
-								cartData?.totals?.currency_minor_unit,
-							country: currentCountry,
-						},
-						'shortcode_checkout'
-					);
+					const currentCountry =
+						cartData?.billing_address?.country ||
+						getUPEConfig( 'storeCountry' );
+
+					if (
+						paymentMethods[ method ]?.countries.length === 0 ||
+						paymentMethods[ method ]?.countries?.includes(
+							currentCountry
+						)
+					) {
+						await mountStripePaymentMethodMessagingElement(
+							api,
+							container,
+							{
+								amount: cartData?.totals?.total_price,
+								currency: cartData?.totals?.currency_code,
+								decimalPlaces:
+									cartData?.totals?.currency_minor_unit,
+								country: currentCountry,
+							},
+							'shortcode_checkout'
+						);
+					}
 				}
 			}
 		}

--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -30,117 +30,66 @@
 	border: none;
 }
 
-.woopayments-rich-payment-method-label {
-	// this will be displayed only on specific scenarios. Otherwise, the "legacy" label will be displayed.
-	display: none;
-}
-
 #payment .payment_methods {
-	li[class*='payment_method_woocommerce_payments'] > label > img {
+	li[class*='payment_method_woocommerce_payments'] label img {
 		float: right;
 		border: 0;
 		padding: 0;
 		height: 24px !important;
 		max-height: 24px !important;
 	}
+}
 
-	&.wc_payment_methods,
-	&.woocommerce-PaymentMethods {
-		li[class*='payment_method_woocommerce_payments'] {
-			display: grid;
-			grid-template-columns: 0fr 0fr 1fr;
-			grid-template-rows: max-content;
+li.wc_payment_method:has( .input-radio:not( :checked )
+		+ label
+		.stripe-pmme-container ) {
+	display: grid;
+	grid-template-columns: min-content 1fr;
+	grid-template-rows: auto auto;
+	align-items: baseline;
 
-			.woopayments-plain-payment-method-label {
+	.input-radio {
+		grid-row: 1;
+		grid-column: 1;
+	}
+
+	label {
+		grid-column: 2;
+		grid-row: 1;
+	}
+
+	img {
+		grid-row: 1 / span 2;
+		align-self: center;
+	}
+
+	.stripe-pmme-container {
+		width: 100%;
+		grid-column: 1;
+		grid-row-start: 2;
+		pointer-events: none;
+	}
+
+	.payment_box {
+		flex: 0 0 100%;
+		grid-row: 2;
+		grid-column: 1 / span 2;
+	}
+}
+
+li.wc_payment_method:has( .input-radio:checked
+		+ label
+		.stripe-pmme-container ) {
+	display: block;
+
+	.input-radio:checked {
+		+ label {
+			.stripe-pmme-container {
 				display: none;
 			}
 
-			> input[name='payment_method'] {
-				&:checked ~ label {
-					.payment-method-title {
-						margin-right: 8px; // 8px gap between .payment-method-title and .test-mode.badge
-					}
-
-					.test-mode.badge {
-						display: inline-block; // hiding the badge when the payment method is not selected
-					}
-
-					.stripe-pmme-container {
-						display: none;
-					}
-				}
-			}
-
-			> label {
-				grid-column: 3;
-				margin-bottom: 0;
-			}
-
-			> div.payment_box {
-				grid-area: 2 / 1 / 3 / 4;
-			}
-
-			> label:has( .woopayments-rich-payment-method-label ) {
-				display: inline-flex;
-				align-items: center;
-				width: 100%;
-
-				> img {
-					display: none; // we'll display the image inside `.woopayments-rich-payment-method-label`, instead.
-				}
-			}
-
-			.woopayments-rich-payment-method-label {
-				display: grid;
-				grid-template-columns: 1fr auto;
-				align-items: center;
-				margin-bottom: 0;
-				flex-grow: 1;
-
-				.label-title-container {
-					display: block;
-				}
-
-				.payment-method-title {
-					white-space: normal; // Allows wrapping if text is too long
-					vertical-align: middle;
-				}
-
-				.test-mode.badge {
-					display: none;
-					background-color: #fff2d7;
-					border-radius: 4px;
-					padding: 4px 6px;
-					font-size: 12px;
-					font-weight: 400;
-					line-height: 16px;
-					color: #4d3716;
-					vertical-align: middle;
-					white-space: nowrap; // Prevents the badge text from wrapping
-				}
-
-				img {
-					border: 0;
-					padding: 0;
-					height: 24px !important;
-					max-height: 24px !important;
-					justify-self: end;
-					margin: 3px 0; // ensuring the images don't appear squished when all the payment methods are rendered next to each others, like in Elementor.
-					align-self: center;
-				}
-
-				.stripe-pmme-container {
-					&:empty {
-						display: none; // hides container if empty, without affecting alignment
-					}
-
-					margin-left: 0.25em; // WooCommerce Core will add a &nbsp; on the left of the payment method's label - this spacing ensures that at least it's consistently aligned.
-					pointer-events: none;
-					grid-column: 1 / 2;
-					grid-row: 2 / 3;
-					align-self: start;
-					width: 100%;
-				}
+			img {
+				grid-column: 2;
 			}
 		}
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -573,58 +573,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Returns the gateway title
-	 *
-	 * @return string
-	 * */
-	public function get_title() {
-		$title = parent::get_title();
-
-		/**
-		 * Allows themes or other plugins to override whether the "rich" payment method label
-		 * (normally displayed on shortcode checkout/my account/pay-for-order pages) will be used.
-		 *
-		 * @since 8.6.0
-		 *
-		 * @param $use_plain_method_label boolean Whether the "plain" payment method label will be displayed.
-		 */
-		if ( apply_filters( 'wcpay_checkout_use_plain_method_label', false ) ) {
-			return $title;
-		}
-
-		if (
-			( is_checkout() || is_add_payment_method_page() ) &&
-			! isset( $_GET['change_payment_method'] )  // phpcs:ignore WordPress.Security.NonceVerification
-		) {
-			$test_mode_badge = '';
-			if ( WC_Payments::mode()->is_test() ) {
-				$test_mode_badge = '<span class="test-mode badge">' . __( 'Test Mode', 'woocommerce-payments' ) . '</span>';
-			}
-
-			$bnpl_messaging_container = '';
-			if ( $this->payment_method->is_bnpl() ) {
-				$bnpl_messaging_container = '<span id="stripe-pmme-container-' . $this->payment_method->get_id() . '" class="stripe-pmme-container"></span>';
-			}
-
-			// the "plain" payment method label is displayed on some sections of the app
-			// - like "pay for order" when a payment method is pre-selected or a payment has previously failed.
-			$html  = '<span class="woopayments-plain-payment-method-label">' . $title . '</span>';
-			$html .= '<div class="woopayments-rich-payment-method-label">';
-			$html .= '<div class="label-title-container">';
-			$html .= '<span class="payment-method-title">&nbsp;' . $title . '</span>';
-			$html .= $test_mode_badge;
-			$html .= '</div>';
-			$html .= $this->get_icon();
-			$html .= $bnpl_messaging_container;
-			$html .= '</div>';
-
-			return $html;
-		}
-
-		return $title;
-	}
-
-	/**
 	 * Updates icon and title using the account country.
 	 * This method runs on init is not in the controller because get_account_country might
 	 * make a request to the API if the account data is not cached.
@@ -3259,15 +3207,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->payments_api_client->save_fraud_ruleset( $ruleset );
 			set_transient( 'wcpay_fraud_protection_settings', $ruleset, DAY_IN_SECONDS );
 		}
-	}
-
-	/**
-	 * Overriding the base method because the `alt` tag would otherwise output the markup returned by the `get_title()` method in this class - which we don't want.
-	 *
-	 * @return string
-	 */
-	public function get_icon() {
-		return '<img src="' . esc_url( WC_HTTPS::force_https_url( $this->get_theme_icon() ) ) . '" alt="' . esc_attr( $this->payment_method->get_title() ) . ' payment method logo" />';
 	}
 
 	/**

--- a/tests/e2e-pw/specs/shopper/klarna-checkout-purchase.spec.ts
+++ b/tests/e2e-pw/specs/shopper/klarna-checkout-purchase.spec.ts
@@ -68,7 +68,6 @@ test.describe( 'Klarna Checkout', () => {
 		await shopperPage
 			.locator( '.wc_payment_methods' )
 			.getByText( 'Klarna' )
-			.nth( 1 )
 			.click();
 
 		await shopper.placeOrder( shopperPage );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9779

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

It has been noted that the way the "test mode" badge is applied on shortcode is breaking some sites email templates and possibly causing incompatibility with some other plugins.

Reverting all the changes to the "test mode" badge in shortcode.
We'll need to find a different solution than to change the `get_title()` method on the card gateway.

Reverting changes to these files:
- `client/checkout/classic/event-handlers.js`
- `client/checkout/classic/style.scss`
- `includes/class-wc-payment-gateway-wcpay.php`
- `tests/e2e-pw/specs/shopper/klarna-checkout-purchase.spec.ts`

I cherry-picked the changes from these PRs:
- https://github.com/Automattic/woocommerce-payments/pull/9495 - the initial PR that modified the `get_title()` method to add the "Test mode" badge
- https://github.com/Automattic/woocommerce-payments/pull/9615 - the PR to fix the "test mode" badge on subscription's "change payment method" page
- https://github.com/Automattic/woocommerce-payments/pull/9648 - the PR that fixed the "alt" text on the payment method icon due to the change to `get_title()` method above
- https://github.com/Automattic/woocommerce-payments/pull/9647 - the PR that further altered the `get_title()` method to add additional markup and make the "test mode" badge appear only when the payment method was selected on the checkout page
- https://github.com/Automattic/woocommerce-payments/pull/9783 - the PR that added a filter to fallback to remove the "test mode" badge

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Block-based checkout should be unaltered
- Add some products to the cart
- Navigate to the shortcode checkout
- Ensure the "test mode" badge is removed from WooPayments payment methods (card, p24, klarna, etc.)
- Place an order with any of the WooPayments payment methods
- The customer and merchant-facing "order received" emails should no longer contain the "test mode" text

E2E tests run: https://github.com/Automattic/woocommerce-payments/actions/runs/12007054058
Failures seem similar to the ones on `develop`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
