### PR TITLE
Checkout: Fix error when wc_address_i18n_params does not have data for a given country

### DIFF
--- a/changelog/fix-allow-addresses-from-woo-supported-countries
+++ b/changelog/fix-allow-addresses-from-woo-supported-countries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Checkout: Fix error when wc_address_i18n_params does not have data for a given country

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -449,8 +449,8 @@ export const isBillingInformationMissing = ( form ) => {
 			if ( country && locale && fieldName !== 'billing_email' ) {
 				const key = fieldName.replace( 'billing_', '' );
 				isRequired =
-					locale[ country ][ key ]?.required ??
-					locale.default[ key ]?.required;
+					locale[ country ]?.[ key ]?.required ??
+					locale.default?.[ key ]?.required;
 			}
 
 			const hasValue = field?.value;


### PR DESCRIPTION
Fixes #9975

#### Changes proposed in this Pull Request

An issue was reported in WooPayments 8.6.0 where the shortcode checkout flow fails if a customer tries to use an address from some given countries.

Although WooPayments is only available for merchants in some select countries, customers should be allowed to complete their purchase even if their billing/shipping address is not within the WooPayments countries list.

This change should prevent trying to access data if a country is not included in Woo's locale data.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add any product to the cart and go to shortcode checkout.
* Use an address from Mexico
* Use the credit card payment method.
* Attempt to complete the purchase.
* The purchase should succeed if the payment data is valid.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
