### PR TITLE
Enable Payment Methods preselected by NOX after onboarding accounts

### DIFF
--- a/changelog/add-9973-enable-pms-from-capabilities
+++ b/changelog/add-9973-enable-pms-from-capabilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Enable Payment Methods preselected by NOX after onboarding accounts

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2052,16 +2052,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			/**
 			 * ==================
 			 * Enforces the update of payment methods to 'enabled' based on the capabilities
-			 * provided during the NOX onboarding process. Merchants have the option to
-			 * preselect their desired payment methods as part of this flow.
+			 * provided during the NOX onboarding process.
 			 *
-			 * The capabilities are provided in the following format:
-			 *
-			 * [
-			 *   'card' => true,
-			 *   'affirm' => true,
-			 *   ...
-			 * ]
+			 * @see WC_Payments_Onboarding_Service::update_enabled_payment_methods_ids
 			 * ==================
 			 */
 			$capabilities = $this->onboarding_service->get_capabilities_from_request();
@@ -2186,16 +2179,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		/**
 		 * ==================
 		 * Enforces the update of payment methods to 'enabled' based on the capabilities
-		 * provided during the NOX onboarding process. Merchants have the option to
-		 * preselect their desired payment methods as part of this flow.
+		 * provided during the NOX onboarding process.
 		 *
-		 * The capabilities are provided in the following format:
-		 *
-		 * [
-		 *   'card' => true,
-		 *   'affirm' => true,
-		 *   ...
-		 * ]
+		 * @see WC_Payments_Onboarding_Service::update_enabled_payment_methods_ids
 		 * ==================
 		 */
 		$capabilities = $this->onboarding_service->get_capabilities_from_request();

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2049,6 +2049,13 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$gateway->update_option( 'enabled', 'yes' );
 			$gateway->update_option( 'test_mode', empty( $onboarding_data['is_live'] ) ? 'yes' : 'no' );
 
+			$capabilities = $this->onboarding_service->get_capabilities_from_request();
+
+			// Activate enabled Payment Methods IDs.
+			if ( ! empty( $capabilities ) ) {
+				$this->update_enabled_payment_methods_ids( $gateway );
+			}
+
 			// Store a state after completing KYC for tracks. This is stored temporarily in option because
 			// user might not have agreed to TOS yet.
 			update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => true ] );
@@ -2567,6 +2574,57 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			},
 			'is_array', // We expect an array back from the cache.
 			$force_refresh
+		);
+	}
+
+	/**
+	 * Updates the enabled payment methods for a gateway.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway Payment gateway instance.
+	 * @param array                    $capabilities Provided capabilities.
+	 */
+	private function update_enabled_payment_methods_ids( $gateway, $capabilities = [] ): void {
+		$enabled_gateways = $gateway->get_upe_enabled_payment_method_ids();
+
+		$enabled_payment_methods = array_unique(
+			array_merge(
+				$enabled_gateways,
+				$this->exclude_placeholder_payment_methods( $capabilities )
+			)
+		);
+
+		$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+
+		foreach ( $enabled_payment_methods as $payment_method_id ) {
+			$payment_gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
+			if ( $payment_gateway ) {
+				$payment_gateway->enable();
+				$payment_gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+			}
+		}
+
+		// If WooPay is enabled, update the gateway option.
+		if ( isset( $capabilities['woopay'] ) && $capabilities['woopay'] ) {
+			$gateway->update_is_woopay_enabled( true );
+		}
+	}
+
+	/**
+	 * Excludes placeholder payment methods and removes duplicates.
+	 *
+	 * @param array $payment_methods Array of payment methods to process.
+	 * @return array Filtered array of unique payment methods.
+	 */
+	private function exclude_placeholder_payment_methods( array $payment_methods ): array {
+		$excluded_methods = [ 'woopay', 'apple_google' ];
+
+		return array_filter(
+			array_unique(
+				array_keys( array_filter( $payment_methods ) )
+			),
+			function ( $payment_method ) use ( $excluded_methods ) {
+				return ! in_array( $payment_method, $excluded_methods, true );
+			}
 		);
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2053,7 +2053,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 			// Activate enabled Payment Methods IDs.
 			if ( ! empty( $capabilities ) ) {
-				$this->update_enabled_payment_methods_ids( $gateway );
+				$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
 			}
 
 			// Store a state after completing KYC for tracks. This is stored temporarily in option because
@@ -2111,6 +2111,13 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway->update_option( 'enabled', 'yes' );
 		$gateway->update_option( 'test_mode', 'live' !== $mode ? 'yes' : 'no' );
 
+		$capabilities = $this->onboarding_service->get_capabilities_from_request();
+
+		// Activate enabled Payment Methods IDs.
+		if ( ! empty( $capabilities ) ) {
+			$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
+		}
+
 		// Store a state after completing KYC for tracks. This is stored temporarily in option because
 		// user might not have agreed to TOS yet.
 		update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => false ] );
