### PR TITLE
Remove unused get transaction endpoint

### DIFF
--- a/changelog/dev-5961-remove-unused-get-transaction-endpoint
+++ b/changelog/dev-5961-remove-unused-get-transaction-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Removed unused get single transaction endpoint

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -98,15 +98,6 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<transaction_id>\w+)',
-			[
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'get_transaction' ],
-				'permission_callback' => [ $this, 'check_permission' ],
-			]
-		);
 	}
 
 	/**
@@ -177,16 +168,6 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 		$filters    = $this->get_transactions_filters( $request );
 
 		return $this->forward_request( 'get_transactions_export', [ $filters, $user_email, $deposit_id, $locale ] );
-	}
-
-	/**
-	 * Retrieve transaction to respond with via API.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 */
-	public function get_transaction( $request ) {
-		$transaction_id = $request->get_param( 'transaction_id' );
-		return $this->forward_request( 'get_transactions', [ 'transaction_id' ] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5961, #8658  

#### Changes proposed in this Pull Request  

This PR addresses #5961 by taking an alternative approach suggested in https://github.com/Automattic/woocommerce-payments/issues/5961#issuecomment-1516010967. Instead of fixing the "Get Transaction by ID" endpoint, the endpoint is removed, as it is currently unused by the client.  

Removing the endpoint helps reduce code complexity and maintenance overhead. If needed in the future, the endpoint can be easily reintroduced.  


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing Instructions  

1. Ensure all tests pass successfully.  
2. (Optional) Manually call the endpoint referenced in #5961 to confirm it returns a 404 error.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
