### PR TITLE
Add TS type assertion for disputes CSV export API response to fix type safety

### DIFF
--- a/changelog/fix-10007-disputes-csv-export-response-type-assertion
+++ b/changelog/fix-10007-disputes-csv-export-response-type-assertion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add type assertion for disputes CSV export response to ensure type safety and fix TypeScript error

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -399,22 +399,25 @@ export const DisputesList = (): JSX.Element => {
 			window.confirm( confirmMessage )
 		) {
 			try {
-				const { exported_disputes: exportedDisputes } = await apiFetch(
-					{
-						path: getDisputesCSV( {
-							userEmail,
-							locale,
-							dateAfter,
-							dateBefore,
-							dateBetween,
-							match,
-							filter,
-							statusIs,
-							statusIsNot,
-						} ),
-						method: 'POST',
-					}
-				);
+				const {
+					exported_disputes: exportedDisputes,
+				} = await apiFetch< {
+					/** The total number of disputes that will be exported in the CSV. */
+					exported_disputes: number;
+				} >( {
+					path: getDisputesCSV( {
+						userEmail,
+						locale,
+						dateAfter,
+						dateBefore,
+						dateBetween,
+						match,
+						filter,
+						statusIs,
+						statusIsNot,
+					} ),
+					method: 'POST',
+				} );
 
 				createNotice(
 					'success',


### PR DESCRIPTION
Fixes #10007


#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->


Add TypeScript type assertion to `apiFetch` call in disputes CSV export to:
- Ensure type safety for `exported_disputes` response property
- Add JSDoc documentation for the exported disputes count
- Fix TypeScript error "Property 'exported_disputes' does not exist on type 'unknown'"

> [!NOTE]
> This is purely a TypeScript type definition change and doesn't affect runtime behaviour or functionality.


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the defined response is accurate, as per server response: https://github.com/Automattic/transact-platform-server/blob/3f95af805939314fafe870cec29f388bfa3949ad/server/wp-content/rest-api-plugins/endpoints/wcpay/service/class-dispute-service.php/#L198-L199
* Ensure relevant GH checks pass (namely JS linting, `tsc --noEmit`)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A** static analysis and linting only
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
