### PR TITLE
Improve E2E test reliability by disabling "Coming Soon" mode and handling dynamic checkout fields

### DIFF
--- a/changelog/dev-10115-disable-coming-soon-mode-for-e2e
+++ b/changelog/dev-10115-disable-coming-soon-mode-for-e2e
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Improve E2E test reliability by resetting configurations and handling optional checkout fields.

--- a/tests/e2e-pw/specs/reset.setup.ts
+++ b/tests/e2e-pw/specs/reset.setup.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { test as setup, expect } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { getMerchant } from '../utils/helpers';
+
+setup( 'disable the coming soon mode', async ( { browser } ) => {
+	const { merchantPage } = await getMerchant( browser );
+
+	// Check if the store is in coming soon mode.
+	await merchantPage.goto( '/wp-admin/' );
+	await merchantPage.waitForLoadState( 'domcontentloaded' );
+
+	const comingSoonBadge = merchantPage.getByText( 'Store coming soon' );
+
+	if ( ! ( await comingSoonBadge.isVisible() ) ) {
+		return;
+	}
+
+	// Disable the coming soon mode.
+	await comingSoonBadge.click();
+	await expect(
+		merchantPage.getByText( 'Manage how your site appears to visitors.' )
+	).toBeVisible();
+	await merchantPage.waitForLoadState( 'domcontentloaded' );
+
+	await merchantPage.locator( 'label' ).filter( { hasText: 'Live' } ).click();
+	await merchantPage
+		.locator( '.woocommerce-save-button', { hasText: 'Save changes' } )
+		.click();
+
+	await expect(
+		merchantPage.getByText( /Your settings have been saved/ )
+	).toBeVisible();
+} );

--- a/tests/e2e-pw/utils/shopper.ts
+++ b/tests/e2e-pw/utils/shopper.ts
@@ -12,29 +12,38 @@ export const isUIUnblocked = async ( page: Page ) => {
 	await expect( page.locator( '.blockUI' ) ).toHaveCount( 0 );
 };
 
+const billingAddressFields = [
+	{ selector: '#billing_first_name', key: 'firstname', type: 'text' },
+	{ selector: '#billing_last_name', key: 'lastname', type: 'text' },
+	{ selector: '#billing_company', key: 'company', type: 'text' },
+	{ selector: '#billing_country', key: 'country', type: 'select' },
+	{ selector: '#billing_address_1', key: 'addressfirstline', type: 'text' },
+	{ selector: '#billing_address_2', key: 'addresssecondline', type: 'text' },
+	{ selector: '#billing_city', key: 'city', type: 'text' },
+	{ selector: '#billing_state', key: 'state', type: 'select' },
+	{ selector: '#billing_postcode', key: 'postcode', type: 'text' },
+	{ selector: '#billing_phone', key: 'phone', type: 'text' },
+	{ selector: '#billing_email', key: 'email', type: 'text' },
+];
+
 export const fillBillingAddress = async (
 	page: Page,
 	billingAddress: CustomerAddress
 ) => {
-	await page
-		.locator( '#billing_first_name' )
-		.fill( billingAddress.firstname );
-	await page.locator( '#billing_last_name' ).fill( billingAddress.lastname );
-	await page.locator( '#billing_company' ).fill( billingAddress.company );
-	await page
-		.locator( '#billing_country' )
-		.selectOption( billingAddress.country );
-	await page
-		.locator( '#billing_address_1' )
-		.fill( billingAddress.addressfirstline );
-	await page
-		.locator( '#billing_address_2' )
-		.fill( billingAddress.addresssecondline );
-	await page.locator( '#billing_city' ).fill( billingAddress.city );
-	await page.locator( '#billing_state' ).selectOption( billingAddress.state );
-	await page.locator( '#billing_postcode' ).fill( billingAddress.postcode );
-	await page.locator( '#billing_phone' ).fill( billingAddress.phone );
-	await page.locator( '#billing_email' ).fill( billingAddress.email );
+	for ( const field of billingAddressFields ) {
+		const element = page.locator( field.selector );
+		const value = billingAddress[ field.key ];
+
+		if ( ! ( await element.isVisible() ) ) {
+			continue;
+		}
+
+		if ( field.type === 'text' ) {
+			await element.fill( value );
+		} else if ( field.type === 'select' ) {
+			await element.selectOption( value );
+		}
+	}
 };
 
 // This is currently the source of some flaky tests since sometimes the form is not submitted


### PR DESCRIPTION
Fixes #10115

#### Changes proposed in this Pull Request

This PR aims to enhance the reliability of our end-to-end tests by disabling the "Coming soon" mode (when enabled) and checking if the checkout fields exist before attempting to fill them. These changes aim to provide a consistent and robust testing environment for all scenarios.

* Setup step to disable "Coming Soon" mode: Introduces a setup step to reset the site configuration and ensure the "Coming Soon" mode is disabled before tests are executed. This guarantees the site is accessible for testing.
* Dynamic handling of checkout fields: Updates test logic to check for the presence of fields on the checkout page before attempting to fill them, accommodating variations based on site configuration.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before checking out to this branch**

* Add `E2E_WC_VERSION=beta` to your `tests/e2e/config/local.env`
* Rebuild your E2E env by running `npm run test:e2e-reset` followed by `npm run test:e2e-setup`
* Run `npm run test:e2e-pw-ui shopper-checkout-purchase`
* Confirm that the site is failing due to the coming soon mode 

**Checkout to this branch**

* Run the test again
* The tests should be passing
  * The "using a 3DS card" test can be a bit flaky due to the fixed timeout on it but it seems to be passing consistently on the CI
* Apply the following diff to remove the main change in the checkout fields handling:
```diff
diff --git a/tests/e2e-pw/utils/shopper.ts b/tests/e2e-pw/utils/shopper.ts
index 5a80d2ec4..36bbf0657 100644
--- a/tests/e2e-pw/utils/shopper.ts
+++ b/tests/e2e-pw/utils/shopper.ts
@@ -34,9 +34,9 @@ export const fillBillingAddress = async (
 		const element = page.locator( field.selector );
 		const value = billingAddress[ field.key ];
 
-		if ( ! ( await element.isVisible() ) ) {
-			continue;
-		}
+		// if ( ! ( await element.isVisible() ) ) {
+		// 	continue;
+		// }
 
 		if ( field.type === 'text' ) {
 			await element.fill( value );

```

* Run the test again
* The `using a basic card` test should fail

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
