### PR TITLE
Use "currency conversion fee"

### DIFF
--- a/changelog/fix-9996-currency-conversion-fee-phrasing
+++ b/changelog/fix-9996-currency-conversion-fee-phrasing
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Use "currency conversion fee", not "foreign exchange fee"
+Use "currency conversion fee" instead "foreign exchange fee" in payment timeline and various other places.

--- a/changelog/fix-9996-currency-conversion-fee-phrasing
+++ b/changelog/fix-9996-currency-conversion-fee-phrasing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Use "currency conversion fee", not "foreign exchange fee"

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -410,12 +410,12 @@ export const feeBreakdown = ( event ) => {
 			fixedRate !== 0
 				? __(
 						/* translators: %1$s% is the fee percentage and %2$s is the fixed rate */
-						'Foreign exchange fee: %1$s%% + %2$s',
+						'Currency conversion fee: %1$s%% + %2$s',
 						'woocommerce-payments'
 				  )
 				: __(
 						/* translators: %1$s% is the fee percentage */
-						'Foreign exchange fee: %1$s%%',
+						'Currency conversion fee: %1$s%%',
 						'woocommerce-payments'
 				  ),
 		'additional-wcpay-subscription':

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -12,7 +12,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events with fe
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 USD was added to your 
+      $20.97 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -50,7 +50,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events without
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 USD was added to your 
+      $20.97 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -120,7 +120,7 @@ exports[`mapTimelineEvents Multi-Currency events formats dispute_won events 1`] 
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $44.99 USD was added to your 
+      $44.99 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
@@ -372,7 +372,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your 
+      $59.50 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -389,7 +389,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
       <ul
         className="fee-breakdown-list"
       >
-         
+
         <li>
           Base fee: 1.4% + £0.20
         </li>
@@ -397,7 +397,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
           International card fee: 1.5%
         </li>
         <li>
-          Foreign exchange fee: 2%
+          Currency conversion fee: 2%
         </li>
         <li>
           Discount
@@ -412,7 +412,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
             </li>
           </ul>
         </li>
-         
+
       </ul>,
       "Net payout: $59.50 USD",
     ],
