### PR TITLE
Fix error log messages incorrecty categorized as info

### DIFF
--- a/changelog/fix-9889-log-level
+++ b/changelog/fix-9889-log-level
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Errors were incorrectly marked as info in logs.

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -36,7 +36,7 @@ class Logger {
 	 *     'debug': Debug-level messages.
 	 */
 	public static function log( $message, $level = 'info' ) {
-		wcpay_get_container()->get( InternalLogger::class )->log( $message );
+		wcpay_get_container()->get( InternalLogger::class )->log( $message, $level );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9889 

#### Changes proposed in this Pull Request

Calls to `Logger::log_error()` were being incorrectly labelled as `info`

This PR passes the log level categorization onto the WooCommerce logger.

#### Testing instructions

* In WooPayments Dev Tools, select `Force the WCPay plugin to act as disconnected from the WCPay Server` and save settings.
* Visit the WooPayments dashboard
* View the logs, ensure you see `error` level logs.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
