### PR TITLE
fix: tokenized cart w/ multiple variations

### DIFF
--- a/changelog/fix-tokenized-cart-multiple-variations
+++ b/changelog/fix-tokenized-cart-multiple-variations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: tokenized cart & multiple variations.
+
+

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -389,7 +389,6 @@ jQuery( ( $ ) => {
 						}
 
 						expressCheckoutButtonUi.unblockButton();
-						expressCheckoutButtonUi.showContainer();
 					} catch ( e ) {
 						expressCheckoutButtonUi.hideContainer();
 					}

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -326,6 +326,21 @@ jQuery( ( $ ) => {
 				'wcpay.express-checkout.update-button-data',
 				'automattic/wcpay/express-checkout',
 				async () => {
+					// if the product cannot be added to cart (because of missing variation selection, etc),
+					// don't try to add it to the cart to get new data - the call will likely fail.
+					if (
+						getExpressCheckoutData( 'button_context' ) === 'product'
+					) {
+						const addToCartButton = $(
+							'.single_add_to_cart_button'
+						);
+
+						// First check if product can be added to cart.
+						if ( addToCartButton.is( '.disabled' ) ) {
+							return;
+						}
+					}
+
 					try {
 						expressCheckoutButtonUi.blockButton();
 
@@ -374,8 +389,9 @@ jQuery( ( $ ) => {
 						}
 
 						expressCheckoutButtonUi.unblockButton();
+						expressCheckoutButtonUi.showContainer();
 					} catch ( e ) {
-						expressCheckoutButtonUi.hide();
+						expressCheckoutButtonUi.hideContainer();
 					}
 				}
 			);

--- a/client/tokenized-express-checkout/transformers/wc-to-stripe.js
+++ b/client/tokenized-express-checkout/transformers/wc-to-stripe.js
@@ -96,7 +96,7 @@ export const transformCartDataForDisplayItems = ( cartData ) => {
  * @return {{id: string, label: string, amount: integer, deliveryEstimate: string}} `shippingRates` for Stripe.
  */
 export const transformCartDataForShippingRates = ( cartData ) =>
-	cartData.shipping_rates?.[ 0 ].shipping_rates
+	cartData.shipping_rates?.[ 0 ]?.shipping_rates
 		.sort( ( rateA, rateB ) => {
 			if ( rateA.selected === rateB.selected ) {
 				return 0; // Keep relative order if both have the same value for 'selected'


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Raised here: paJDYF-g3R-p2#comment-27375

Implementing multiple variations support for tokenized cart ECE.

Before:
![2024-12-17 09 47 45](https://github.com/user-attachments/assets/3999bc2f-bcc3-4346-8251-c73650c6e17a)

After:
![2024-12-17 09 47 12](https://github.com/user-attachments/assets/de84fb84-bc26-42b8-8328-d6cb4107d555)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a product with multiple variations (e.g.: Size + Color)
- As a customer, interact with the variations
- The ECE button should re-render as you change variations
- You should be able to click on the ECE button, as long as you made a selection on all the variations

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.