### PR TITLE
Update the Jetpack onboarding flow

### DIFF
--- a/changelog/update-jetpack-onboarding-flow
+++ b/changelog/update-jetpack-onboarding-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update Jetpack onboarding flow

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -200,6 +200,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 			add_query_arg(
 				[
 					'from'        => 'woocommerce-payments',
+					'plugin_name' => 'woocommerce-payments',
 					'calypso_env' => $calypso_env,
 				],
 				$this->connection_manager->get_authorization_url( null, $redirect )


### PR DESCRIPTION
Fixes #9501

#### Changes proposed in this Pull Request

This updates the query params to use the Jetpack flow. You can see a before and after next.

#### Testing instructions

⚠️ This should be tested with `D168388`

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- **On your sandbox**, clone `D168388`.
- Change your hosts file to point `jetpack.wordpress.com` to point to your sandbox.

Testing backward compatibility
* Use the `develop` branch
* Make sure WooPayments isn't active on your site. If it is, please reset the connection.
* If your local site is already connected to Jetpack, you must break that. You can use the `Jetpack Debug` plugin and navigate to `Jetpack Debug => Broken Token`. Click on "Clear blog token"
* Go back to WooPayments and click "Complete Setup"
* You should be redirected to the old page

<img width="1630" alt="Screenshot 2024-12-12 at 08 39 50" src="https://github.com/user-attachments/assets/d96c6c79-ec56-4e16-a82f-5af372985c0a" />

- Now, clone this branch
- Go back to WooPayments overview and click "Complete Setup"
- You should see the new page

<img width="1620" alt="Screenshot 2024-12-12 at 08 36 45" src="https://github.com/user-attachments/assets/d3bbe37d-905e-4dbb-b0ef-d510520ecebd" />

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
