### PR TITLE
Update currency conversion method for booking products

### DIFF
--- a/changelog/fix-472-mccy-wc-bookings
+++ b/changelog/fix-472-mccy-wc-bookings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update currency conversion method for booking products.

--- a/includes/multi-currency/Compatibility/WooCommerceBookings.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBookings.php
@@ -10,6 +10,7 @@ namespace WCPay\MultiCurrency\Compatibility;
 use WCPay\MultiCurrency\FrontendCurrencies;
 use WCPay\MultiCurrency\MultiCurrency;
 use WCPay\MultiCurrency\Utils;
+use WC_Product;
 
 /**
  * Class that controls Multi Currency Compatibility with WooCommerce Bookings Plugin.
@@ -43,6 +44,7 @@ class WooCommerceBookings extends BaseCompatibility {
 		// Add needed actions and filters if Bookings is active.
 		if ( class_exists( 'WC_Bookings' ) ) {
 			if ( ! is_admin() || wp_doing_ajax() ) {
+				add_filter( 'woocommerce_bookings_calculated_booking_cost', [ $this, 'adjust_amount_for_calculated_booking_cost' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_block_cost', [ $this, 'get_price' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_cost', [ $this, 'get_price' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_display_cost', [ $this, 'get_price' ], 50, 1 );
@@ -50,7 +52,7 @@ class WooCommerceBookings extends BaseCompatibility {
 				add_filter( 'woocommerce_product_booking_person_type_get_cost', [ $this, 'get_price' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_resource_base_costs', [ $this, 'get_resource_prices' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_resource_block_costs', [ $this, 'get_resource_prices' ], 50, 1 );
-				add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ] );
+				add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ], 50, 2 );
 				add_action( 'wp_ajax_wc_bookings_calculate_costs', [ $this, 'add_wc_price_args_filter_for_ajax' ], 9 );
 				add_action( 'wp_ajax_nopriv_wc_bookings_calculate_costs', [ $this, 'add_wc_price_args_filter_for_ajax' ], 9 );
 			}
@@ -58,7 +60,28 @@ class WooCommerceBookings extends BaseCompatibility {
 	}
 
 	/**
-	 * Returns the price for an item.
+	 * Adjusts the calculated booking cost for the selected currency, applying rounding and charm pricing as necessary.
+	 *
+	 * @param mixed $costs The original calculated booking costs.
+	 * @return mixed The booking cost adjusted for the selected currency.
+	 */
+	public function adjust_amount_for_calculated_booking_cost( $costs ) {
+		/**
+		 * Prevents adjustment of the calculated booking cost during cart addition.
+		 *
+		 * When a booking is added to the cart, the Booking plugin calculates the booking cost and
+		 * overrides the cart item price with this calculated amount. To avoid interfering with this process,
+		 * this function skips any additional adjustments at this stage.
+		 */
+		if ( $this->utils->is_call_in_backtrace( [ 'WC_Cart->add_to_cart' ] ) ) {
+			return $costs;
+		}
+
+		return $this->multi_currency->adjust_amount_for_selected_currency( $costs );
+	}
+
+	/**
+	 * Retrieves the price for an item, converting it based on the selected currency and context.
 	 *
 	 * @param mixed $price The item's price.
 	 *
@@ -68,7 +91,19 @@ class WooCommerceBookings extends BaseCompatibility {
 		if ( ! $price ) {
 			return $price;
 		}
-		return $this->multi_currency->get_price( $price, 'product' );
+
+		// Skip conversion during specific booking cost calculations to avoid double conversion.
+		if ( $this->utils->is_call_in_backtrace( [ 'WC_Cart->add_to_cart' ] ) && $this->utils->is_call_in_backtrace( [ 'WC_Bookings_Cost_Calculation::calculate_booking_cost' ] ) ) {
+			return $price;
+		}
+
+		/**
+		 * When showing the price in HTML, the function applies currency conversion, charm pricing,
+		 * and rounding. For internal calculations, it uses the raw exchange rate, with charm pricing
+		 * and rounding adjustments applied only to the final calculated amount (handled in
+		 * adjust_amount_for_calculated_booking_cost).
+		 */
+		return $this->multi_currency->get_price( $price, $this->utils->is_call_in_backtrace( [ 'WC_Product_Booking->get_price_html' ] ) ? 'product' : 'exchange_rate' );
 	}
 
 	/**
@@ -90,26 +125,15 @@ class WooCommerceBookings extends BaseCompatibility {
 	/**
 	 * Checks to see if the product's price should be converted.
 	 *
-	 * @param bool $return Whether to convert the product's price or not. Default is true.
+	 * @param bool       $return Whether to convert the product's price or not. Default is true.
+	 * @param WC_Product $product The product instance being checked.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $return ): bool {
-		// If it's already false, return it.
-		if ( ! $return ) {
+	public function should_convert_product_price( bool $return, WC_Product $product ): bool {
+		// If it's already false, or the product is not a booking, ignore it.
+		if ( ! $return || $product->get_type() !== 'booking' ) {
 			return $return;
-		}
-
-		// This prevents a double conversion of the price in the cart.
-		if ( $this->utils->is_call_in_backtrace( [ 'WC_Product_Booking->get_price' ] ) ) {
-			$calls = [
-				'WC_Cart_Totals->calculate_item_totals',
-				'WC_Cart->get_product_price',
-				'WC_Cart->get_product_subtotal',
-			];
-			if ( $this->utils->is_call_in_backtrace( $calls ) ) {
-				return false;
-			}
 		}
 
 		// Fixes price display on product page and in shop.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1327,6 +1327,20 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Adjusts the given amount for the currently selected currency.
+	 *
+	 * Applies charm pricing if specified, and adjusts the amount according to
+	 * the selected currency's conversion rate.
+	 *
+	 * @param  float $amount              The original amount to adjust.
+	 * @param  bool  $apply_charm_pricing Optional. Whether to apply charm pricing to the adjusted amount. Default true.
+	 * @return float                       The amount adjusted for the selected currency.
+	 */
+	public function adjust_amount_for_selected_currency( $amount, $apply_charm_pricing = true ) {
+		return $this->get_adjusted_price( $amount, $apply_charm_pricing, $this->get_selected_currency() );
+	}
+
+	/**
 	 * Gets the price after adjusting it with the rounding and charm settings.
 	 *
 	 * @param float    $price               The price to be adjusted.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1108,7 +1108,7 @@ class MultiCurrency {
 		woocommerce_admin_meta_boxes.rounding_precision = <?php echo (int) $rounding_precision; ?>;
 		</script>
 			<?php
-		endif;
+			endif;
 	}
 
 	/**
@@ -1252,10 +1252,10 @@ class MultiCurrency {
 	public function is_multi_currency_settings_page(): bool {
 		global $current_screen, $current_tab;
 		return (
-			is_admin()
-			&& $current_tab && $current_screen
-			&& 'wcpay_multi_currency' === $current_tab
-			&& 'woocommerce_page_wc-settings' === $current_screen->base
+		is_admin()
+		&& $current_tab && $current_screen
+		&& 'wcpay_multi_currency' === $current_tab
+		&& 'woocommerce_page_wc-settings' === $current_screen->base
 		);
 	}
 
@@ -1277,7 +1277,7 @@ class MultiCurrency {
 		$query_union = [];
 
 		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) &&
-					\Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
+				\Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			foreach ( $currencies as $currency ) {
 				$query_union[] = $wpdb->prepare(
 					"SELECT %s AS currency_code, EXISTS(SELECT currency FROM {$wpdb->prefix}wc_orders WHERE currency=%s LIMIT 1) AS exists_in_orders",
@@ -1339,6 +1339,7 @@ class MultiCurrency {
 	 */
 	public function adjust_amount_for_selected_currency( $amount, $apply_charm_pricing = true ) {
 		return $this->get_adjusted_price( $amount, $apply_charm_pricing, $this->get_selected_currency() );
+	}
 
 	/**
 	 * Returns the amount with the backend format.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the method for calculating currency conversion in Booking products to prevent precision errors.

#### Testing Instructions

p1735230380385089-slack-C01BZUL57SQ

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.