### PR TITLE
Reduce API impact from test drive setup

### DIFF
--- a/changelog/update-s6837-reduce-api-impact-for-test-drive-setup
+++ b/changelog/update-s6837-reduce-api-impact-for-test-drive-setup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Reduce the maximum number of API calls during the test-drive process and add maximum duration cut off logic.
+
+

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -214,6 +214,9 @@ const ConnectAccountPage: React.FC = () => {
 					...extraQueryArgs,
 				} );
 			} else {
+				// Schedule another check after 2.5 seconds.
+				// 2.5 seconds plus 0.5 seconds for the fetch request is 3 seconds.
+				// With a maximum of 10 checks, we will wait for 30 seconds before ending the process normally.
 				setTimeout( () => checkAccountStatus( extraQueryArgs ), 2500 );
 			}
 		} );

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -95,6 +95,16 @@ const ConnectAccountPage: React.FC = () => {
 	const loaderProgressRef = useRef( testDriveLoaderProgress );
 	loaderProgressRef.current = testDriveLoaderProgress;
 
+	// Use a timer to track the elapsed time for the test drive mode setup.
+	let testDriveSetupStartTime: number;
+	// The test drive setup will be forced finished after 40 seconds
+	// (10 seconds for the initial calls plus 30 for checking the account status in a loop).
+	const testDriveSetupMaxDuration = 40;
+
+	// Helper function to calculate the elapsed time in seconds.
+	const elapsed = ( time: number ) =>
+		Math.round( ( Date.now() - time ) / 1000 );
+
 	const {
 		connectUrl,
 		connect: { availableCountries, country },
@@ -176,16 +186,17 @@ const ConnectAccountPage: React.FC = () => {
 			// Limit to a maximum of 15 checks or 30 seconds.
 			updateLoaderProgress( 100, 4 );
 
-			// If the account status is not a pending one or progress percentage is above 95,
-			// consider our work done and redirect the merchant.
-			// Otherwise, schedule another check after 2 seconds.
+			// If the account status is not a pending one, the progress percentage is above 95,
+			// or we've exceeded the timeout, consider our work done and redirect the merchant.
+			// Otherwise, schedule another check after a 2.5 seconds wait.
 			if (
 				( account &&
 					( account as AccountData ).status &&
 					! ( account as AccountData ).status.includes(
 						'pending'
 					) ) ||
-				loaderProgressRef.current > 95
+				loaderProgressRef.current > 95 ||
+				elapsed( testDriveSetupStartTime ) > testDriveSetupMaxDuration
 			) {
 				setTestDriveLoaderProgress( 100 );
 				const queryArgs = {
@@ -203,12 +214,15 @@ const ConnectAccountPage: React.FC = () => {
 					...extraQueryArgs,
 				} );
 			} else {
-				setTimeout( () => checkAccountStatus( extraQueryArgs ), 2000 );
+				setTimeout( () => checkAccountStatus( extraQueryArgs ), 2500 );
 			}
 		} );
 	};
 
 	const handleSetupTestDriveMode = async () => {
+		// Record the start time of the test drive setup.
+		testDriveSetupStartTime = Date.now();
+		// Initialize the progress bar.
 		setTestDriveLoaderProgress( 5 );
 		setTestDriveModeSubmitted( true );
 		trackConnectAccountClicked( true );

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -183,8 +183,8 @@ const ConnectAccountPage: React.FC = () => {
 			method: 'GET',
 		} ).then( ( account ) => {
 			// Simulate the update of the loader progress bar by 4% per check.
-			// Limit to a maximum of 15 checks or 30 seconds.
-			updateLoaderProgress( 100, 4 );
+			// Limit to a maximum of 10 checks (6% progress per each request starting from 40% = max 10 checks).
+			updateLoaderProgress( 100, 6 );
 
 			// If the account status is not a pending one, the progress percentage is above 95,
 			// or we've exceeded the timeout, consider our work done and redirect the merchant.
@@ -270,6 +270,7 @@ const ConnectAccountPage: React.FC = () => {
 					}
 
 					clearInterval( updateProgress );
+					// Update the progress bar to 40% since we've finished the initial account setup.
 					setTestDriveLoaderProgress( 40 );
 
 					// Check the url for the `wcpay-connection-success` parameter, indicating a successful connection.


### PR DESCRIPTION
Contributes to https://github.com/Automattic/transact-platform-server/issues/6837

#### Changes proposed in this Pull Request

To help reduce the potential impact of the test-drive setup process that checks the account status in a loop:
- we reduced the maximum number of account status checks to 10 from 15
- we added a maximum duration to the whole process of 40 seconds (10 for the initial account creation and 30 seconds for the loop), after which the process is forcefully ended.

#### Testing instructions

* Checkout this PR's branch on your local WooPayments client installation and build it by running `npm run build`
* Make sure your local server installation is on the latest `trunk`. Do NOT listen for webhooks.
* Make sure you don't have a connected account.
* Set your store's base location country to US from WooCommerce > Settings > General
* Add a `sleep(3);` line at the beginning of the `WC_REST_Payments_Accounts_Controller::get_account_data()` [method](https://github.com/Automattic/woocommerce-payments/blob/15055b1745783c79b8f47098a58852a230a7ce1f/includes/admin/class-wc-rest-payments-accounts-controller.php#L44-L44) to simulate a slow response from the backend.
* Go to the Connect page and start the test-drive onboarding flow from the "I'm setting up a store for someone else." section and then clicking on "Enable sandbox mode":
![Screenshot 2024-12-20 at 11 00 54](https://github.com/user-attachments/assets/39ac258f-dbd6-4403-848f-2a23e3037cc2)
* You will see the test-drive setup screen, and the process will be cut short before the progress bar reaches the end (at around 60-70%)
![Screenshot 2024-12-20 at 11 01 54](https://github.com/user-attachments/assets/36fb3052-1bed-4f7f-97bf-99d450497840)
* Remove the sleep you added.
* Reset the account from the Payments overview page.
* Go to your local server and listen for webhooks by running `npm run listen`
* Go to the Connect page and start the test-drive onboarding flow again.
* On the test-drive setup screen, you will probably see that the process is cut shot again, but with more progress (80-90%).
* Reset your account again and change your store's base location to DE.
* Go to the Connect page and start the test-drive onboarding flow again.
* This time, the test-drive setup process show complete quickly (at around 60%) and you should end up with a `Complete` account status on the Payments Overview page:
![Screenshot 2024-12-20 at 11 10 34](https://github.com/user-attachments/assets/433b0230-5a14-42c3-af12-817fded57cc3)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
