### PR TITLE
Prevent browser error on dispute evidence submission

### DIFF
--- a/changelog/fix-9830-browser-error-on-dispute-submission
+++ b/changelog/fix-9830-browser-error-on-dispute-submission
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Browser error no longer shows after dispute evidence submission

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -455,6 +455,8 @@ export default ( { query } ) => {
 	const [ dispute, setDispute ] = useState();
 	const [ loading, setLoading ] = useState( false );
 	const [ evidence, setEvidence ] = useState( {} ); // Evidence to update.
+	const [ redirectAfterSave, setRedirectAfterSave ] = useState( false );
+
 	const {
 		createSuccessNotice,
 		createErrorNotice,
@@ -603,11 +605,6 @@ export default ( { query } ) => {
 		const message = submit
 			? __( 'Evidence submitted!', 'woocommerce-payments' )
 			: __( 'Evidence saved!', 'woocommerce-payments' );
-		const href = getAdminUrl( {
-			page: 'wc-admin',
-			path: '/payments/disputes',
-			filter: 'awaiting_response',
-		} );
 
 		recordEvent(
 			submit
@@ -639,8 +636,19 @@ export default ( { query } ) => {
 			],
 		} );
 
-		window.location.replace( href );
+		setRedirectAfterSave( true );
 	};
+
+	useEffect( () => {
+		if ( redirectAfterSave && pristine ) {
+			const href = getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/disputes',
+				filter: 'awaiting_response',
+			} );
+			window.location.replace( href );
+		}
+	}, [ redirectAfterSave, pristine ] );
 
 	const handleSaveError = ( err, submit ) => {
 		recordEvent(

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -477,7 +477,7 @@ export default ( { query } ) => {
 		);
 
 	const confirmationNavigationCallback = useConfirmNavigation( () => {
-		if ( pristine ) {
+		if ( pristine || redirectAfterSave ) {
 			return;
 		}
 
@@ -490,6 +490,7 @@ export default ( { query } ) => {
 	useEffect( confirmationNavigationCallback, [
 		pristine,
 		confirmationNavigationCallback,
+		redirectAfterSave,
 	] );
 
 	useEffect( () => {

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -690,8 +690,8 @@ export default ( { query } ) => {
 				},
 			} );
 			setDispute( updatedDispute );
-			handleSaveSuccess( submit );
 			setEvidence( {} );
+			handleSaveSuccess( submit );
 			updateDisputeInStore( updatedDispute );
 		} catch ( err ) {
 			handleSaveError( err, submit );


### PR DESCRIPTION
Fixes #9830

#### Changes proposed in this Pull Request

Successful dispute evidence submission causes the browser to navigate to refresh the page. This was triggering the browser alert due to a hook on `onbeforeunload`.

![Screenshot 2024-11-28 at 3 47 21 PM](https://github.com/user-attachments/assets/19a37202-47ff-48f1-9255-5638fea75fe6)

This change ensures the evidence is reset before attempting to navigate away which prevents the browser alert.

It looks like this bug may have been introduced in #4458 when the browser navigation was introduced due to caching issues.

I chatted with @Jinksi about the best way to approach this change as there are a few improvements that could be made. For now, we agreed that the one-line fix approach is best. p1732845547215289-slack-C02BW3Z8SHK

**Update**: The one line fix did not work in all cases due to the way that react batches state updates async. This PR has been updated to handle this case and support both Submission and Saving of evidence.

#### Testing instructions

1. Open dispute 
2. Save draft evidence, confirm browser pop-up does not occur.
3. Re-open dispute
4. Submit evidence.
5. Confirm browser alert about changes not being saved does not show.

-------------------

- [x] Run `npm run changelog` to add a changelog file.
- [x] Covered with tests
- [x] Tested on mobile

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.