### PR TITLE
Use paragraph selector instead of label for pmme appearance

### DIFF
--- a/changelog/fix-pmme-appearance-blocks
+++ b/changelog/fix-pmme-appearance-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use paragraph selector instead of label for pmme appearance

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -23,6 +23,7 @@ export const appearanceSelectors = {
 		appendTarget: '.woocommerce-billing-fields__field-wrapper',
 		upeThemeInputSelector: '#billing_first_name',
 		upeThemeLabelSelector: '.woocommerce-checkout .form-row label',
+		upeThemeTextSelector: '.woocommerce-checkout .form-row',
 		rowElement: 'p',
 		validClasses: [ 'form-row' ],
 		invalidClasses: [
@@ -46,6 +47,7 @@ export const appearanceSelectors = {
 		appendTarget: '#contact-fields',
 		upeThemeInputSelector: '.wc-block-components-text-input #email',
 		upeThemeLabelSelector: '.wc-block-components-text-input label',
+		upeThemeTextSelector: '.wc-block-components-text-input',
 		rowElement: 'div',
 		validClasses: [ 'wc-block-components-text-input', 'is-active' ],
 		invalidClasses: [ 'wc-block-components-text-input', 'has-error' ],
@@ -73,6 +75,7 @@ export const appearanceSelectors = {
 		appendTarget: '.product .cart .quantity',
 		upeThemeInputSelector: '.product .cart .quantity .qty',
 		upeThemeLabelSelector: '.product .cart .quantity label',
+		upeThemeTextSelector: '.product .cart .quantity',
 		rowElement: 'div',
 		validClasses: [ 'input-text' ],
 		invalidClasses: [ 'input-text', 'has-error' ],
@@ -91,6 +94,7 @@ export const appearanceSelectors = {
 		appendTarget: '.cart .quantity',
 		upeThemeInputSelector: '.cart .quantity .qty',
 		upeThemeLabelSelector: '.cart .quantity label',
+		upeThemeTextSelector: '.cart .quantity',
 		rowElement: 'div',
 		validClasses: [ 'input-text' ],
 		invalidClasses: [ 'input-text', 'has-error' ],
@@ -111,6 +115,7 @@ export const appearanceSelectors = {
 		upeThemeInputSelector:
 			'.wc-block-cart .wc-block-components-quantity-selector .wc-block-components-quantity-selector__input',
 		upeThemeLabelSelector: '.wc-block-components-text-input',
+		upeThemeTextSelector: '.wc-block-components-text-input',
 		rowElement: 'div',
 		validClasses: [ 'wc-block-components-text-input' ],
 		invalidClasses: [ 'wc-block-components-text-input', 'has-error' ],
@@ -133,6 +138,7 @@ export const appearanceSelectors = {
 		appendTarget: '.woocommerce-billing-fields__field-wrapper',
 		upeThemeInputSelector: '#billing_first_name',
 		upeThemeLabelSelector: '.woocommerce-checkout .form-row label',
+		upeThemeTextSelector: '.woocommerce-checkout .form-row',
 		rowElement: 'p',
 		validClasses: [ 'form-row' ],
 		invalidClasses: [
@@ -476,6 +482,11 @@ export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 		'.Label'
 	);
 
+	const paragraphRules = getFieldStyles(
+		selectors.upeThemeTextSelector,
+		'.Text'
+	);
+
 	const tabRules = getFieldStyles( selectors.upeThemeInputSelector, '.Tab' );
 	const selectedTabRules = getFieldStyles(
 		selectors.hiddenInput,
@@ -505,9 +516,9 @@ export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 	);
 	const globalRules = {
 		colorBackground: backgroundColor,
-		colorText: labelRules.color,
-		fontFamily: labelRules.fontFamily,
-		fontSizeBase: labelRules.fontSize,
+		colorText: paragraphRules.color,
+		fontFamily: paragraphRules.fontFamily,
+		fontSizeBase: paragraphRules.fontSize,
 	};
 
 	const isFloatingLabel = elementsLocation === 'blocks_checkout';
@@ -528,8 +539,8 @@ export const getAppearance = ( elementsLocation, forWooPay = false ) => {
 				'.Tab--selected': selectedTabRules,
 				'.TabIcon:hover': tabIconHoverRules,
 				'.TabIcon--selected': selectedTabIconRules,
-				'.Text': labelRules,
-				'.Text--redirect': labelRules,
+				'.Text': paragraphRules,
+				'.Text--redirect': paragraphRules,
 			} )
 		),
 	};

--- a/client/checkout/upe-styles/upe-styles.js
+++ b/client/checkout/upe-styles/upe-styles.js
@@ -55,6 +55,7 @@ const borderOutlineBackgroundProps = [
 ];
 const upeSupportedProperties = {
 	'.Label': [ ...paddingColorProps, ...textFontTransitionProps ],
+	'.Text': [ ...paddingColorProps, ...textFontTransitionProps ],
 	'.Input': [
 		...paddingColorProps,
 		...textFontTransitionProps,
@@ -112,4 +113,6 @@ export const upeRestrictedProperties = {
 	'.TabLabel': upeSupportedProperties[ '.TabLabel' ],
 	'.Block': upeSupportedProperties[ '.Block' ],
 	'.Container': upeSupportedProperties[ '.Container' ],
+	'.Text': upeSupportedProperties[ '.Text' ],
+	'.Text--redirect': upeSupportedProperties[ '.Text' ],
 };


### PR DESCRIPTION
Fixes #9803

#### Changes proposed in this Pull Request

We were using the Label text styles for the `.Text` class for in Stripe Appearance API. This works well in the shortcode checkout because they have similar styles, but the Blocks checkout uses floating labels, so their style is very different from paragraph text.
This PR updates the selector for all location, however it is noticeable only in the blocks checkout.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/011ed789-1af3-4a95-93a3-00165b71aaff) | ![image](https://github.com/user-attachments/assets/670a38a6-2799-4e2c-845b-566f49e73cbc) |

#### Testing instructions

1. Comment [these lines](https://github.com/Automattic/woocommerce-payments/blob/447eb9b446e7583928d1d6fa23c4403d5221d757/includes/class-wc-payments-checkout.php#L227-L233) to prevent the appearance object from caching
1. Use a dark theme, or use CSS to update your background color to a dark color and the text color to a light color.
1. Do not enable Blocks Checkout dark mode.
1. Go to the blocks checkout and see the PMME does not look good in `develop`, but it looks good in this branch.
2. Ensure no other place the pmme is displayed is broken:
	- Shortcode checkout
	- Shortcode cart
	- Blocks cart
	- Product page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
