### PR TITLE
Fix return types in DocBlocks

### DIFF
--- a/changelog/dev-4293-address-additional-union-types
+++ b/changelog/dev-4293-address-additional-union-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix return types

--- a/includes/admin/class-wc-rest-payments-customer-controller.php
+++ b/includes/admin/class-wc-rest-payments-customer-controller.php
@@ -99,7 +99,7 @@ class WC_REST_Payments_Customer_Controller extends WC_Payments_REST_Controller {
 	 * @param array|mixed     $item Item to prepare.
 	 * @param WP_REST_Request $request Request instance.
 	 *
-	 * @return WP_REST_Response|WP_Error|WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -219,7 +219,7 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function finalize_embedded_kyc( WP_REST_Request $request ) {
 		$source         = $request->get_param( 'source' ) ?? '';

--- a/includes/admin/class-wc-rest-payments-payment-intents-create-controller.php
+++ b/includes/admin/class-wc-rest-payments-payment-intents-create-controller.php
@@ -318,7 +318,7 @@ class WC_REST_Payments_Payment_Intents_Create_Controller extends WC_Payments_RES
 	 * @param array|mixed     $item Item to prepare.
 	 * @param WP_REST_Request $request Request instance.
 	 *
-	 * @return WP_REST_Response|WP_Error|WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$prepared_item                   = [];

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -146,7 +146,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
-	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_summary( $request ) {
 

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -62,7 +62,7 @@ class WC_Payments_Token_Service {
 	 *
 	 * @param   array   $payment_method                                          Payment method to be added.
 	 * @param   WP_User $user                                                    User to attach payment method to.
-	 * @return  WC_Payment_Token|WC_Payment_Token_CC|WC_Payment_Token_WCPay_SEPA The WC object for the payment token.
+	 * @return  WC_Payment_Token The WC object for the payment token.
 	 */
 	public function add_token_to_user( $payment_method, $user ) {
 		// Clear cached payment methods.

--- a/includes/reports/class-wc-rest-payments-reports-authorizations-controller.php
+++ b/includes/reports/class-wc-rest-payments-reports-authorizations-controller.php
@@ -127,7 +127,7 @@ class WC_REST_Payments_Reports_Authorizations_Controller extends WC_Payments_RES
 	 * @param array|mixed     $item Item to prepare.
 	 * @param WP_REST_Request $request Request instance.
 	 *
-	 * @return WP_REST_Response|WP_Error|WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 

--- a/includes/reports/class-wc-rest-payments-reports-transactions-controller.php
+++ b/includes/reports/class-wc-rest-payments-reports-transactions-controller.php
@@ -115,7 +115,7 @@ class WC_REST_Payments_Reports_Transactions_Controller extends WC_Payments_REST_
 	 * @param array|mixed     $item Item to prepare.
 	 * @param WP_REST_Request $request Request instance.
 	 *
-	 * @return WP_REST_Response|WP_Error|WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 


### PR DESCRIPTION
Fixes #4293 

#### Changes proposed in this Pull Request

This pull request includes changes to the DocBlock return types of multiple methods across various files in the `includes` directory. I noticed these issues while working on https://github.com/Automattic/woocommerce-payments/issues/4293

Return type corrections:

* [`includes/admin/class-wc-rest-payments-customer-controller.php`](diffhunk://#diff-bc212008554583825797b82f0d4b259c975b3991a961d0980f975d91c84655dfL102-R102): Updated the return type of `prepare_item_for_response` to remove the redundant `WP_REST_Response`.
* [`includes/admin/class-wc-rest-payments-onboarding-controller.php`](diffhunk://#diff-85ef5ba70d4c0b4eb342fa58c0f55264a025373567f623793b4612c2d00be189L222-R222): Updated the return type of `finalize_embedded_kyc` to remove the redundant `WP_HTTP_Response`.
* [`includes/admin/class-wc-rest-payments-payment-intents-create-controller.php`](diffhunk://#diff-0c5687f0090bb0d63dcb401f9f415dcbd2671b2eb39aac21040fc05e2aff90c4L321-R321): Updated the return type of `prepare_item_for_response` to remove the redundant `WP_REST_Response`.
* [`includes/admin/class-wc-rest-payments-reader-controller.php`](diffhunk://#diff-caf095d72581da0c2fa09f946140ac52d19b1e58c3df617f0b7f1e841a6755ffL149-R149): Updated the return type of `get_summary` to remove the redundant `WP_HTTP_Response`.
* [`includes/class-wc-payments-token-service.php`](diffhunk://#diff-ad7970a483b7b3582e959f6236b3c69739d80349cb2236536c7db538726ffe2fL65-R65): Simplified the return type of `add_token_to_user` to only include `WC_Payment_Token`.
* [`includes/reports/class-wc-rest-payments-reports-authorizations-controller.php`](diffhunk://#diff-c03b0d9da916bb2db43ac0054c6d393bc4d7f7a9992d4bd773ce5609ec178b39L130-R130): Updated the return type of `prepare_item_for_response` to remove the redundant `WP_REST_Response`.
* [`includes/reports/class-wc-rest-payments-reports-transactions-controller.php`](diffhunk://#diff-fb9b42b2f97cc82954580a626be6dbeaf224404c1f49031ff664caeb0c4d2f9aL118-R118): Updated the return type of `prepare_item_for_response` to remove the redundant `WP_REST_Response`.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI checks should pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
