### PR TITLE
Add login confirmation check to ECE in Blocks

### DIFF
--- a/changelog/fix-9806-ECE-subscription-checkout-signed-out
+++ b/changelog/fix-9806-ECE-subscription-checkout-signed-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure ECE login confirmation dialog is shown on Blocks.

--- a/client/express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/express-checkout/blocks/hooks/use-express-checkout.js
@@ -8,6 +8,7 @@ import { useStripe, useElements } from '@stripe/react-stripe-js';
  * Internal dependencies
  */
 import {
+	displayLoginConfirmation,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
 	normalizeLineItems,
@@ -52,6 +53,12 @@ export const useExpressCheckout = ( {
 
 	const onButtonClick = useCallback(
 		( event ) => {
+			// If login is required for checkout, display redirect confirmation dialog.
+			if ( getExpressCheckoutData( 'login_confirmation' ) ) {
+				displayLoginConfirmation( event.expressPaymentType );
+				return;
+			}
+
 			const options = {
 				lineItems: normalizeLineItems( billing?.cartTotalItems ),
 				emailRequired: true,

--- a/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
@@ -8,6 +8,7 @@ import { useStripe, useElements } from '@stripe/react-stripe-js';
  * Internal dependencies
  */
 import {
+	displayLoginConfirmation,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
 	normalizeLineItems,
@@ -52,6 +53,12 @@ export const useExpressCheckout = ( {
 
 	const onButtonClick = useCallback(
 		( event ) => {
+			// If login is required for checkout, display redirect confirmation dialog.
+			if ( getExpressCheckoutData( 'login_confirmation' ) ) {
+				displayLoginConfirmation( event.expressPaymentType );
+				return;
+			}
+
 			const options = {
 				lineItems: normalizeLineItems( billing?.cartTotalItems ),
 				emailRequired: true,


### PR DESCRIPTION
Fixes #9806.

#### Changes proposed in this Pull Request

This modifies the Blocks implementation of the ECE on-click handler for both regular ECE and tokenized ECE. It adds an initial validation step to check whether login confirmation is required. If confirmation is needed, an alert is displayed. This validation ensures proper handling of guest checkout settings and adjusts the ECE payment flow accordingly. Previously, this check was missing in the Blocks implementation but was already present in the shortcode implementation.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test: Ensure ECE works as expected when it's clicked**

1. As a merchant, create a simple subscription product. You'll use only this product during this test.
2. Take the scenarios I described [here](https://github.com/Automattic/woocommerce-payments/issues/9806#issuecomment-2536965242).
3. Go through each scenario by modifying those two settings in **WooCommerce > Settings > Accounts & Privacy**.
    - Result `Transaction is successfully processed` means you should be able to checkout with ECE as usual.
    - Result `Alert with login redirect is displayed` means the login confirmation alert should be displayed, not the payment sheet.
      <img width="446" alt="Image" src="https://github.com/user-attachments/assets/ec4cc3db-640a-4bec-9d9d-a137dc60e1a2" />
4. Run this test on all pages you can checkout with ECE, in all pages the behavior must be the same: product page, shortcode cart and checkout and Blocks cart and checkout.

**Test: Ensure tokenized ECE works as expected when it's clicked**

1. As a merchant, go to the WCPay Dev Tools.
2. Enable the Cart-Token implementation for ECE feature flag and save.
3. Repeat all steps from the test above, they must show the same results.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
