### PR TITLE
fix: tokenized ECE item compatibility w/ product bundles

### DIFF
--- a/changelog/fix-tokenized-ece-product-bundles-totals
+++ b/changelog/fix-tokenized-ece-product-bundles-totals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: tokenized ECE item compatibility w/ product bundles
+
+

--- a/client/tokenized-express-checkout/compatibility/__tests__/wc-product-bundles.test.js
+++ b/client/tokenized-express-checkout/compatibility/__tests__/wc-product-bundles.test.js
@@ -1,0 +1,253 @@
+/**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import '../wc-product-bundles';
+
+describe( 'ECE product bundles compatibility', () => {
+	it( 'filters out cart items that are bundled by something else', () => {
+		const cartData = applyFilters(
+			'wcpay.express-checkout.map-line-items',
+			{
+				items: [
+					{
+						key: 'd179a6924eafc82d7864f1e0caedbe95',
+						id: 261,
+						type: 'bundle',
+						quantity: 1,
+						item_data: [
+							{
+								key: 'Includes',
+								value: 'T-Shirt &times; 1',
+							},
+							{
+								key: 'Includes',
+								value: 'T-Shirt with Logo &times; 2',
+							},
+							{
+								key: 'Includes',
+								value: 'V-Neck T-Shirt - Medium &times; 1',
+							},
+						],
+						extensions: {
+							bundles: {
+								bundled_items: [
+									'abda15f782e68dc63bd615d6a05fa3d2',
+									'4d16fa6ebc10a1d66013b0f85640eb2b',
+									'ff279cc5574ef1cf45aa76bde0d66baa',
+								],
+								bundle_data: {
+									configuration: {
+										'1': {
+											product_id: 13,
+											quantity: 1,
+											discount: 20,
+											optional_selected: 'yes',
+										},
+										'2': {
+											product_id: 30,
+											quantity: 2,
+											discount: '',
+										},
+										'3': {
+											product_id: 10,
+											quantity: 1,
+											discount: '',
+											attributes: {
+												attribute_size: 'Medium',
+											},
+											variation_id: '25',
+										},
+										'4': {
+											product_id: 10,
+											quantity: 0,
+											discount: '',
+											optional_selected: 'no',
+											attributes: [],
+										},
+									},
+									is_editable: false,
+									is_price_hidden: false,
+									is_subtotal_hidden: false,
+									is_hidden: false,
+									is_meta_hidden_in_cart: true,
+									is_meta_hidden_in_summary: false,
+								},
+							},
+						},
+					},
+					{
+						key: 'abda15f782e68dc63bd615d6a05fa3d2',
+						id: 13,
+						type: 'simple',
+						quantity: 1,
+						extensions: {
+							bundles: {
+								bundled_by: 'd179a6924eafc82d7864f1e0caedbe95',
+								bundled_item_data: {
+									bundle_id: 261,
+									bundled_item_id: 1,
+									is_removable: true,
+									is_indented: true,
+									is_subtotal_aggregated: true,
+									is_parent_visible: true,
+									is_last: false,
+									is_price_hidden: false,
+									is_subtotal_hidden: false,
+									is_thumbnail_hidden: false,
+									is_hidden_in_cart: false,
+									is_hidden_in_summary: true,
+								},
+							},
+						},
+					},
+					{
+						key: '4d16fa6ebc10a1d66013b0f85640eb2b',
+						id: 30,
+						type: 'simple',
+						quantity: 2,
+						extensions: {
+							bundles: {
+								bundled_by: 'd179a6924eafc82d7864f1e0caedbe95',
+								bundled_item_data: {
+									bundle_id: 261,
+									bundled_item_id: 2,
+									is_removable: false,
+									is_indented: true,
+									is_subtotal_aggregated: true,
+									is_parent_visible: true,
+									is_last: false,
+									is_price_hidden: true,
+									is_subtotal_hidden: true,
+									is_thumbnail_hidden: false,
+									is_hidden_in_cart: false,
+									is_hidden_in_summary: true,
+								},
+							},
+						},
+					},
+					{
+						key: 'ff279cc5574ef1cf45aa76bde0d66baa',
+						id: 25,
+						type: 'variation',
+						quantity: 1,
+						extensions: {
+							bundles: {
+								bundled_by: 'd179a6924eafc82d7864f1e0caedbe95',
+								bundled_item_data: {
+									bundle_id: 261,
+									bundled_item_id: 3,
+									is_removable: false,
+									is_indented: true,
+									is_subtotal_aggregated: true,
+									is_parent_visible: true,
+									is_last: true,
+									is_price_hidden: true,
+									is_subtotal_hidden: true,
+									is_thumbnail_hidden: false,
+									is_hidden_in_cart: false,
+									is_hidden_in_summary: true,
+								},
+							},
+						},
+					},
+					{
+						key: 'c51ce410c124a10e0db5e4b97fc2af39',
+						id: 13,
+						type: 'simple',
+						quantity: 1,
+						extensions: {
+							bundles: [],
+						},
+					},
+				],
+				items_count: 2,
+			}
+		);
+
+		expect( cartData ).toStrictEqual( {
+			items: [
+				{
+					extensions: {
+						bundles: {
+							bundle_data: {
+								configuration: {
+									'1': {
+										discount: 20,
+										optional_selected: 'yes',
+										product_id: 13,
+										quantity: 1,
+									},
+									'2': {
+										discount: '',
+										product_id: 30,
+										quantity: 2,
+									},
+									'3': {
+										attributes: {
+											attribute_size: 'Medium',
+										},
+										discount: '',
+										product_id: 10,
+										quantity: 1,
+										variation_id: '25',
+									},
+									'4': {
+										attributes: [],
+										discount: '',
+										optional_selected: 'no',
+										product_id: 10,
+										quantity: 0,
+									},
+								},
+								is_editable: false,
+								is_hidden: false,
+								is_meta_hidden_in_cart: true,
+								is_meta_hidden_in_summary: false,
+								is_price_hidden: false,
+								is_subtotal_hidden: false,
+							},
+							bundled_items: [
+								'abda15f782e68dc63bd615d6a05fa3d2',
+								'4d16fa6ebc10a1d66013b0f85640eb2b',
+								'ff279cc5574ef1cf45aa76bde0d66baa',
+							],
+						},
+					},
+					id: 261,
+					item_data: [
+						{
+							key: 'Includes',
+							value: 'T-Shirt &times; 1',
+						},
+						{
+							key: 'Includes',
+							value: 'T-Shirt with Logo &times; 2',
+						},
+						{
+							key: 'Includes',
+							value: 'V-Neck T-Shirt - Medium &times; 1',
+						},
+					],
+					key: 'd179a6924eafc82d7864f1e0caedbe95',
+					quantity: 1,
+					type: 'bundle',
+				},
+				{
+					extensions: {
+						bundles: [],
+					},
+					id: 13,
+					key: 'c51ce410c124a10e0db5e4b97fc2af39',
+					quantity: 1,
+					type: 'simple',
+				},
+			],
+			items_count: 2,
+		} );
+	} );
+} );

--- a/client/tokenized-express-checkout/compatibility/wc-product-bundles.js
+++ b/client/tokenized-express-checkout/compatibility/wc-product-bundles.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'wcpay.express-checkout.map-line-items',
+	'automattic/wcpay/express-checkout',
+	( cartData ) => {
+		return {
+			...cartData,
+			// ensuring that the items that are bundled by another don't appear in the summary.
+			// otherwise they might be contributing to the wrong order total, creating errors.
+			items: cartData.items.filter(
+				( item ) => ! item.extensions?.bundles?.bundled_by
+			),
+		};
+	}
+);

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -13,6 +13,7 @@ import '../checkout/express-checkout-buttons.scss';
 import './compatibility/wc-deposits';
 import './compatibility/wc-order-attribution';
 import './compatibility/wc-product-page';
+import './compatibility/wc-product-bundles';
 import {
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutButtonStyleSettings,

--- a/client/tokenized-express-checkout/transformers/wc-to-stripe.js
+++ b/client/tokenized-express-checkout/transformers/wc-to-stripe.js
@@ -8,6 +8,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { getExpressCheckoutData } from '../utils';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * GooglePay/ApplePay expect the prices to be formatted in cents.
@@ -34,10 +35,16 @@ export const transformPrice = ( price, priceObject ) => {
  * - https://docs.stripe.com/js/elements_object/express_checkout_element_shippingaddresschange_event
  * - https://docs.stripe.com/js/elements_object/express_checkout_element_shippingratechange_event
  *
- * @param {Object} cartData Store API Cart response object.
+ * @param {Object} rawCartData Store API Cart response object.
  * @return {{pending: boolean, name: string, amount: integer}} `displayItems` for Stripe.
  */
