### PR TITLE
Rename Order # to Order Id in client side exports and pages

### DIFF
--- a/changelog/fix-2679-order-Id-column-rename
+++ b/changelog/fix-2679-order-Id-column-rename
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update Order # in Reporting and CSV export to Order Id

--- a/changelog/update-9910-transaction-id-label
+++ b/changelog/update-9910-transaction-id-label
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Change ID to uppercase in the 'Transaction ID' column label for consistency with similar unique IDs in the UI.
-
-

--- a/changelog/update-9910-transaction-id-label
+++ b/changelog/update-9910-transaction-id-label
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Change ID to uppercase in the 'Transaction ID' column label for consistency with similar unique IDs in the UI.
+
+

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -106,8 +106,8 @@ const getHeaders = ( sortColumn?: string ): DisputesTableHeader[] => [
 	},
 	{
 		key: 'order',
-		label: __( 'Order #', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Order #', 'woocommerce-payments' ),
+		label: __( 'Order Id', 'woocommerce-payments' ),
+		screenReaderLabel: __( 'Order Id', 'woocommerce-payments' ),
 		required: true,
 	},
 	{

--- a/client/disputes/test/__snapshots__/index.tsx.snap
+++ b/client/disputes/test/__snapshots__/index.tsx.snap
@@ -252,12 +252,12 @@ exports[`Disputes list renders correctly 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order #
+                      Order Id
                     </span>
                   </th>
                   <th

--- a/client/disputes/test/index.tsx
+++ b/client/disputes/test/index.tsx
@@ -304,7 +304,7 @@ describe( 'Disputes list', () => {
 				'Status',
 				'Reason',
 				'Source',
-				'"Order #"',
+				'"Order Id"',
 				'Customer',
 				'Email',
 				'Country',

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -151,7 +151,7 @@ const getColumns = (
 	[
 		{
 			key: 'transaction_id',
-			label: __( 'Transaction Id', 'woocommerce-payments' ),
+			label: __( 'Transaction ID', 'woocommerce-payments' ),
 			visible: false,
 			isLeftAligned: true,
 		},

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -236,8 +236,8 @@ const getColumns = (
 		},
 		{
 			key: 'order',
-			label: __( 'Order #', 'woocommerce-payments' ),
-			screenReaderLabel: __( 'Order number', 'woocommerce-payments' ),
+			label: __( 'Order Id', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Order Id', 'woocommerce-payments' ),
 			required: true,
 		},
 		includeSubscription && {

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -151,7 +151,7 @@ const getColumns = (
 	[
 		{
 			key: 'transaction_id',
-			label: __( 'Transaction ID', 'woocommerce-payments' ),
+			label: __( 'Transaction Id', 'woocommerce-payments' ),
 			visible: false,
 			isLeftAligned: true,
 		},

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -425,12 +425,12 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order number
+                      Order Id
                     </span>
                   </th>
                   <th
@@ -1413,12 +1413,12 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order number
+                      Order Id
                     </span>
                   </th>
                   <th
@@ -2398,12 +2398,12 @@ exports[`Transactions list renders correctly when filtered by payout 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order number
+                      Order Id
                     </span>
                   </th>
                   <th
@@ -3074,12 +3074,12 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order number
+                      Order Id
                     </span>
                   </th>
                   <th
@@ -4136,12 +4136,12 @@ exports[`Transactions list when not filtered by payout renders correctly 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order number
+                      Order Id
                     </span>
                   </th>
                   <th
@@ -5166,12 +5166,12 @@ exports[`Transactions list when not filtered by payout renders table summary onl
                     <span
                       aria-hidden="true"
                     >
-                      Order #
+                      Order Id
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Order number
+                      Order Id
                     </span>
                   </th>
                   <th

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -621,7 +621,7 @@ describe( 'Transactions list', () => {
 			getByRole( 'button', { name: 'Download' } ).click();
 
 			const expected = [
-				'"Transaction Id"',
+				'"Transaction ID"',
 				'"Date / Time (UTC)"',
 				'Type',
 				'Channel',

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -631,7 +631,7 @@ describe( 'Transactions list', () => {
 				'Amount',
 				'Fees',
 				'Net',
-				'"Order #"',
+				'"Order Id"',
 				'"Payment Method"',
 				'Customer',
 				'Email',

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -621,7 +621,7 @@ describe( 'Transactions list', () => {
 			getByRole( 'button', { name: 'Download' } ).click();
 
 			const expected = [
-				'"Transaction ID"',
+				'"Transaction Id"',
 				'"Date / Time (UTC)"',
 				'Type',
 				'Channel',


### PR DESCRIPTION
Fixes #2679

#### Changes proposed in this Pull Request
Changes Order # to Order Id on the page and the csv export to indicate that its the WooCommerce Order Id and NOT the Order Number, which may be customized using plugins.

#### Testing instructions
- Load the Transactions or Disputes page and check the column
- CSV export for less than 25 rows, should show "Order Id"

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
