### PR TITLE
Limit WooPay theme-ing availability to shortcode entrypoint

### DIFF
--- a/changelog/add-limit-woopay-themeing-to-shortcode-checkout
+++ b/changelog/add-limit-woopay-themeing-to-shortcode-checkout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Updates the availability criteria of WooPay Global theme-ing feature. This feature is unreleased and behind a feature flag.
+
+

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -13,6 +13,7 @@ import {
 	appendRedirectionParams,
 	shouldSkipWooPay,
 	deleteSkipWooPayCookie,
+	isSupportedThemeEntrypoint,
 } from './utils';
 import { getAppearanceType } from '../utils';
 
@@ -180,6 +181,11 @@ export const handleWooPayEmailInput = async (
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
+		const appearance =
+			isSupportedThemeEntrypoint( appearanceType ) &&
+			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
+				? getAppearance( appearanceType, true )
+				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
 			request(
@@ -189,9 +195,7 @@ export const handleWooPayEmailInput = async (
 					order_id: getConfig( 'order_id' ),
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
-					appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-						? getAppearance( appearanceType, true )
-						: null,
+					appearance: appearance,
 				}
 			).then( ( response ) => {
 				if ( response?.data?.session ) {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -14,6 +14,7 @@ import {
 	getTargetElement,
 	validateEmail,
 	appendRedirectionParams,
+	isSupportedThemeEntrypoint,
 } from '../utils';
 import { getTracksIdentity } from 'tracks';
 import { getAppearance } from 'wcpay/checkout/upe-styles';
@@ -100,6 +101,11 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
+		const appearance =
+			isSupportedThemeEntrypoint( appearanceType ) &&
+			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
+				? getAppearance( appearanceType, true )
+				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
 			request(
@@ -109,9 +115,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 					order_id: getConfig( 'order_id' ),
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
-					appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-						? getAppearance( appearanceType, true )
-						: null,
+					appearance: appearance,
 				}
 			).then( ( response ) => {
 				if ( response?.data?.session ) {

--- a/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/test/woopay-express-checkout-button.test.js
@@ -70,37 +70,6 @@ describe( 'WoopayExpressCheckoutButton', () => {
 	const mockRequest = jest.fn().mockResolvedValue( true );
 	const mockAddToCart = jest.fn().mockResolvedValue( true );
 	const api = new WCPayAPI( {}, mockRequest );
-	const mockAppearance = {
-		rules: {
-			'.Block': {},
-			'.Input': {},
-			'.Input--invalid': {},
-			'.Label': {},
-			'.Tab': {},
-			'.Tab--selected': {},
-			'.Tab:hover': {},
-			'.TabIcon--selected': {
-				color: undefined,
-			},
-			'.TabIcon:hover': {
-				color: undefined,
-			},
-			'.Text': {},
-			'.Text--redirect': {},
-			'.Heading': {},
-			'.Button': {},
-			'.Container': {},
-			'.Link': {},
-		},
-		theme: 'stripe',
-		variables: {
-			colorBackground: '#ffffff',
-			colorText: undefined,
-			fontFamily: undefined,
-			fontSizeBase: undefined,
-		},
-		labels: 'above',
-	};
 
 	beforeEach( () => {
 		expressCheckoutIframe.mockImplementation( () => jest.fn() );
@@ -198,7 +167,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 				case 'order_id':
 					return 1;
 				case 'appearance':
-					return mockAppearance;
+					return null;
 				default:
 					return 'foo';
 			}
@@ -224,7 +193,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 				order_id: 1,
 				key: 'testkey',
 				billing_email: 'test@test.com',
-				appearance: mockAppearance,
+				appearance: null,
 			} );
 			expect( expressCheckoutIframe ).not.toHaveBeenCalled();
 		} );

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -19,6 +19,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 import {
 	appendRedirectionParams,
 	deleteSkipWooPayCookie,
+	isSupportedThemeEntrypoint,
 } from 'wcpay/checkout/woopay/utils';
 import WooPayFirstPartyAuth from 'wcpay/checkout/woopay/express-button/woopay-first-party-auth';
 import { getAppearance } from 'wcpay/checkout/upe-styles';
@@ -221,6 +222,11 @@ export const WoopayExpressCheckoutButton = ( {
 			setIsLoading( true );
 
 			const appearanceType = getAppearanceType();
+			const appearance =
+				isSupportedThemeEntrypoint( appearanceType ) &&
+				getConfig( 'isWooPayGlobalThemeSupportEnabled' )
+					? getAppearance( appearanceType, true )
+					: null;
 
 			if ( isProductPage ) {
 				const productData = getProductDataRef.current();
@@ -242,11 +248,7 @@ export const WoopayExpressCheckoutButton = ( {
 					}
 					WooPayFirstPartyAuth.getWooPaySessionFromMerchant( {
 						_ajax_nonce: getConfig( 'woopaySessionNonce' ),
-						appearance: getConfig(
-							'isWooPayGlobalThemeSupportEnabled'
-						)
-							? getAppearance( appearanceType, true )
-							: null,
+						appearance: appearance,
 					} )
 						.then( async ( response ) => {
 							if (
@@ -290,9 +292,7 @@ export const WoopayExpressCheckoutButton = ( {
 					order_id: getConfig( 'order_id' ),
 					key: getConfig( 'key' ),
 					billing_email: getConfig( 'billing_email' ),
-					appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-						? getAppearance( appearanceType, true )
-						: null,
+					appearance: appearance,
 				} )
 					.then( async ( response ) => {
 						if ( response?.blog_id && response?.data?.session ) {

--- a/client/checkout/woopay/utils.js
+++ b/client/checkout/woopay/utils.js
@@ -94,3 +94,13 @@ export const deleteSkipWooPayCookie = () => {
 	document.cookie =
 		'skip_woopay=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
 };
+
+/**
+ * Determine Global theming availability for the entrypoint based on the appearanceType.
+ *
+ * @param {string} appearanceType entrypoint identifier.
+ * @return {boolean} True if Global theming should be enabled for the entrypoint.
+ */
+export const isSupportedThemeEntrypoint = ( appearanceType ) => {
+	return appearanceType === 'woopay_shortcode_checkout';
+};


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9866

#### Changes proposed in this Pull Request

Limit the WooPay global theme availability only to the shoppers entering WooPay via the shortcode checkout page in the merchant site.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure WooPay global theme feature is enabled. You can do this by enabling "Enable WooPay global theme support" in WCPay Dev tools on both the merchant site and the local WooPay site.
* Apply a custom theme to the merchant site.
* Test each of the following entrypoints and make sure WooPay checkout is only styled for Shortcode entrypoints

| Entrypoint | Should be enabled? |
| --- | --- |
| Product Button | ❌  |
| Blocks Cart Button | ❌  |
| Blocks Cart Direct Checkout | ❌  |
| Blocks Checkout Page Button | ❌  |
| Blocks Checkout Page email field | ❌  |
| Shortcode Cart Button | ❌  |
| Shortcode Cart Direct Checkout | ❌  |
| Shortcode Checkout Page Button | ✅ | 
| Shortcode Checkout Page email field | ✅ |
 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