-export const transformCartDataForDisplayItems = ( cartData ) => {
+export const transformCartDataForDisplayItems = ( rawCartData ) => {
+	// allowing extensions to manipulate the individual items returned by the backend.
+	const cartData = applyFilters(
+		'wcpay.express-checkout.map-line-items',
+		rawCartData
+	);
+
 	const displayItems = cartData.items.map( ( item ) => ( {
 		amount: transformPrice(
 			parseInt( item.totals?.line_subtotal || item.prices.price, 10 ),


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

While testing the product bundles extension, I noticed that there was an error in the JS console saying that the total prices didn't match the individual prices.

> IntegrationError: The amount xxxx is less than the total amount of the line items provided

This is because the products added by the product bundle extension to the cart object are all present in the `items` data from the cart response.
We were iterating over all the individual items, so they could appear in the priced total.
But these bundled items aren't sold individually, they're part of the pricing of the main item.

Fixing by adding a filter specifically for the product bundles that filters out the items from the cart in the `transformCartDataForDisplayItems` utility.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product bundle via the WC Product Bundles extension: https://github.com/woocommerce/woocommerce-product-bundles
  - Ensure at least one of the items is "priced individually"
<img width="414" alt="Screenshot 2024-12-18 at 5 30 42 PM" src="https://github.com/user-attachments/assets/139c8ea8-735a-47b0-a518-69fa665bcd5d" />

- Ensure you have the "Enable Cart-Token implementation for ECE" flag active in your WCPay dev tools
- Go to the product page of the bundle you created
- Add the product to the cart
- Go to the cart page
- There should no longer be an error in the console

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
