### PR TITLE
Fix rounding error with deposit products

### DIFF
--- a/changelog/fix-rounding-error-with-deposit-products
+++ b/changelog/fix-rounding-error-with-deposit-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ceil product prices after applying currency conversion, but before charm pricing and price rounding from settings is applied.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -832,7 +832,12 @@ class MultiCurrency {
 			return (float) $price;
 		}
 
+		// We must ceil the converted price here so that we don't introduce rounding errors when
+		// summing up costs. Consider, e.g. a converted price of 10.003 for a 2-decimal currency.
+		// A single product would cost 10.00, but 2 of them would cost 20.01, _unless_ we round
+		// the individual parts correctly.
 		$converted_price = ( (float) $price ) * $currency->get_rate();
+		$converted_price = $this->ceil_price_for_currency( $converted_price, $currency );
 
 		if ( 'tax' === $type || 'coupon' === $type || 'exchange_rate' === $type ) {
 			return $converted_price;
@@ -1354,6 +1359,39 @@ class MultiCurrency {
 			return $price;
 		}
 		return ceil( $price / $rounding ) * $rounding;
+	}
+
+	/**
+	 * Ceils the price to the precision dictated by the number of decimals in the provided currency.
+	 *
+	 * For example: US$10.0091 -> US$10.01, JPY 1001.01 -> JPY 1002.
+	 *
+	 * @param float    $price     The price to be ceiled.
+	 * @param Currency $currency  The currency used to figure out the ceil precision.
+	 *
+	 * @return float  The ceiled price.
+	 */
+	protected function ceil_price_for_currency( float $price, Currency $currency ): float {
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found, example comments look like code.
+
+		// Example to explain the math:
+		// $price            = 10.003.
+		// expected rounding = 10.01.
+
+		// $num_decimals = 2.
+		// $factor.      = 10^2 = 100.
+		$num_decimals = absint(
+			$this->localization_service->get_currency_format(
+				$currency->get_code()
+			)['num_decimals']
+		);
+		$factor       = 10 ** $num_decimals; // 10^{$num_decimals}.
+
+		// ceil( 10.003 * $factor ) = ceil( 1_000.3 ) = 1_001.
+		// 1_001 / 100 = 10.01.
+		return ceil( $price * $factor ) / $factor; // = 10.01.
+
+		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
 	}
 
 	/**

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -620,24 +620,27 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
-		// 0.708099 * 10 = 7,08099
-		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'coupon' ) );
+		// 0.708099 * 10 = 7.08099.
+		// ceil( 7.08099, 2 ) = 7.09.
+		$this->assertSame( 7.09, $this->multi_currency->get_price( '10.0', 'coupon' ) );
 	}
 
 	public function test_get_price_returns_converted_exchange_rate_without_adjustments() {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
-		// 0.708099 * 10 = 7,08099
-		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'exchange_rate' ) );
+		// 0.708099 * 10 = 7.08099.
+		// ceil( 7.08099, 2 ) = 7.09.
+		$this->assertSame( 7.09, $this->multi_currency->get_price( '10.0', 'exchange_rate' ) );
 	}
 
 	public function test_get_price_returns_converted_tax_price() {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
-		// 0.708099 * 10 = 7,08099
-		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'tax' ) );
+		// 0.708099 * 10 = 7.08099.
+		// ceil( 7.08099, 2 ) = 7.09.
+		$this->assertSame( 7.09, $this->multi_currency->get_price( '10.0', 'tax' ) );
 	}
 
 	/**
@@ -1014,7 +1017,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function get_price_provider() {
 		return [
-			[ '5.2499', '0.00', 5.2499 ],
+			[ '5.2499', '0.00', 5.25 ], // Even though the precision is 0.00 we make sure the amount is ceiled to the currency's number of digits.
 			[ '5.2499', '0.25', 5.25 ],
 			[ '5.2500', '0.25', 5.25 ],
 			[ '5.2501', '0.25', 5.50 ],


### PR DESCRIPTION
Fixes #9905 

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Ceil prices before applying charm pricing or currency rounding rules.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> You must have the WooCommerce Deposits plugin active and enabled.

1. Go to **WooCommerce &rarr; Settings &rarr; Multi-Currency** and pick a currency that is not the store currency.
2. Open the settings for that currency and set the manual rate for the currency to `3.783325`.
3. Set "charm pricing" to `none` and "price rounding" to `0.00`.
4. Make sure to enable "Add a currency switcher to the Storefront theme on breadcrumb section."
5. Create a deposits product:
    * Create a simple product. Set the price to $25
    * Go to the "Deposits" tab on the admin product page.
    * Enable deposits with "Yes - deposits are optional"
    * Set Deposit Type to "Inherit storewide settings (percent)"
    * Deposit Amount: 50
    * Save
6. Go to the page of the product you just created.
7. Make sure the selected currency is the one you set the manual rate for in step (2).
8. Make sure the product price is `94.59`
9. Verify "Pay Deposit" is selected.
10. Increase the number to "2" in the quantity input.
11. Click "Add to cart"
12. Make sure the subtotal in the cart is `94.59`.
    * You did not read the price wrong; we're paying 50% deposit on 2 products so we expect this to be the same amount as the single product price :)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
