### PR TITLE
Ensure WooPay eligibility is taken into account when retrieving WooPay enable state in the settings

### DIFF
--- a/changelog/fix-9787-woopay-enable-state-settings
+++ b/changelog/fix-9787-woopay-enable-state-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Consider WooPay eligibility when retrieving WooPay enable state in the settings.

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -513,7 +513,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'payment_request_button_border_radius'   => $this->wcpay_gateway->get_option( 'payment_request_button_border_radius', WC_Payments_Express_Checkout_Button_Handler::DEFAULT_BORDER_RADIUS_IN_PX ),
 				'is_saved_cards_enabled'                 => $this->wcpay_gateway->is_saved_cards_enabled(),
 				'is_card_present_eligible'               => $this->wcpay_gateway->is_card_present_eligible() && isset( WC()->payment_gateways()->get_available_payment_gateways()['cod'] ),
-				'is_woopay_enabled'                      => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
+				'is_woopay_enabled'                      => WC_Payments_Features::is_woopay_eligible() && 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
 				'show_woopay_incompatibility_notice'     => get_option( 'woopay_invalid_extension_found', false ),
 				'woopay_custom_message'                  => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
 				'woopay_store_logo'                      => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -73,7 +73,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	/**
 	 * @var Database_Cache|MockObject
 	 */
-	private $mock_db_cache;
+	private $mock_cache;
 
 	/**
 	 * WC_Payments_Localization_Service instance.
@@ -117,15 +117,19 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );
 
+		// Mock the main class's cache service.
+		$this->_cache     = WC_Payments::get_database_cache();
+		$this->mock_cache = $this->createMock( Database_Cache::class );
+		WC_Payments::set_database_cache( $this->mock_cache );
+
 		$this->mock_api_client = $this->getMockBuilder( WC_Payments_API_Client::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->mock_wcpay_account                = $this->createMock( WC_Payments_Account::class );
-		$this->mock_db_cache                     = $this->createMock( Database_Cache::class );
 		$this->mock_session_service              = $this->createMock( WC_Payments_Session_Service::class );
 		$order_service                           = new WC_Payments_Order_Service( $this->mock_api_client );
-		$customer_service                        = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_wcpay_account, $this->mock_db_cache, $this->mock_session_service, $order_service );
+		$customer_service                        = new WC_Payments_Customer_Service( $this->mock_api_client, $this->mock_wcpay_account, $this->mock_cache, $this->mock_session_service, $order_service );
 		$token_service                           = new WC_Payments_Token_Service( $this->mock_api_client, $customer_service );
 		$compatibility_service                   = new Compatibility_Service( $this->mock_api_client );
 		$action_scheduler_service                = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client, $order_service, $compatibility_service );
@@ -743,6 +747,32 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		$this->assertArrayHasKey( 'account_domestic_currency', $response->get_data() );
 		$this->assertSame( $this->domestic_currency, $response->get_data()['account_domestic_currency'] );
+	}
+
+	public function test_get_settings_is_woopay_enabled_returns_true(): void {
+		$current_platform_checkout = $this->gateway->get_option( 'platform_checkout' );
+
+		$this->gateway->update_option( 'platform_checkout', 'yes' );
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
+
+		$response = $this->controller->get_settings();
+
+		$this->assertArrayHasKey( 'is_woopay_enabled', $response->get_data() );
+		$this->assertTrue( $response->get_data()['is_woopay_enabled'] );
+		$this->gateway->update_option( 'platform_checkout', $current_platform_checkout );
+	}
+
+	public function test_get_settings_is_woopay_enabled_returns_false_if_it_is_not_eligible(): void {
+		$current_platform_checkout = $this->gateway->get_option( 'platform_checkout' );
+
+		$this->gateway->update_option( 'platform_checkout', 'yes' );
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
+
+		$response = $this->controller->get_settings();
+
+		$this->assertArrayHasKey( 'is_woopay_enabled', $response->get_data() );
+		$this->assertFalse( $response->get_data()['is_woopay_enabled'] );
+		$this->gateway->update_option( 'platform_checkout', $current_platform_checkout );
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -209,6 +209,8 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	public function tear_down() {
 		parent::tear_down();
 		WC_Blocks_REST_API_Registration_Preventer::stop_preventing();
+		// Restore the cache service in the main class.
+		WC_Payments::set_database_cache( $this->_cache );
 	}
 
 	public function test_get_settings_request_returns_status_code_200() {


### PR DESCRIPTION
Fixes #9787.

#### Changes proposed in this Pull Request

We have an issue in the express checkout preview where the WooPay button is being displayed when WooPay is not eligible. This happens in a very specific path where the merchant firstly onboards with a US account, reset and then onboards again with a non-US account. The issue occurs because WooPay is enabled in the settings from the first onboard, even though it's not eligible anymore.

This PR fix the issue by adding a check in the settings controller to verify the WooPay eligibility too when retrieving the WooPay enabled state information.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Confirm issue: WooPay button is visible in preview when it's not eligible**

1. Set up a Jurassic Ninja site with just WooCommerce.
2. As a merchant, go through the WooCommerce onboarding and select US as the country.
3. Install and activate WooPayments.
4. Onboard through the sandbox mode.
5. Navigate to **Payments > Settings** and scroll down to **Express checkouts**.
6. Make sure WooPay is visible and enabled and click on **Customize**.
7. Ensure you can see the WooPay button in the preview.
8. Navigate to **WooCommerce > Settings**.
9. Change the country/state to a non-US one (e.g. Germany or New Zealand) and save.
10. Navigate to **Payments > Overview** and scroll down to **Account details**.
11. Under **Account Tools** click on **Reset account** and confirm.
12. Onboard through the sandbox mode again.
13. Navigate to **Payments > Settings** and scroll down to **Express checkouts**.
14. Ensure WooPay is **NOT** visible anymore, meaning the site is no longer eligible to WooPay.
15. Click on **Customize** for Apple Pay/Google Pay.
16. Ensure you still can see the WooPay button in the preview.

**Test: WooPay button is not visible in preview when it's not eligible**

1. Checkout to this branch.
2. Run `npm run build:release`.
3. As a merchant, upload the zip to the site you setup above.
4. Navigate to **Payments > Settings** and scroll down to **Express checkouts**.
5. Ensure WooPay is still **NOT** visible.
6. Click on **Customize** for Apple Pay/Google Pay.
7. Ensure you **CANNOT** see the WooPay button in the preview.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
