### PR TITLE
fix: unhandled request rejection in ECE implementation

### DIFF
--- a/changelog/fix-unhandled-request-rejection
+++ b/changelog/fix-unhandled-request-rejection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: unhandled request rejection in ECE implementation.

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -587,23 +587,24 @@ jQuery( ( $ ) => {
 			} else {
 				// If this is the cart or checkout page, we need to request the
 				// cart details.
-				const cart = await api.expressCheckoutECEGetCartDetails();
-				if ( cart.total.amount === 0 ) {
-					expressCheckoutButtonUi.hideContainer();
-					expressCheckoutButtonUi.getButtonSeparator().hide();
-				} else {
-					await wcpayECE.startExpressCheckoutElement( {
-						mode: 'payment',
-						total: cart.total.amount,
-						currency: getExpressCheckoutData( 'checkout' )
-							?.currency_code,
-						requestShipping: cart.needs_shipping,
-						requestPhone:
-							getExpressCheckoutData( 'checkout' )
-								?.needs_payer_phone ?? false,
-						displayItems: cart.displayItems,
-					} );
-				}
+				api.expressCheckoutECEGetCartDetails().then( async ( cart ) => {
+					if ( cart.total.amount === 0 ) {
+						expressCheckoutButtonUi.hideContainer();
+						expressCheckoutButtonUi.getButtonSeparator().hide();
+					} else {
+						await wcpayECE.startExpressCheckoutElement( {
+							mode: 'payment',
+							total: cart.total.amount,
+							currency: getExpressCheckoutData( 'checkout' )
+								?.currency_code,
+							requestShipping: cart.needs_shipping,
+							requestPhone:
+								getExpressCheckoutData( 'checkout' )
+									?.needs_payer_phone ?? false,
+							displayItems: cart.displayItems,
+						} );
+					}
+				} );
 			}
 
 			// After initializing a new express checkout button, we need to reset the paymentAborted flag.

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -532,35 +532,43 @@ jQuery( ( $ ) => {
 				} );
 			} else {
 				// If this is the cart page, or checkout page, or pay-for-order page, we need to request the cart details.
-				const cartData = await getCartApiHandler().getCart();
-				const total = transformPrice(
-					parseInt( cartData.totals.total_price, 10 ) -
-						parseInt( cartData.totals.total_refund || 0, 10 ),
-					cartData.totals
-				);
-				if ( total === 0 ) {
-					expressCheckoutButtonUi.hideContainer();
-					expressCheckoutButtonUi.getButtonSeparator().hide();
-				} else {
-					await wcpayECE.startExpressCheckoutElement( {
-						mode: 'payment',
-						total,
-						currency: cartData.totals.currency_code.toLowerCase(),
-						// pay-for-order should never display the shipping selection.
-						requestShipping:
-							getExpressCheckoutData( 'button_context' ) !==
-								'pay_for_order' && cartData.needs_shipping,
-						shippingRates: transformCartDataForShippingRates(
-							cartData
-						),
-						requestPhone:
-							getExpressCheckoutData( 'checkout' )
-								?.needs_payer_phone ?? false,
-						displayItems: transformCartDataForDisplayItems(
-							cartData
-						),
+				getCartApiHandler()
+					.getCart()
+					.then( async ( cartData ) => {
+						const total = transformPrice(
+							parseInt( cartData.totals.total_price, 10 ) -
+								parseInt(
+									cartData.totals.total_refund || 0,
+									10
+								),
+							cartData.totals
+						);
+						if ( total === 0 ) {
+							expressCheckoutButtonUi.hideContainer();
+							expressCheckoutButtonUi.getButtonSeparator().hide();
+						} else {
+							await wcpayECE.startExpressCheckoutElement( {
+								mode: 'payment',
+								total,
+								currency: cartData.totals.currency_code.toLowerCase(),
+								// pay-for-order should never display the shipping selection.
+								requestShipping:
+									getExpressCheckoutData(
+										'button_context'
+									) !== 'pay_for_order' &&
+									cartData.needs_shipping,
+								shippingRates: transformCartDataForShippingRates(
+									cartData
+								),
+								requestPhone:
+									getExpressCheckoutData( 'checkout' )
+										?.needs_payer_phone ?? false,
+								displayItems: transformCartDataForDisplayItems(
+									cartData
+								),
+							} );
+						}
 					} );
-				}
 			}
 
 			// After initializing a new express checkout button, we need to reset the paymentAborted flag.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

While reviewing the changes to `client/express-checkout` for inclusion in the `client/tokenized-express-checkout` directory, I noticed [this PR being merged](https://github.com/Automattic/woocommerce-payments/pull/9770).
I wanted to ensure the same changes were included (which they were).
However, the change from a `.then(..)` to `async`/`await` without a `try`/`catch` raised a flag to me.

Discussing here: https://github.com/Automattic/woocommerce-payments/pull/9770#pullrequestreview-2469611093

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
