### PR TITLE
Load checkout scripts when they are not previously loaded on checkout page

### DIFF
--- a/changelog/load-checkout-scripts-on-checkout-if-not-loaded
+++ b/changelog/load-checkout-scripts-on-checkout-if-not-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Load checkout scripts when they are not previously loaded on checkout page.


### PR DESCRIPTION
Fixes #4219

#### Changes Proposed in This Pull Request

This PR introduces an additional hook executed on the checkout form to ensure checkout scripts are loaded if they haven't been enqueued. These scripts are typically added within the payment fields. If the fields are not rendered, or this function isn't invoked during a standard (non-AJAX) request, the scripts fail to load, causing issues like the one described in the linked issue.


#### Testing Instructions

1. **Switch to the `develop` branch.**  
2. **Ensure you have at least two shipping methods enabled.**  
3. **Add the following filter to your code** (e.g., inside `functions.php`). Note that checking out to the `develop` branch might overwrite this change, so ensure the filter is re-added if needed. Adjust the shipping method name in the example (`local_pickup`) to match one you have configured. This filter removes WooCommerce Payments as a gateway for the specified shipping method:  

    ```php
    add_filter(
        'woocommerce_available_payment_gateways',
        function ( $available_gateways ) {
            $chosen_shipping = WC()->session->get( 'chosen_shipping_methods' )[0] ?? '';
            if ( isset( $available_gateways['woocommerce_payments'] ) && 0 === strpos( $chosen_shipping, 'local_pickup' ) ) {
                unset( $available_gateways['woocommerce_payments'] );
            }
            return $available_gateways;
        }
    );
    ```

4. **Test behavior on the `develop` branch:**  
   - Ensure the filter from Step 3 is in place, as switching to the `develop` branch might overwrite it.  
   - Go to the checkout page.  
   - Select the shipping method configured in the filter (e.g., `local_pickup`). Confirm that WooCommerce Payments is **not available** as a payment option.  
   - Switch to a different shipping method. Confirm that WooCommerce Payments is displayed, and payment fields are rendered.  
   - Switch back to the shipping method that disables WooCommerce Payments and refresh the page.  
   - After the page refresh, switch to another shipping method that supports WooCommerce Payments. Confirm that the checkout blocks or payment fields (e.g., credit card fields) are **not rendered**.  

5. **Switch to this branch and repeat the test:**  
   - Perform the same steps as above.  
   - Confirm that this time the payment fields or credit card fields are correctly rendered for the supported shipping methods.  

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
