### PR TITLE
Enhance Embedded Components and MOX to support custom width and paddings

### DIFF
--- a/changelog/update-9919-embedded-components-width
+++ b/changelog/update-9919-embedded-components-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Embedded Components and MOX to support custom width and paddings.

--- a/client/onboarding/style.scss
+++ b/client/onboarding/style.scss
@@ -85,20 +85,12 @@ body.wcpay-onboarding__body {
 			}
 
 			&__content {
-				max-width: 620px;
+				max-width: 615px;
 				width: 100%;
-
-				&:has( > form:only-child ) {
-					padding: 0 $gap-larger;
-				}
 
 				@media screen and ( max-width: $break-mobile ) {
 					width: 100%;
 					padding: 0 $gap;
-
-					&:has( > form:only-child ) {
-						padding: 0 $gap;
-					}
 				}
 			}
 

--- a/client/onboarding/style.scss
+++ b/client/onboarding/style.scss
@@ -85,10 +85,20 @@ body.wcpay-onboarding__body {
 			}
 
 			&__content {
-				max-width: 400px;
+				max-width: 620px;
+				width: 100%;
 
-				@media screen and ( min-width: $break-mobile ) {
-					width: 400px;
+				&:has( > form:only-child ) {
+					padding: 0 $gap-larger;
+				}
+
+				@media screen and ( max-width: $break-mobile ) {
+					width: 100%;
+					padding: 0 $gap;
+
+					&:has( > form:only-child ) {
+						padding: 0 $gap;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes #9919

#### Changes proposed in this Pull Request
This PR updates the width of MOX input fields and Embedded Components to align with Stripe’s recent changes to their embedded components, which now expand to full width. The update ensures that the MOX input fields and Embedded Components are styled appropriately to maintain consistency and usability across various screen sizes.

Demo video: https://www.loom.com/share/9c593f9c6a634333861771016af5d61c

<img width="1287" alt="Screenshot 2024-12-18 at 22 40 43" src="https://github.com/user-attachments/assets/2794c6be-b7df-43f4-a5b2-020d51738317" />


<img width="1139" alt="Screenshot 2024-12-18 at 18 28 33" src="https://github.com/user-attachments/assets/90bc7bb0-bd86-480b-a0f3-7117fb322a30" />

#### Testing instructions
- Reset any connected accounts.
- Navigate to the connect page and start onboarding with MOX.
- Verify MOX input/select fields have a max width of 615px Desktop and Tablet.
- Ensure the embedded components iframe has a width of 615px on Desktop and Tablet.
- Verify MOX input/select fields have 100% width with 1rem padding on Mobile.
- Ensure the embedded components iframe has 100% width with 1rem padding on Mobile.

#### Additional context
Design discussions: p1734451485224089-slack-C03KTTK2YMA

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.