### PR TITLE
Update WooPay theme checkbox copy in settings page

### DIFF
--- a/changelog/fix-change-woopay-theming-settings-copy
+++ b/changelog/fix-change-woopay-theming-settings-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+WooPay theming copy in the settings page

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -213,7 +213,7 @@ const WooPaySettings = ( { section } ) => {
 						<div className="woopay-global-theme-support">
 							<h4>
 								{ __(
-									'WooPay Global Theme Support',
+									'Checkout theme',
 									'woocommerce-payments'
 								) }
 							</h4>
@@ -227,9 +227,27 @@ const WooPaySettings = ( { section } ) => {
 										updateIsWooPayGlobalThemeSupportEnabled
 									}
 									label={ __(
-										'Enable WooPay Global Theme Support',
+										'Enable global theme support',
 										'woocommerce-payments'
 									) }
+									help={ interpolateComponents( {
+										mixedString: __(
+											'When enabled, WooPay checkout will be themed with your store’s brand colors and fonts. ' +
+												'{{docs}}Learn more {{/docs}}',
+											'woocommerce-payments'
+										),
+										components: {
+											docs: (
+												/* eslint-disable-next-line jsx-a11y/anchor-has-content */
+												<a
+													target="_blank"
+													rel="noreferrer"
+													// eslint-disable-next-line max-len
+													href="https://woocommerce.com/document/woopay-merchant-documentation/#checkout-appearance"
+												/>
+											),
+										},
+									} ) }
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
Fixes #9738 

#### Changes proposed in this Pull Request

- The title is changed to "Checkout theme"
- The checkbox label is changed to "Enable global theme support"
- Add secondary text, on the next row: "When enabled, WooPay checkout will be themed with your store’s brand colors and fonts. Learn more"

Before
![CleanShot 2024-11-28 at 11 44 29](https://github.com/user-attachments/assets/26dab15b-8363-4595-ad11-07f1ded70c47) 
After
![CleanShot 2024-11-28 at 11 43 55](https://github.com/user-attachments/assets/d6460cab-93e9-49f7-9702-69e64b459e3a) 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure WooPay theming is enabled for you local site. I do this by forcing `true` in [this function](https://github.com/Automattic/transact-platform-server/blob/de52ab019b215320c021c4d5ece593555f95fe36/server/wp-content/rest-api-plugins/endpoints/wcpay/service/class-account-service.php#L2489)
* As a merchant, go to Payments -> Settings 
* Select 'Customize' button next to WooPay.
* Make sure checkout appearance section follows the acceptance criteria defined in #9738

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
