### PR TITLE
Reporting: Overview - improve mobile view of Balances card

### DIFF
--- a/changelog/fix-8599-balances-card-layout
+++ b/changelog/fix-8599-balances-card-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Improve the mobile rendering of the Balances box within Payment Overview

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -73,7 +73,7 @@ const AccountBalances: React.FC = () => {
 		};
 
 		return (
-			<Flex gap={ 0 } className="wcpay-account-balances__balances">
+			<div className="wcpay-account-balances__balances">
 				<BalanceBlock
 					id={ `wcpay-account-balances-${ loadingData.currencyCode }-total` }
 					title={ fundLabelStrings.total }
@@ -88,7 +88,7 @@ const AccountBalances: React.FC = () => {
 					currencyCode={ loadingData.currencyCode }
 					isLoading
 				/>
-			</Flex>
+			</div>
 		);
 	}
 
@@ -115,7 +115,7 @@ const AccountBalances: React.FC = () => {
 
 	return (
 		<>
-			<Flex gap={ 0 } className="wcpay-account-balances__balances">
+			<div className="wcpay-account-balances__balances">
 				<BalanceBlock
 					id={ `wcpay-account-balances-${ selectedOverview.currencyCode }-total` }
 					title={ fundLabelStrings.total }
@@ -134,7 +134,7 @@ const AccountBalances: React.FC = () => {
 						/>
 					}
 				/>
-			</Flex>
+			</div>
 			{ selectedOverview.instantBalance &&
 				selectedOverview.instantBalance.amount > 0 && (
 					<Flex

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -73,7 +73,7 @@ const AccountBalances: React.FC = () => {
 		};
 
 		return (
-			<Card>
+			<Card className="wcpay-account-balances">
 				<CardHeader>Balances</CardHeader>
 				<CardBody className="wcpay-account-balances__balances">
 					<BalanceBlock
@@ -118,7 +118,7 @@ const AccountBalances: React.FC = () => {
 
 	return (
 		<>
-			<Card>
+			<Card className="wcpay-account-balances">
 				<CardHeader>Balances</CardHeader>
 				<CardBody className="wcpay-account-balances__balances">
 					<BalanceBlock

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -74,7 +74,7 @@ const AccountBalances: React.FC = () => {
 
 		return (
 			<Card className="wcpay-account-balances">
-				<CardHeader>Balances</CardHeader>
+				<CardHeader>Balance</CardHeader>
 				<CardBody className="wcpay-account-balances__balances">
 					<BalanceBlock
 						id={ `wcpay-account-balances-${ loadingData.currencyCode }-total` }
@@ -119,7 +119,7 @@ const AccountBalances: React.FC = () => {
 	return (
 		<>
 			<Card className="wcpay-account-balances">
-				<CardHeader>Balances</CardHeader>
+				<CardHeader>Balance</CardHeader>
 				<CardBody className="wcpay-account-balances__balances">
 					<BalanceBlock
 						id={ `wcpay-account-balances-${ selectedOverview.currencyCode }-total` }

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { useDispatch } from '@wordpress/data';
-import { Flex } from '@wordpress/components';
+import { Card, CardBody, CardHeader, Flex } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
@@ -73,22 +73,25 @@ const AccountBalances: React.FC = () => {
 		};
 
 		return (
-			<div className="wcpay-account-balances__balances">
-				<BalanceBlock
-					id={ `wcpay-account-balances-${ loadingData.currencyCode }-total` }
-					title={ fundLabelStrings.total }
-					amount={ 0 }
-					currencyCode={ loadingData.currencyCode }
-					isLoading
-				/>
-				<BalanceBlock
-					id={ `wcpay-account-balances-${ loadingData.currencyCode }-available` }
-					title={ fundLabelStrings.available }
-					amount={ 0 }
-					currencyCode={ loadingData.currencyCode }
-					isLoading
-				/>
-			</div>
+			<Card>
+				<CardHeader>Balances</CardHeader>
+				<CardBody className="wcpay-account-balances__balances">
+					<BalanceBlock
+						id={ `wcpay-account-balances-${ loadingData.currencyCode }-total` }
+						title={ fundLabelStrings.total }
+						amount={ 0 }
+						currencyCode={ loadingData.currencyCode }
+						isLoading
+					/>
+					<BalanceBlock
+						id={ `wcpay-account-balances-${ loadingData.currencyCode }-available` }
+						title={ fundLabelStrings.available }
+						amount={ 0 }
+						currencyCode={ loadingData.currencyCode }
+						isLoading
+					/>
+				</CardBody>
+			</Card>
 		);
 	}
 
@@ -115,26 +118,31 @@ const AccountBalances: React.FC = () => {
 
 	return (
 		<>
-			<div className="wcpay-account-balances__balances">
-				<BalanceBlock
-					id={ `wcpay-account-balances-${ selectedOverview.currencyCode }-total` }
-					title={ fundLabelStrings.total }
-					amount={ totalBalance }
-					currencyCode={ selectedOverview.currencyCode }
-					tooltip={ <TotalBalanceTooltip balance={ totalBalance } /> }
-				/>
-				<BalanceBlock
-					id={ `wcpay-account-balances-${ selectedOverview.currencyCode }-available` }
-					title={ fundLabelStrings.available }
-					amount={ selectedOverview.availableFunds }
-					currencyCode={ selectedOverview.currencyCode }
-					tooltip={
-						<AvailableBalanceTooltip
-							balance={ selectedOverview.availableFunds }
-						/>
-					}
-				/>
-			</div>
+			<Card>
+				<CardHeader>Balances</CardHeader>
+				<CardBody className="wcpay-account-balances__balances">
+					<BalanceBlock
+						id={ `wcpay-account-balances-${ selectedOverview.currencyCode }-total` }
+						title={ fundLabelStrings.total }
+						amount={ totalBalance }
+						currencyCode={ selectedOverview.currencyCode }
+						tooltip={
+							<TotalBalanceTooltip balance={ totalBalance } />
+						}
+					/>
+					<BalanceBlock
+						id={ `wcpay-account-balances-${ selectedOverview.currencyCode }-available` }
+						title={ fundLabelStrings.available }
+						amount={ selectedOverview.availableFunds }
+						currencyCode={ selectedOverview.currencyCode }
+						tooltip={
+							<AvailableBalanceTooltip
+								balance={ selectedOverview.availableFunds }
+							/>
+						}
+					/>
+				</CardBody>
+			</Card>
 			{ selectedOverview.instantBalance &&
 				selectedOverview.instantBalance.amount > 0 && (
 					<Flex

--- a/client/components/account-balances/style.scss
+++ b/client/components/account-balances/style.scss
@@ -1,8 +1,8 @@
 .wcpay-account-balances__balances__item {
 	flex-direction: column;
 	align-items: flex-start;
-	padding: 24px;
 	flex: 1;
+	padding-left: 16px;
 
 	&__title {
 		font-size: 12px;
@@ -21,8 +21,10 @@
 	}
 
 	@include breakpoint( '<660px' ) {
-		margin: 0 24px;
-		padding: 16px 0 24px 0;
+		padding-left: 0;
+		&:not( :first-child ) {
+			padding-top: 16px;
+		}
 	}
 }
 
@@ -37,6 +39,7 @@
 
 .wcpay-account-balances__balances {
 	display: flex;
+	padding: 24px 24px 32px 24px !important;
 
 	& > * + * {
 		border-left: 1px solid $gray-200;
@@ -68,7 +71,7 @@
 
 	@include breakpoint( '<660px' ) {
 		flex-direction: column;
-
+		gap: 16px;
 		& > * + * {
 			border-left: none;
 			border-top: 1px solid $gray-200;

--- a/client/components/account-balances/style.scss
+++ b/client/components/account-balances/style.scss
@@ -39,6 +39,7 @@
 
 .wcpay-account-balances__balances {
 	display: flex;
+	margin-bottom: 0;
 
 	& > * + * {
 		border-left: 1px solid $gray-200;
@@ -76,4 +77,9 @@
 			border-top: 1px solid $gray-200;
 		}
 	}
+}
+
+.components-card.wcpay-account-balances {
+	margin-bottom: 0;
+	box-shadow: none;
 }

--- a/client/components/account-balances/style.scss
+++ b/client/components/account-balances/style.scss
@@ -39,7 +39,6 @@
 
 .wcpay-account-balances__balances {
 	display: flex;
-	padding: 24px 24px 32px 24px !important;
 
 	& > * + * {
 		border-left: 1px solid $gray-200;

--- a/client/components/account-balances/style.scss
+++ b/client/components/account-balances/style.scss
@@ -1,7 +1,3 @@
-.wcpay-account-balances__balances > * + * {
-	border-left: 1px solid $gray-200;
-}
-
 .wcpay-account-balances__balances__item {
 	flex-direction: column;
 	align-items: flex-start;
@@ -23,6 +19,11 @@
 		margin: 0;
 		color: $gray-900;
 	}
+
+	@include breakpoint( '<660px' ) {
+		margin: 0 24px;
+		padding: 16px 0 24px 0;
+	}
 }
 
 .wcpay-account-balances__instant-deposit-notice .components-notice__content {
@@ -35,6 +36,12 @@
 }
 
 .wcpay-account-balances__balances {
+	display: flex;
+
+	& > * + * {
+		border-left: 1px solid $gray-200;
+	}
+
 	.wcpay-account-balances__balances__item__tooltip {
 		line-height: 20px;
 	}
@@ -56,6 +63,15 @@
 			white-space: nowrap;
 			color: $wp-blue-70;
 			margin-right: 0;
+		}
+	}
+
+	@include breakpoint( '<660px' ) {
+		flex-direction: column;
+
+		& > * + * {
+			border-left: none;
+			border-top: 1px solid $gray-200;
 		}
 	}
 }

--- a/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
@@ -3,9 +3,7 @@
 exports[`AccountBalances renders the correct tooltip text for the total balance 1`] = `
 <div>
   <div
-    class="components-flex wcpay-account-balances__balances css-1ng0jhd-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-    data-wp-c16t="true"
-    data-wp-component="Flex"
+    class="wcpay-account-balances__balances"
   >
     <div
       class="wcpay-account-balances__balances__item"

--- a/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AccountBalances renders the correct tooltip text for the total balance 1`] = `
 <div>
   <div
-    class="components-surface components-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+    class="components-surface components-card wcpay-account-balances css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
     data-wp-c16t="true"
     data-wp-component="Card"
   >

--- a/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
@@ -3,100 +3,131 @@
 exports[`AccountBalances renders the correct tooltip text for the total balance 1`] = `
 <div>
   <div
-    class="wcpay-account-balances__balances"
+    class="components-surface components-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+    data-wp-c16t="true"
+    data-wp-component="Card"
   >
     <div
-      class="wcpay-account-balances__balances__item"
+      class="css-mgwsf4-View-Content em57xhy0"
     >
-      <p
-        class="wcpay-account-balances__balances__item__title"
-        id="wcpay-account-balances-usd-total"
+      <div
+        class="components-flex components-card__header components-card-header css-1g5oj2q-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="CardHeader"
       >
-        <span>
-          Total balance
-        </span>
-        <button
-          class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
-          type="button"
+        Balances
+      </div>
+      <div
+        class="components-card__body components-card-body wcpay-account-balances__balances css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        data-wp-c16t="true"
+        data-wp-component="CardBody"
+      >
+        <div
+          class="wcpay-account-balances__balances__item"
         >
-          <div
-            class="wcpay-tooltip__content-wrapper"
+          <p
+            class="wcpay-account-balances__balances__item__title"
+            id="wcpay-account-balances-usd-total"
           >
-            <div
-              aria-label="Total balance tooltip"
-              role="button"
-              tabindex="0"
+            <span>
+              Total balance
+            </span>
+            <button
+              class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
+              type="button"
             >
-              <svg
-                class="gridicon gridicons-help-outline"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="wcpay-tooltip__content-wrapper"
               >
-                <g>
-                  <path
-                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2v-1.141A3.991 3.991 0 0016 10zm-3 6h-2v2h2v-2z"
-                  />
-                </g>
-              </svg>
-            </div>
-          </div>
-        </button>
-      </p>
-      <p
-        aria-labelledby="wcpay-account-balances-usd-total"
-        class="wcpay-account-balances__balances__item__amount"
-      >
-        $300.00
-      </p>
+                <div
+                  aria-label="Total balance tooltip"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="gridicon gridicons-help-outline"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2v-1.141A3.991 3.991 0 0016 10zm-3 6h-2v2h2v-2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </button>
+          </p>
+          <p
+            aria-labelledby="wcpay-account-balances-usd-total"
+            class="wcpay-account-balances__balances__item__amount"
+          >
+            $300.00
+          </p>
+        </div>
+        <div
+          class="wcpay-account-balances__balances__item"
+        >
+          <p
+            class="wcpay-account-balances__balances__item__title"
+            id="wcpay-account-balances-usd-available"
+          >
+            <span>
+              Available funds
+            </span>
+            <button
+              class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
+              type="button"
+            >
+              <div
+                class="wcpay-tooltip__content-wrapper"
+              >
+                <div
+                  aria-label="Available funds tooltip"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="gridicon gridicons-help-outline"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2v-1.141A3.991 3.991 0 0016 10zm-3 6h-2v2h2v-2z"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </button>
+          </p>
+          <p
+            aria-labelledby="wcpay-account-balances-usd-available"
+            class="wcpay-account-balances__balances__item__amount"
+          >
+            $200.00
+          </p>
+        </div>
+      </div>
     </div>
     <div
-      class="wcpay-account-balances__balances__item"
-    >
-      <p
-        class="wcpay-account-balances__balances__item__title"
-        id="wcpay-account-balances-usd-available"
-      >
-        <span>
-          Available funds
-        </span>
-        <button
-          class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
-          type="button"
-        >
-          <div
-            class="wcpay-tooltip__content-wrapper"
-          >
-            <div
-              aria-label="Available funds tooltip"
-              role="button"
-              tabindex="0"
-            >
-              <svg
-                class="gridicon gridicons-help-outline"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g>
-                  <path
-                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2v-1.141A3.991 3.991 0 0016 10zm-3 6h-2v2h2v-2z"
-                  />
-                </g>
-              </svg>
-            </div>
-          </div>
-        </button>
-      </p>
-      <p
-        aria-labelledby="wcpay-account-balances-usd-available"
-        class="wcpay-account-balances__balances__item__amount"
-      >
-        $200.00
-      </p>
-    </div>
+      aria-hidden="true"
+      class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+      data-wp-c16t="true"
+      data-wp-component="Elevation"
+    />
+    <div
+      aria-hidden="true"
+      class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+      data-wp-c16t="true"
+      data-wp-component="Elevation"
+    />
   </div>
 </div>
 `;

--- a/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`AccountBalances renders the correct tooltip text for the total balance 
         data-wp-c16t="true"
         data-wp-component="CardHeader"
       >
-        Balances
+        Balance
       </div>
       <div
         class="components-card__body components-card-body wcpay-account-balances__balances css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"


### PR DESCRIPTION
Fixes #8599 

#### Changes proposed in this Pull Request

* Make the items within the Balance card stack vertically on mobile view, as per recommended design
* Add card title - `Balances` 
* Use Card component instead of Flex

#### Screen recording
https://github.com/user-attachments/assets/2df4c486-0afd-4237-af13-b6cfdfd06671


#### Screen recording with instant deposit notice

https://github.com/user-attachments/assets/116af7a4-4b91-44c1-a4a8-6b3c58d39f4c

#### Screen recording with instant deposit button without notice

https://github.com/user-attachments/assets/3cd69845-ce0b-4ce1-b8fe-bec07551e503


#### Testing instructions

* Checkout this branch
* Browse to `Payments > Overview` and notice that the Balances card now appears with a title.
* Resize the browser window. When it falls below 660px, the card items should stack vertically, similar to the recording
* Use an account with an instant balance, or overwrite the index.tsx of the account balances component with [this code](https://gist.github.com/nagpai/7df1b5c3963b1539cff86f6044e8409c) ( take care not to push :D ) . 
* You should now see the instant deposit box and button. Check how it looks when you resize
* Remove the notice and have only the button by tweaking the code, or canceling the notice ( if you are using a test site with instant payout ) . Resize the window and check how it looks. 
* Compare all results with what is shown in the screen recordings, and the figma mockup.   

#### Notes
* Figma design - o5NOD3EJaKSoILbvvZiAwU-fi

<img width="1798" alt="Mobile views" src="https://github.com/Automattic/woocommerce-payments/assets/94967682/447ef755-e927-42f0-b906-717fe722825b">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.