### PR TITLE
Add support for utilizing NOX capabilities as URL parameters during account creation

### DIFF
--- a/changelog/update-pass-capabilities-to-onboarding-as-get-params
+++ b/changelog/update-pass-capabilities-to-onboarding-as-get-params
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add support for utilizing NOX capabilities as URL parameters during account creation.

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -197,6 +197,7 @@ const ConnectAccountPage: React.FC = () => {
 					from: 'WCPAY_CONNECT',
 					redirect_to_settings_page:
 						urlParams.get( 'redirect_to_settings_page' ) || '',
+					capabilities: urlParams.get( 'capabilities' ) || '',
 				} );
 			} else {
 				setTimeout( checkAccountStatus, 2000 );

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -197,7 +197,6 @@ const ConnectAccountPage: React.FC = () => {
 					from: 'WCPAY_CONNECT',
 					redirect_to_settings_page:
 						urlParams.get( 'redirect_to_settings_page' ) || '',
-					capabilities: urlParams.get( 'capabilities' ) || '',
 				} );
 			} else {
 				setTimeout( checkAccountStatus, 2000 );
@@ -212,6 +211,7 @@ const ConnectAccountPage: React.FC = () => {
 
 		const customizedConnectUrl = addQueryArgs( connectUrl, {
 			test_drive: 'true',
+			capabilities: urlParams.get( 'capabilities' ) || '',
 		} );
 
 		const updateProgress = setInterval( updateLoaderProgress, 2500, 40, 5 );

--- a/client/onboarding/utils.ts
+++ b/client/onboarding/utils.ts
@@ -65,9 +65,11 @@ export const createAccountSession = async (
 	data: OnboardingFields,
 	isPoEligible: boolean
 ): Promise< AccountKycSession > => {
+	const urlParams = new URLSearchParams( window.location.search );
 	return await apiFetch< AccountKycSession >( {
 		path: addQueryArgs( `${ NAMESPACE }/onboarding/kyc/session`, {
 			self_assessment: fromDotNotation( data ),
+			capabilities: urlParams.get( 'capabilities' ) || '',
 			progressive: isPoEligible,
 		} ),
 		method: 'GET',

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1252,7 +1252,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$auto_start_test_drive_onboarding = $create_test_drive_account &&
 												! empty( $_GET['auto_start_test_drive_onboarding'] ) &&
 												'true' === $_GET['auto_start_test_drive_onboarding'];
-			$capabilities                     = wc_clean( wp_unslash( $_GET['capabilities'] ) );
+			$capabilities                     = ! empty( $_GET['capabilities'] ) ? wc_clean( wp_unslash( $_GET['capabilities'] ) ) : [];
 			// We will onboard in test mode if the test_mode GET param is set, if we are creating a test drive account,
 			// or if we are in dev mode.
 			$should_onboard_in_test_mode = ( isset( $_GET['test_mode'] ) && wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) ||

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1507,7 +1507,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 							'test_mode'                   => $should_onboard_in_test_mode ? 'true' : false,
 							'test_drive'                  => $create_test_drive_account ? 'true' : false,
 							'auto_start_test_drive_onboarding' => $auto_start_test_drive_onboarding ? 'true' : false,
-							'capabilities'                => rawurlencode( $capabilities_string ),
+							'capabilities'                => $capabilities_string ? rawurlencode( $capabilities_string ) : '',
 							'from'                        => WC_Payments_Onboarding_Service::FROM_WPCOM_CONNECTION,
 							'source'                      => $onboarding_source,
 							'redirect_to_settings_page'   => $redirect_to_settings_page ? 'true' : false,
@@ -1578,7 +1578,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 								'promo'        => ! empty( $incentive_id ) ? $incentive_id : false,
 								'test_drive'   => 'true',
 								'auto_start_test_drive_onboarding' => 'true', // This is critical.
-								'capabilities' => rawurlencode( $capabilities_string ),
+								'capabilities' => $capabilities_string ? rawurlencode( $capabilities_string ) : '',
 								'test_mode'    => $should_onboard_in_test_mode ? 'true' : false,
 								'source'       => $onboarding_source,
 								'redirect_to_settings_page' => $redirect_to_settings_page ? 'true' : false,
@@ -1985,7 +1985,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$self_assessment_data = isset( $_GET['self_assessment'] ) ? wc_clean( wp_unslash( $_GET['self_assessment'] ) ) : [];
-		$capabilities         = isset( $_GET['capabilities'] ) ? json_decode( wc_clean( wp_unslash( $_GET['capabilities'] ) ), true ) : [];
+		$capabilities         = ! empty( $_GET['capabilities'] ) ? json_decode( wc_clean( wp_unslash( $_GET['capabilities'] ) ), true ) : [];
 		if ( 'test_drive' === $setup_mode ) {
 			// If we get to the overview page, we want to show the success message.
 			$return_url = add_query_arg( 'wcpay-sandbox-success', 'true', $return_url );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1252,7 +1252,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$auto_start_test_drive_onboarding = $create_test_drive_account &&
 												! empty( $_GET['auto_start_test_drive_onboarding'] ) &&
 												'true' === $_GET['auto_start_test_drive_onboarding'];
-			$capabilities                     = ! empty( $_GET['capabilities'] ) ? wc_clean( wp_unslash( $_GET['capabilities'] ) ) : [];
+			$capabilities_string              = ! empty( $_GET['capabilities'] ) ? wc_clean( wp_unslash( $_GET['capabilities'] ) ) : '';
 			// We will onboard in test mode if the test_mode GET param is set, if we are creating a test drive account,
 			// or if we are in dev mode.
 			$should_onboard_in_test_mode = ( isset( $_GET['test_mode'] ) && wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) ||
@@ -1507,7 +1507,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 							'test_mode'                   => $should_onboard_in_test_mode ? 'true' : false,
 							'test_drive'                  => $create_test_drive_account ? 'true' : false,
 							'auto_start_test_drive_onboarding' => $auto_start_test_drive_onboarding ? 'true' : false,
-							'capabilties'                 => $capabilities,
+							'capabilities'                => rawurlencode( $capabilities_string ),
 							'from'                        => WC_Payments_Onboarding_Service::FROM_WPCOM_CONNECTION,
 							'source'                      => $onboarding_source,
 							'redirect_to_settings_page'   => $redirect_to_settings_page ? 'true' : false,
@@ -1578,7 +1578,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 								'promo'        => ! empty( $incentive_id ) ? $incentive_id : false,
 								'test_drive'   => 'true',
 								'auto_start_test_drive_onboarding' => 'true', // This is critical.
-								'capabilities' => $capabilities,
+								'capabilities' => rawurlencode( $capabilities_string ),
 								'test_mode'    => $should_onboard_in_test_mode ? 'true' : false,
 								'source'       => $onboarding_source,
 								'redirect_to_settings_page' => $redirect_to_settings_page ? 'true' : false,
@@ -1985,7 +1985,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$self_assessment_data = isset( $_GET['self_assessment'] ) ? wc_clean( wp_unslash( $_GET['self_assessment'] ) ) : [];
-		$capabilities         = isset( $_GET['capabilities'] ) ? wc_clean( wp_unslash( $_GET['capabilities'] ) ) : [];
+		$capabilities         = isset( $_GET['capabilities'] ) ? json_decode( wc_clean( wp_unslash( $_GET['capabilities'] ) ), true ) : [];
 		if ( 'test_drive' === $setup_mode ) {
 			// If we get to the overview page, we want to show the success message.
 			$return_url = add_query_arg( 'wcpay-sandbox-success', 'true', $return_url );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1985,7 +1985,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$self_assessment_data = isset( $_GET['self_assessment'] ) ? wc_clean( wp_unslash( $_GET['self_assessment'] ) ) : [];
-		$capabilities         = ! empty( $_GET['capabilities'] ) ? json_decode( wc_clean( wp_unslash( $_GET['capabilities'] ) ), true ) : [];
+		$capabilities         = ! empty( $_GET['capabilities'] ) ? json_decode( wc_clean( wp_unslash( $_GET['capabilities'] ) ), true ) ?? [] : [];
 		if ( 'test_drive' === $setup_mode ) {
 			// If we get to the overview page, we want to show the success message.
 			$return_url = add_query_arg( 'wcpay-sandbox-success', 'true', $return_url );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1509,7 +1509,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 							// These are starting capabilities for the account.
 							// They are collected by the payment method step of the
 							// WC Payments settings page native onboarding experience.
-							'capabilities'                => wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ),
+							'capabilities'                => rawurlencode( wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ) ),
 							'from'                        => WC_Payments_Onboarding_Service::FROM_WPCOM_CONNECTION,
 							'source'                      => $onboarding_source,
 							'redirect_to_settings_page'   => $redirect_to_settings_page ? 'true' : false,
@@ -1543,7 +1543,8 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					// This is because there is no interim step between the user clicking the connect link and the onboarding wizard.
 					! empty( $from ) ? $from : $next_step_from,
 					[
-						'source' => $onboarding_source,
+						'source'       => $onboarding_source,
+						'capabilities' => rawurlencode( wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ) ),
 					]
 				);
 				return;
@@ -1583,7 +1584,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 								// These are starting capabilities for the account.
 								// They are collected by the payment method step of the
 								// WC Payments settings page native onboarding experience.
-								'capabilities' => wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ),
+								'capabilities' => rawurlencode( wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ) ),
 								'test_mode'    => $should_onboard_in_test_mode ? 'true' : false,
 								'source'       => $onboarding_source,
 								'redirect_to_settings_page' => $redirect_to_settings_page ? 'true' : false,

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1538,14 +1538,19 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 				&& WC_Payments_Onboarding_Service::FROM_ONBOARDING_WIZARD !== $from
 				&& ! $this->is_stripe_connected() ) {
 
+				$additional_params = [
+					'source' => $onboarding_source,
+				];
+
+				if ( $this->onboarding_service->get_capabilities_from_request() ) {
+					$additional_params['capabilities'] = rawurlencode( wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ) );
+				}
+
 				$this->redirect_service->redirect_to_onboarding_wizard(
 					// When we redirect to the onboarding wizard, we carry over the `from`, if we have it.
 					// This is because there is no interim step between the user clicking the connect link and the onboarding wizard.
 					! empty( $from ) ? $from : $next_step_from,
-					[
-						'source'       => $onboarding_source,
-						'capabilities' => rawurlencode( wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ) ),
-					]
+					$additional_params
 				);
 				return;
 			}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1251,6 +1251,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$auto_start_test_drive_onboarding = $create_test_drive_account &&
 												! empty( $_GET['auto_start_test_drive_onboarding'] ) &&
 												'true' === $_GET['auto_start_test_drive_onboarding'];
