### PR TITLE
Show "postal code check" label based on store country

### DIFF
--- a/changelog/fix-9896-postal-code-label
+++ b/changelog/fix-9896-postal-code-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Localize postal code check label based on country.

--- a/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
@@ -565,7 +565,7 @@ exports[`Order details page should match the snapshot - Charge without payment i
                 <h4
                   class="payment-method-detail__label"
                 >
-                  ZIP check
+                  Postal code check
                 </h4>
                 <p
                   class="payment-method-detail__value"

--- a/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
@@ -565,7 +565,7 @@ exports[`Order details page should match the snapshot - Charge without payment i
                 <h4
                   class="payment-method-detail__label"
                 >
-                  Zip check
+                  ZIP check
                 </h4>
                 <p
                   class="payment-method-detail__value"

--- a/client/payment-details/payment-method/card/index.js
+++ b/client/payment-details/payment-method/card/index.js
@@ -79,22 +79,6 @@ const formatPaymentMethodDetails = ( charge ) => {
 };
 
 /**
- * Returns the label for the postal code check.
- *
- * @return {string} The label for the postal code check.
- */
-const getPostalCodeCheckLabel = () => {
-	switch ( wcpaySettings.connect.country ) {
-		case 'US':
-			return 'ZIP check';
-		case 'UK':
-			return 'Postcode check';
-		default:
-			return __( 'Postal code check', 'woocommerce-payments' );
-	}
-};
-
-/**
  * Placeholders to display while loading.
  */
 const paymentMethodPlaceholders = {
@@ -221,7 +205,10 @@ const CardDetails = ( { charge = {}, isLoading } ) => {
 
 				<Detail
 					isLoading={ isLoading }
-					label={ getPostalCodeCheckLabel() }
+					label={
+						/* translators: Label for results of a postal code (ZIP code, in US) check performed by a credit card issuer. */
+						__( 'Postal code check', 'woocommerce-payments' )
+					}
 				>
 					<Check checked={ postalCodeCheck } />
 				</Detail>

--- a/client/payment-details/payment-method/card/index.js
+++ b/client/payment-details/payment-method/card/index.js
@@ -79,6 +79,22 @@ const formatPaymentMethodDetails = ( charge ) => {
 };
 
 /**
+ * Returns the label for the postal code check.
+ *
+ * @return {string} The label for the postal code check.
+ */
+const getPostalCodeCheckLabel = () => {
+	switch ( wcpaySettings.connect.country ) {
+		case 'US':
+			return 'ZIP check';
+		case 'UK':
+			return 'Postcode check';
+		default:
+			return __( 'Postal code check', 'woocommerce-payments' );
+	}
+};
+
+/**
  * Placeholders to display while loading.
  */
 const paymentMethodPlaceholders = {
@@ -205,7 +221,7 @@ const CardDetails = ( { charge = {}, isLoading } ) => {
 
 				<Detail
 					isLoading={ isLoading }
-					label={ __( 'Zip check', 'woocommerce-payments' ) }
+					label={ getPostalCodeCheckLabel() }
 				>
 					<Check checked={ postalCodeCheck } />
 				</Detail>

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`Payment details page should match the snapshot - Charge query param 1`]
                     aria-busy="true"
                     class="is-loadable-placeholder is-block"
                   >
-                    ZIP check
+                    Postal code check
                   </span>
                 </h4>
                 <p
@@ -1048,7 +1048,7 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
                 <h4
                   class="payment-method-detail__label"
                 >
-                  ZIP check
+                  Postal code check
                 </h4>
                 <p
                   class="payment-method-detail__value"

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`Payment details page should match the snapshot - Charge query param 1`]
                     aria-busy="true"
                     class="is-loadable-placeholder is-block"
                   >
-                    Zip check
+                    ZIP check
                   </span>
                 </h4>
                 <p
@@ -1048,7 +1048,7 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
                 <h4
                   class="payment-method-detail__label"
                 >
-                  Zip check
+                  ZIP check
                 </h4>
                 <p
                   class="payment-method-detail__value"

--- a/client/style.scss
+++ b/client/style.scss
@@ -104,6 +104,10 @@
 		font-weight: normal;
 		line-height: 20px;
 		padding: 4px 0;
+
+		@media screen and ( max-width: 470px ) {
+			flex: 0 0 40%;
+		}
 	}
 
 	&__value {


### PR DESCRIPTION
Fixes #9896.

#### Changes proposed in this Pull Request

This PR does two things:

1. Changes the "postal code check" label to display dynamically based on the store country. I chose that approach over just localizing "Postal code check" because that leaves it open to the translator to decide how to translate, and we'd have assume they will have context on how that's called in that (US/UK) country. Let me know if you think otherwise.
2. Fixes the capitalization on "ZIP code"; previously was "Zip code".

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test: Ensure the postal code check label changes based on the store country**

1. As a merchant, navigate to **WooCommerce > Settings** and note your **Country / State**.
3. Navigate to **Payments > Transactions** and click on any item in the transaction list.
4. Scroll down to the **Payment method** section and ensure the "Postal code check" label value matches the country as defined in this PR.
5. Navigate back to  **WooCommerce > Settings**, change your **Country / State** and save.
6. Repeat steps 2 to 4 until you confirm all 3 variations are correct.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
