### PR TITLE
chore: remove ECE error assignment on loaderror

### DIFF
--- a/changelog/chore-remove-ece-error-assignment-on-loaderror
+++ b/changelog/chore-remove-ece-error-assignment-on-loaderror
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: chore: remove ECE error assignment on loaderror
+
+

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -256,10 +256,6 @@ jQuery( ( $ ) => {
 			expressCheckoutButtonUi.renderButton( eceButton );
 
 			eceButton.on( 'loaderror', () => {
-				wcPayECEError = __(
-					'The cart is incompatible with express checkout.',
-					'woocommerce-payments'
-				);
 				if ( ! document.getElementById( 'wcpay-woopay-button' ) ) {
 					expressCheckoutButtonUi.getButtonSeparator().hide();
 				}

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -235,10 +235,6 @@ jQuery( ( $ ) => {
 			expressCheckoutButtonUi.renderButton( eceButton );
 
 			eceButton.on( 'loaderror', () => {
-				wcPayECEError = __(
-					'The cart is incompatible with express checkout.',
-					'woocommerce-payments'
-				);
 				if ( ! document.getElementById( 'wcpay-woopay-button' ) ) {
 					expressCheckoutButtonUi.getButtonSeparator().hide();
 				}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed here: p1733843761767399-slack-C01BZUL57SQ

The `wcPayECEError` variable holds an error message, [which is displayed on the `click` action - when the ECE button is clicked](https://github.com/Automattic/woocommerce-payments/blob/0ea8272f82e760b0648c072d0307b1bc76582f90/client/express-checkout/index.js#L304-L307).

I noticed that once of the instances where wcPayECEError is assigned is [on the button's `loaderror` event](https://github.com/Automattic/woocommerce-payments/blob/0ea8272f82e760b0648c072d0307b1bc76582f90/client/express-checkout/index.js#L259-L262).

The `loaderror` event is triggered by Stripe when the element fails to load: https://docs.stripe.com/js/element/events/on_loaderror

But if the element failed to load, the `click` event would never get triggered (since there's no element to click on).

Removing [this assignment](https://github.com/Automattic/woocommerce-payments/blob/0ea8272f82e760b0648c072d0307b1bc76582f90/client/express-checkout/index.js#L259-L262) from the codebase.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There should be no change in functionality on the ECE button.
Go to a product page, clicking on the GooglePay/ApplePay button should still work.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.