### PR TITLE
Hide transaction fee on admin order view screen when transaction is not captured

### DIFF
--- a/changelog/fix-9418-hide-transaction-fees-when-transaction-is-not-captured
+++ b/changelog/fix-9418-hide-transaction-fees-when-transaction-is-not-captured
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide transaction fee on admin view order screen when transaction is not captured.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Identity_Crisis as Jetpack_Identity_Crisis;
+use WCPay\Constants\Intent_Status;
 use WCPay\Core\Server\Request;
 use WCPay\Database_Cache;
 use WCPay\Logger;
@@ -1253,7 +1254,7 @@ class WC_Payments_Admin {
 	 */
 	public function display_wcpay_transaction_fee( $order_id ) {
 		$order = wc_get_order( $order_id );
-		if ( ! $order || ! $order->get_meta( '_wcpay_transaction_fee' ) ) {
+		if ( ! $order || ! $order->get_meta( '_wcpay_transaction_fee' ) || Intent_Status::REQUIRES_CAPTURE === $order->get_meta( WC_Payments_Order_Service::INTENTION_STATUS_META_KEY ) ) {
 			return;
 		}
 		?>


### PR DESCRIPTION
Fixes #9418 

#### Changes proposed in this Pull Request

This small PR hides transaction fees on the admin order view screen when the charge or transaction is not yet captured.

#### Testing Instructions

1. Set WooPayments to "Issue an authorization on checkout, and capture later."
2. Switch to the `develop` branch.
3. Add an item to the cart and process the payment on the checkout page.
4. Go to the order's view screen in the WP Admin page and confirm that the transaction fee is displayed as shown below:  
   ![image](https://github.com/user-attachments/assets/4223f7f1-662c-4345-bdfd-50c13f8bfc84)

5. Switch to this branch.
6. Repeat the steps above.
7. On the order's view screen in WP Admin, notice that the transaction fee is no longer displayed since the transaction is not yet captured.
<img width="1534" alt="image" src="https://github.com/user-attachments/assets/7d207135-8638-497e-9530-d42853915816" />

8. Capture the transaction in the **Transactions** tab.
9. Return to the order's view screen in WP Admin.
10. Confirm that the transaction fee is now displayed.
<img width="1515" alt="image" src="https://github.com/user-attachments/assets/6b6ddfec-fb0a-4cd6-8293-041d89da1ed6" />



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
