### PR TITLE
Fixed UPE country detection in Checkout for non-logged in users

### DIFF
--- a/changelog/fix-upe-country-selection
+++ b/changelog/fix-upe-country-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed UPE country detection in Checkout for non-logged in users

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -375,10 +375,9 @@ export const togglePaymentMethodForCountry = ( upeElement ) => {
 		billingInput = document.querySelector( '#billing_country' );
 	}
 
-	/* global wcpayCustomerData */
 	// in the case of "pay for order", there is no "billing country" input, so we need to rely on backend data.
 	const billingCountry =
-		billingInput?.value || wcpayCustomerData?.billing_country || '';
+		billingInput?.value || window?.wcpayCustomerData?.billing_country || '';
 
 	const upeContainer = upeElement?.closest( '.wc_payment_method' );
 	if ( supportedCountries.includes( billingCountry ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When there's no country selected in the checkout we try to get it from `wcpayCustomerData` which is unavailable, causing an error and displaying Klarna and Afterpay as an option when they shouldn't be displayed. This PR fixes that by using `window?.wcpayCustomerData`.

<img width="415" alt="image" src="https://github.com/user-attachments/assets/acf18a16-80c1-4308-a6d9-15568165b001">

<img width="488" alt="image" src="https://github.com/user-attachments/assets/f506a7f5-525e-4c98-a81b-a3ca1a3eebe2">

<img width="294" alt="image" src="https://github.com/user-attachments/assets/e87909a5-8219-4dcc-b8a0-b1169f31627e">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you are not logged in and there's no default country for guests.
2. Go to the shortcode checkout.
3. In `develop`: See Afterpay and Klarna are displayed and there's an error in the console.
4. In `fix-upe-country-selection`: Afterpay and Klarna are not displayed and there's no error in the console.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
