### PR TITLE
Reporting: Fix transaction list sort by payout currency

### DIFF
--- a/changelog/fix-10038-payout-currency-sort
+++ b/changelog/fix-10038-payout-currency-sort
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix transaction list sorting by payout currency

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -202,7 +202,7 @@ const getColumns = (
 			visible: false,
 		},
 		{
-			key: 'deposit_currency',
+			key: 'currency',
 			label: __( 'Payout Currency', 'woocommerce-payments' ),
 			screenReaderLabel: __( 'Payout Currency', 'woocommerce-payments' ),
 			isSortable: true,
@@ -537,7 +537,7 @@ export const TransactionsList = (
 				display: clickable( txn.customer_currency.toUpperCase() ),
 			},
 			customer_amount: formatCustomerAmount(),
-			deposit_currency: {
+			currency: {
 				value: txn.currency.toUpperCase(),
 				display: clickable( txn.currency.toUpperCase() ),
 			},


### PR DESCRIPTION
Fixes #10038 

#### Changes proposed in this Pull Request

* Correct the key for `Payout currency` to `currency` from `deposit_currency` 
* This will fix the error we are currently seeing while sorting the Transactions list report by `Payout currency`

https://github.com/user-attachments/assets/37c0e007-7ddb-4e29-80b1-6cedeedc6995

#### Testing instructions

* Checkout this branch on your test site
* It is good to have a test site with transactions using multiple currencies
* Browse to `Payments > Transactions` 
* Unhide the `Payout currency` column
* Click the sort button on the `Payout currency` column
* You should see the transactions getting sorted correctly without any `No data to display` message as earlier.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
