### PR TITLE
Set a default minimum height to the WooPay button.

### DIFF
--- a/changelog/as-fix-min-height-woopay-button
+++ b/changelog/as-fix-min-height-woopay-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Set a default minimum height to the WooPay button.

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -142,6 +142,7 @@
 	white-space: nowrap;
 	text-transform: none;
 	list-style-type: none;
+	min-height: auto;
 
 	&:not( :disabled ):hover {
 		background: #e0e0e0 !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9454

#### Changes proposed in this Pull Request

Resets the minimum height of the WooPay button.

#### Testing instructions


- Switch to the `develop` branch.
- Add a CSS rule that affects the heights of all buttons in the page. You can try adding the following to the main CSS file of your theme.
  ```
  button {
    min-height: 5em;
  }
  ```
- Notice the WooPay button has increased its height:
  <img width="368" alt="Screenshot 2025-01-10 at 3 56 22 PM" src="https://github.com/user-attachments/assets/d1ff6ff0-b702-4404-bab7-b27ad50aaa3f" />
- Switch to this branch `as-fix-min-height-woopay-button`
- Verify the height is the expected.
<img width="532" alt="Screenshot 2025-01-10 at 4 01 10 PM" src="https://github.com/user-attachments/assets/e60698f0-ed67-496a-9180-a2513e543321" />

- Verify that the WooPay button has the expected height on all pages where it is rendered.
- Verify that the different button sizes render with the correct height.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
