### PR TITLE
Enable ECE for Virtual Variable Subscriptions with Free Trials

### DIFF
--- a/changelog/as-fix-ece-variable-subs-free-trial
+++ b/changelog/as-fix-ece-variable-subs-free-trial
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Enable ECE for Virtual Variable Subscriptions with Free Trials.

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -252,6 +252,7 @@ jQuery( ( $ ) => {
 				'expressCheckout',
 				getExpressCheckoutButtonStyleSettings()
 			);
+			window.eceButton = eceButton;
 
 			expressCheckoutButtonUi.renderButton( eceButton );
 
@@ -441,6 +442,17 @@ jQuery( ( $ ) => {
 
 					$.when( wcpayECE.getSelectedProductData() )
 						.then( ( response ) => {
+							// We won't support this type of subscription yet.
+							if (
+								getExpressCheckoutData( 'product' )
+									.product_type === 'variable-subscription' &&
+								response.needs_shipping &&
+								response.has_free_trial
+							) {
+								window.eceButton.destroy();
+								return;
+							}
+
 							const isDeposits = wcpayECE.productHasDepositOption();
 							/**
 							 * If the customer aborted the express checkout,
@@ -453,8 +465,11 @@ jQuery( ( $ ) => {
 								! wcpayECE.paymentAborted &&
 								getExpressCheckoutData( 'product' )
 									.needs_shipping === response.needs_shipping;
-
-							if ( ! isDeposits && needsShipping ) {
+							if (
+								! isDeposits &&
+								needsShipping &&
+								! window.eceButton._destroyed
+							) {
 								elements.update( {
 									amount: response.total.amount,
 								} );

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -468,7 +468,7 @@ jQuery( ( $ ) => {
 							if (
 								! isDeposits &&
 								needsShipping &&
-								! window.eceButton._destroyed
+								! ( window.eceButton._destroyed ?? false )
 							) {
 								elements.update( {
 									amount: response.total.amount,

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -252,7 +252,6 @@ jQuery( ( $ ) => {
 				'expressCheckout',
 				getExpressCheckoutButtonStyleSettings()
 			);
-			window.eceButton = eceButton;
 
 			expressCheckoutButtonUi.renderButton( eceButton );
 
@@ -368,7 +367,7 @@ jQuery( ( $ ) => {
 			} );
 
 			if ( getExpressCheckoutData( 'button_context' ) === 'product' ) {
-				wcpayECE.attachProductPageEventListeners( elements );
+				wcpayECE.attachProductPageEventListeners( elements, eceButton );
 			}
 		},
 
@@ -419,7 +418,7 @@ jQuery( ( $ ) => {
 			return api.expressCheckoutECEGetSelectedProductData( data );
 		},
 
-		attachProductPageEventListeners: ( elements ) => {
+		attachProductPageEventListeners: ( elements, eceButton ) => {
 			// WooCommerce Deposits support.
 			// Trigger the "woocommerce_variation_has_changed" event when the deposit option is changed.
 			// Needs to be defined before the `woocommerce_variation_has_changed` event handler is set.
@@ -449,7 +448,7 @@ jQuery( ( $ ) => {
 								response.needs_shipping &&
 								response.has_free_trial
 							) {
-								window.eceButton.destroy();
+								eceButton.destroy();
 								return;
 							}
 
@@ -468,7 +467,7 @@ jQuery( ( $ ) => {
 							if (
 								! isDeposits &&
 								needsShipping &&
-								! ( window.eceButton._destroyed ?? false )
+								! ( eceButton._destroyed ?? false )
 							) {
 								elements.update( {
 									amount: response.total.amount,

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -441,7 +441,8 @@ jQuery( ( $ ) => {
 
 					$.when( wcpayECE.getSelectedProductData() )
 						.then( ( response ) => {
-							// We won't support this type of subscription yet.
+							// We do not support variable subscriptions with variations
+							// that require shipping and include a free trial.
 							if (
 								getExpressCheckoutData( 'product' )
 									.product_type === 'variable-subscription' &&

--- a/client/express-checkout/utils/index.ts
+++ b/client/express-checkout/utils/index.ts
@@ -66,6 +66,7 @@ export interface WCPayExpressCheckoutParams {
 	product: {
 		needs_shipping: boolean;
 		currency: string;
+		product_type: string;
 		shippingOptions: {
 			id: string;
 			label: string;

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -333,6 +333,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 			$data['needs_shipping'] = wc_shipping_enabled() && 0 !== wc_get_shipping_method_count( true ) && $product->needs_shipping();
 			$data['currency']       = strtolower( get_woocommerce_currency() );
 			$data['country_code']   = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+			$data['has_free_trial'] = class_exists( 'WC_Subscriptions_Product' ) ? WC_Subscriptions_Product::get_trial_length( $product ) > 0 : false;
 
 			wp_send_json( $data );
 		} catch ( Exception $e ) {

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -742,6 +742,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		$data['needs_shipping'] = ( wc_shipping_enabled() && 0 !== wc_get_shipping_method_count( true ) && $product->needs_shipping() );
 		$data['currency']       = strtolower( $currency );
 		$data['country_code']   = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+		$data['product_type']   = $product->get_type();
 
 		return apply_filters( 'wcpay_payment_request_product_data', $data, $product );
 	}
@@ -767,13 +768,9 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			// Simple subscription that needs shipping with free trials is not supported.
 			$is_free_trial_simple_subs = class_exists( 'WC_Subscriptions_Product' ) && $product->get_type() === 'subscription' && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0;
 
-			// Disable ECE for all variable subscriptions with free trials, as they are not currently supported. For now, ECE will be disabled for all such cases, and a solution will be addressed in a separate PR.
-			$is_free_trial_variable_sub = class_exists( 'WC_Subscriptions_Product' ) && $product->get_type() === 'variable-subscription' && WC_Subscriptions_Product::get_trial_length( $product ) > 0;
-
 			if (
 			! in_array( $product->get_type(), $this->supported_product_types(), true )
 			|| $is_free_trial_simple_subs
-			|| $is_free_trial_variable_sub
 			|| ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) // Pre Orders charge upon release not supported.
 			|| ( class_exists( 'WC_Composite_Products' ) && $product->is_type( 'composite' ) ) // Composite products are not supported on the product page.
 			|| ( class_exists( 'WC_Mix_and_Match' ) && $product->is_type( 'mix-and-match' ) ) // Mix and match products are not supported on the product page.


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9771

#### Changes proposed in this Pull Request

Removes the condition added in #9897 that enables ECE for all subscriptions with a free trial.

However, new conditions have been added to restrict enabling ECE only for virtual variable subscriptions with a free trial ([Case 15, 16](https://github.com/Automattic/woocommerce-payments/issues/9771#issuecomment-2518829514)), as we still do not support shipping options with free trials with variable subscriptions ([Case 11, 12](https://github.com/Automattic/woocommerce-payments/issues/9771#issuecomment-2518829514)).

#### Testing instructions

[Here](https://github.com/Automattic/woocommerce-payments/issues/9771#issuecomment-2518829514) we have a table with the cases in which this PR enables ECE, specifically cases 15 and 16. Additionally, this PR should keep ECE disabled for cases 11 and 12.

**Verify ECE is enabled for cases 15 and 16**

- Create a variable subscription product
- Add at least a couple virtual variations:
  - Add a variation with Free trial only.
  - Add a variation with Free trial and a sign up fee.
- Go to the product page.
- Verify ECE shows in each selected variation
- Verify the purchase is processed correctly.

**Verify ECE is not enabled for cases 11 and 12**

- Create another variable subscription product
- Add at least a couple variation (**ensure they are not virtual**)
  - Add a variation with free trial only.
  - Add a variation with free trial and a sign up fee.
- Go to the product page.
- Verify ECE is shown when the page loads but disappears once a variation is selected.


> [!TIP]
> You can combine cases from both groups to verify that ECE is enabled and disabled accordingly.


> [!WARNING]  
> The amounts displayed on the payment sheet for cases 15 and 16 are still _incorrect_. However, the amount being charged to the payment method is correct, which can be verified when proceeding with the purchase. This will be addressed in a separate issue/PR, likely in [#9799](https://github.com/Automattic/woocommerce-payments/issues/9799).


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
