### PR TITLE
Ensure ECE button load events are triggered for multiple buttons on the same page

### DIFF
--- a/changelog/fix-9795-debounce-of-ece-load-events
+++ b/changelog/fix-9795-debounce-of-ece-load-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure ECE button load events are triggered for multiple buttons on the same page.

--- a/client/express-checkout/tracking.js
+++ b/client/express-checkout/tracking.js
@@ -17,20 +17,29 @@ export const trackExpressCheckoutButtonClick = ( paymentMethod, source ) => {
 	recordUserEvent( event, { source } );
 };
 
+const debouncedTrackApplePayButtonLoad = debounce( ( { source } ) => {
+	recordUserEvent( 'applepay_button_load', { source } );
+}, 1000 );
+
+const debouncedTrackGooglePayButtonLoad = debounce( ( { source } ) => {
+	recordUserEvent( 'gpay_button_load', { source } );
+}, 1000 );
+
 // Track the button load event.
-export const trackExpressCheckoutButtonLoad = debounce(
-	( { paymentMethods, source } ) => {
-		const expressPaymentTypeEvents = {
-			googlePay: 'gpay_button_load',
-			applePay: 'applepay_button_load',
-		};
+export const trackExpressCheckoutButtonLoad = ( {
+	paymentMethods,
+	source,
+} ) => {
+	const expressPaymentTypeEvents = {
+		googlePay: debouncedTrackGooglePayButtonLoad,
+		applePay: debouncedTrackApplePayButtonLoad,
+	};
 
-		for ( const paymentMethod of paymentMethods ) {
-			const event = expressPaymentTypeEvents[ paymentMethod ];
-			if ( ! event ) continue;
+	for ( const paymentMethod of paymentMethods ) {
+		const debouncedTrackFunction =
+			expressPaymentTypeEvents[ paymentMethod ];
+		if ( ! debouncedTrackFunction ) continue;
 
-			recordUserEvent( event, { source } );
-		}
-	},
-	1000
-);
+		debouncedTrackFunction( { source } );
+	}
+};

--- a/client/tokenized-express-checkout/tracking.js
+++ b/client/tokenized-express-checkout/tracking.js
@@ -17,20 +17,29 @@ export const trackExpressCheckoutButtonClick = ( paymentMethod, source ) => {
 	recordUserEvent( event, { source } );
 };
 
+const debouncedTrackApplePayButtonLoad = debounce( ( { source } ) => {
+	recordUserEvent( 'applepay_button_load', { source } );
+}, 1000 );
+
+const debouncedTrackGooglePayButtonLoad = debounce( ( { source } ) => {
+	recordUserEvent( 'gpay_button_load', { source } );
+}, 1000 );
+
 // Track the button load event.
-export const trackExpressCheckoutButtonLoad = debounce(
-	( { paymentMethods, source } ) => {
-		const expressPaymentTypeEvents = {
-			googlePay: 'gpay_button_load',
-			applePay: 'applepay_button_load',
-		};
+export const trackExpressCheckoutButtonLoad = ( {
+	paymentMethods,
+	source,
+} ) => {
+	const expressPaymentTypeEvents = {
+		googlePay: debouncedTrackGooglePayButtonLoad,
+		applePay: debouncedTrackApplePayButtonLoad,
+	};
 
-		for ( const paymentMethod of paymentMethods ) {
-			const event = expressPaymentTypeEvents[ paymentMethod ];
-			if ( ! event ) continue;
+	for ( const paymentMethod of paymentMethods ) {
+		const debouncedTrackFunction =
+			expressPaymentTypeEvents[ paymentMethod ];
+		if ( ! debouncedTrackFunction ) continue;
 
-			recordUserEvent( event, { source } );
-		}
-	},
-	1000
-);
+		debouncedTrackFunction( { source } );
+	}
+};


### PR DESCRIPTION
Fixes #9795 

#### Changes proposed in this Pull Request

This PR resolves an issue where Apple Pay and Google Pay button load events were not triggered when both buttons were present on the same page. The root cause was the debouncing of trackExpressCheckoutButtonLoad, which suppressed subsequent calls with different arguments. The implementation now debounces load events independently for each payment method, ensuring all events are correctly tracked.

#### Testing instructions

**Prerequisites:**
- Ensure Apple Pay and Google Pay are enabled in the plugin settings.
- Use a publicly accessible URL for testing.
- Use Safari for testing to ensure Apple Pay and Google Pay buttons are loaded on the page.
- Test this on the blocks version of the Cart or Checkout pages. The shortcode version did not have this issue

**Test the fix:**

1. Open the blocks version of the Cart or Checkout page with Safari.
2. Ensure that both the Apple Pay and Google Pay buttons are displayed on the screen.
3. Use one of the following methods to verify the events:
     1. **Network Inspector:**
        - Open the browser's developer tools.
        - Go to the "Network" tab and filter for tracking requests.
        - Confirm that both `gpay_button_load` and `applepay_button_load` events are sent when the page loads. (search for `admin-ajax` calls)
     2. **Debugging in Code:**
        - Open `class-woopay-tracker.php`.
        - Add a debugger breakpoint at [this line](https://github.com/Automattic/woocommerce-payments/blob/24f3972cde01c4a188f48d8edd3a0a83375800ed/includes/class-woopay-tracker.php#L327). Observe the `$event_obj` variable.
        - Reload the Cart or Checkout page.
        - Verify that both events were tracked, one for `gpay_button_load` and one for `applepay_button_load`.

**Expected Outcome:**
   - Both `gpay_button_load` and `applepay_button_load` events should be triggered when the respective buttons load.
   - No event should be missed or suppressed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
