### PR TITLE
Set gateway method title when the title is defined

### DIFF
--- a/changelog/fix-method-title-availability
+++ b/changelog/fix-method-title-availability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Set payment method title once title is known.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -321,8 +321,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		];
 
 		if ( 'card' !== $this->stripe_id ) {
-			$this->id           = self::GATEWAY_ID . '_' . $this->stripe_id;
-			$this->method_title = "WooPayments ($this->title)";
+			$this->id = self::GATEWAY_ID . '_' . $this->stripe_id;
 		}
 
 		// Capabilities have different keys than the payment method ID's,
@@ -366,7 +365,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string
 	 */
 	public function get_title() {
-		$this->title = $this->payment_method->get_title();
+		$this->title        = $this->payment_method->get_title();
+		$this->method_title = "WooPayments ($this->title)";
 		return parent::get_title();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9981

#### Changes proposed in this Pull Request
This PR sets the payment method title once the title is known. There should be other ways to approach this but to avoid any new side effects, we're setting the payment method title in the same place where the title is getting assigned a value.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* pay with e.g. P24
* navigate to order details in admin panel
* upon clicking the `Refund` button, confirm that the payment method title is shown on the button `Refund $18.00 via WooPayments (Przelewy 24)` 
    * https://github.com/Automattic/woocommerce-payments/issues/9981's description attaches the screen shot on where to find the button

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