@@ -2167,6 +2174,13 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway = WC_Payments::get_gateway();
 		$gateway->update_option( 'enabled', 'yes' );
 		$gateway->update_option( 'test_mode', 'live' !== $mode ? 'yes' : 'no' );
+
+		$capabilities = $this->onboarding_service->get_capabilities_from_request();
+
+		// Activate enabled Payment Methods IDs.
+		if ( ! empty( $capabilities ) ) {
+			$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
+		}
 
 		// Store a state after completing KYC for tracks. This is stored temporarily in option because
 		// user might not have agreed to TOS yet.
@@ -2606,6 +2620,12 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		// If WooPay is enabled, update the gateway option.
 		if ( isset( $capabilities['woopay'] ) && $capabilities['woopay'] ) {
 			$gateway->update_is_woopay_enabled( true );
+		}
+
+		// If Apple Pay and Google Pay are disabled update the gateway option,
+		// otherwise they are enabled by default.
+		if ( isset( $capabilities['apple_google'] ) && ! $capabilities['apple_google'] ) {
+			$gateway->update_option( 'payment_request', 'no' );
 		}
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2053,7 +2053,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 			// Activate enabled Payment Methods IDs.
 			if ( ! empty( $capabilities ) ) {
-				$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
+				$this->onboarding_service->update_enabled_payment_methods_ids( $gateway, $capabilities );
 			}
 
 			// Store a state after completing KYC for tracks. This is stored temporarily in option because
@@ -2112,10 +2112,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway->update_option( 'test_mode', 'live' !== $mode ? 'yes' : 'no' );
 
 		$capabilities = $this->onboarding_service->get_capabilities_from_request();
-
 		// Activate enabled Payment Methods IDs.
 		if ( ! empty( $capabilities ) ) {
-			$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
+			$this->onboarding_service->update_enabled_payment_methods_ids( $gateway, $capabilities );
 		}
 
 		// Store a state after completing KYC for tracks. This is stored temporarily in option because
@@ -2176,10 +2175,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway->update_option( 'test_mode', 'live' !== $mode ? 'yes' : 'no' );
 
 		$capabilities = $this->onboarding_service->get_capabilities_from_request();
-
 		// Activate enabled Payment Methods IDs.
 		if ( ! empty( $capabilities ) ) {
-			$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
+			$this->onboarding_service->update_enabled_payment_methods_ids( $gateway, $capabilities );
 		}
 
 		// Store a state after completing KYC for tracks. This is stored temporarily in option because
@@ -2591,62 +2589,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		);
 	}
 
