### PR TITLE
Fix Jetpack onboarding by replacing the "from" query param

### DIFF
--- a/changelog/replace-from-url-query
+++ b/changelog/replace-from-url-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix Jetpack onboarding URL query from "woocommerce-payments" to "woocommerce-core-profiler"

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -199,7 +199,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 		wp_safe_redirect(
 			add_query_arg(
 				[
-					'from'        => 'woocommerce-payments',
+					'from'        => 'woocommerce-core-profiler',
 					'plugin_name' => 'woocommerce-payments',
 					'calypso_env' => $calypso_env,
 				],


### PR DESCRIPTION
Fixes a bug. Context: p1734010450311319-slack-C0800LPNCET

#### Changes proposed in this Pull Request

This fixes the current bug where the Jetpack onboarding returns to the Jetpack page instead of WooPayments.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* After connecting Jetpack to your store, you should be sent back to the WooPayments onboarding.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.