### PR TITLE
Refine ECE availability check for Variable Subscriptions

### DIFF
--- a/changelog/as-fix-ece-variable-subs
+++ b/changelog/as-fix-ece-variable-subs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Refine verification for disabling ECE on subscriptions that require shipping.


### PR DESCRIPTION
Part of https://github.com/Automattic/woocommerce-payments/issues/9771

#### Changes proposed in this Pull Request

This PR does not introduce any new features; it simply aims to refine the condition currently used to disable ECE for subscriptions, as it is incorrect for variable subscriptions.

Currently, the condition disables ECE for all types of subscriptions that require shipping if a "Free Trial" is added to the subscription. This is incorrect for variable subscriptions because the “needs_shipping” method should be checked against the selected variation in this case.

What this PR does is keep ECE disabled for all shipping subscriptions but adds a specific check for variable subscriptions. A subsequent PR will be made to address [cases 15 and 16](https://github.com/Automattic/woocommerce-payments/issues/9771#issuecomment-2518829514) of #9771

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The PR should affect the **product page** only.

- Ensure ECE loads correctly for simple products on the product page.
- Ensure ECE does not appear for simple subscriptions with “free trials.”
- Ensure ECE does not appear for variable subscriptions with “free trials,” regardless of whether the variations require shipping or not.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
