### PR TITLE
Skip mysqlcheck SSL Requirement during E2E environment setup

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -27,11 +27,11 @@ cli()
 set +e
 # Wait for containers to be started up before the setup.
 # The db being accessible means that the db container started and the WP has been downloaded and the plugin linked
-cli wp db check --path=/var/www/html --quiet > /dev/null
+cli wp db check --skip_ssl --path=/var/www/html --quiet > /dev/null
 while [[ $? -ne 0 ]]; do
 	echo "Waiting until the service is ready..."
 	sleep 5
-	cli wp db check --path=/var/www/html --quiet > /dev/null
+	cli wp db check --skip_ssl --path=/var/www/html --quiet > /dev/null
 done
 
 # If the plugin is already active then return early

--- a/changelog/fix-skip-ssl-requirement-env-setup
+++ b/changelog/fix-skip-ssl-requirement-env-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Skip mysqlcheck SSL Requirement during E2E environment setup

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -123,11 +123,11 @@ step "Setting up CLIENT site"
 # Wait for containers to be started up before the setup.
 # The db being accessible means that the db container started and the WP has been downloaded and the plugin linked
 set +e
-cli wp db check --path=/var/www/html --quiet > /dev/null
+cli wp db check --skip_ssl --path=/var/www/html --quiet > /dev/null
 while [[ $? -ne 0 ]]; do
 	echo "Waiting until the service is ready..."
 	sleep 5
-	cli wp db check --path=/var/www/html --quiet > /dev/null
+	cli wp db check --skip_ssl --path=/var/www/html --quiet > /dev/null
 done
 echo "Client DB is up and running..."
 set -e


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

A recent upstream change in the `wordpress:cli` image caused issues when setting up the environment, making all E2E tests to timeout due to the following error:

```
mysqlcheck: Got error: 2026: TLS/SSL error: SSL is required, but the server does not support it when trying to connect
```

In this PR, we are adding a flag to skip the SSL requirement, since all the tests run inside docker compose.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* PW E2E tests pass (or at least don't timeout) for this PR
* E2E tests pass (or at least don't timeout) for this branch 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
