### PR TITLE
Ensure WooPay ‘Enabled by Default’ Value Is Correctly Set In Sandbox Mode

### DIFF
--- a/changelog/fix-9421-auto-enable-woopay-in-sandbox-mode
+++ b/changelog/fix-9421-auto-enable-woopay-in-sandbox-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure WooPay 'enabled by default' value is correctly set in sandbox mode.

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -166,7 +166,7 @@ const ConnectAccountPage: React.FC = () => {
 		}
 	};
 
-	const checkAccountStatus = () => {
+	const checkAccountStatus = ( extraQueryArgs = {} ) => {
 		// Fetch account status from the cache.
 		apiFetch( {
 			path: `/wc/v3/payments/accounts`,
@@ -188,18 +188,22 @@ const ConnectAccountPage: React.FC = () => {
 				loaderProgressRef.current > 95
 			) {
 				setTestDriveLoaderProgress( 100 );
-
-				// Redirect to the Connect URL and let it figure it out where to point the merchant.
-				window.location.href = addQueryArgs( connectUrl, {
+				const queryArgs = {
 					test_drive: 'true',
 					'wcpay-sandbox-success': 'true',
 					source: determineTrackingSource(),
 					from: 'WCPAY_CONNECT',
 					redirect_to_settings_page:
 						urlParams.get( 'redirect_to_settings_page' ) || '',
+				};
+
+				// Redirect to the Connect URL and let it figure it out where to point the merchant.
+				window.location.href = addQueryArgs( connectUrl, {
+					...queryArgs,
+					...extraQueryArgs,
 				} );
 			} else {
-				setTimeout( checkAccountStatus, 2000 );
+				setTimeout( () => checkAccountStatus( extraQueryArgs ), 2000 );
 			}
 		} );
 	};
@@ -264,7 +268,9 @@ const ConnectAccountPage: React.FC = () => {
 					// The account has been successfully onboarded.
 					if ( !! connectionSuccess ) {
 						// Start checking the account status in a loop.
-						checkAccountStatus();
+						checkAccountStatus( {
+							'wcpay-connection-success': '1',
+						} );
 					} else {
 						// Redirect to the response URL, but attach our test drive flags.
 						// This URL is generally a Connect page URL.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2004,12 +2004,19 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$collect_payout_requirements
 		);
 
-		// Store the 'woopay_enabled_by_default' flag in a transient to be used later.
-		set_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT, filter_var( $onboarding_data['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN ), DAY_IN_SECONDS );
+		$should_enable_woopay   = filter_var( $onboarding_data['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN );
+		$is_test_mode           = in_array( $setup_mode, [ 'test', 'test_drive' ], true );
+		$account_already_exists = isset( $onboarding_data['url'] ) && false === $onboarding_data['url'];
+
+		// Only store the 'woopay_enabled_by_default' flag in a transient, to be enabled later, if
+		// it should be enabled and the account doesn't already exist, or we are in test mode.
+		if ( $should_enable_woopay && ( ! $account_already_exists || $is_test_mode ) ) {
+			set_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT, $should_enable_woopay, DAY_IN_SECONDS );
+		}
 
 		// If an account already exists for this site and/or there is no need for KYC verifications, we're done.
 		// Our platform will respond with a `false` URL in this case.
-		if ( isset( $onboarding_data['url'] ) && false === $onboarding_data['url'] ) {
+		if ( $account_already_exists ) {
 			// Set the gateway options.
 			$gateway = WC_Payments::get_gateway();
 			$gateway->update_option( 'enabled', 'yes' );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2004,6 +2004,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$collect_payout_requirements
 		);
 
+		// Store the 'woopay_enabled_by_default' flag in a transient to be used later.
+		set_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT, filter_var( $onboarding_data['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN ), DAY_IN_SECONDS );
+
 		// If an account already exists for this site and/or there is no need for KYC verifications, we're done.
 		// Our platform will respond with a `false` URL in this case.
 		if ( isset( $onboarding_data['url'] ) && false === $onboarding_data['url'] ) {
@@ -2027,9 +2030,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			);
 		}
 
-		// We have an account that needs to be verified (has a URL to redirect the merchant to).
-		// Store the relevant onboarding data.
-		set_transient( self::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT, filter_var( $onboarding_data['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN ), DAY_IN_SECONDS );
 		// Save the onboarding state for a day.
 		// This is used to verify the state when finalizing the onboarding and connecting the account.
 		// On finalizing the onboarding, the transient gets deleted.

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -944,6 +944,39 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( get_transient( WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT ) );
 	}
 
+	public function test_ensure_woopay_not_enabled_by_default_for_existing_live_accounts() {
+		// Arrange.
+		// We need to be in the WP admin dashboard.
+		$this->set_is_admin( true );
+		// Test as an admin user.
+		wp_set_current_user( 1 );
+
+		// Configure the request to be in sandbox mode.
+		$_GET['wcpay-connect'] = 'connect-from';
+		$_REQUEST['_wpnonce']  = wp_create_nonce( 'wcpay-connect' );
+		$_GET['progressive']   = 'true';
+		$_GET['from']          = WC_Payments_Onboarding_Service::FROM_ONBOARDING_WIZARD;
+
+		// The Jetpack connection is in working order.
+		$this->mock_jetpack_connection();
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_onboarding_data' )
+			->willReturn(
+				[
+					'url'                       => false,
+					'woopay_enabled_by_default' => true,
+				]
+			);
+
+		// Act.
+		$this->wcpay_account->maybe_handle_onboarding();
+
+		// Assert.
+		$this->assertFalse( get_transient( WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT ) );
+	}
+
 	public function test_maybe_handle_onboarding_init_stripe_onboarding_existing_account() {
 		// Arrange.
 		// We need to be in the WP admin dashboard.

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -907,7 +907,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->wcpay_account->maybe_handle_onboarding();
 	}
 
-	public function test_ensure_woopay_enabled_by_default_value_set_in_sandbox_mode() {
+	public function test_ensure_woopay_enabled_by_default_value_set_in_sandbox_mode_kyc() {
 		// Arrange.
 		// We need to be in the WP admin dashboard.
 		$this->set_is_admin( true );

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -907,6 +907,43 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->wcpay_account->maybe_handle_onboarding();
 	}
 
+	public function test_ensure_woopay_enabled_by_default_value_set_in_sandbox_mode() {
+		// Arrange.
+		// We need to be in the WP admin dashboard.
+		$this->set_is_admin( true );
+		// Test as an admin user.
+		wp_set_current_user( 1 );
+
+		// Configure the request to be in sandbox mode.
+		$_GET['wcpay-connect'] = 'connect-from';
+		$_REQUEST['_wpnonce']  = wp_create_nonce( 'wcpay-connect' );
+		$_GET['progressive']   = 'true';
+		$_GET['test_mode']     = 'true';
+		$_GET['from']          = WC_Payments_Onboarding_Service::FROM_ONBOARDING_WIZARD;
+
+		// The Jetpack connection is in working order.
+		$this->mock_jetpack_connection();
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_onboarding_data' )
+			->willReturn(
+				[
+					'url'                       => false,
+					'woopay_enabled_by_default' => true,
+				]
+			);
+
+		$original_value = get_transient( WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT );
+
+		// Act.
+		$this->wcpay_account->maybe_handle_onboarding();
+
+		// Assert.
+		$this->assertFalse( $original_value );
+		$this->assertTrue( get_transient( WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT ) );
+	}
+
 	public function test_maybe_handle_onboarding_init_stripe_onboarding_existing_account() {
 		// Arrange.
 		// We need to be in the WP admin dashboard.


### PR DESCRIPTION
Fixes #9421 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The changes in this PR ensure that the WooPay 'enabled by default' value is correctly set in the KYC flow's sandbox mode. Previously, it was only set in live mode.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!WARNING]
> The `WCPay Dev` plugin should not be used for the following tests since it impacts the results.

**Regression Test: Ensure WooPay is enabled by default in live mode**
* Create a new merchant site.
* Ensure [sandbox mode](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/) is disabled.
* As a merchant, navigate to the `Payments` and click the `Connect your store` button.
* Go through the KYC flow to completion.
* Navigate to `Payments > Settings` and scroll down to the `Express checkouts` section.
* Ensure `WooPay` checkbox is checked.

**Ensure WooPay is enabled by default in sandbox mode**
* Create a new merchant site.
* Ensure [sandbox mode](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/) is enabled.
* As a merchant, navigate to the `Payments` and click the `Connect your store` button.
* Go through the KYC flow to completion.
* Navigate to `Payments > Settings` and scroll down to the `Express checkouts` section.
* Ensure `WooPay` checkbox is checked.

**Ensure unit tests pass**
* Ensure all tests from `npm run test:php` run successfully.
* Ensure all tests from `npm run test:js` run successfully.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
