### PR TITLE
Remove redundant stripe payment elements mount for pay for order

### DIFF
--- a/changelog/chore-remove-redundant-init-for-payfororder
+++ b/changelog/chore-remove-redundant-init-for-payfororder
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Avoid getting the appearance for pay for order page with the wrong appearance key.

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -122,7 +122,7 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	if ( $addPaymentMethodForm.length || $payForOrderForm.length ) {
+	if ( $addPaymentMethodForm.length ) {
 		maybeMountStripePaymentElement( 'add_payment_method' );
 	}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request
Stripe payment elements are mounted for pay for order page right below the line where we remove the redundant check.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* remove `_transient_wcpay_upe_appearance` from `wp_options`
* adjust the background on your site e.g. from light to dark
* navigate to Pay for order page and after opening it, confirm that
    * Stripe Payment elements have the dark appearance 
    * the appearance transient (`_transient_wcpay_upe_appearance`) was saved to the DB
* switch back from the dark to light background and refresh the pay for order page
* confirm that the elements are still having dark appearance, since we're using the transient and not re-calculating styles
* remove `_transient_wcpay_upe_appearance` from the `wp_options` once more and confirm that elements are light  upon subsequent page refresh
* perform some quick sanity checks on the add payment method page (e.g. no errors in the console)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
