### PR TITLE
Fix rounding problems with Level 3 data

### DIFF
--- a/changelog/fix-9114-level3-rounding
+++ b/changelog/fix-9114-level3-rounding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add a rounding entry to Level 3 data for rare cases where rounding errors break calculations.


### PR DESCRIPTION
Fixes #9114

#### Changes proposed in this Pull Request

When there are inconsistencies in Level 3 data because of rounding errors, add a separate line item to address and compensate for them.

Example from the issue: A product with price $21 is added to the cart 3 times, with an add-on that costs $10. The $10 need to be divided between all 3 products, leading to $3.33 being added to each of them. However, once everything gets put back together, 3x$3.33=$9.99, making a cent go missing. In those cases, Stripe rejects the transaction.

This PR adds an additional line item with the difference, 1 cent in this case, to make the calculations right again.

#### Testing instructions

Use the testing instructions from the issue: https://github.com/Automattic/woocommerce-payments/issues/9114

Alternatively, use xDebug to make sure that the "rounding fix" line has been included.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests
- [x] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
