### PR TITLE
fix: tokenized ECE do not show button when missing billing email

### DIFF
--- a/changelog/fix-tokenized-ece-pay-for-order-without-billing-email
+++ b/changelog/fix-tokenized-ece-pay-for-order-without-billing-email
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: tokenized ECE do not show button when missing billing email
+
+


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The Store API (which is used by the Tokenized ECE to process an order) doesn't allow to process an order if the billing email is not present.
This is logged in WC Core here: https://github.com/woocommerce/woocommerce/issues/48540

However, while the discussion is happening, we'd like to quickly patch the tokenized ECE to provide a message in the merchant's logs when such thing happens.
At the same time, I'm disabling the ECE button if the billing email is not present, so that the customer doesn't see any errors when attempting to process the order.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a merchant, create an order in `wp-admin`
- Ensure you're adding some information, but omit the billing address
<img width="2159" alt="Screenshot 2024-12-20 at 2 06 30 PM" src="https://github.com/user-attachments/assets/4657dd4c-9413-4243-989e-b0b862c001b5" />
- Save the order, and click on the "Customer payment page →" link
- The page should not display the GooglePay/ApplePay buttons
<img width="1162" alt="Screenshot 2024-12-20 at 2 06 20 PM" src="https://github.com/user-attachments/assets/4a17a1e4-a002-4d9a-bfa1-664186048d7c" />
- At least one message should be added in the logs
<img width="966" alt="Screenshot 2024-12-20 at 2 06 06 PM" src="https://github.com/user-attachments/assets/16190a2b-8fb7-49c0-9bcd-6cdfd51c6cd6" />
- Update the same order to include a billing email
<img width="2223" alt="Screenshot 2024-12-20 at 2 06 46 PM" src="https://github.com/user-attachments/assets/40cc1e66-a648-4c98-a2ce-a94b2abe459a" />
- Refresh the "Customer payment" page
- The ECE button should now be displayed
- You should be able to pay for the order with the ECE button
<img width="1102" alt="Screenshot 2024-12-20 at 2 06 53 PM" src="https://github.com/user-attachments/assets/1fd24503-3b28-41ca-9f7f-7f332c3de06c" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
