### PR TITLE
Make test instructions copy icon use the same color as the text next to it

### DIFF
--- a/changelog/test-instructions-item-color
+++ b/changelog/test-instructions-item-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make test instructions copy icon use the same color as the text next to it

--- a/client/checkout/style.scss
+++ b/client/checkout/style.scss
@@ -26,16 +26,19 @@
 		display: block;
 		width: 1.2em;
 		height: 1.2em;
-		background: url( 'assets/images/icons/copy.svg?asset' ) no-repeat center;
-		background-size: contain;
+		mask-image: url( 'assets/images/icons/copy.svg?asset' );
+		mask-size: contain;
+		mask-repeat: no-repeat;
+		mask-position: center;
+		background-color: currentColor;
 	}
 
 	&:hover {
 		background-color: transparent;
-		filter: invert( 0.3 );
+		opacity: 0.7;
 
 		i {
-			filter: invert( 0.3 );
+			opacity: 0.7;
 		}
 	}
 
@@ -43,15 +46,13 @@
 		transform: scale( 0.9 );
 	}
 
-	&.state--success {
-		i {
-			background-image: url( 'assets/images/icons/check-green.svg?asset' );
-		}
+	&:focus {
+		outline: none;
 	}
 
-	.theme--night & {
+	&.state--success {
 		i {
-			filter: invert( 100% ) hue-rotate( 180deg );
+			mask-image: url( 'assets/images/icons/check-green.svg?asset' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #9773

#### Changes proposed in this Pull Request

This PR updates the color of the icon in the test instructions to be the same color as the text.

| Before | After |
|--------|--------|
| <img width="345" alt="Screenshot 2024-12-02 at 18 37 34" src="https://github.com/user-attachments/assets/e5d40c2e-9fe0-44ec-9547-ba2f87d76e1c"> | <img width="345" alt="Screenshot 2024-12-02 at 18 34 49" src="https://github.com/user-attachments/assets/b3ab43d4-d075-4659-add9-860533b35859"> |
| <img width="345" alt="Screenshot 2024-12-02 at 18 36 16" src="https://github.com/user-attachments/assets/b78b9089-7982-4264-939e-f4a87d0b25f8"> | <img width="345" alt="Screenshot 2024-12-02 at 18 35 35" src="https://github.com/user-attachments/assets/bee4adc3-a384-44c2-a4a2-fbd542efed18"> | 

#### Testing instructions

Use the shortcode checkout and blocks checkout and ensure the copy icon and the success checkmark have the same color as the text next to it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