-	/**
-	 * Updates the enabled payment methods for a gateway.
-	 *
-	 * @param WC_Payment_Gateway_WCPay $gateway Payment gateway instance.
-	 * @param array                    $capabilities Provided capabilities.
-	 */
-	private function update_enabled_payment_methods_ids( $gateway, $capabilities = [] ): void {
-		$enabled_gateways = $gateway->get_upe_enabled_payment_method_ids();
-
-		$enabled_payment_methods = array_unique(
-			array_merge(
-				$enabled_gateways,
-				$this->exclude_placeholder_payment_methods( $capabilities )
-			)
-		);
-
-		$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
-
-		foreach ( $enabled_payment_methods as $payment_method_id ) {
-			$payment_gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
-			if ( $payment_gateway ) {
-				$payment_gateway->enable();
-				$payment_gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
-			}
-		}
-
-		// If WooPay is enabled, update the gateway option.
-		if ( isset( $capabilities['woopay'] ) && $capabilities['woopay'] ) {
-			$gateway->update_is_woopay_enabled( true );
-		}
-
-		// If Apple Pay and Google Pay are disabled update the gateway option,
-		// otherwise they are enabled by default.
-		if ( isset( $capabilities['apple_google'] ) && ! $capabilities['apple_google'] ) {
-			$gateway->update_option( 'payment_request', 'no' );
-		}
-	}
-
-	/**
-	 * Excludes placeholder payment methods and removes duplicates.
-	 *
-	 * @param array $payment_methods Array of payment methods to process.
-	 * @return array Filtered array of unique payment methods.
-	 */
-	private function exclude_placeholder_payment_methods( array $payment_methods ): array {
-		$excluded_methods = [ 'woopay', 'apple_google' ];
-
-		return array_filter(
-			array_unique(
-				array_keys( array_filter( $payment_methods ) )
-			),
-			function ( $payment_method ) use ( $excluded_methods ) {
-				return ! in_array( $payment_method, $excluded_methods, true );
-			}
-		);
-	}
 
 	/**
 	 * Send a Tracks event.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2049,6 +2049,21 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$gateway->update_option( 'enabled', 'yes' );
 			$gateway->update_option( 'test_mode', empty( $onboarding_data['is_live'] ) ? 'yes' : 'no' );
 
+			/**
+			 * ==================
+			 * Enforces the update of payment methods to 'enabled' based on the capabilities
+			 * provided during the NOX onboarding process. Merchants have the option to
+			 * preselect their desired payment methods as part of this flow.
+			 *
+			 * The capabilities are provided in the following format:
+			 *
+			 * [
+			 *   'card' => true,
+			 *   'affirm' => true,
+			 *   ...
+			 * ]
+			 * ==================
+			 */
 			$capabilities = $this->onboarding_service->get_capabilities_from_request();
 
 			// Activate enabled Payment Methods IDs.
@@ -2111,12 +2126,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway->update_option( 'enabled', 'yes' );
 		$gateway->update_option( 'test_mode', 'live' !== $mode ? 'yes' : 'no' );
 
-		$capabilities = $this->onboarding_service->get_capabilities_from_request();
-		// Activate enabled Payment Methods IDs.
-		if ( ! empty( $capabilities ) ) {
-			$this->onboarding_service->update_enabled_payment_methods_ids( $gateway, $capabilities );
-		}
-
 		// Store a state after completing KYC for tracks. This is stored temporarily in option because
 		// user might not have agreed to TOS yet.
 		update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => false ] );
@@ -2174,6 +2183,21 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway->update_option( 'enabled', 'yes' );
 		$gateway->update_option( 'test_mode', 'live' !== $mode ? 'yes' : 'no' );
 