+			$capabilities                     = wc_clean( wp_unslash( $_GET['capabilities'] ) );
 			// We will onboard in test mode if the test_mode GET param is set, if we are creating a test drive account,
 			// or if we are in dev mode.
 			$should_onboard_in_test_mode = ( isset( $_GET['test_mode'] ) && wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) ||
@@ -1501,6 +1502,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 							'test_mode'                   => $should_onboard_in_test_mode ? 'true' : false,
 							'test_drive'                  => $create_test_drive_account ? 'true' : false,
 							'auto_start_test_drive_onboarding' => $auto_start_test_drive_onboarding ? 'true' : false,
+							'capabilties'                 => $capabilities,
 							'from'                        => WC_Payments_Onboarding_Service::FROM_WPCOM_CONNECTION,
 							'source'                      => $onboarding_source,
 							'redirect_to_settings_page'   => $redirect_to_settings_page ? 'true' : false,
@@ -1568,11 +1570,12 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 							null,
 							$from, // Carry over `from` since we are doing a short-circuit.
 							[
-								'promo'      => ! empty( $incentive_id ) ? $incentive_id : false,
-								'test_drive' => 'true',
+								'promo'        => ! empty( $incentive_id ) ? $incentive_id : false,
+								'test_drive'   => 'true',
 								'auto_start_test_drive_onboarding' => 'true', // This is critical.
-								'test_mode'  => $should_onboard_in_test_mode ? 'true' : false,
-								'source'     => $onboarding_source,
+								'capabilities' => $capabilities,
+								'test_mode'    => $should_onboard_in_test_mode ? 'true' : false,
+								'source'       => $onboarding_source,
 								'redirect_to_settings_page' => $redirect_to_settings_page ? 'true' : false,
 							]
 						);
