### PR TITLE
Set orderby to `none` for order queries where checking if order exists.

### DIFF
--- a/changelog/fix-10046-set-orderby-none-for-exist-checks
+++ b/changelog/fix-10046-set-orderby-none-for-exist-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set orderby to `none` for order queries where checking if order exists.

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -275,6 +275,7 @@ class WC_Payments_Incentives_Service {
 					'payment_method' => 'woocommerce_payments',
 					'return'         => 'ids',
 					'limit'          => 1,
+					'orderby'        => 'none',
 				]
 			)
 		) ) {
@@ -319,6 +320,7 @@ class WC_Payments_Incentives_Service {
 						'date_created' => '>=' . strtotime( '-90 days' ),
 						'return'       => 'ids',
 						'limit'        => 1,
+						'orderby'      => 'none',
 					]
 				)
 			),


### PR DESCRIPTION
Partially Fixes #10046 (caching should still be added)

#### Changes proposed in this Pull Request

Set orderby to `none` for order queries where checking if order exists.

The queries run by `wc_get_orders()` as requested from `WC_Payments_Incentives_Service->get_store_context()` are pretty slow for sites with a large number or orders. Since we only need to check if an order exists, we can optimize these queries a bit by setting the `orderby` clause to `none`.  This allows the query to return as soon as it finds the first matching record rather than needing to continue to scan for all the matching rows so it can sort to find the newest order.

This only improves the query performance if an order matching the criteria exists, but it is at least a start.  We should add caching around these queries to avoid the need to have them run every admin page load.

#### Testing instructions

* Visit the WordPress admin of a site with WooPayments active, but not connected.
* Verify that the payments_menu_badge loads correctly based on the state of the site.
