### PR TITLE
Fix blank Overview page when WC onboarding is disabled

### DIFF
--- a/changelog/fix-9742-blank-overview-page-without-wc-features
+++ b/changelog/fix-9742-blank-overview-page-without-wc-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blank Payments > Overview page when WC onboarding is disabled.

--- a/client/onboarding/utils.ts
+++ b/client/onboarding/utils.ts
@@ -140,7 +140,7 @@ export const isPoEligible = async (
  * @return {string | undefined} The MCC code for the selected industry. Will return undefined if no industry is selected.
  */
 export const getMccFromIndustry = (): string | undefined => {
-	const industry = wcSettings.admin.onboarding.profile.industry?.[ 0 ];
+	const industry = wcSettings.admin?.onboarding?.profile?.industry?.[ 0 ];
 	if ( ! industry ) {
 		return undefined;
 	}


### PR DESCRIPTION
Fixes #9742 

#### Changes proposed in this Pull Request

We are now more defensive about missing WC Admin onboarding data and avoid the JS error that leads to the blank Payments > Onboarding page.

#### Testing instructions

* Create a new JN site with WooCommerce, WooPayments using this PR's live branch, WCPay Dev Tools, and the WooCommerce Beta Tester plugin (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-beta-tester&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce-payments=fix/9742-blank-overview-page-without-wc-features))
* Go to the new store's WP admin, click on the "WooCommerce" main menu item, go through the profiler, skip it by clicking on "Skip guided setup", and set your store's location to US.
* Make sure WooPayments is activated and is using this PR's branch. If not, go to Jetpack > Beta Tester, click on "Manage" for WooCommerce Payments and activate the `fix/9742-blank-overview-page-without-wc-features` feature branch.
* Click on the "Payments" main menu item and you should see the WooPayments Connect page.
* Onboard a test-drive account from the "I'm setting up a store for someone else".
* You should end up on the Payments > Overview page.
* Go to Tools > WCA Test Helper > Features and disable the `onboarding` and `onboarding-tasks` features:
![Image](https://github.com/user-attachments/assets/390cff94-ed28-4305-8cfc-aaa3d0b1e67a)
* Refresh the page and click on the "Payments" menu item and you should see the Overview page:
![Screenshot 2024-12-20 at 15 12 48](https://github.com/user-attachments/assets/a5ab5b62-fe1a-436b-a69c-96d2d6aed004)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
