### PR TITLE
Remove hooks from customer service constructor

### DIFF
--- a/changelog/dev-7264-remove-hooks-from-customer-service-constructor
+++ b/changelog/dev-7264-remove-hooks-from-customer-service-constructor
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Remove hooks from customer and token services to dedicated methods"
+Remove hooks from customer and token services to dedicated methods

--- a/changelog/dev-7264-remove-hooks-from-customer-service-constructor
+++ b/changelog/dev-7264-remove-hooks-from-customer-service-constructor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove hooks from customer and token services to dedicated methods"

--- a/dev/phpcs/WCPay/ruleset.xml
+++ b/dev/phpcs/WCPay/ruleset.xml
@@ -17,10 +17,6 @@
 
 		<exclude-pattern>*/includes/class-wc-payments-order-success-page.php</exclude-pattern>
 
-		<!-- https://github.com/Automattic/woocommerce-payments/issues/7264 -->
-		<exclude-pattern>*/includes/class-wc-payments-customer-service.php</exclude-pattern>
-		<exclude-pattern>*/includes/class-wc-payments-token-service.php</exclude-pattern>
-
 		<!-- https://github.com/Automattic/woocommerce-payments/issues/7265 -->
 		<exclude-pattern>*/includes/class-wc-payments-webhook-reliability-service.php</exclude-pattern>
 	</rule>

--- a/dev/phpcs/WCPay/ruleset.xml
+++ b/dev/phpcs/WCPay/ruleset.xml
@@ -17,6 +17,10 @@
 
 		<exclude-pattern>*/includes/class-wc-payments-order-success-page.php</exclude-pattern>
 
+		<!-- https://github.com/Automattic/woocommerce-payments/issues/7264 -->
+		<exclude-pattern>*/includes/class-wc-payments-customer-service.php</exclude-pattern>
+		<exclude-pattern>*/includes/class-wc-payments-token-service.php</exclude-pattern>
+
 		<!-- https://github.com/Automattic/woocommerce-payments/issues/7265 -->
 		<exclude-pattern>*/includes/class-wc-payments-webhook-reliability-service.php</exclude-pattern>
 	</rule>

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -99,7 +99,12 @@ class WC_Payments_Customer_Service {
 		$this->database_cache      = $database_cache;
 		$this->session_service     = $session_service;
 		$this->order_service       = $order_service;
+	}
 
+	/**
+	 * Initialize hooks
+	 */
+	public function init_hooks() {
 		/*
 		 * Adds the WooCommerce Payments customer ID found in the user session
 		 * to the WordPress user as metadata.

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -47,7 +47,12 @@ class WC_Payments_Token_Service {
 	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Customer_Service $customer_service ) {
 		$this->payments_api_client = $payments_api_client;
 		$this->customer_service    = $customer_service;
+	}
 
+	/**
+	 * Initializes hooks.
+	 */
+	public function init_hooks() {
 		add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
 		add_action( 'woocommerce_payment_token_set_default', [ $this, 'woocommerce_payment_token_set_default' ], 10, 2 );
 		add_filter( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -554,6 +554,7 @@ class WC_Payments {
 		self::$onboarding_service->init_hooks();
 		self::$incentives_service->init_hooks();
 		self::$compatibility_service->init_hooks();
+		self::$customer_service->init_hooks();
 
 		$payment_method_classes = [
 			CC_Payment_Method::class,

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -555,6 +555,7 @@ class WC_Payments {
 		self::$incentives_service->init_hooks();
 		self::$compatibility_service->init_hooks();
 		self::$customer_service->init_hooks();
+		self::$token_service->init_hooks();
 
 		$payment_method_classes = [
 			CC_Payment_Method::class,


### PR DESCRIPTION
Fixes #7264

#### Changes proposed in this Pull Request

This PR refactors the customer service and token service classes by moving hooks from the constructor to a dedicated function.

#### Testing instructions

* Make sure that all tests are passing

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
