### PR TITLE
Invalidate transactions store when transaction is captured

### DIFF
--- a/changelog/fix-9735-render-transactions-correctly-on-capture
+++ b/changelog/fix-9735-render-transactions-correctly-on-capture
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure captured transactions appear in the Transactions tab without requiring a page refresh.

--- a/client/data/authorizations/actions.ts
+++ b/client/data/authorizations/actions.ts
@@ -196,6 +196,13 @@ export function* submitCaptureAuthorization(
 			'getPaymentIntent'
 		);
 
+		// Need to invalidate transactions tab to update newly captured transaction if needed.
+		yield controls.dispatch(
+			STORE_NAME,
+			'invalidateResolutionForStoreSelector',
+			'getTransactions'
+		);
+
 		// Create success notice.
 		yield controls.dispatch(
 			'core/notices',

--- a/client/data/authorizations/test/actions.test.ts
+++ b/client/data/authorizations/test/actions.test.ts
@@ -120,6 +120,14 @@ describe( 'Authorizations actions', () => {
 
 			expect( generator.next().value ).toEqual(
 				controls.dispatch(
+					'wc/payments',
+					'invalidateResolutionForStoreSelector',
+					'getTransactions'
+				)
+			);
+
+			expect( generator.next().value ).toEqual(
+				controls.dispatch(
 					'core/notices',
 					'createSuccessNotice',
 					'Payment for order #254 captured successfully.'


### PR DESCRIPTION
Fixes #9735

#### Changes proposed in this Pull Request

This PR resolves an issue where a captured transaction would not appear in the Transactions tab until the page was refreshed. The fix invalidates the transactions store, ensuring new transactions are fetched and displayed correctly when the user navigates back to the Transactions tab.

#### Testing instructions

1. Enable auth + capture.
2. Purchase a product.
3. Navigate to **Payments > Transactions**.
4. Select the **Uncaptured** tab.
5. Capture the transaction purchased in step 2.
6. Select the **Transactions** tab.
7. Note that the transaction captured in step 5 is present.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