+		/**
+		 * ==================
+		 * Enforces the update of payment methods to 'enabled' based on the capabilities
+		 * provided during the NOX onboarding process. Merchants have the option to
+		 * preselect their desired payment methods as part of this flow.
+		 *
+		 * The capabilities are provided in the following format:
+		 *
+		 * [
+		 *   'card' => true,
+		 *   'affirm' => true,
+		 *   ...
+		 * ]
+		 * ==================
+		 */
 		$capabilities = $this->onboarding_service->get_capabilities_from_request();
 		// Activate enabled Payment Methods IDs.
 		if ( ! empty( $capabilities ) ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -277,6 +277,13 @@ class WC_Payments_Onboarding_Service {
 		);
 		$actioned_notes = self::get_actioned_notes();
 
+		$capabilities = $this->get_capabilities_from_request();
+		$gateway      = WC_Payments::get_gateway();
+		// Activate enabled Payment Methods IDs.
+		if ( ! empty( $capabilities ) ) {
+			$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
+		}
+
 		try {
 			$account_session = $this->payments_api_client->initialize_onboarding_embedded_kyc(
 				'live' === $setup_mode,
@@ -1023,5 +1030,62 @@ class WC_Payments_Onboarding_Service {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Updates the enabled payment methods for a gateway.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway Payment gateway instance.
+	 * @param array                    $capabilities Provided capabilities.
+	 */
+	public function update_enabled_payment_methods_ids( $gateway, $capabilities = [] ): void {
+		$enabled_gateways = $gateway->get_upe_enabled_payment_method_ids();
+
+		$enabled_payment_methods = array_unique(
+			array_merge(
+				$enabled_gateways,
+				$this->exclude_placeholder_payment_methods( $capabilities )
+			)
+		);
+
+		$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+
+		foreach ( $enabled_payment_methods as $payment_method_id ) {
+			$payment_gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
+			if ( $payment_gateway ) {
+				$payment_gateway->enable();
+				$payment_gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
+			}
+		}
+
+		// If WooPay is enabled, update the gateway option.
+		if ( isset( $capabilities['woopay'] ) && $capabilities['woopay'] ) {
+			$gateway->update_is_woopay_enabled( true );
+		}
+
+		// If Apple Pay and Google Pay are disabled update the gateway option,
+		// otherwise they are enabled by default.
+		if ( isset( $capabilities['apple_google'] ) && ! $capabilities['apple_google'] ) {
+			$gateway->update_option( 'payment_request', 'no' );
+		}
+	}
+
+	/**
+	 * Excludes placeholder payment methods and removes duplicates.
+	 *
+	 * @param array $payment_methods Array of payment methods to process.
+	 * @return array Filtered array of unique payment methods.
+	 */
+	private function exclude_placeholder_payment_methods( array $payment_methods ): array {
+		$excluded_methods = [ 'woopay', 'apple_google' ];
+
+		return array_filter(
+			array_unique(
+				array_keys( array_filter( $payment_methods ) )
+			),
+			function ( $payment_method ) use ( $excluded_methods ) {
+				return ! in_array( $payment_method, $excluded_methods, true );
+			}
+		);
 	}
 }

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1077,6 +1077,7 @@ class WC_Payments_Onboarding_Service {
 	 * WooPay and Apple Pay & Google Pay are considered placeholder payment methods and are excluded.
 	 *
 	 * @param array $payment_methods Array of payment methods to process.
+	 *
 	 * @return array Filtered array of unique payment methods.
 	 */
 	private function exclude_placeholder_payment_methods( array $payment_methods ): array {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1048,6 +1048,7 @@ class WC_Payments_Onboarding_Service {
 			)
 		);
 
+		// Update the gateway option.
 		$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
 
 		foreach ( $enabled_payment_methods as $payment_method_id ) {
@@ -1073,10 +1074,13 @@ class WC_Payments_Onboarding_Service {
 	/**
 	 * Excludes placeholder payment methods and removes duplicates.
 	 *
+	 * WooPay and Apple Pay & Google Pay are considered placeholder payment methods and are excluded.
+	 *
 	 * @param array $payment_methods Array of payment methods to process.
 	 * @return array Filtered array of unique payment methods.
 	 */
 	private function exclude_placeholder_payment_methods( array $payment_methods ): array {
+		// Placeholder payment methods.
 		$excluded_methods = [ 'woopay', 'apple_google' ];
 
 		return array_filter(

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1070,6 +1070,10 @@ class WC_Payments_Onboarding_Service {
 		// Update the gateway option.
 		$gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_payment_methods );
 
+		/**
+		 * Keeps the list of enabled payment method IDs synchronized between the default
+		 * `woocommerce_woocommerce_payments_settings` and duplicates in individual gateway settings.
+		 */
 		foreach ( $enabled_payment_methods as $payment_method_id ) {
 			$payment_gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
 			if ( $payment_gateway ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -277,8 +277,17 @@ class WC_Payments_Onboarding_Service {
 		);
 		$actioned_notes = self::get_actioned_notes();
 
+		/**
+		 * ==================
+		 * Enforces the update of payment methods to 'enabled' based on the capabilities
+		 * provided during the NOX onboarding process.
+		 *
+		 * @see self::update_enabled_payment_methods_ids
+		 * ==================
+		 */
 		$capabilities = $this->get_capabilities_from_request();
 		$gateway      = WC_Payments::get_gateway();
+
 		// Activate enabled Payment Methods IDs.
 		if ( ! empty( $capabilities ) ) {
 			$this->update_enabled_payment_methods_ids( $gateway, $capabilities );
@@ -1033,7 +1042,17 @@ class WC_Payments_Onboarding_Service {
 	}
 
 	/**
-	 * Updates the enabled payment methods for a gateway.
+	 * Update payment methods to 'enabled' based on the capabilities
+	 * provided during the NOX onboarding process. Merchants can preselect their preferred
+	 * payment methods as part of this flow.
+	 *
+	 * The capabilities are provided in the following format:
+	 *
+	 * [
+	 *   'card' => true,
+	 *   'affirm' => true,
+	 *   ...
+	 * ]
 	 *
 	 * @param WC_Payment_Gateway_WCPay $gateway Payment gateway instance.
 	 * @param array                    $capabilities Provided capabilities.
@@ -1060,13 +1079,13 @@ class WC_Payments_Onboarding_Service {
 		}
 
 		// If WooPay is enabled, update the gateway option.
-		if ( isset( $capabilities['woopay'] ) && $capabilities['woopay'] ) {
+		if ( ! empty( $capabilities['woopay'] ) ) {
 			$gateway->update_is_woopay_enabled( true );
 		}
 
 		// If Apple Pay and Google Pay are disabled update the gateway option,
 		// otherwise they are enabled by default.
-		if ( isset( $capabilities['apple_google'] ) && ! $capabilities['apple_google'] ) {
+		if ( empty( $capabilities['apple_google'] ) ) {
 			$gateway->update_option( 'payment_request', 'no' );
 		}
 	}


### PR DESCRIPTION
Fixes #9973

#### Changes proposed in this Pull Request
This PR manages the payment method capabilities preselected by NOX. It enables the corresponding payment methods and stores them in the `upe_enabled_payment_method_ids`, ensuring they appear as enabled on the WooPayments settings page.

#### Testing instructions
**Prerequisites**
- Reset your connected account if there is any.
- Install and navigate to WCPay Dev Tools.
- Delete saved WCPay Gateway settings:
- <img width="1321" alt="Screenshot 2024-12-20 at 13 54 29" src="https://github.com/user-attachments/assets/6ca59cb4-8609-42a8-b8a9-7cd1fb89a926" />
- Have woocommerce installed locally and synced within WooPayments. See Pe4Hk0-3f-p2 for details. 
- Enable the feature flag to see reactified settings page. pe4Hk0-1ly-p2.

**Testing with Test-Drive onboarding**
1. Go to wp-admin → Settings → Payments or directly navigate to: http://your.url/wp-admin/admin.php?page=wc-settings&tab=checkout.
2. Select United States from the country selector.
3. Click the Enable or Complete Setup button next to the WooPayments gateway.
4. On the recommended payment methods screen, enable or disable the payment methods of your choice and click Continue.
5. After completing the onboarding process, navigate to Payments → Settings.
6. Verify that the payment methods you selected are activated.

**Testing with Embedded onboarding**
1. Go to Tools > WCA Test Helper > Tools and "Reset Onboarding Wizard":
![Screenshot 2024-12-13 at 11 37 40](https://github.com/user-attachments/assets/22bb6561-7e01-4bdb-9184-8fd4a8ea8825)
2 Click on WooCommerce to kickstart the WC onboarding wizard. Don't skip it, click on "Set up my store" and on the second step select "I'm already selling" and then "Yes, I'm selling online". The rest of the info doesn't matter.
![Screenshot 2024-12-13 at 11 38 32](https://github.com/user-attachments/assets/f88f3a1c-2841-4b12-ad45-5d6fcb79d4a3)
3. Click on "Continue" and finish the onboarding (skip the extensions step so you don't install anything).
4. Go to Plugins and make sure WooPayments is not active.
5. Click on the Payments menu item and you will end up on the new Payments settings page.
6. Select United States from the country selector.
7. Click on Enable for WooPayments and you should be taken to the recommended payment methods screen.
8. On the recommended payment methods screen, enable or disable the payment methods of your choice and click Continue.
9. After completing the embedded onboarding process, navigate to Payments → Settings.
10. Verify that the payment methods you selected are activated.

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
