### PR TITLE
Translate hard coded strings in the fees tooltip breakdown

### DIFF
--- a/changelog/fix-8620-fee-types-in-fees-brakedown-tooltip-are-not-internationalised
+++ b/changelog/fix-8620-fee-types-in-fees-brakedown-tooltip-are-not-internationalised
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use translatable strings on the fee breakdown tooltip of the payment settings screen.

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -171,7 +171,6 @@ export const formatMethodFeesTooltip = (
 			) }
 			{ hasFees( accountFees.fx ) ? (
 				<div>
-					<div>Currency conversion fee</div>
 					<div>
 						{ __(
 							'Currency conversion fee',

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -143,7 +143,7 @@ export const formatMethodFeesTooltip = (
 	return (
 		<div className={ 'wcpay-fees-tooltip' }>
 			<div>
-				<div>Base fee</div>
+				<div>{ __( 'Base fee', 'woocommerce-payments' ) }</div>
 				<div>
 					{ getFeeDescriptionString(
 						accountFees.base,
@@ -153,7 +153,12 @@ export const formatMethodFeesTooltip = (
 			</div>
 			{ hasFees( accountFees.additional ) ? (
 				<div>
-					<div>International payment method fee</div>
+					<div>
+						{ __(
+							'International payment method fee',
+							'woocommerce-payments'
+						) }
+					</div>
 					<div>
 						{ getFeeDescriptionString(
 							accountFees.additional,
@@ -166,14 +171,18 @@ export const formatMethodFeesTooltip = (
 			) }
 			{ hasFees( accountFees.fx ) ? (
 				<div>
-					<div>Foreign exchange fee</div>
+					<div>
+						{ __( 'Foreign exchange fee', 'woocommerce-payments' ) }
+					</div>
 					<div>{ getFeeDescriptionString( accountFees.fx ) }</div>
 				</div>
 			) : (
 				''
 			) }
 			<div>
-				<div>Total per transaction</div>
+				<div>
+					{ __( 'Total per transaction', 'woocommerce-payments' ) }
+				</div>
 				<div className={ 'wcpay-fees-tooltip__bold' }>
 					{ getFeeDescriptionString( total ) }
 				</div>
@@ -295,7 +304,7 @@ export const formatAccountFeesDescription = (
 			currentBaseFeeDescription = sprintf(
 				// eslint-disable-next-line max-len
 				/* translators: %1 Base fee (that don't apply to this account at this moment), %2: Current fee (e.g: "2.9% + $.30 per transaction") */
-				__( '<s>%1$s</s> %2$s', 'woocommerce-payments' ),
+				__( '%1$s %2$s', 'woocommerce-payments' ),
 				feeDescription,
 				currentBaseFeeDescription
 			);


### PR DESCRIPTION
Fixes #8620 

#### Changes proposed in this Pull Request

This pull request includes changes to the `client/utils/account-fees.tsx` file to wrap static text strings with the localization function to ensure they can be translated.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Payments > Settings and hover the fee "pill" next to any payment method to trigger the fees breakdown tooltip.
* Check the tooltip content is rendered correctly
<img width="446" alt="Screenshot 2024-12-19 at 16 59 36" src="https://github.com/user-attachments/assets/384b2d8d-09da-4c8e-8b0c-28c48b5c4153" />

Translations are not available yet, but you can optionally check that the strings in the scope of this PR are included in the `pot` file. To do so:
1. Build the client so the `pot` file is generated: `npm run build:client`.
2. Check that it contains the new translatable strings:
```shell
grep "International payment method fee" languages/woocommerce-payments.pot
msgid "International payment method fee"
``` 

Or open the `languages/woocommerce-payments.pot` file and manually search for the strings. It should show something like this:
<img width="914" alt="Screenshot 2024-12-19 at 17 07 31" src="https://github.com/user-attachments/assets/9d6d612e-7665-4200-bf3b-62d9f43a091a" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
