### PR TITLE
Add ECE support to shipping subscriptions with free trial and sign up fee

### DIFF
--- a/changelog/as-fix-ece-shipping-subs-with-free-trial-and-sign-up-fee-tokenized-carts
+++ b/changelog/as-fix-ece-shipping-subs-with-free-trial-and-sign-up-fee-tokenized-carts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Enable ECE for shipping subscriptions with free trial and sign up fee.

--- a/client/tokenized-express-checkout/event-handlers.js
+++ b/client/tokenized-express-checkout/event-handlers.js
@@ -65,7 +65,7 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 		lastSelectedAddress = event.address;
 
 		event.resolve( {
-			shippingRates: transformCartDataForShippingRates( cartData ),
+			shippingRates: shippingRates,
 			lineItems: transformCartDataForDisplayItems( cartData ),
 		} );
 	} catch ( error ) {

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -347,6 +347,20 @@ jQuery( ( $ ) => {
 						// checking if items needed shipping, before assigning new cart data.
 						const didItemsNeedShipping = options.requestShipping;
 
+						// TODO: Support for this case will be added later.
+						// See https://github.com/Automattic/woocommerce-payments/issues/9983
+						if (
+							cachedCartData.needs_shipping &&
+							cachedCartData.items[ 0 ].extensions.subscriptions
+								.trial_length > 0 &&
+							! Number(
+								cachedCartData.items[ 0 ].extensions
+									.subscriptions.sign_up_fees
+							) > 0
+						) {
+							throw new Error( 'Not supported yet' );
+						}
+
 						/**
 						 * If the customer aborted the payment request, we need to re init the payment request button to ensure the shipping
 						 * options are re-fetched. If the customer didn't abort the payment request, and the product's shipping status is

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -347,8 +347,9 @@ jQuery( ( $ ) => {
 						// checking if items needed shipping, before assigning new cart data.
 						const didItemsNeedShipping = options.requestShipping;
 
-						// TODO: Support for this case will be added later.
-						// See https://github.com/Automattic/woocommerce-payments/issues/9983
+						// Disable ECE for shipping variable subscriptions with free trial and **no** sign up fee.
+						// Applies to Case 11 from matrix:
+						// https://github.com/Automattic/woocommerce-payments/issues/9983
 						if (
 							cachedCartData.needs_shipping &&
 							cachedCartData.items[ 0 ].extensions.subscriptions

--- a/client/tokenized-express-checkout/transformers/wc-to-stripe.js
+++ b/client/tokenized-express-checkout/transformers/wc-to-stripe.js
@@ -102,8 +102,11 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
  * @param {Object} cartData Store API Cart response object.
  * @return {{id: string, label: string, amount: integer, deliveryEstimate: string}} `shippingRates` for Stripe.
  */
-export const transformCartDataForShippingRates = ( cartData ) =>
-	cartData.shipping_rates?.[ 0 ]?.shipping_rates
+export const transformCartDataForShippingRates = ( cartData ) => {
+	const shippingRates =
+		cartData.extensions?.subscriptions?.[ 0 ]?.shipping_rates ??
+		cartData.shipping_rates;
+	return shippingRates?.[ 0 ]?.shipping_rates
 		.sort( ( rateA, rateB ) => {
 			if ( rateA.selected === rateB.selected ) {
 				return 0; // Keep relative order if both have the same value for 'selected'
@@ -127,3 +130,4 @@ export const transformCartDataForShippingRates = ( cartData ) =>
 				.map( decodeEntities )
 				.join( ' - ' ),
 		} ) );
+};

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -871,6 +871,10 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		if ( in_array( $product->get_type(), $subscription_types, true ) && class_exists( 'WC_Subscriptions_Product' ) ) {
 			// When there is no sign-up fee, `get_sign_up_fee` falls back to an int 0.
 			$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $product );
+			// If the subscription includes a free trial, the base price should be considered as zero.
+			if ( WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+				$base_price = 0;
+			}
 		}
 
 		if ( ! is_numeric( $base_price ) || ! is_numeric( $sign_up_fee ) ) {

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -795,12 +795,12 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		if ( is_null( $product ) || ! is_object( $product ) ) {
 			$is_supported = false;
 		} else {
-			// Simple subscription that needs shipping with free trials is not supported.
-			$is_free_trial_simple_subs = class_exists( 'WC_Subscriptions_Product' ) && $product->get_type() === 'subscription' && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0;
-
+			// Applies to case 3 from matrix: https://github.com/Automattic/woocommerce-payments/issues/9771#issuecomment-2518829514.
+			// Note: This does not check variable subscriptions, as that will be handled on the frontend.
+			$is_free_trial_simple_subs_no_sign_up_fee = class_exists( 'WC_Subscriptions_Product' ) && $product->get_type() === 'subscription' && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 && WC_Subscriptions_Product::get_sign_up_fee( $product ) === 0;
 			if (
 			! in_array( $product->get_type(), $this->supported_product_types(), true )
-			|| $is_free_trial_simple_subs
+			|| $is_free_trial_simple_subs_no_sign_up_fee
 			|| ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) // Pre Orders charge upon release not supported.
 			|| ( class_exists( 'WC_Composite_Products' ) && $product->is_type( 'composite' ) ) // Composite products are not supported on the product page.
 			|| ( class_exists( 'WC_Mix_and_Match' ) && $product->is_type( 'mix-and-match' ) ) // Mix and match products are not supported on the product page.


### PR DESCRIPTION
Part of https://github.com/Automattic/woocommerce-payments/issues/9771

### Changes proposed in this Pull Request

Enables ECE for subscriptions that require shipping with a free trial and sign-up fee.

### Testing instructions


* Switch to this branch
* For reference, case matrix is [here](https://github.com/Automattic/woocommerce-payments/issues/9771#issuecomment-2518829514).

**Verify ECE is enabled for case 4**

- Create a simple subscription with a free trial and a sign up fee.
- Go to the product page.
- Verify ECE is enabled and can checkout without issues.

**Verify ECE is enabled for case 12**

- Create a variable subscription with at least one variation with only the following options:
  - With Free trial
  - With a Sign up fee.
- Go to the product page.
- Verify ECE is enabled and can checkout without issues.

**Verify ECE is not enabled for Case 3**

- Create a simple subscription with a free trial (do not add a sign up fee).
- Go to the product page.
- Verify ECE is not displayed.

**Verify ECE is not enabled for Case 11**

- Create a variable subscription with at least one variation with only the following options:
  - Free trial.
- Go to the product page.
- Verify ECE is hidden after selecting the variation.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
