### PR TITLE
Add check for `wc_get_payment_gateway_by_order`

### DIFF
--- a/changelog/fix-add-payment-method-check
+++ b/changelog/fix-add-payment-method-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Added a check for the gateway id before comparing it
+
+

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -543,7 +543,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		$properties      = [ 'payment_title' => 'other' ];
 
 		// If the order was placed using WooCommerce Payments, record the payment title using Tracks.
-		if ( strpos( $payment_gateway->id, 'woocommerce_payments' ) === 0 ) {
+		if ( isset( $payment_gateway->id ) && strpos( $payment_gateway->id, 'woocommerce_payments' ) === 0 ) {
 			$order         = wc_get_order( $order_id );
 			$payment_title = $order->get_payment_method_title();
 			$properties    = [ 'payment_title' => $payment_title ];


### PR DESCRIPTION
We're getting a lot of notices on WooCommerce.com regarding this.

Note that even [core itself guards against this](https://github.com/woocommerce/woocommerce/blob/06e099977345f1fb6a6826d3d32d50309905b245/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php#L384).