### PR TITLE
fix: console warning for useEffect on plugins page

### DIFF
--- a/changelog/fix-use-effect-console-warning
+++ b/changelog/fix-use-effect-console-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: console warning on plugins page
+
+

--- a/client/plugins-page/index.js
+++ b/client/plugins-page/index.js
@@ -77,12 +77,12 @@ const PluginsPage = () => {
 	useEffect( () => {
 		// If the survey is dismissed skip event listeners.
 		if ( isModalDismissed() ) {
-			return null;
+			return;
 		}
 
 		// Abort if the deactivation link is not present.
 		if ( deactivationLink === null ) {
-			return null;
+			return;
 		}
 
 		// Handle click event.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed this error on the main `wp-admin` "Plugins" page:
<img width="1288" alt="Screenshot 2024-12-10 at 2 34 57 PM" src="https://github.com/user-attachments/assets/9472d082-feed-452e-b19b-6febc2116be0">

> react-dom.js?ver=18.3.1:73 Warning: useEffect must not return anything besides a function, which is used for clean-up. You returned null. If your effect does not require clean up, return undefined (or nothing). Error Component Stack
    at PluginsPage (index.js:15:39)
overrideMethod @ hook.js:608
printWarning @ react-dom.js?ver=18.3.1:73
error @ react-dom.js?ver=18.3.1:47
commitHookEffectListMount @ react-dom.js?ver=18.3.1:23239
commitPassiveMountOnFiber @ react-dom.js?ver=18.3.1:24975
commitPassiveMountEffects_complete @ react-dom.js?ver=18.3.1:24940
commitPassiveMountEffects_begin @ react-dom.js?ver=18.3.1:24927
commitPassiveMountEffects @ react-dom.js?ver=18.3.1:24915
flushPassiveEffectsImpl @ react-dom.js?ver=18.3.1:27088
flushPassiveEffects @ react-dom.js?ver=18.3.1:27033
(anonymous) @ react-dom.js?ver=18.3.1:26818
workLoop @ react.js?ver=18.3.1:2653
flushWork @ react.js?ver=18.3.1:2626
performWorkUntilDeadline @ react.js?ver=18.3.1:2920

This is caused by returning `null` in the `useEffect` hook.
Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `wp-admin` > Plugins
- Ensure you have WooPayments plugin enabled
- Open the console
- Error should no longer be present

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