@@ -1977,6 +1980,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$self_assessment_data = isset( $_GET['self_assessment'] ) ? wc_clean( wp_unslash( $_GET['self_assessment'] ) ) : [];
+		$capabilities         = isset( $_GET['capabilities'] ) ? wc_clean( wp_unslash( $_GET['capabilities'] ) ) : [];
 		if ( 'test_drive' === $setup_mode ) {
 			// If we get to the overview page, we want to show the success message.
 			$return_url = add_query_arg( 'wcpay-sandbox-success', 'true', $return_url );
@@ -1991,7 +1995,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		];
 
 		$user_data    = $this->onboarding_service->get_onboarding_user_data();
-		$account_data = $this->onboarding_service->get_account_data( $setup_mode, $self_assessment_data );
+		$account_data = $this->onboarding_service->get_account_data( $setup_mode, $self_assessment_data, $capabilities );
 
 		$onboarding_data = $this->payments_api_client->get_onboarding_data(
 			'live' === $setup_mode,

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1252,7 +1252,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$auto_start_test_drive_onboarding = $create_test_drive_account &&
 												! empty( $_GET['auto_start_test_drive_onboarding'] ) &&
 												'true' === $_GET['auto_start_test_drive_onboarding'];
-			$capabilities_string              = ! empty( $_GET['capabilities'] ) ? wc_clean( wp_unslash( $_GET['capabilities'] ) ) : '';
 			// We will onboard in test mode if the test_mode GET param is set, if we are creating a test drive account,
 			// or if we are in dev mode.
 			$should_onboard_in_test_mode = ( isset( $_GET['test_mode'] ) && wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) ||
@@ -1498,7 +1497,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			// If there is a working one, we can proceed with the Stripe account handling.
 			try {
 				$this->maybe_init_jetpack_connection(
-				// Carry over all the important GET params, so we have them after the Jetpack connection setup.
+					// Carry over all the important GET params, so we have them after the Jetpack connection setup.
 					add_query_arg(
 						[
 							'promo'                       => ! empty( $incentive_id ) ? $incentive_id : false,
@@ -1507,7 +1506,10 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 							'test_mode'                   => $should_onboard_in_test_mode ? 'true' : false,
 							'test_drive'                  => $create_test_drive_account ? 'true' : false,
 							'auto_start_test_drive_onboarding' => $auto_start_test_drive_onboarding ? 'true' : false,
-							'capabilities'                => $capabilities_string ? rawurlencode( $capabilities_string ) : '',
+							// These are starting capabilities for the account.
+							// They are collected by the payment method step of the
+							// WC Payments settings page native onboarding experience.
+							'capabilities'                => wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ),
 							'from'                        => WC_Payments_Onboarding_Service::FROM_WPCOM_CONNECTION,
 							'source'                      => $onboarding_source,
 							'redirect_to_settings_page'   => $redirect_to_settings_page ? 'true' : false,
@@ -1578,7 +1580,10 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 								'promo'        => ! empty( $incentive_id ) ? $incentive_id : false,
 								'test_drive'   => 'true',
 								'auto_start_test_drive_onboarding' => 'true', // This is critical.
-								'capabilities' => $capabilities_string ? rawurlencode( $capabilities_string ) : '',
+								// These are starting capabilities for the account.
+								// They are collected by the payment method step of the
+								// WC Payments settings page native onboarding experience.
+								'capabilities' => wp_json_encode( $this->onboarding_service->get_capabilities_from_request() ),
 								'test_mode'    => $should_onboard_in_test_mode ? 'true' : false,
 								'source'       => $onboarding_source,
 								'redirect_to_settings_page' => $redirect_to_settings_page ? 'true' : false,
@@ -1985,7 +1990,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$self_assessment_data = isset( $_GET['self_assessment'] ) ? wc_clean( wp_unslash( $_GET['self_assessment'] ) ) : [];
-		$capabilities         = ! empty( $_GET['capabilities'] ) ? json_decode( wc_clean( wp_unslash( $_GET['capabilities'] ) ), true ) ?? [] : [];
+
 		if ( 'test_drive' === $setup_mode ) {
 			// If we get to the overview page, we want to show the success message.
 			$return_url = add_query_arg( 'wcpay-sandbox-success', 'true', $return_url );
@@ -2000,7 +2005,14 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		];
 
 		$user_data    = $this->onboarding_service->get_onboarding_user_data();
-		$account_data = $this->onboarding_service->get_account_data( $setup_mode, $self_assessment_data, $capabilities );
+		$account_data = $this->onboarding_service->get_account_data(
+			$setup_mode,
+			$self_assessment_data,
+			// These are starting capabilities for the account.
+			// They are collected by the payment method step of the
+			// WC Payments settings page native onboarding experience.
+			$this->onboarding_service->get_capabilities_from_request()
+		);
 
 		$onboarding_data = $this->payments_api_client->get_onboarding_data(
 			'live' === $setup_mode,
@@ -2598,7 +2610,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	}
 
 	/**
-	 * Extract the test drive settings from the account data that we want to store for the live account.
+	 * Extract the useful test drive settings from the account data.
+	 *
+	 * We will use this data to migrate the test drive settings when onboarding the live account.
 	 * ATM we only store the enabled payment methods.
 	 *
 	 * @return array The test drive settings for the live account.

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -391,7 +391,7 @@ class WC_Payments_Onboarding_Service {
 		if ( ! empty( $capabilities ) ) {
 			foreach ( $capabilities as $capability => $value ) {
 				// Skip processing for the 'apple_google' capability.
-				if ( 'apple_google' === $capability ) {
+				if ( 'apple_google' === $capability || 'woopay' === $capability ) {
 					continue;
 				}
 				if ( 'card' === $capability ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -268,15 +268,19 @@ class WC_Payments_Onboarding_Service {
 			'site_locale'   => get_locale(),
 		];
 		$user_data      = $this->get_onboarding_user_data();
-		$account_data   = $this->get_account_data( $setup_mode, $self_assessment_data );
+		$account_data   = $this->get_account_data(
+			$setup_mode,
+			$self_assessment_data,
+			$this->get_capabilities_from_request()
+		);
 		$actioned_notes = self::get_actioned_notes();
 
 		try {
 			$account_session = $this->payments_api_client->initialize_onboarding_embedded_kyc(
 				'live' === $setup_mode,
 				$site_data,
-				array_filter( $user_data ), // nosemgrep: audit.php.lang.misc.array-filter-no-callback -- output of array_filter is escaped.
-				array_filter( $account_data ), // nosemgrep: audit.php.lang.misc.array-filter-no-callback -- output of array_filter is escaped.
+				WC_Payments_Utils::array_filter_recursive( $user_data ), // nosemgrep: audit.php.lang.misc.array-filter-no-callback -- output of array_filter is escaped.
+				WC_Payments_Utils::array_filter_recursive( $account_data ), // nosemgrep: audit.php.lang.misc.array-filter-no-callback -- output of array_filter is escaped.
 				$actioned_notes,
 				$progressive
 			);

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -181,6 +181,67 @@ class WC_Payments_Onboarding_Service {
 	}
 
 	/**
+	 * Get the onboarding capabilities from the request.
+	 *
+	 * The capabilities are expected to be passed as an array of capabilities keyed by the capability ID and
+	 * with boolean values. If the value is true, the capability is requested when the account is created.
+	 *
+	 * @return array The standardized capabilities that were passed in the request.
+	 *               Empty array if no capabilities were passed or none were valid.
+	 */
+	public function get_capabilities_from_request(): array {
+		$capabilities = [];
+
+		if ( empty( $_REQUEST['capabilities'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+			return $capabilities;
+		}
+
+		// Try to extract the capabilities.
+		// They might be already decoded or not, so we need to handle both cases.
+		// We expect them to be an array.
+		$capabilities = wc_clean( wp_unslash( $_REQUEST['capabilities'] ) ); // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! is_array( $capabilities ) ) {
+			$capabilities = json_decode( $capabilities, true ) ?? [];
+		}
+
+		if ( empty( $capabilities ) ) {
+			return [];
+		}
+
+		// Sanitize and validate.
+		$capabilities = array_combine(
+			array_map(
+				function ( $key ) {
+					// Keep numeric keys as integers so we can remove them later.
+					if ( is_numeric( $key ) ) {
+						return intval( $key );
+					}
+
+					return sanitize_text_field( $key );
+				},
+				array_keys( $capabilities )
+			),
+			array_map(
+				function ( $value ) {
+					return filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+				},
+				$capabilities
+			)
+		);
+
+		// Filter out any invalid entries.
+		$capabilities = array_filter(
+			$capabilities,
+			function ( $value, $key ) {
+				return is_string( $key ) && is_bool( $value );
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
+		return $capabilities;
+	}
+
+	/**
 	 * Retrieve the embedded KYC session and handle initial account creation (if necessary).
 	 *
 	 * Will return the session key used to initialise the embedded onboarding session.
@@ -365,9 +426,11 @@ class WC_Payments_Onboarding_Service {
 	/**
 	 * Get account data for onboarding from self assessment data.
 	 *
-	 * @param string $setup_mode Setup mode.
+	 * @param string $setup_mode           Setup mode.
 	 * @param array  $self_assessment_data Self assessment data.
-	 * @param array  $capabilities Payment Methods capabilities.
+	 * @param array  $capabilities         Optional. List keyed by capabilities IDs (payment methods) with boolean values.
+	 *                                     If the value is true, the capability is requested when the account is created.
+	 *                                     If the value is false, the capability is not requested when the account is created.
 	 *
 	 * @return array Account data.
 	 */
@@ -388,18 +451,30 @@ class WC_Payments_Onboarding_Service {
 			'business_name' => get_bloginfo( 'name' ),
 		];
 
-		if ( ! empty( $capabilities ) ) {
-			foreach ( $capabilities as $capability => $value ) {
-				// Skip processing for the 'apple_google' capability.
-				if ( 'apple_google' === $capability || 'woopay' === $capability ) {
-					continue;
-				}
-				if ( 'card' === $capability ) {
-					$account_data['capabilities']['transfers'] = [ 'requested' => 'true' ];
-				}
-				if ( $value ) {
-					$account_data['capabilities'][ $capability . '_payments' ] = [ 'requested' => 'true' ];
-				}
+		foreach ( $capabilities as $capability => $should_request ) {
+			// Remove the `_payments` suffix from the capability, if present.
+			if ( strpos( $capability, '_payments' ) === strlen( $capability ) - 9 ) {
+				$capability = str_replace( '_payments', '', $capability );
+			}
+
+			// Skip the special 'apple_google' because it is not a payment method.
+			// Skip the 'woopay' because it is automatically handled by the API.
+			if ( 'apple_google' === $capability || 'woopay' === $capability ) {
+				continue;
+			}
+
+			if ( 'card' === $capability ) {
+				// Card is always requested.
+				$account_data['capabilities']['card_payments'] = [ 'requested' => 'true' ];
+				// When requesting card, we also need to request transfers.
+				// The platform should handle this automatically, but it is best to be thorough.
+				$account_data['capabilities']['transfers'] = [ 'requested' => 'true' ];
+				continue;
+			}
+
+			// We only request, not unrequest capabilities.
+			if ( $should_request ) {
+				$account_data['capabilities'][ $capability . '_payments' ] = [ 'requested' => 'true' ];
 			}
 		}
 
@@ -452,6 +527,7 @@ class WC_Payments_Onboarding_Service {
 				]
 			);
 		}
+
 		return $account_data;
 	}
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -199,6 +199,7 @@ class WC_Payments_Onboarding_Service {
 		// Try to extract the capabilities.
 		// They might be already decoded or not, so we need to handle both cases.
 		// We expect them to be an array.
+		// We disable the warning because we have our own sanitization and validation.
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$capabilities = wp_unslash( $_REQUEST['capabilities'] );
 		if ( ! is_array( $capabilities ) ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -199,7 +199,8 @@ class WC_Payments_Onboarding_Service {
 		// Try to extract the capabilities.
 		// They might be already decoded or not, so we need to handle both cases.
 		// We expect them to be an array.
-		$capabilities = wc_clean( wp_unslash( $_REQUEST['capabilities'] ) ); // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$capabilities = wp_unslash( $_REQUEST['capabilities'] );
 		if ( ! is_array( $capabilities ) ) {
 			$capabilities = json_decode( $capabilities, true ) ?? [];
 		}

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -390,6 +390,10 @@ class WC_Payments_Onboarding_Service {
 
 		if ( ! empty( $capabilities ) ) {
 			foreach ( $capabilities as $capability => $value ) {
+				// Skip processing for the 'apple_google' capability.
+				if ( 'apple_google' === $capability ) {
+					continue;
+				}
 				if ( 'card' === $capability ) {
 					$account_data['capabilities']['transfers'] = [ 'requested' => 'true' ];
 				}

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -386,8 +386,18 @@ class WC_Payments_Onboarding_Service {
 			'country'       => WC()->countries->get_base_country() ?? null,
 			'url'           => ! $home_is_localhost && wp_http_validate_url( $home_url ) ? $home_url : $fallback_url,
 			'business_name' => get_bloginfo( 'name' ),
-			'capabilities'  => $capabilities,
 		];
+
+		if ( ! empty( $capabilities ) ) {
+			foreach ( $capabilities as $capability => $value ) {
+				if ( 'card_payments' === $capability ) {
+					$account_data['capabilities']['transfers'] = [ 'requested' => 'true' ];
+				}
+				if ( $value ) {
+					$account_data['capabilities'][ $capability . '_payments' ] = [ 'requested' => 'true' ];
+				}
+			}
+		}
 
 		if ( ! empty( $self_assessment_data ) ) {
 			$business_type = $self_assessment_data['business_type'] ?? null;

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -390,7 +390,7 @@ class WC_Payments_Onboarding_Service {
 
 		if ( ! empty( $capabilities ) ) {
 			foreach ( $capabilities as $capability => $value ) {
-				if ( 'card_payments' === $capability ) {
+				if ( 'card' === $capability ) {
 					$account_data['capabilities']['transfers'] = [ 'requested' => 'true' ];
 				}
 				if ( $value ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -366,10 +366,11 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * @param string $setup_mode Setup mode.
 	 * @param array  $self_assessment_data Self assessment data.
+	 * @param array  $capabilities Payment Methods capabilities.
 	 *
 	 * @return array Account data.
 	 */
-	public function get_account_data( string $setup_mode, array $self_assessment_data ): array {
+	public function get_account_data( string $setup_mode, array $self_assessment_data, array $capabilities = [] ): array {
 		$home_url = get_home_url();
 		// If the site is running on localhost, use a bogus URL. This is to avoid Stripe's errors.
 		// wp_http_validate_url does not check that, unfortunately.
@@ -384,6 +385,7 @@ class WC_Payments_Onboarding_Service {
 			'country'       => WC()->countries->get_base_country() ?? null,
 			'url'           => ! $home_is_localhost && wp_http_validate_url( $home_url ) ? $home_url : $fallback_url,
 			'business_name' => get_bloginfo( 'name' ),
+			'capabilities'  => $capabilities,
 		];
 
 		if ( ! empty( $self_assessment_data ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR manages the capabilities passed from the WooCommerce Payments NOX screen to the onboarding page and account creation process.

#### Testing instructions

> [!IMPORTANT]  
> Note: To test this PR, check out [this PR](https://github.com/woocommerce/woocommerce/pull/53688) on the WooCommerce core repository.

Case 1:
1. Navigate to wp-admin → Settings → Payments
2. From the country selector, choose United States.
3. Enable the WooPayments gateway.
4. Verify that the Recommended Payment Methods screen is displayed.
5. Confirm that the toggle buttons for payment methods are functional.
6. Click the Continue button and ensure you are redirected to the onboarding page and a test-drive account is created with the selected capabilities.

Case 2:
1. Navigate to wp-admin → Settings → Payments or directly visit: http://your.url/wp-admin/admin.php?page=wc-settings&tab=checkout.
2. Reset your account.
3. From the country selector, choose Bahamas.
4. Click Complete Setup.
5. Click the Continue button and ensure you are redirected to the onboarding page and a test-drive account is created with the all capabilities.

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