@@ -437,7 +437,7 @@ exports[`mapTimelineEvents single currency events formats captured events with j
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your 
+      $59.50 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -475,7 +475,7 @@ exports[`mapTimelineEvents single currency events formats captured events withou
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your 
+      $59.50 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -564,7 +564,7 @@ exports[`mapTimelineEvents single currency events formats dispute_won events 1`]
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $115.00 USD was added to your 
+      $115.00 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
@@ -590,7 +590,7 @@ exports[`mapTimelineEvents single currency events formats financing paydown even
   {
     "body": [
       <React.Fragment>
-        Loan repayment: 
+        Loan repayment:
         <Link
           href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
         >
@@ -673,7 +673,7 @@ exports[`mapTimelineEvents single currency events in person payments - tap to pa
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $19.19 USD was added to your 
+      $19.19 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -690,14 +690,14 @@ exports[`mapTimelineEvents single currency events in person payments - tap to pa
       <ul
         className="fee-breakdown-list"
       >
-         
+
         <li>
           Base fee: 2.6% + $0.10
         </li>
         <li>
           Tap to pay transaction fee: 0% + $0.10
         </li>
-         
+
       </ul>,
       "Net payout: $19.19 USD",
     ],
@@ -722,7 +722,7 @@ exports[`mapTimelineEvents single currency events should not render fee breakup 
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your 
+      $59.50 USD was added to your
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -12,7 +12,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events with fe
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 USD was added to your
+      $20.97 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -50,7 +50,7 @@ exports[`mapTimelineEvents Multi-Currency events formats captured events without
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 USD was added to your
+      $20.97 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -120,7 +120,7 @@ exports[`mapTimelineEvents Multi-Currency events formats dispute_won events 1`] 
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $44.99 USD was added to your
+      $44.99 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
@@ -372,7 +372,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your
+      $59.50 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -389,7 +389,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
       <ul
         className="fee-breakdown-list"
       >
-
+         
         <li>
           Base fee: 1.4% + £0.20
         </li>
@@ -412,7 +412,7 @@ exports[`mapTimelineEvents single currency events formats captured events with f
             </li>
           </ul>
         </li>
-
+         
       </ul>,
       "Net payout: $59.50 USD",
     ],
@@ -437,7 +437,7 @@ exports[`mapTimelineEvents single currency events formats captured events with j
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your
+      $59.50 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -475,7 +475,7 @@ exports[`mapTimelineEvents single currency events formats captured events withou
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your
+      $59.50 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -564,7 +564,7 @@ exports[`mapTimelineEvents single currency events formats dispute_won events 1`]
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $115.00 USD was added to your
+      $115.00 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
@@ -590,7 +590,7 @@ exports[`mapTimelineEvents single currency events formats financing paydown even
   {
     "body": [
       <React.Fragment>
-        Loan repayment:
+        Loan repayment: 
         <Link
           href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
         >
@@ -673,7 +673,7 @@ exports[`mapTimelineEvents single currency events in person payments - tap to pa
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $19.19 USD was added to your
+      $19.19 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -690,14 +690,14 @@ exports[`mapTimelineEvents single currency events in person payments - tap to pa
       <ul
         className="fee-breakdown-list"
       >
-
+         
         <li>
           Base fee: 2.6% + $0.10
         </li>
         <li>
           Tap to pay transaction fee: 0% + $0.10
         </li>
-
+         
       </ul>,
       "Net payout: $19.19 USD",
     ],
@@ -722,7 +722,7 @@ exports[`mapTimelineEvents single currency events should not render fee breakup 
     "body": [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 USD was added to your
+      $59.50 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b281"
       >

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -166,7 +166,7 @@ export const formatMethodFeesTooltip = (
 			) }
 			{ hasFees( accountFees.fx ) ? (
 				<div>
-					<div>Foreign exchange fee</div>
+					<div>Currency conversion fee</div>
 					<div>{ getFeeDescriptionString( accountFees.fx ) }</div>
 				</div>
 			) : (

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -23,7 +23,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     </div>
     <div>
       <div>
-        Foreign exchange fee
+        Currency conversion fee
       </div>
       <div>
         1%
@@ -102,7 +102,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     </div>
     <div>
       <div>
-        Foreign exchange fee
+        Currency conversion fee
       </div>
       <div>
         1%

--- a/includes/class-wc-payments-captured-event-note.php
+++ b/includes/class-wc-payments-captured-event-note.php
@@ -327,9 +327,9 @@ class WC_Payments_Captured_Event_Note {
 
 		$res['additional-fx'] = 0 !== $fixed_rate
 			/* translators: %1$s% is the fee percentage and %2$s is the fixed rate */
-			? __( 'Foreign exchange fee: %1$s%% + %2$s', 'woocommerce-payments' )
+			? __( 'Currency conversion fee: %1$s%% + %2$s', 'woocommerce-payments' )
 			/* translators: %1$s% is the fee percentage */
-			: __( 'Foreign exchange fee: %1$s%%', 'woocommerce-payments' );
+			: __( 'Currency conversion fee: %1$s%%', 'woocommerce-payments' );
 
 		$res['additional-wcpay-subscription'] = 0 !== $fixed_rate
 			/* translators: %1$s% is the fee percentage and %2$s is the fixed rate */

--- a/tests/fixtures/captured-payments/discount.json
+++ b/tests/fixtures/captured-payments/discount.json
@@ -60,7 +60,7 @@
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-international": "International card fee: 1%",
-      "additional-fx": "Foreign exchange fee: 1%",
+      "additional-fx": "Currency conversion fee: 1%",
       "discount": {
         "label": "Discount",
         "variable": "Variable fee: -4.9%",

--- a/tests/fixtures/captured-payments/foreign-card.json
+++ b/tests/fixtures/captured-payments/foreign-card.json
@@ -53,7 +53,7 @@
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
       "additional-international": "International card fee: 1%",
-      "additional-fx": "Foreign exchange fee: 1%"
+      "additional-fx": "Currency conversion fee: 1%"
     },
     "netString": "Net payout: $95.47 USD"
   }

--- a/tests/fixtures/captured-payments/fx-decimal.json
+++ b/tests/fixtures/captured-payments/fx-decimal.json
@@ -45,7 +45,7 @@
     "feeString": "Fee (3.9% + $0.30): -$4.39",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
-      "additional-fx": "Foreign exchange fee: 1%"
+      "additional-fx": "Currency conversion fee: 1%"
     },
     "netString": "Net payout: $100.65 USD"
   }

--- a/tests/fixtures/captured-payments/fx-partial-capture.json
+++ b/tests/fixtures/captured-payments/fx-partial-capture.json
@@ -57,7 +57,7 @@
     "feeString": "Fee (3.51% + £0.21): -$0.88",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
-      "additional-fx": "Foreign exchange fee: 1%",
+      "additional-fx": "Currency conversion fee: 1%",
       "discount": {
         "label": "Discount",
         "variable": "Variable fee: -0.39%",

--- a/tests/fixtures/captured-payments/fx-with-capped-fee.json
+++ b/tests/fixtures/captured-payments/fx-with-capped-fee.json
@@ -55,7 +55,7 @@
     "feeBreakdown": {
       "base": "Base fee: capped at $6.00",
       "additional-international": "International card fee: 1.5%",
-      "additional-fx": "Foreign exchange fee: 1%"
+      "additional-fx": "Currency conversion fee: 1%"
     },
     "netString": "Net payout: $971.04 USD"
   }

--- a/tests/fixtures/captured-payments/fx.json
+++ b/tests/fixtures/captured-payments/fx.json
@@ -46,7 +46,7 @@
     "feeString": "Fee (3.9% + $0.30): -$4.20",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
-      "additional-fx": "Foreign exchange fee: 1%"
+      "additional-fx": "Currency conversion fee: 1%"
     },
     "netString": "Net payout: $95.84 USD"
   }

--- a/tests/fixtures/captured-payments/jpy-payment.json
+++ b/tests/fixtures/captured-payments/jpy-payment.json
@@ -57,7 +57,7 @@
 		"feeBreakdown": {
 			"base": "Base fee: 3.6%",
 			"additional-international": "International card fee: 2%",
-			"additional-fx": "Foreign exchange fee: 2%"
+			"additional-fx": "Currency conversion fee: 2%"
 		},
 		"netString": "Net payout: ¥4,507 JPY"
 	}

--- a/tests/fixtures/captured-payments/subscription.json
+++ b/tests/fixtures/captured-payments/subscription.json
@@ -53,7 +53,7 @@
     "feeString": "Fee (4.9% + $0.30): -$3.04",
     "feeBreakdown": {
       "base": "Base fee: 2.9% + $0.30",
-      "additional-fx": "Foreign exchange fee: 1%",
+      "additional-fx": "Currency conversion fee: 1%",
       "additional-wcpay-subscription": "Subscription transaction fee: 1%"
     },
     "netString": "Net payout: $52.87 USD"


### PR DESCRIPTION
Fixes #9996

#### Changes proposed in this Pull Request

Use "currency conversion fee", not "foreign exchange fee". This is for a couple reasons:

- It matches [Stripe's usage](https://docs.stripe.com/currencies/conversions), where "currency conversion fee" refers to the fee charged for changing funds from one currency to another. "Foreign exchange" refers to the actual rate of exchange/conversion.
- "Currency conversion" is a more accessible term that more accurately describes the situation. 

The changes here should not break anything, as they are entirely string changes.

Other notes:

- I checked Transact Platform Server, but there doesn't seem to be anything worth changing there. All uses of "foreign exchange" are internal, or in comments.
- I did NOT change any uses of `FX` or similar. There are tons of these, and what I'm most concerned about with this PR is merchant-facing content.