### PR TITLE
fix: undefined `$cart_contains_subscription`

### DIFF
--- a/changelog/frosso-patch-1
+++ b/changelog/frosso-patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: undefined $cart_contains_subscription

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1876,8 +1876,9 @@ class WC_Payments {
 	public static function load_stripe_bnpl_site_messaging() {
 		// The messaging element shall not be shown for subscription products.
 		// As we are not too deep into subscriptions API, we follow simplistic approach for now.
-		$is_subscription           = false;
-		$are_subscriptions_enabled = class_exists( 'WC_Subscriptions' ) || class_exists( 'WC_Subscriptions_Core_Plugin' );
+		$is_subscription            = false;
+		$cart_contains_subscription = false;
+		$are_subscriptions_enabled  = class_exists( 'WC_Subscriptions' ) || class_exists( 'WC_Subscriptions_Core_Plugin' );
 		if ( $are_subscriptions_enabled ) {
 				global $product;
 				$is_subscription            = $product && WC_Subscriptions_Product::is_subscription( $product );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1880,9 +1880,9 @@ class WC_Payments {
 		$cart_contains_subscription = false;
 		$are_subscriptions_enabled  = class_exists( 'WC_Subscriptions' ) || class_exists( 'WC_Subscriptions_Core_Plugin' );
 		if ( $are_subscriptions_enabled ) {
-				global $product;
-				$is_subscription            = $product && WC_Subscriptions_Product::is_subscription( $product );
-				$cart_contains_subscription = is_cart() && WC_Subscriptions_Cart::cart_contains_subscription();
+			global $product;
+			$is_subscription            = $product && WC_Subscriptions_Product::is_subscription( $product );
+			$cart_contains_subscription = is_cart() && WC_Subscriptions_Cart::cart_contains_subscription();
 		}
 
 		if ( ! $is_subscription && ! $cart_contains_subscription ) {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed here: p1733478206393759-slack-CU6SYV31A

The current implementation of `$cart_contains_subscription` might cause a `Warning` because it could be evaluated without being defined in some scenarios.

`$cart_contains_subscription` is only declared and assigned a value if `$are_subscriptions_enabled evaluates` to `true`.
However, it is evaluated in the conditional statement `if ( ! $is_subscription && ! $cart_contains_subscription )` regardless of whether `$are_subscriptions_enabled` is `true` or `false`.
If `$are_subscriptions_enabled` is `false`, `$cart_contains_subscription` remains undefined, resulting in a PHP warning.

Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I don't have testing instructions because I only used static analysis.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.