### PR TITLE
Use the filter param in server-side disputes CSV export

### DIFF
--- a/changelog/fix-9987-filter-csv-disputes
+++ b/changelog/fix-9987-filter-csv-disputes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix filtering on server-side Disputes filtering

--- a/changelog/fix-9987-filter-csv-disputes
+++ b/changelog/fix-9987-filter-csv-disputes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix filtering on server-side Disputes filtering
+Fix filtering in async Disputes CSV export

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -152,7 +152,6 @@ export const useDisputesSummary = ( {
 	filter,
 	status_is: statusIs,
 	status_is_not: statusIsNot,
-	search,
 }: Query ): DisputesSummary =>
 	useSelect(
 		( select ) => {

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -98,11 +98,6 @@ export const useDisputes = ( {
 		( select ) => {
 			const { getDisputes, isResolving } = select( STORE_NAME );
 
-			const search =
-				filter === 'awaiting_response'
-					? disputeAwaitingResponseStatuses
-					: undefined;
-
 			const query = {
 				paged: Number.isNaN( parseInt( paged ?? '', 10 ) )
 					? '1'
@@ -119,7 +114,7 @@ export const useDisputes = ( {
 					dateBetween.sort( ( a, b ) =>
 						moment( a ).diff( moment( b ) )
 					),
-				search,
+				filter,
 				statusIs,
 				statusIsNot,
 				orderBy: orderBy || 'created',
@@ -158,15 +153,11 @@ export const useDisputesSummary = ( {
 	filter,
 	status_is: statusIs,
 	status_is_not: statusIsNot,
+	search,
 }: Query ): DisputesSummary =>
 	useSelect(
 		( select ) => {
 			const { getDisputesSummary, isResolving } = select( STORE_NAME );
-
-			const search =
-				filter === 'awaiting_response'
-					? disputeAwaitingResponseStatuses
-					: undefined;
 
 			const query = {
 				paged: Number.isNaN( parseInt( paged ?? '', 10 ) )
@@ -180,7 +171,7 @@ export const useDisputesSummary = ( {
 				dateBefore,
 				dateAfter,
 				dateBetween,
-				search,
+				filter,
 				statusIs,
 				statusIsNot,
 			};

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -17,7 +17,6 @@ import type {
 } from 'wcpay/types/disputes';
 import type { ApiError } from 'wcpay/types/errors';
 import { STORE_NAME } from '../constants';
-import { disputeAwaitingResponseStatuses } from 'wcpay/disputes/filters/config';
 
 /**
  * Returns the dispute object, error object, and loading state.

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -32,7 +32,10 @@ const formatQueryFilters = ( query ) => ( {
 		formatDateValue( query.dateBetween[ 0 ] ),
 		formatDateValue( query.dateBetween[ 1 ], true ),
 	],
-	search: query.search,
+	search:
+		query.filter === 'awaiting_response'
+			? disputeAwaitingResponseStatuses
+			: query.search,
 	status_is: query.statusIs,
 	status_is_not: query.statusIsNot,
 	locale: query.locale,

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -20,6 +20,7 @@ import {
 	updateDisputesSummary,
 	updateErrorForDispute,
 } from './actions';
+import { disputeAwaitingResponseStatuses } from 'wcpay/disputes/filters/config';
 
 const formatQueryFilters = ( query ) => ( {
 	user_email: query.userEmail,
@@ -38,11 +39,18 @@ const formatQueryFilters = ( query ) => ( {
 } );
 
 export function getDisputesCSV( query ) {
+	const queryWithSearch = {
+		...query,
+		search:
+			query.filter === 'awaiting_response'
+				? disputeAwaitingResponseStatuses
+				: query.search,
+	};
+
 	const path = addQueryArgs(
 		`${ NAMESPACE }/disputes/download`,
-		formatQueryFilters( query )
+		formatQueryFilters( queryWithSearch )
 	);
-
 	return path;
 }
 

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -42,17 +42,9 @@ const formatQueryFilters = ( query ) => ( {
 } );
 
 export function getDisputesCSV( query ) {
-	const queryWithSearch = {
-		...query,
-		search:
-			query.filter === 'awaiting_response'
-				? disputeAwaitingResponseStatuses
-				: query.search,
-	};
-
 	const path = addQueryArgs(
 		`${ NAMESPACE }/disputes/download`,
-		formatQueryFilters( queryWithSearch )
+		formatQueryFilters( query )
 	);
 	return path;
 }

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -372,6 +372,7 @@ export const DisputesList = (): JSX.Element => {
 			date_after: dateAfter,
 			date_between: dateBetween,
 			match,
+			filter,
 			status_is: statusIs,
 			status_is_not: statusIsNot,
 		} = getQuery();
@@ -407,6 +408,7 @@ export const DisputesList = (): JSX.Element => {
 							dateBefore,
 							dateBetween,
 							match,
+							filter,
 							statusIs,
 							statusIsNot,
 						} ),


### PR DESCRIPTION
Fixes #9987 

Filtering for `awaiting_response` was implemented separately for `useDisputes` and `useDisputesSummary` and missing for `getDisputesCSV`, causing the bug where the CSV was not filtered.

#### Changes proposed in this Pull Request

- Consolidated filtering for `awaiting_response` in `formatQueryFilters`
- Removed the duplicate code and params from `hooks.ts`
- Added `filter` param to `getDisputesCSV`


#### Testing instructions

- Check that the Disputes listing on Payments > Disputes filters correctly for `Needs Response` and advanced filters.
- Ensure that the summary is updated.
- Bug from #9987 should be fixed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
