### PR TITLE
Remove unused useEffect import to fix GH linter warning

### DIFF
--- a/changelog/dev-10034-linter-warning-useeffect-unused-import
+++ b/changelog/dev-10034-linter-warning-useeffect-unused-import
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Not user-facing: removed an unused `useEffect` import causing linter warnings
+
+

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button, Modal } from '@wordpress/components';


### PR DESCRIPTION
Fixes #10034

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This is a cleanup PR – simply removes an unused `useEffect` import that was causing a linter warning to appear on all PRs in the files tab.

<img width="886" alt="image" src="https://github.com/user-attachments/assets/381b6348-8dbf-41fd-b310-07e842f5acbf" />

PR to see example of warning: https://github.com/Automattic/woocommerce-payments/pull/10030/files.


This is a preview GH feature, so you may need to enable it in your GH user settings to see the warning, unless it is enabled repo-wide (unsure).

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. View the GH files tab for this PR.
2. Ensure that the warning is not displayed.
3. GH checks should all succeed.

I've confirmed that this PR fixes the warning:

<img width="782" alt="image" src="https://github.com/user-attachments/assets/313fd51f-7247-419a-8737-c7880e5b45da" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A**
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
