### PR TITLE
Remove browser based CSV export, default to async server-side export

### DIFF
--- a/changelog/update-9764-remove-browser-export
+++ b/changelog/update-9764-remove-browser-export
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove browser based CSV export, use async CSV export for Disputes, DPayouts and Transactions.

--- a/client/deposits/list/index.tsx
+++ b/client/deposits/list/index.tsx
@@ -11,11 +11,6 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
-import {
-	downloadCSVFile,
-	generateCSVDataFromTable,
-	generateCSVFileName,
-} from '@woocommerce/csv-export';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
 import { parseInt } from 'lodash';
@@ -220,8 +215,6 @@ export const DepositsList = (): JSX.Element => {
 	const storeCurrencies =
 		depositsSummary.store_currencies ||
 		( isCurrencyFiltered ? [ getQuery().store_currency_is ] : [] );
-
-	const title = __( 'Payouts', 'woocommerce-payments' );
 
 	const downloadable = !! rows.length;
 

--- a/client/deposits/list/index.tsx
+++ b/client/deposits/list/index.tsx
@@ -312,48 +312,11 @@ export const DepositsList = (): JSX.Element => {
 
 	const onDownload = async () => {
 		setIsDownloading( true );
-		const downloadType = totalRows > rows.length ? 'endpoint' : 'browser';
 
-		if ( 'endpoint' === downloadType ) {
-			if ( ! isDefaultSiteLanguage() && ! isExportModalDismissed() ) {
-				setCSVExportModalOpen( true );
-			} else {
-				endpointExport( '' );
-			}
+		if ( ! isDefaultSiteLanguage() && ! isExportModalDismissed() ) {
+			setCSVExportModalOpen( true );
 		} else {
-			const params = getQuery();
-
-			const csvColumns = [
-				{
-					...columns[ 0 ],
-					label: __( 'Payout Id', 'woocommerce-payments' ),
-				},
-				...columns.slice( 1 ),
-			];
-
-			const csvRows = rows.map( ( row ) => [
-				row[ 0 ],
-				{
-					...row[ 1 ],
-					value: dateI18n(
-						'Y-m-d',
-						moment.utc( row[ 1 ].value ).toISOString(),
-						true
-					),
-				},
-				...row.slice( 2 ),
-			] );
-
-			downloadCSVFile(
-				generateCSVFileName( title, params ),
-				generateCSVDataFromTable( csvColumns, csvRows )
-			);
-
-			recordEvent( 'wcpay_deposits_download', {
-				exported_deposits: rows.length,
-				total_deposits: depositsSummary.count,
-				download_type: 'browser',
-			} );
+			endpointExport( '' );
 		}
 
 		setIsDownloading( false );

--- a/client/deposits/list/test/index.tsx
+++ b/client/deposits/list/test/index.tsx
@@ -279,7 +279,7 @@ describe( 'Deposits list', () => {
 			} );
 		} );
 
-		test( 'should fetch the server side export', async () => {
+		test( 'should fetch export when the download button is clicked', async () => {
 			const { getByRole } = render( <DepositsList /> );
 
 			getByRole( 'button', { name: 'Download' } ).click();

--- a/client/deposits/list/test/index.tsx
+++ b/client/deposits/list/test/index.tsx
@@ -5,10 +5,7 @@
  */
 import { render, waitFor } from '@testing-library/react';
 import { updateQueryString } from '@woocommerce/navigation';
-import { downloadCSVFile } from '@woocommerce/csv-export';
 import apiFetch from '@wordpress/api-fetch';
-
-import os from 'os';
 
 /**
  * Internal dependencies
@@ -19,7 +16,6 @@ import {
 	useDepositsSummary,
 	useReportingExportLanguage,
 } from 'wcpay/data';
-import { formatDate, getUnformattedAmount } from 'wcpay/utils/test-utils';
 import {
 	CachedDeposit,
 	CachedDeposits,
@@ -115,10 +111,6 @@ const mockUseDeposits = useDeposits as jest.MockedFunction<
 
 const mockUseDepositsSummary = useDepositsSummary as jest.MockedFunction<
 	typeof useDepositsSummary
->;
-
-const mockDownloadCSVFile = downloadCSVFile as jest.MockedFunction<
-	typeof downloadCSVFile
 >;
 
 const mockUseReportingExportLanguage = useReportingExportLanguage as jest.MockedFunction<

--- a/client/deposits/list/test/index.tsx
+++ b/client/deposits/list/test/index.tsx
@@ -279,66 +279,18 @@ describe( 'Deposits list', () => {
 			} );
 		} );
 
-		test( 'should render expected columns in CSV when the download button is clicked', () => {
+		test( 'should fetch the server side export', async () => {
 			const { getByRole } = render( <DepositsList /> );
+
 			getByRole( 'button', { name: 'Download' } ).click();
-
-			const expected = [
-				'"Payout Id"',
-				'Date',
-				'Type',
-				'Amount',
-				'Status',
-				'"Bank account"',
-				'"Bank reference ID"',
-			];
-
-			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];
-			const csvHeaderRow = csvContent.split( os.EOL )[ 0 ].split( ',' );
-			expect( csvHeaderRow ).toEqual( expected );
-		} );
-
-		test( 'should match the visible rows', () => {
-			const { getByRole, getAllByRole } = render( <DepositsList /> );
-			getByRole( 'button', { name: 'Download' } ).click();
-
-			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];
-			const csvRows = csvContent.split( os.EOL );
-			const displayRows = getAllByRole( 'row' );
-
-			expect( csvRows.length ).toEqual( displayRows.length );
-
-			const csvFirstDeposit = csvRows[ 1 ].split( ',' );
-			const displayFirstDeposit = Array.from(
-				displayRows[ 1 ].querySelectorAll( 'td' )
-			).map( ( td ) => td.textContent );
-
-			// Note:
-			//
-			// 1. CSV and display indexes are off by 1 because the first field in CSV is deposit id,
-			//    which is missing in display.
-			//
-			// 2. The indexOf check in amount's expect is because the amount in CSV may not contain
-			//    trailing zeros as in the display amount.
-			//
-			expect( formatDate( csvFirstDeposit[ 1 ], 'M j, Y' ) ).toBe(
-				displayFirstDeposit[ 0 ]
-			); // date
-			expect( csvFirstDeposit[ 2 ] ).toBe( displayFirstDeposit[ 1 ] ); // type
-			expect(
-				getUnformattedAmount( displayFirstDeposit[ 2 ] ).indexOf(
-					csvFirstDeposit[ 3 ]
-				)
-			).not.toBe( -1 ); // amount
-			expect( csvFirstDeposit[ 4 ] ).toBe(
-				`"${ displayFirstDeposit[ 3 ] }"`
-			); // status
-			expect( csvFirstDeposit[ 5 ] ).toBe(
-				`"${ displayFirstDeposit[ 4 ] }"`
-			); // bank account
-			expect( csvFirstDeposit[ 6 ] ).toBe(
-				`${ displayFirstDeposit[ 5 ] }`
-			); // bank reference key
+			await waitFor( () => {
+				expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+				expect( mockApiFetch ).toHaveBeenCalledWith( {
+					method: 'POST',
+					path:
+						'/wc/v3/payments/deposits/download?user_email=mock%40example.com&locale=en',
+				} );
+			} );
 		} );
 
 		test( 'should fetch export after confirmation when download button is selected for unfiltered exports larger than 1000.', async () => {

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -444,71 +444,11 @@ export const DisputesList = (): JSX.Element => {
 
 	const onDownload = async () => {
 		setIsDownloading( true );
-		const title = __( 'Disputes', 'woocommerce-payments' );
-		const downloadType = totalRows > rows.length ? 'endpoint' : 'browser';
 
-		if ( 'endpoint' === downloadType ) {
-			if ( ! isDefaultSiteLanguage() && ! isExportModalDismissed() ) {
-				setCSVExportModalOpen( true );
-			} else {
-				endpointExport( '' );
-			}
+		if ( ! isDefaultSiteLanguage() && ! isExportModalDismissed() ) {
+			setCSVExportModalOpen( true );
 		} else {
-			const csvColumns = [
-				{
-					...headers[ 0 ],
-					label: __( 'Dispute Id', 'woocommerce-payments' ),
-				},
-				...headers.slice( 1, -1 ), // Remove details (position 0)  and action (last position) column headers.
-			];
-
-			const csvRows = rows.map( ( row ) => {
-				return [
-					...row.slice( 0, 3 ), // Amount, Currency, Status.
-					{
-						// Reason.
-						...row[ 3 ],
-						value:
-							disputeStatusMapping[ row[ 3 ].value ?? '' ]
-								.message,
-					},
-					{
-						// Source.
-						...row[ 4 ],
-						value: formatStringValue(
-							( row[ 4 ].value ?? '' ).toString()
-						),
-					},
-					...row.slice( 5, 10 ), // Order #, Customer, Email, Country.
-					{
-						// Disputed On.
-						...row[ 10 ],
-						value: dateI18n(
-							'Y-m-d',
-							moment( row[ 10 ].value ).toISOString()
-						),
-					},
-					{
-						// Respond by.
-						...row[ 11 ],
-						value: dateI18n(
-							'Y-m-d / g:iA',
-							moment( row[ 11 ].value ).toISOString()
-						),
-					},
-				];
-			} );
-
-			downloadCSVFile(
-				generateCSVFileName( title, getQuery() ),
-				generateCSVDataFromTable( csvColumns, csvRows )
-			);
-
-			recordEvent( 'wcpay_disputes_download', {
-				exported_disputes: csvRows.length,
-				total_disputes: disputesSummary.count,
-				download_type: 'browser',
-			} );
+			endpointExport( '' );
 		}
 
 		setIsDownloading( false );

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -11,11 +11,6 @@ import moment from 'moment';
 import { Button } from '@wordpress/components';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery, getHistory } from '@woocommerce/navigation';
-import {
-	downloadCSVFile,
-	generateCSVDataFromTable,
-	generateCSVFileName,
-} from '@woocommerce/csv-export';
 import classNames from 'classnames';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
@@ -43,7 +38,6 @@ import {
 } from 'multi-currency/interface/functions';
 import DisputesFilters from './filters';
 import DownloadButton from 'components/download-button';
-import disputeStatusMapping from 'components/dispute-status-chip/mappings';
 import { CachedDispute, DisputesTableHeader } from 'wcpay/types/disputes';
 import { getDisputesCSV } from 'wcpay/data/disputes/resolvers';
 import {

--- a/client/disputes/test/index.tsx
+++ b/client/disputes/test/index.tsx
@@ -3,9 +3,7 @@
  * External dependencies
  */
 import { render, waitFor } from '@testing-library/react';
-import { downloadCSVFile } from '@woocommerce/csv-export';
 import apiFetch from '@wordpress/api-fetch';
-import os from 'os';
 
 /**
  * Internal dependencies
@@ -17,7 +15,6 @@ import {
 	useReportingExportLanguage,
 	useSettings,
 } from 'data/index';
-import { formatDate, getUnformattedAmount } from 'wcpay/utils/test-utils';
 import React from 'react';
 import {
 	CachedDispute,
@@ -58,10 +55,6 @@ jest.mock( 'data/index', () => ( {
 	useReportingExportLanguage: jest.fn( () => [ 'en', jest.fn() ] ),
 	useSettings: jest.fn(),
 } ) );
-
-const mockDownloadCSVFile = downloadCSVFile as jest.MockedFunction<
-	typeof downloadCSVFile
->;
 
 const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 

--- a/client/disputes/test/index.tsx
+++ b/client/disputes/test/index.tsx
@@ -43,6 +43,7 @@ jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn( () => ( {
 		setIsMatching: jest.fn(),
 		onLoad: jest.fn(),
+		onHistoryChange: jest.fn(),
 	} ) ),
 	registerStore: jest.fn(),
 	select: jest.fn(),
@@ -165,6 +166,8 @@ const mockDisputes = [
 
 describe( 'Disputes list', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
+
 		// mock Date.now that moment library uses to get current date for testing purposes
 		Date.now = jest.fn( () =>
 			new Date( '2019-11-07T12:33:37.000Z' ).getTime()
@@ -293,79 +296,19 @@ describe( 'Disputes list', () => {
 			} );
 		} );
 
-		test( 'should render expected columns in CSV when the download button is clicked ', () => {
+		test( 'should fetch export when the download button is clicked', async () => {
 			const { getByRole } = render( <DisputesList /> );
+
 			getByRole( 'button', { name: 'Download' } ).click();
 
-			const expected = [
-				'"Dispute Id"',
-				'Amount',
-				'Currency',
-				'Status',
-				'Reason',
-				'Source',
-				'"Order #"',
-				'Customer',
-				'Email',
-				'Country',
-				'"Disputed on"',
-				'"Respond by"',
-			];
-
-			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];
-			const csvHeaderRow = csvContent.split( os.EOL )[ 0 ].split( ',' );
-			expect( csvHeaderRow ).toEqual( expected );
-		} );
-
-		test( 'should match the visible rows', () => {
-			const { getByRole, getAllByRole } = render( <DisputesList /> );
-			getByRole( 'button', { name: 'Download' } ).click();
-
-			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];
-			const csvRows = csvContent.split( os.EOL );
-			const displayRows = getAllByRole( 'row' );
-
-			expect( csvRows.length ).toEqual( displayRows.length );
-
-			const csvFirstDispute = csvRows[ 1 ].split( ',' );
-			const displayFirstDispute = Array.from(
-				displayRows[ 1 ].querySelectorAll( 'td' )
-			).map( ( td ) => td.textContent );
-
-			// Note:
-			//
-			// 1. CSV and display indexes are off by 2 because:
-			// 		- the first field in CSV is dispute id, which is missing in display.
-			// 		- the third field in CSV is currency, which is missing in display (it's displayed in "amount" column).
-			//
-			// 2. The indexOf check in amount's expect is because the amount in CSV may not contain
-			//    trailing zeros as in the display amount.
-			//
-			expect(
-				getUnformattedAmount( displayFirstDispute[ 0 ] ).indexOf(
-					csvFirstDispute[ 1 ]
-				)
-			).not.toBe( -1 ); // amount
-
-			expect( csvFirstDispute[ 2 ] ).toBe( 'usd' );
-
-			expect( csvFirstDispute[ 3 ] ).toBe(
-				`"${ displayFirstDispute[ 1 ] }"`
-			); //status
-
-			expect( csvFirstDispute[ 4 ] ).toBe(
-				`"${ displayFirstDispute[ 2 ] }"`
-			); // reason
-
-			expect( csvFirstDispute[ 6 ] ).toBe( displayFirstDispute[ 4 ] ); // order
-
-			expect( csvFirstDispute[ 7 ] ).toBe(
-				`"${ displayFirstDispute[ 5 ] }"`
-			); // customer
-
-			expect( formatDate( csvFirstDispute[ 11 ], 'Y-m-d / g:iA' ) ).toBe(
-				formatDate( displayFirstDispute[ 6 ], 'Y-m-d / g:iA' )
-			); // date respond by
+			await waitFor( () => {
+				expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+				expect( mockApiFetch ).toHaveBeenCalledWith( {
+					method: 'POST',
+					path:
+						'/wc/v3/payments/disputes/download?user_email=mock%40example.com&locale=en',
+				} );
+			} );
 		} );
 	} );
 } );

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -711,35 +711,10 @@ export const TransactionsList = (
 	const onDownload = async () => {
 		setIsDownloading( true );
 
-		// We destructure page and path to get the right params.
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { page, path, ...params } = getQuery();
-		const downloadType = totalRows > rows.length ? 'endpoint' : 'browser';
-
-		recordEvent( 'wcpay_transactions_download_csv_click', {
-			location: props.depositId ? 'deposit_details' : 'transactions',
-			download_type: downloadType,
-			exported_transactions: rows.length,
-			total_transactions: transactionsSummary.count,
-		} );
-
-		if ( 'endpoint' === downloadType ) {
-			if ( ! isDefaultSiteLanguage() && ! isExportModalDismissed() ) {
-				setCSVExportModalOpen( true );
-			} else {
-				endpointExport( '' );
-			}
+		if ( ! isDefaultSiteLanguage() && ! isExportModalDismissed() ) {
+			setCSVExportModalOpen( true );
 		} else {
-			const columnsToDisplayInCsv = columnsToDisplay.map( ( column ) => {
-				if ( column.labelInCsv ) {
-					return { ...column, label: column.labelInCsv };
-				}
-				return column;
-			} );
-			downloadCSVFile(
-				generateCSVFileName( title, params ),
-				generateCSVDataFromTable( columnsToDisplayInCsv, rows )
-			);
+			endpointExport( '' );
 		}
 
 		setIsDownloading( false );

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -21,11 +21,6 @@ import {
 	getQuery,
 	updateQueryString,
 } from '@woocommerce/navigation';
-import {
-	downloadCSVFile,
-	generateCSVDataFromTable,
-	generateCSVFileName,
-} from '@woocommerce/csv-export';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -62,7 +57,6 @@ import autocompleter from 'transactions/autocompleter';
 import './style.scss';
 import TransactionsFilters from '../filters';
 import Page from '../../components/page';
-import { recordEvent } from 'tracks';
 import DownloadButton from 'components/download-button';
 import CSVExportModal from 'components/csv-export-modal';
 import { getTransactionsCSV } from '../../data/transactions/resolvers';

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -7,12 +7,8 @@ import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';
-import { dateI18n } from '@wordpress/date';
-import { downloadCSVFile } from '@woocommerce/csv-export';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { getUserTimeZone } from 'wcpay/utils/test-utils';
-import moment from 'moment';
-import os from 'os';
 
 /**
  * Internal dependencies
@@ -57,10 +53,6 @@ jest.mock( 'data/index', () => ( {
 	useTransactionsSummary: jest.fn(),
 	useReportingExportLanguage: jest.fn( () => [ 'en', jest.fn() ] ),
 } ) );
-
-const mockDownloadCSVFile = downloadCSVFile as jest.MockedFunction<
-	typeof downloadCSVFile
->;
 
 const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 
@@ -198,18 +190,6 @@ const getMockTransactions: () => Transaction[] = () => [
 		loan_id: undefined,
 	},
 ];
-
-function getUnformattedAmount( formattedAmount: string ) {
-	const amount = formattedAmount.replace( /[^0-9,.' ]/g, '' ).trim();
-	return amount.replace( ',', '.' ); // Euro fix
-}
-
-function formatDate( date: string ) {
-	return dateI18n(
-		'M j, Y / g:iA',
-		moment.utc( date ).local().toISOString()
-	);
-}
 
 describe( 'Transactions list', () => {
 	beforeEach( () => {

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -615,104 +615,20 @@ describe( 'Transactions list', () => {
 			} );
 		} );
 
-		test( 'should render expected columns in CSV when the download button is clicked', () => {
+		test( 'should fetch export when the download button is clicked', async () => {
 			const { getByRole } = render( <TransactionsList /> );
 
 			getByRole( 'button', { name: 'Download' } ).click();
 
-			const expected = [
-				'"Transaction ID"',
-				'"Date / Time (UTC)"',
-				'Type',
-				'Channel',
-				'"Paid Currency"',
-				'"Amount Paid"',
-				'"Payout Currency"',
-				'Amount',
-				'Fees',
-				'Net',
-				'"Order #"',
-				'"Payment Method"',
-				'Customer',
-				'Email',
-				'Country',
-				'"Risk level"',
-				'"Payout ID"',
-				'"Payout date"',
-				'"Payout status"',
-			];
-
-			// checking if columns in CSV are rendered correctly
-			expect(
-				mockDownloadCSVFile.mock.calls[ 0 ][ 1 ]
-					.split( '\n' )[ 0 ]
-					.split( ',' )
-			).toEqual( expected );
-		} );
-
-		test( 'should match the visible rows', () => {
-			const { getByRole, getAllByRole } = render( <TransactionsList /> );
-
-			getByRole( 'button', { name: 'Download' } ).click();
-
-			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];
-			const csvRows = csvContent.split( os.EOL );
-			const displayRows: HTMLElement[] = getAllByRole( 'row' );
-
-			expect( csvRows.length ).toEqual( displayRows.length );
-
-			const csvFirstTransaction = csvRows[ 1 ].split( ',' );
-			const displayFirstTransaction: string[] = Array.from(
-				displayRows[ 1 ].querySelectorAll( 'td' )
-			).map( ( td: HTMLElement ) => td.textContent || '' );
-
-			// Date/Time column is a th
-			// Extract is separately and prepend to csvFirstTransaction
-			const displayFirstRowHead: string[] = Array.from(
-				displayRows[ 1 ].querySelectorAll( 'th' )
-			).map( ( th: HTMLElement ) => th.textContent || '' );
-			displayFirstTransaction.unshift( displayFirstRowHead[ 0 ] );
-
-			// Note:
-			//
-			// 1. CSV and display indexes are off by 1 because the first field in CSV is transaction id,
-			//    which is missing in display.
-			//
-			// 2. The indexOf check in amount's expect is because the amount in CSV may not contain
-			//    trailing zeros as in the display amount.
-			//
-			expect( displayFirstTransaction[ 0 ] ).toBe(
-				formatDate( csvFirstTransaction[ 1 ].replace( /['"]+/g, '' ) ) // strip extra quotes
-			); // date
-			expect( displayFirstTransaction[ 1 ] ).toBe(
-				csvFirstTransaction[ 2 ]
-			); // type
-			expect( displayFirstTransaction[ 2 ] ).toBe(
-				csvFirstTransaction[ 3 ]
-			); // channel
-			expect(
-				getUnformattedAmount( displayFirstTransaction[ 3 ] ).indexOf(
-					csvFirstTransaction[ 7 ]
-				)
-			).not.toBe( -1 ); // amount
-			expect(
-				-Number( getUnformattedAmount( displayFirstTransaction[ 4 ] ) )
-			).toEqual(
-				Number(
-					csvFirstTransaction[ 8 ].replace( /['"]+/g, '' ) // strip extra quotes
-				)
-			); // fees
-			expect(
-				getUnformattedAmount( displayFirstTransaction[ 5 ] ).indexOf(
-					csvFirstTransaction[ 9 ]
-				)
-			).not.toBe( -1 ); // net
-			expect( displayFirstTransaction[ 6 ] ).toBe(
-				csvFirstTransaction[ 10 ]
-			); // order number
-			expect( displayFirstTransaction[ 8 ] ).toBe(
-				csvFirstTransaction[ 12 ].replace( /['"]+/g, '' ) // strip extra quotes
-			); // customer
+			await waitFor( () => {
+				expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+				expect( mockApiFetch ).toHaveBeenCalledWith( {
+					method: 'POST',
+					path: `/wc/v3/payments/transactions/download?user_email=mock%40example.com&user_timezone=${ encodeURIComponent(
+						getUserTimeZone()
+					) }&locale=en`,
+				} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #9969
Fixes #9303 by removing JS-based CSV export

#### Changes proposed in this Pull Request

When the number of rows are less than 25, browser based CSV export was used. This is removed. 
Export defaults to async server-side export for transactions, disputes and payouts.

#### Testing instructions
- Test on Disputes, Payouts and Transactions page.
- Ensure less than 25 rows in the page
- Click on the Download button.
- For less than 25 rows, earlier it used to default to client side export with the CSV downloaded immediately. With this branch `update/9764-remove-browser-export`, it will use the server side async export. The export will be generated async and sent by email.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
