### PR TITLE
Fixed Affirm using black logo on dark themes

### DIFF
--- a/changelog/fix-upe-theme-block
+++ b/changelog/fix-upe-theme-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed Affirm using black logo on dark themes

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -64,7 +64,6 @@ const upeMethods = {
 };
 
 const enabledPaymentMethodsConfig = getUPEConfig( 'paymentMethodsConfig' );
-const upeAppearanceTheme = getUPEConfig( 'wcBlocksUPEAppearanceTheme' );
 const isStripeLinkEnabled = isLinkEnabled( enabledPaymentMethodsConfig );
 
 // Create an API object, which will be used throughout the checkout.
@@ -117,7 +116,6 @@ Object.entries( enabledPaymentMethodsConfig )
 					iconLight={ upeConfig.icon }
 					iconDark={ upeConfig.darkIcon }
 					upeName={ upeName }
-					upeAppearanceTheme={ upeAppearanceTheme }
 				/>
 			),
 			ariaLabel: 'WooPayments',

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -46,19 +46,14 @@ const PaymentMethodMessageWrapper = ( {
 	);
 };
 
-export default ( {
-	api,
-	title,
-	countries,
-	iconLight,
-	iconDark,
-	upeName,
-	upeAppearanceTheme,
-} ) => {
+export default ( { api, title, countries, iconLight, iconDark, upeName } ) => {
 	const cartData = wp.data.select( 'wc/store/cart' ).getCartData();
 	const isTestMode = getUPEConfig( 'testMode' );
 	const [ appearance, setAppearance ] = useState(
 		getUPEConfig( 'wcBlocksUPEAppearance' )
+	);
+	const [ upeAppearanceTheme, setUpeAppearanceTheme ] = useState(
+		getUPEConfig( 'wcBlocksUPEAppearanceTheme' )
 	);
 
 	// Stripe expects the amount to be sent as the minor unit of 2 digits.
@@ -85,6 +80,7 @@ export default ( {
 				'blocks_checkout'
 			);
 			setAppearance( upeAppearance );
+			setUpeAppearanceTheme( upeAppearance.theme );
 		}
 
 		if ( ! appearance ) {


### PR DESCRIPTION
Fixes #9804

#### Changes proposed in this Pull Request

The Affirm logo was not updating correctly according to the theme. This PR fixes it by updating the theme after generating the appearance object. We can't use the same fix for shortcode checkout because it is rendered by PHP, so it requires refreshing the page after updating the appearance object.

p1731716238180769-slack-CU6SYV31A

#### Testing instructions

1. Comment [these lines](https://github.com/Automattic/woocommerce-payments/blob/447eb9b446e7583928d1d6fa23c4403d5221d757/includes/class-wc-payments-checkout.php#L227-L233) to prevent the appearance object from caching
1. Use a dark theme, or use CSS to update your background color to a dark color and the text color to a light color.
1. Go to the blocks checkout and see the affirm logo is white.
2. Switch to a light theme.
3. Go to the blocks checkout and see the affirm logo is black.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.