### PR TITLE
Pass theme editor footer and header styles to WooPay

### DIFF
--- a/changelog/fix-woopay-theme-editor-header-footer
+++ b/changelog/fix-woopay-theme-editor-header-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass theme editor footer and header styles to WooPay.

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -156,9 +156,9 @@ export const appearanceSelectors = {
 		buttonSelectors: [ '#place_order' ],
 		linkSelectors: [ 'a' ],
 		containerSelectors: [ '.woocommerce-checkout-review-order-table' ],
-		headerSelectors: [ '.site-header' ],
-		footerSelectors: [ '.site-footer' ],
-		footerLink: [ '.site-footer a' ],
+		headerSelectors: [ '.site-header', 'header > div' ],
+		footerSelectors: [ '.site-footer', 'footer > div' ],
+		footerLink: [ '.site-footer a', 'footer a' ],
 	},
 
 	/**


### PR DESCRIPTION
Fixes #10076

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Pass shortcode checkout page header and footer styles to WooPay when using a theme that supports theme editor.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable WooPay global theming on merchant site.
* Enable a theme that uses theme editor such as Twenty Twenty-Four.
* Customize the theme footer and header styles.
* Checkout with WooPay.
* The footer and header styles should be applied to WooPay (it will get the color of the first text and link that appear on these elements).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
