### PR TITLE
Consistently format the order notes for refunds and charges

### DIFF
--- a/changelog/feature-consistent-note-formatting
+++ b/changelog/feature-consistent-note-formatting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure consistent formatting of refund notes with MC.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1752,7 +1752,8 @@ class WC_Payments_Order_Service {
 	 * @return string HTML note.
 	 */
 	private function generate_payment_refunded_note( float $refunded_amount, string $refunded_currency, string $wcpay_refund_id, string $refund_reason, WC_Order $order ): string {
-		$formatted_price = WC_Payments_Explicit_Price_Formatter::get_explicit_price( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $refunded_amount, [ 'currency' => strtoupper( $refunded_currency ) ] ), $order );
+		$multi_currency_instance = WC_Payments_Multi_Currency();
+		$formatted_price         = WC_Payments_Explicit_Price_Formatter::get_explicit_price( $multi_currency_instance->get_backend_formatted_wc_price( $refunded_amount, [ 'currency' => strtoupper( $refunded_currency ) ] ), $order );
 
 		if ( empty( $refund_reason ) ) {
 			$note = sprintf(
@@ -1927,7 +1928,14 @@ class WC_Payments_Order_Service {
 	 * @return string The formatted order total.
 	 */
 	private function get_order_amount( $order ) {
-		return WC_Payments_Explicit_Price_Formatter::get_explicit_price( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $order->get_total(), [ 'currency' => $order->get_currency() ] ), $order );
+		$multi_currency_instance = WC_Payments_Multi_Currency();
+		$order_price             = $order->get_total();
+		if ( ! $order_price ) {
+			return $order_price;
+		}
+
+		$formatted_price = $multi_currency_instance->get_backend_formatted_wc_price( $order_price, [ 'currency' => $order->get_currency() ] );
+		return WC_Payments_Explicit_Price_Formatter::get_explicit_price( $formatted_price, $order );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1930,9 +1930,6 @@ class WC_Payments_Order_Service {
 	private function get_order_amount( $order ) {
 		$multi_currency_instance = WC_Payments_Multi_Currency();
 		$order_price             = $order->get_total();
-		if ( ! $order_price ) {
-			return $order_price;
-		}
 
 		$formatted_price = $multi_currency_instance->get_backend_formatted_wc_price( $order_price, [ 'currency' => $order->get_currency() ] );
 		return WC_Payments_Explicit_Price_Formatter::get_explicit_price( $formatted_price, $order );

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1752,10 +1752,7 @@ class WC_Payments_Order_Service {
 	 * @return string HTML note.
 	 */
 	private function generate_payment_refunded_note( float $refunded_amount, string $refunded_currency, string $wcpay_refund_id, string $refund_reason, WC_Order $order ): string {
-		$formatted_price = WC_Payments_Explicit_Price_Formatter::get_explicit_price(
-			wc_price( $refunded_amount, [ 'currency' => strtoupper( $refunded_currency ) ] ),
-			$order
-		);
+		$formatted_price = WC_Payments_Explicit_Price_Formatter::get_explicit_price( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $refunded_amount, [ 'currency' => strtoupper( $refunded_currency ) ] ), $order );
 
 		if ( empty( $refund_reason ) ) {
 			$note = sprintf(
@@ -1930,7 +1927,7 @@ class WC_Payments_Order_Service {
 	 * @return string The formatted order total.
 	 */
 	private function get_order_amount( $order ) {
-		return WC_Payments_Explicit_Price_Formatter::get_explicit_price( wc_price( $order->get_total(), [ 'currency' => $order->get_currency() ] ), $order );
+		return WC_Payments_Explicit_Price_Formatter::get_explicit_price( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $order->get_total(), [ 'currency' => $order->get_currency() ] ), $order );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1335,6 +1335,10 @@ class MultiCurrency {
 	 * @return string The formatted amount.
 	 */
 	public function get_backend_formatted_wc_price( float $amount, array $args = [] ): string {
+		if ( ! self::has_additional_currencies_enabled() ) {
+			return wc_price( $amount, $args );
+		}
+
 		$has_filter = has_filter( 'wc_price_args', [ $this->backend_currencies, 'build_wc_price_args' ] );
 		if ( false !== $has_filter ) {
 			return wc_price( $amount, $args );

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -17,6 +17,7 @@ use WCPay\MultiCurrency\Interfaces\MultiCurrencySettingsInterface;
 use WCPay\MultiCurrency\Logger;
 use WCPay\MultiCurrency\Notes\NoteMultiCurrencyAvailable;
 use WCPay\MultiCurrency\Utils;
+use WC_Payments_Features;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1335,7 +1336,8 @@ class MultiCurrency {
 	 * @return string The formatted amount.
 	 */
 	public function get_backend_formatted_wc_price( float $amount, array $args = [] ): string {
-		if ( ! self::has_additional_currencies_enabled() ) {
+		// Return early if MC isn't enabled or merchant has a single currency.
+		if ( ! self::has_additional_currencies_enabled() || ! WC_Payments_Features::is_customer_multi_currency_enabled() ) {
 			return wc_price( $amount, $args );
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1327,6 +1327,27 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Returns the amount with the backend format.
+	 *
+	 * @param float $amount The amount to format.
+	 * @param array $args The arguments to pass to wc_price.
+	 *
+	 * @return string The formatted amount.
+	 */
+	public function get_backend_formatted_wc_price( float $amount, array $args = [] ): string {
+		$has_filter = has_filter( 'wc_price_args', [ $this->backend_currencies, 'build_wc_price_args' ] );
+		if ( false !== $has_filter ) {
+			return wc_price( $amount, $args );
+		}
+
+		add_filter( 'wc_price_args', [ $this->backend_currencies, 'build_wc_price_args' ], 50 );
+		$price = wc_price( $amount, $args );
+		remove_filter( 'wc_price_args', [ $this->backend_currencies, 'build_wc_price_args' ], 50 );
+
+		return $price;
+	}
+
+	/**
 	 * Gets the price after adjusting it with the rounding and charm settings.
 	 *
 	 * @param float    $price               The price to be adjusted.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -278,7 +278,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$this->assertTrue( $result );
 		$this->assertStringContainsString( 'successfully processed', $latest_wcpay_note->content );
-		$this->assertStringContainsString( wc_price( 19.99, [ 'currency' => 'USD' ] ), $latest_wcpay_note->content );
+		$this->assertStringContainsString( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( 19.99, [ 'currency' => 'USD' ] ), $latest_wcpay_note->content );
 		$this->assertStringContainsString( 're_123456789', $latest_wcpay_note->content );
 	}
 
@@ -349,7 +349,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$this->assertTrue( $result );
 		$this->assertStringContainsString( 'successfully processed', $latest_wcpay_note->content );
-		$this->assertStringContainsString( wc_price( 19.99, [ 'currency' => strtoupper( $currency ) ] ), $latest_wcpay_note->content );
+		$this->assertStringContainsString( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( 19.99, [ 'currency' => strtoupper( $currency ) ] ), $latest_wcpay_note->content );
 	}
 
 	public function test_process_refund_with_reason_non_usd() {
@@ -419,7 +419,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$this->assertStringContainsString( 'successfully processed', $latest_wcpay_note->content );
 		$this->assertStringContainsString( 'some reason', $latest_wcpay_note->content );
-		$this->assertStringContainsString( wc_price( 19.99, [ 'currency' => strtoupper( $currency ) ] ), $latest_wcpay_note->content );
+		$this->assertStringContainsString( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( 19.99, [ 'currency' => strtoupper( $currency ) ] ), $latest_wcpay_note->content );
 		$this->assertTrue( $result );
 	}
 
@@ -511,7 +511,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$this->assertTrue( $result );
 		$this->assertStringContainsString( 'successfully processed', $latest_wcpay_note->content );
-		$this->assertStringContainsString( wc_price( $amount, [ 'currency' => $currency ] ), $latest_wcpay_note->content );
+		$this->assertStringContainsString( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $amount, [ 'currency' => $currency ] ), $latest_wcpay_note->content );
 	}
 
 	public function test_process_refund_interac_present_without_payment_method_id_meta() {
@@ -591,7 +591,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$this->assertTrue( $result );
 		$this->assertStringContainsString( 'successfully processed', $latest_wcpay_note->content );
-		$this->assertStringContainsString( wc_price( $amount, [ 'currency' => 'USD' ] ), $latest_wcpay_note->content );
+		$this->assertStringContainsString( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $amount, [ 'currency' => 'USD' ] ), $latest_wcpay_note->content );
 	}
 
 	public function test_process_refund_interac_present_without_app_refund() {
@@ -809,7 +809,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$this->assertTrue( $result );
 		$this->assertStringContainsString( 'successfully processed', $latest_wcpay_note->content );
-		$this->assertStringContainsString( wc_price( $amount, [ 'currency' => strtoupper( $currency ) ] ), $latest_wcpay_note->content );
+		$this->assertStringContainsString( WC_Payments_Multi_Currency()->get_backend_formatted_wc_price( $amount, [ 'currency' => strtoupper( $currency ) ] ), $latest_wcpay_note->content );
 	}
 
 	public function test_process_refund_on_uncaptured_payment() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -652,6 +652,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->exactly( 2 ) )
 			->method( 'save' );
 
+			$this->mock_order
+				->method( 'get_total' )
+				->willReturn( 15.00 );
+
 		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'has_status' )
@@ -746,6 +750,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'save' );
+
+			$this->mock_order
+				->method( 'get_total' )
+				->willReturn( 15.00 );
 
 		$this->mock_order
 			->expects( $this->exactly( 2 ) )
@@ -939,6 +947,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			)
 			->willReturn( false );
 
+			$this->mock_order
+				->method( 'get_total' )
+				->willReturn( 15.00 );
+
 		$this->mock_order
 			->expects( $this->once() )
 			->method( 'payment_complete' );
@@ -1040,6 +1052,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				[ '_intention_status', $intent_status ]
 			);
 
+			$this->mock_order
+				->method( 'get_total' )
+				->willReturn( 15.00 );
+
 		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'save' );
@@ -1123,6 +1139,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->with( '_payment_method_id' )
 			->willReturn( 'pm_123123123123123' );
 
+			$this->mock_order
+				->method( 'get_total' )
+				->willReturn( 15.00 );
+
 		$this->mock_order
 			->expects( $this->exactly( 3 ) )
 			->method( 'has_status' )
@@ -1189,6 +1209,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'get_meta' )
 			->with( '_payment_method_id' )
 			->willReturn( 'pm_123123123123123' );
+
+			$this->mock_order
+				->method( 'get_total' )
+				->willReturn( 15.00 );
 
 		$this->mock_order
 			->expects( $this->exactly( 3 ) )


### PR DESCRIPTION
Fixes #8345 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- Add a helper method for formatting the order notes consistently based on whether MC is enabled or not.
- Update the usage in order service for `charge` and `refund` notes.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the steps mentioned in #8345 and ensure the behavior is consistent.
* Also disable MC and ensure the store settings are used, whereas with MC enabled, MC settings override the store ones.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
