### PR TITLE
Upgrade `@woocommerce/csv-export` to v1.10.0 – fixes unnecessary escaping of negative values in CSV exports

### DIFF
--- a/changelog/fix-9303-upgrade-woocommerce-csv-export-package
+++ b/changelog/fix-9303-upgrade-woocommerce-csv-export-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Upgrade `@woocommerce/csv-export` package to v1.10.0 – fixes unnecessary escaping of negative values in CSV exports that was preventing numerical analysis in spreadsheet applications

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@typescript-eslint/parser": "4.15.2",
         "@woocommerce/api": "0.2.0",
         "@woocommerce/components": "12.3.0",
-        "@woocommerce/csv-export": "1.9.0",
+        "@woocommerce/csv-export": "1.10.0",
         "@woocommerce/currency": "4.3.0",
         "@woocommerce/date": "4.2.0",
         "@woocommerce/dependency-extraction-webpack-plugin": "2.2.0",
@@ -10969,6 +10969,11 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@woocommerce/components/node_modules/@types/node": {
+      "version": "16.18.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.122.tgz",
+      "integrity": "sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg=="
+    },
     "node_modules/@woocommerce/components/node_modules/@types/react": {
       "version": "17.0.80",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
@@ -10987,6 +10992,19 @@
         "@types/react": "*",
         "@types/wordpress__data": "*",
         "@types/wordpress__rich-text": "*"
+      }
+    },
+    "node_modules/@woocommerce/components/node_modules/@woocommerce/csv-export": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.9.0.tgz",
+      "integrity": "sha512-fo1byPYTljic8ml5HxvxafdhrYc8pMYXqjlGZtZ9xNxWL2yffXJvskbcb7Kj6JSQhHT3BCh/5PlczJci9vQuDQ==",
+      "dependencies": {
+        "@types/node": "^16.18.68",
+        "browser-filesaver": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.11.1",
+        "pnpm": "^9.1.0"
       }
     },
     "node_modules/@woocommerce/components/node_modules/@wordpress/api-fetch": {
@@ -11652,22 +11670,18 @@
       }
     },
     "node_modules/@woocommerce/csv-export": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.9.0.tgz",
-      "integrity": "sha512-fo1byPYTljic8ml5HxvxafdhrYc8pMYXqjlGZtZ9xNxWL2yffXJvskbcb7Kj6JSQhHT3BCh/5PlczJci9vQuDQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.10.0.tgz",
+      "integrity": "sha512-OckWCp52fGFcyK2lwBJyiheBbvUFl0dO3Ai6tSfX+jApJa8SUlx9txhwKVSz4Xnpo+nH0B0SPHjoPtQeQeXa2w==",
+      "dev": true,
       "dependencies": {
-        "@types/node": "^16.18.68",
+        "@types/node": "20.x.x",
         "browser-filesaver": "^1.1.1"
       },
       "engines": {
         "node": "^20.11.1",
-        "pnpm": "^9.1.0"
+        "pnpm": "9.1.3"
       }
-    },
-    "node_modules/@woocommerce/csv-export/node_modules/@types/node": {
-      "version": "16.18.102",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.102.tgz",
-      "integrity": "sha512-eSe2YwGCcRjqPidxfm20IAq02krERWcIIJW4FNPkU0zQLbc4L9pvhsmB0p6UJecjEf0j/E2ERHsKq7madvthKw=="
     },
     "node_modules/@woocommerce/currency": {
       "version": "4.3.0",
@@ -13773,6 +13787,24 @@
       "engines": {
         "node": "^20.11.1",
         "pnpm": "^8.12.1"
+      }
+    },
+    "node_modules/@woocommerce/onboarding/node_modules/@types/node": {
+      "version": "16.18.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.122.tgz",
+      "integrity": "sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg=="
+    },
+    "node_modules/@woocommerce/onboarding/node_modules/@woocommerce/csv-export": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.9.0.tgz",
+      "integrity": "sha512-fo1byPYTljic8ml5HxvxafdhrYc8pMYXqjlGZtZ9xNxWL2yffXJvskbcb7Kj6JSQhHT3BCh/5PlczJci9vQuDQ==",
+      "dependencies": {
+        "@types/node": "^16.18.68",
+        "browser-filesaver": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.11.1",
+        "pnpm": "^9.1.0"
       }
     },
     "node_modules/@woocommerce/onboarding/node_modules/@woocommerce/experimental": {
@@ -20443,23 +20475,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/rechoir/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -20650,18 +20665,6 @@
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wordpress/scripts/node_modules/supports-hyperlinks/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@typescript-eslint/parser": "4.15.2",
     "@woocommerce/api": "0.2.0",
     "@woocommerce/components": "12.3.0",
-    "@woocommerce/csv-export": "1.9.0",
+    "@woocommerce/csv-export": "1.10.0",
     "@woocommerce/currency": "4.3.0",
     "@woocommerce/date": "4.2.0",
     "@woocommerce/dependency-extraction-webpack-plugin": "2.2.0",
@@ -215,7 +215,7 @@
   "overrides": {
     "@automattic/puppeteer-utils": "github:Automattic/puppeteer-utils#update/babel-deps",
     "@woocommerce/components": {
-      "@woocommerce/csv-export": "1.9.0",
+      "@woocommerce/csv-export": "1.10.0",
       "@woocommerce/currency": "4.3.0"
     },
     "@wordpress/scripts": {


### PR DESCRIPTION
Fixes #9303

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR upgrades the `@woocommerce/csv-export` package to v1.10.0 ([npm](https://www.npmjs.com/package/@woocommerce/csv-export/v/1.10.0)).

This fixes unnecessary escaping of negative values in CSV exports that was preventing numerical analysis in spreadsheet applications.

> [!IMPORTANT]
> I discovered in this PR that the `csv-export` package version used by WooCommerce core (`wp-content/plugins/woocommerce/assets/client/admin/csv-export/index.js`) overrides the version imported into WooPayments.
> **Therefore, this fix will only work when using WC 9.6+ ([currently pre-release](https://github.com/woocommerce/woocommerce/releases/tag/9.6.0-beta.1))**.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. **Install WooCommerce 9.6** ([currently pre-release](https://github.com/woocommerce/woocommerce/releases/tag/9.6.0-beta.1)). 
	- This is required because the `csv-export` version in `wp-content/plugins/woocommerce/assets/client/admin/csv-export/index.js` will override the version imported into `WooPayments`.
3. Go to `WP-Admin → Payments → Transactions` on a WooPayments account that doesn't have many transactions (you can use the advanced filters in the "show" dropdown if the account has many transactions to reduce the number of transactions shown to ~20 or so)
4. Click on the download button to automatically download the WooPayments transactions
![download transactions](https://github.com/user-attachments/assets/af4d0ebf-3051-47c1-94ec-44eac05b5d4e)
5. Open the downloaded CSV file, check the **Fees** column and ensure that the negative values are not prepended with a `'` character.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **Unit tests in package `@woocommerce/csv-export` are sufficient**
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
