### PR TITLE
Payouts: Rename 'Bank reference key' to 'Bank reference ID' for consistency

### DIFF
--- a/changelog/update-1-5316-rename-bank-reference-id
+++ b/changelog/update-1-5316-rename-bank-reference-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change 'Bank reference key' label to 'Bank reference ID' in Payouts list column for consistency.

--- a/client/deposits/list/index.tsx
+++ b/client/deposits/list/index.tsx
@@ -98,9 +98,9 @@ const getColumns = ( sortByDate?: boolean ): DepositsTableHeader[] => [
 		isLeftAligned: true,
 	},
 	{
-		key: 'bankReferenceKey',
-		label: __( 'Bank reference key', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Bank reference key', 'woocommerce-payments' ),
+		key: 'bankReferenceId',
+		label: __( 'Bank reference ID', 'woocommerce-payments' ),
+		screenReaderLabel: __( 'Bank reference ID', 'woocommerce-payments' ),
 	},
 ];
 
@@ -170,7 +170,7 @@ export const DepositsList = (): JSX.Element => {
 				value: deposit.bankAccount,
 				display: clickable( deposit.bankAccount ),
 			},
-			bankReferenceKey: {
+			bankReferenceId: {
 				value: deposit.bank_reference_key,
 				display: clickable( deposit.bank_reference_key ?? 'N/A' ),
 			},

--- a/client/deposits/list/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/list/test/__snapshots__/index.tsx.snap
@@ -321,12 +321,12 @@ exports[`Deposits list renders correctly a single deposit 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Bank reference key
+                      Bank reference ID
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Bank reference key
+                      Bank reference ID
                     </span>
                   </th>
                 </tr>
@@ -1009,12 +1009,12 @@ exports[`Deposits list renders correctly with multiple currencies 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Bank reference key
+                      Bank reference ID
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Bank reference key
+                      Bank reference ID
                     </span>
                   </th>
                 </tr>

--- a/client/deposits/list/test/index.tsx
+++ b/client/deposits/list/test/index.tsx
@@ -290,7 +290,7 @@ describe( 'Deposits list', () => {
 				'Amount',
 				'Status',
 				'"Bank account"',
-				'"Bank reference key"',
+				'"Bank reference ID"',
 			];
 
 			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];

--- a/client/types/deposits.d.ts
+++ b/client/types/deposits.d.ts
@@ -9,7 +9,7 @@ export interface DepositsTableHeader extends TableCardColumn {
 		| 'amount'
 		| 'status'
 		| 'bankAccount'
-		| 'bankReferenceKey';
+		| 'bankReferenceId';
 	cellClassName?: string;
 }
 


### PR DESCRIPTION
Fixes #9909 

#### Changes proposed in this Pull Request

Rename the column label for `Bank reference key` to `Bank reference ID` on the Payouts list report page. 

#### Testing instructions

* Checkout this branch and browse to Payments > Payouts
* The header of the payout lists should have `Bank reference ID` instead of 'Bank reference key`.

<img src="https://github.com/user-attachments/assets/78858c14-b229-464f-8863-d91a4e59042f" width="500px" />

#### Note
* Ref internal discussion - p1733483582646479/1732857021.096589-slack-C02BW3Z8SHK

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.