### PR TITLE
Update confirmation modal after progressive onboarding

### DIFF
--- a/changelog/update-confirmation-modal-nox
+++ b/changelog/update-confirmation-modal-nox
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update confirmation modal after onbarding

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -63,14 +63,14 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 
 	return (
 		<Modal
-			title={ '' }
+			title={ __(
+				"You're ready to accept payments!",
+				'woocommerce-payments'
+			) }
 			className="wcpay-progressive-onboarding-eligibility-modal"
 			onRequestClose={ handleDismiss }
 		>
 			<ConfettiAnimation />
-			<h1 className="wcpay-progressive-onboarding-eligibility-modal__heading">
-				{ __( 'You’re ready to sell.', 'woocommerce-payments' ) }
-			</h1>
 			<h2 className="wcpay-progressive-onboarding-eligibility-modal__subheading">
 				{ __(
 					'Start selling now and fast track the setup process, or continue the process to set up payouts with WooPayments.',

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -59,15 +59,6 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 		setModalVisible( false );
 	};
 
-	// Workaround to remove Modal header from the modal until `hideHeader` prop can be used.
-	useEffect( () => {
-		document
-			.querySelector(
-				'.wcpay-progressive-onboarding-eligibility-modal .components-modal__header-heading-container'
-			)
-			?.remove();
-	}, [] );
-
 	if ( ! modalVisible || modalDismissed ) return null;
 
 	return (

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button, Modal } from '@wordpress/components';
-import { Icon, store, widget, tool } from '@wordpress/icons';
+import { Icon, store, currencyDollar } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
 
@@ -95,46 +95,39 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 			</h2>
 			<div className="wcpay-progressive-onboarding-eligibility-modal__benefits">
 				<div>
-					<Icon icon={ store } size={ 32 } />
-					<h3 className="wcpay-progressive-onboarding-eligibility-modal__benefits__subtitle">
+					<Icon icon={ store } width={ 24 } height={ 24 } />
+					<div>
+						<h3 className="wcpay-progressive-onboarding-eligibility-modal__benefits__subtitle">
+							{ __(
+								'Start selling instantly',
+								'woocommerce-payments'
+							) }
+						</h3>
 						{ __(
-							'Start selling instantly',
+							'You have a $5,000 balance limit or 30 days from your first transaction to verify and set up payouts in your account.',
 							'woocommerce-payments'
 						) }
-					</h3>
-					{ sprintf(
-						/* translators: %s: WooPayments */
-						__(
-							'%s enables you to start processing credit card payments right away.',
+					</div>
+				</div>
+				<div>
+					<Icon icon={ currencyDollar } width={ 24 } height={ 24 } />
+					<div>
+						<h3 className="wcpay-progressive-onboarding-eligibility-modal__benefits__subtitle">
+							{ __(
+								'Start receiving payouts',
+								'woocommerce-payments'
+							) }
+						</h3>
+						{ __(
+							'Provide some additional details about your business so you can continue accepting payments and begin receiving payouts without restrictions.',
 							'woocommerce-payments'
-						),
-						'WooPayments'
-					) }
-				</div>
-				<div>
-					<Icon icon={ widget } size={ 32 } />
-					<h3 className="wcpay-progressive-onboarding-eligibility-modal__benefits__subtitle">
-						{ __( 'Quick and easy setup', 'woocommerce-payments' ) }
-					</h3>
-					{ __(
-						'The setup process is super simple and ensures your store is ready to accept card payments.',
-						'woocommerce-payments'
-					) }
-				</div>
-				<div>
-					<Icon icon={ tool } size={ 32 } />
-					<h3 className="wcpay-progressive-onboarding-eligibility-modal__benefits__subtitle">
-						{ __( 'Flexible process', 'woocommerce-payments' ) }
-					</h3>
-					{ __(
-						'You have a $5,000 balance limit or 30 days from your first transaction to verify and set up payouts in your account.',
-						'woocommerce-payments'
-					) }
+						) }
+					</div>
 				</div>
 			</div>
 			<div className="wcpay-progressive-onboarding-eligibility-modal__footer">
 				<Button variant="secondary" onClick={ handleSetup }>
-					{ __( 'Start receiving payouts', 'woocommerce-payments' ) }
+					{ __( 'Set up deposits', 'woocommerce-payments' ) }
 				</Button>
 				<Button variant="primary" onClick={ handlePaymentsOnly }>
 					{ __( 'Start selling', 'woocommerce-payments' ) }

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { Button, Modal } from '@wordpress/components';
 import { Icon, store, widget, tool } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
+import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
@@ -72,10 +73,25 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 		>
 			<ConfettiAnimation />
 			<h2 className="wcpay-progressive-onboarding-eligibility-modal__subheading">
-				{ __(
-					'Start selling now and fast track the setup process, or continue the process to set up payouts with WooPayments.',
-					'woocommerce-payments'
-				) }
+				{ interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'Great news — your %s account has been activated. You can now start accepting payments on your store, subject to {{restrictionsLink}}certain restrictions{{/restrictionsLink}}.',
+							'woocommerce-payments'
+						),
+						'WooPayments'
+					),
+					components: {
+						restrictionsLink: (
+							// eslint-disable-next-line jsx-a11y/anchor-has-content
+							<a
+								rel="external noopener noreferrer"
+								target="_blank"
+								href="https://woocommerce.com/document/woopayments/startup-guide/gradual-signup/"
+							/>
+						),
+					},
+				} ) }
 			</h2>
 			<div className="wcpay-progressive-onboarding-eligibility-modal__benefits">
 				<div>

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -127,7 +127,7 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 			</div>
 			<div className="wcpay-progressive-onboarding-eligibility-modal__footer">
 				<Button variant="secondary" onClick={ handleSetup }>
