### PR TITLE
Show a beta badge next to WooPay theme checkbox

### DIFF
--- a/changelog/add-beta-badge-woopay-theme
+++ b/changelog/add-beta-badge-woopay-theme
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Adds a label to a gated feature.
+
+

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -58,6 +58,18 @@
 }
 
 .woopay-settings {
+	&__badge {
+		background-color: $studio-gray-5;
+		padding: 0 8px;
+		border-radius: 2px;
+		font-size: 12px;
+		line-height: 20px;
+		margin-left: 4px;
+	}
+	&__global-theme-label {
+		display: inline-flex;
+		align-items: center;
+	}
 	&__custom-message-wrapper {
 		position: relative;
 

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -226,10 +226,17 @@ const WooPaySettings = ( { section } ) => {
 									onChange={
 										updateIsWooPayGlobalThemeSupportEnabled
 									}
-									label={ __(
-										'Enable global theme support',
-										'woocommerce-payments'
-									) }
+									label={
+										<div className="woopay-settings__global-theme-label">
+											{ __(
+												'Enable global theme support',
+												'woocommerce-payments'
+											) }
+											<span className="woopay-settings__badge">
+												Beta
+											</span>
+										</div>
+									}
 									help={ interpolateComponents( {
 										mixedString: __(
 											'When enabled, WooPay checkout will be themed with your store’s brand colors and fonts. ' +


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9999

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This PR adds a beta badge that shows up next to the "Enable global theme support" checkbox in settings page.
I looked into using the [Badge](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs) component from `wordpress/components`. The version of the components library that's currently used in WooPayments doesn't have the Badge component. Because this will only be used on a single place and is expected to be short-lived, I manually styled the badge. 

![CleanShot 2024-12-18 at 15 38 10](https://github.com/user-attachments/assets/6fc97997-95f4-4e4e-aec2-9e3c2b00a06f)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure the WooPay global theme feature is enabled for the merchant via MC (or through dev tools override)
2. Go to Payments -> Settings -> Customize button next to WooPay
3. "Enable global theme support" checkbox should have a "Beta" badge next to it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
