### PR TITLE
Add failure reason to failed timeline events

### DIFF
--- a/changelog/update-5713-failed-orders-should-include-more-info-on-transaction-details-page
+++ b/changelog/update-5713-failed-orders-should-include-more-info-on-transaction-details-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add failure reason to failed payments in the timeline.

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -30,7 +30,7 @@ import {
 import { formatFee } from 'utils/fees';
 import { getAdminUrl } from 'wcpay/utils';
 import { ShieldIcon } from 'wcpay/icons';
-import { fraudOutcomeRulesetMapping } from './mappings';
+import { fraudOutcomeRulesetMapping, paymentFailureMapping } from './mappings';
 
 /**
  * Creates a timeline item about a payment status change
@@ -772,6 +772,10 @@ const mapEventToTimelineItems = ( event ) => {
 				),
 			];
 		case 'failed':
+			const paymentFailureMessage =
+				paymentFailureMapping[ event.reason ] ||
+				paymentFailureMapping.default;
+
 			return [
 				getStatusChangeTimelineItem(
 					event,
@@ -779,11 +783,14 @@ const mapEventToTimelineItems = ( event ) => {
 				),
 				getMainTimelineItem(
 					event,
-					stringWithAmount(
-						/* translators: %s is a monetary amount */
-						__( 'A payment of %s failed.', 'woocommerce-payments' ),
-						event.amount,
-						true
+					sprintf(
+						/* translators: %1$s is the payment amount, %2$s is the failure reason message */
+						__(
+							'A payment of %1$s failed: %2$s.',
+							'woocommerce-payments'
+						),
+						formatExplicitCurrency( event.amount, event.currency ),
+						paymentFailureMessage
 					),
 					<CrossIcon className="is-error" />
 				),

--- a/client/payment-details/timeline/mappings.ts
+++ b/client/payment-details/timeline/mappings.ts
@@ -65,3 +65,46 @@ export const fraudOutcomeRulesetMapping = {
 		),
 	},
 };
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const paymentFailureMapping = {
+	card_declined: __(
+		'The card was declined by the bank',
+		'woocommerce-payments'
+	),
+	expired_card: __( 'The card has expired', 'woocommerce-payments' ),
+	incorrect_cvc: __(
+		'The security code is incorrect',
+		'woocommerce-payments'
+	),
+	incorrect_number: __(
+		'The card number is incorrect',
+		'woocommerce-payments'
+	),
+	incorrect_zip: __( 'The postal code is incorrect', 'woocommerce-payments' ),
+	invalid_cvc: __( 'The security code is invalid', 'woocommerce-payments' ),
+	invalid_expiry_month: __(
+		'The expiration month is invalid',
+		'woocommerce-payments'
+	),
+	invalid_expiry_year: __(
+		'The expiration year is invalid',
+		'woocommerce-payments'
+	),
+	invalid_number: __( 'The card number is invalid', 'woocommerce-payments' ),
+	processing_error: __(
+		'An error occurred while processing the card',
+		'woocommerce-payments'
+	),
+	authentication_required: __(
+		'The payment requires authentication',
+		'woocommerce-payments'
+	),
+	insufficient_funds: __(
+		'The card has insufficient funds to complete the purchase',
+		'woocommerce-payments'
+	),
+
+	// Default fallback
+	default: __( 'The payment was declined', 'woocommerce-payments' ),
+};

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -933,7 +933,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                         </g>
                       </svg>
                       <span>
-                        A payment of $77.00 failed.
+                        A payment of $77.00 failed: The card was declined by the bank.
                       </span>
                     </div>
                     <span

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -265,7 +265,7 @@ exports[`mapTimelineEvents formats card_declined events 1`] = `
   {
     "body": [],
     "date": 2020-04-01T03:35:13.000Z,
-    "headline": "A payment of $77.00 USD failed.",
+    "headline": "A payment of $77.00 USD failed: The card was declined by the bank.",
     "icon": <CrossIcon
       className="is-error"
     />,

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -662,4 +662,59 @@ describe( 'mapTimelineEvents', () => {
 			).toMatchSnapshot();
 		} );
 	} );
+
+	test( 'formats payment failure events with different error codes', () => {
+		const testCases = [
+			{
+				reason: 'insufficient_funds',
+				expectedMessage:
+					'A payment of $77.00 USD failed: The card has insufficient funds to complete the purchase.',
+			},
+			{
+				reason: 'expired_card',
+				expectedMessage:
+					'A payment of $77.00 USD failed: The card has expired.',
+			},
+			{
+				reason: 'invalid_cvc',
+				expectedMessage:
+					'A payment of $77.00 USD failed: The security code is invalid.',
+			},
+			{
+				reason: 'unknown_reason',
+				expectedMessage:
+					'A payment of $77.00 USD failed: The payment was declined.',
+			},
+		];
+
+		testCases.forEach( ( { reason, expectedMessage } ) => {
+			const events = mapTimelineEvents( [
+				{
+					amount: 7700,
+					currency: 'USD',
+					datetime: 1585712113,
+					reason,
+					type: 'failed',
+				},
+			] );
+
+			expect( events[ 1 ].headline ).toBe( expectedMessage );
+		} );
+	} );
+
+	test( 'formats payment failure events with different currencies', () => {
+		const events = mapTimelineEvents( [
+			{
+				amount: 7700,
+				currency: 'EUR',
+				datetime: 1585712113,
+				reason: 'card_declined',
+				type: 'failed',
+			},
+		] );
+
+		expect( events[ 1 ].headline ).toBe(
+			'A payment of €77.00 EUR failed: The card was declined by the bank.'
+		);
+	} );
 } );


### PR DESCRIPTION
Fixes #5713 

#### Changes proposed in this Pull Request

This pull request includes changes to enhance the handling of payment failure events in the payment details timeline `client/payment-details/timeline`. The most important changes include adding a new mapping for payment failure reasons, updating the timeline item formatting for failed payments, and adding new tests to cover different failure scenarios.

The mappings are based on Stripe's error codes: https://docs.stripe.com/error-codes

Screenshot for reference:

<img width="1041" alt="Screenshot 2024-12-17 at 14 17 46" src="https://github.com/user-attachments/assets/af694b2f-ab5d-4db1-a720-5c28a380b2ac" />


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Covered by unit tests
* Manual tests: TBD

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) :  'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