-					{ __( 'Set up deposits', 'woocommerce-payments' ) }
+					{ __( 'Set up payouts', 'woocommerce-payments' ) }
 				</Button>
 				<Button variant="primary" onClick={ handlePaymentsOnly }>
 					{ __( 'Start selling', 'woocommerce-payments' ) }

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -104,7 +104,7 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 							) }
 						</h3>
 						{ __(
-							'You have a $5,000 balance limit or 30 days from your first transaction to verify and set up payouts in your account.',
+							'You have 30 days from your first transaction or until you reach $5,000 in sales to verify your information and set up payouts.',
 							'woocommerce-payments'
 						) }
 					</div>

--- a/client/overview/modal/progressive-onboarding-eligibility/style.scss
+++ b/client/overview/modal/progressive-onboarding-eligibility/style.scss
@@ -2,27 +2,33 @@
 	&.components-modal__frame {
 		border-radius: 2px !important;
 		overflow: visible;
+
+		@media screen and ( max-width: $break-small ) {
+			height: fit-content;
+			margin: auto auto;
+			max-width: 90vw;
+		}
 	}
 
 	.components-modal__content {
 		box-sizing: border-box;
-		max-width: 700px;
-		margin: 0;
+		max-width: 516px;
+		margin: 72px 0 0;
 		padding: $gap-larger;
 		display: flex;
 		flex-direction: column;
-		align-items: center;
+		padding: $gap $gap-larger $gap-larger $gap-larger;
+		flex: 1;
+		overflow: auto;
 	}
 
 	.components-modal__header {
-		height: 0;
+		.components-modal__header-heading {
+			font-weight: 300;
+			text-wrap: auto;
+		}
 
 		.components-button {
-			position: absolute;
-			left: initial;
-			top: $gap-smaller;
-			right: $gap-smaller;
-
 			svg {
 				width: 32px;
 				height: 32px;
@@ -31,50 +37,72 @@
 	}
 
 	&__heading {
-		font-size: 40px;
+		font-size: 20px;
 		font-weight: 400;
-		line-height: 60px;
+		line-height: 28px;
 		margin-bottom: $gap-smallest;
 	}
 
 	&__subheading {
 		@include wc-body-large;
-		text-align: center;
-		font-weight: normal;
-		color: $gray-60;
-		max-width: 480px;
+		font-weight: 400;
+		color: $gray-700;
+		font-size: 13px;
+		line-height: 20px;
 		margin: 0 0 $gap-large 0;
+		text-wrap: wrap !important;
 	}
 
 	&__benefits {
-		display: grid;
-		grid-template-columns: repeat( 3, 1fr );
-		column-gap: $gap-largest;
-		padding: 0 $gap;
-		fill: $studio-woocommerce-purple-50;
-		font-size: 14px;
+		fill: $gray-900;
+		font-size: 13px;
 		line-height: 20px;
-		color: $gray-60;
+		color: $gray-700;
+
+		> div {
+			display: grid;
+			grid-template-columns: auto 1fr;
+			gap: $gap;
+			color: $gray-700;
+			font-weight: 400;
+			font-size: 13px;
+			line-height: 20px;
+		}
+
+		> div:not( :last-child ) {
+			margin-bottom: $gap;
+		}
 
 		svg {
 			display: block;
-			margin: $gap-smaller auto;
+			margin: $gap-smallest 0;
+			color: $gray-900;
 		}
 
 		&__subtitle {
 			@include wp-subtitle;
-			margin: $gap-large 0 $gap-smallest;
+			margin: $gap-smallest 0;
+			font-weight: 600;
+			color: $gray-900;
+			line-height: 20px;
+			font-size: 13px;
 		}
 
 		@media screen and ( max-width: $break-small ) {
 			grid-template-columns: 1fr;
 			row-gap: $gap-large;
+
+			svg {
+				width: 24px;
+				height: 24px;
+			}
 		}
 	}
 
 	&__footer {
-		text-align: center;
-		margin: $gap-large 0;
+		text-align: right;
+		margin: $gap-large 0 0 0;
+		width: 100%;
 
 		& :first-child {
 			margin-right: $gap;
@@ -86,6 +114,11 @@
 			font-size: 14px;
 			line-height: 20px;
 			height: 40px;
+		}
+
+		@media screen and ( max-width: $break-small ) {
+			text-wrap: nowrap;
+			text-align: center;
 		}
 	}
 

--- a/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
@@ -83,7 +83,7 @@ describe( 'Progressive Onboarding Eligibility Modal', () => {
 
 		user.click(
 			screen.getByRole( 'button', {
-				name: 'Set up deposits',
+				name: 'Set up payouts',
 			} )
 		);
 

--- a/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
@@ -36,7 +36,7 @@ describe( 'Progressive Onboarding Eligibility Modal', () => {
 
 		const queryHeading = () =>
 			screen.queryByRole( 'heading', {
-				name: 'You’re ready to sell.',
+				name: "You're ready to accept payments!",
 			} );
 
 		expect( queryHeading() ).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe( 'Progressive Onboarding Eligibility Modal', () => {
 
 		user.click(
 			screen.getByRole( 'button', {
-				name: 'Start receiving payouts',
+				name: 'Set up deposits',
 			} )
 		);
 

--- a/client/overview/task-list/strings.tsx
+++ b/client/overview/task-list/strings.tsx
@@ -423,10 +423,7 @@ export default {
 			),
 		},
 		go_live: {
-			title: __(
-				'Set up real payments on your store',
-				'woocommerce-payments'
-			),
+			title: __( 'Set up live payments', 'woocommerce-payments' ),
 			time: __( '10 minutes', 'woocommerce-payments' ),
 		},
 	},

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -326,7 +326,7 @@ describe( 'Overview page', () => {
 		render( <OverviewPage /> );
 
 		expect(
-			screen.getByText( 'You’re ready to sell.' )
+			screen.getByText( "You're ready to accept payments!" )
 		).toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
Fixes #9873

#### Changes proposed in this Pull Request

This changes the confirmation modal after the onboarding according to the designs in #9873 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make [this variable](https://github.com/Automattic/woocommerce-payments/blob/develop/client/overview/index.js#L112) `true`
* Remove [this line](https://github.com/Automattic/woocommerce-payments/blob/develop/client/overview/modal/progressive-onboarding-eligibility/index.tsx#L71)
* Visit `Payments > Overview`, you should see a modal:

<img width="641" alt="Screenshot 2024-12-10 at 16 05 38" src="https://github.com/user-attachments/assets/18d0c52e-3aad-4b98-9967-96712b9729f2">

<img width="482" alt="Screenshot 2024-12-10 at 16 05 31" src="https://github.com/user-attachments/assets/f69c66b2-bb78-48a1-9174-d8dd130a02c1">

Please check both mobile/desktop versions.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
