### PR TITLE
Changed the term "VAT" on Documents Listing Page to "Tax" to be applicable to all countries

### DIFF
--- a/changelog/fix-9923-replace-VAT-term
+++ b/changelog/fix-9923-replace-VAT-term
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Replaced the term "VAT" with "Tax" in Documents Listing Page

--- a/client/documents/filters/test/__snapshots__/index.tsx.snap
+++ b/client/documents/filters/test/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ HTMLOptionsCollection [
   <option
     value="vat_invoice"
   >
-    VAT Invoice
+    Tax Invoice
   </option>,
 ]
 `;

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -66,13 +66,13 @@ const getDocumentDescription = ( document: Document ) => {
 		case 'vat_invoice':
 			if ( document.period_from && document.period_to ) {
 				return sprintf(
-					__( 'VAT invoice for %s to %s', 'woocommerce-payments' ),
+					__( 'Tax invoice for %s to %s', 'woocommerce-payments' ),
 					formatDateTimeFromString( document.period_from ),
 					formatDateTimeFromString( document.period_to )
 				);
 			}
 			return __(
-				'VAT invoice without proper period dates',
+				'Tax invoice without proper period dates',
 				'woocommerce-payments'
 			);
 

--- a/client/documents/list/test/__snapshots__/index.tsx.snap
+++ b/client/documents/list/test/__snapshots__/index.tsx.snap
@@ -222,12 +222,12 @@ exports[`Documents list renders correctly 1`] = `
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT Invoice
+                    Tax Invoice
                   </td>
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT invoice without proper period dates
+                    Tax invoice without proper period dates
                   </td>
                   <td
                     class="woocommerce-table__item is-numeric"
@@ -250,12 +250,12 @@ exports[`Documents list renders correctly 1`] = `
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT Invoice
+                    Tax Invoice
                   </td>
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT invoice without proper period dates
+                    Tax invoice without proper period dates
                   </td>
                   <td
                     class="woocommerce-table__item is-numeric"
@@ -537,12 +537,12 @@ exports[`Documents list renders table summary only when the documents summary da
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT Invoice
+                    Tax Invoice
                   </td>
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT invoice without proper period dates
+                    Tax invoice without proper period dates
                   </td>
                   <td
                     class="woocommerce-table__item is-numeric"
@@ -565,12 +565,12 @@ exports[`Documents list renders table summary only when the documents summary da
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT Invoice
+                    Tax Invoice
                   </td>
                   <td
                     class="woocommerce-table__item is-left-aligned"
                   >
-                    VAT invoice without proper period dates
+                    Tax invoice without proper period dates
                   </td>
                   <td
                     class="woocommerce-table__item is-numeric"

--- a/client/documents/strings.ts
+++ b/client/documents/strings.ts
@@ -7,5 +7,5 @@ import { __ } from '@wordpress/i18n';
 
 // Mapping of transaction types to display string.
 export const displayType = {
-	vat_invoice: __( 'VAT Invoice', 'woocommerce-payments' ),
+	vat_invoice: __( 'Tax Invoice', 'woocommerce-payments' ),
 };


### PR DESCRIPTION
Fixes #9923 

#### Changes proposed in this Pull Request
Changes the term "VAT" to Tax in document listing page

Before:
![image](https://github.com/user-attachments/assets/5347dcc8-8aea-42fb-a1e1-15b8a23b610c)

After:
![image](https://github.com/user-attachments/assets/07e804e9-3002-441d-b79a-4d7dfe0bd094)

##### Notes:
Searched for instances of VAT in codebase and found only the above page and VAT Task Form, which is already customized for JP vs other countries. So updated this page.

#### Testing instructions
- Account country should be supporting VAT.
- You can enable the documents section by checking "Enable WCPay Documents section" using WCPay Dev Tools
- Insert a document to be displayed:
`wp wcpay add_document_for_account [account_id] vat_invoice --mode=test --period_from="2024-04-01 00:00:00" --period_to="2024-04-30 23:59:59"`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
