### PR TITLE
Broaden billing field queries from form-scoped to document-scoped

### DIFF
--- a/changelog/fix-scope-out-billing-fields-selectors
+++ b/changelog/fix-scope-out-billing-fields-selectors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Broaden billing field queries from form-scoped to document-scoped

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -76,7 +76,7 @@ jQuery( function ( $ ) {
 	} );
 
 	$checkoutForm.on( generateCheckoutEventNames(), function () {
-		if ( isBillingInformationMissing( this ) ) {
+		if ( isBillingInformationMissing() ) {
 			return;
 		}
 

--- a/client/checkout/utils/test/upe.test.js
+++ b/client/checkout/utils/test/upe.test.js
@@ -36,6 +36,7 @@ function buildForm( fields ) {
 		input.value = field.value;
 		form.appendChild( input );
 	} );
+	document.body.appendChild( form );
 	return form;
 }
 
@@ -57,6 +58,11 @@ describe( 'UPE checkout utils', () => {
 		} );
 
 		beforeEach( () => {
+			const existingCheckoutForm = document.querySelector( 'form' );
+			if ( existingCheckoutForm ) {
+				existingCheckoutForm.remove();
+			}
+
 			getUPEConfig.mockImplementation( ( argument ) => {
 				if ( argument === 'enabledBillingFields' ) {
 					return {
@@ -99,7 +105,7 @@ describe( 'UPE checkout utils', () => {
 		} );
 
 		it( 'should return false when the billing information is not missing', () => {
-			const form = buildForm( [
+			buildForm( [
 				{ id: 'billing_first_name', value: 'Test' },
 				{ id: 'billing_last_name', value: 'User' },
 				{ id: 'billing_email', value: 'test@example.com' },
@@ -108,11 +114,11 @@ describe( 'UPE checkout utils', () => {
 				{ id: 'billing_city', value: 'Anytown' },
 				{ id: 'billing_postcode', value: '12345' },
 			] );
-			expect( isBillingInformationMissing( form ) ).toBe( false );
+			expect( isBillingInformationMissing() ).toBe( false );
 		} );
 
 		it( 'should return true when the billing information is missing', () => {
-			const form = buildForm( [
+			buildForm( [
 				{ id: 'billing_first_name', value: 'Test' },
 				{ id: 'billing_last_name', value: 'User' },
 				{ id: 'billing_email', value: 'test@example.com' },
@@ -121,11 +127,11 @@ describe( 'UPE checkout utils', () => {
 				{ id: 'billing_city', value: 'Anytown' },
 				{ id: 'billing_postcode', value: '' },
 			] );
-			expect( isBillingInformationMissing( form ) ).toBe( true );
+			expect( isBillingInformationMissing() ).toBe( true );
 		} );
 
 		it( 'should use the defaults when there is no specific locale data for a country', () => {
-			const form = buildForm( [
+			buildForm( [
 				{ id: 'billing_first_name', value: 'Test' },
 				{ id: 'billing_last_name', value: 'User' },
 				{ id: 'billing_email', value: 'test@example.com' },
@@ -134,11 +140,11 @@ describe( 'UPE checkout utils', () => {
 				{ id: 'billing_city', value: 'Anytown' },
 				{ id: 'billing_postcode', value: '' },
 			] );
-			expect( isBillingInformationMissing( form ) ).toBe( true );
+			expect( isBillingInformationMissing() ).toBe( true );
 		} );
 
 		it( 'should return false when the locale data for a country has no required fields', () => {
-			const form = buildForm( [
+			buildForm( [
 				{ id: 'billing_first_name', value: 'Test' },
 				{ id: 'billing_last_name', value: 'User' },
 				{ id: 'billing_email', value: 'test@example.com' },
@@ -147,7 +153,7 @@ describe( 'UPE checkout utils', () => {
 				{ id: 'billing_city', value: 'Anytown' },
 				{ id: 'billing_postcode', value: '' },
 			] );
-			expect( isBillingInformationMissing( form ) ).toBe( true );
+			expect( isBillingInformationMissing() ).toBe( true );
 		} );
 	} );
 

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -404,17 +404,18 @@ function getParsedLocale() {
 	}
 }
 
-export const isBillingInformationMissing = ( form ) => {
+export const isBillingInformationMissing = () => {
 	const enabledBillingFields = getUPEConfig( 'enabledBillingFields' );
 
 	// first name and last name are kinda special - we just need one of them to be at checkout
 	const name = `${
-		form.querySelector(
+		document.querySelector(
 			`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.first_name }`
 		)?.value || ''
 	} ${
-		form.querySelector( `#${ SHORTCODE_BILLING_ADDRESS_FIELDS.last_name }` )
-			?.value || ''
+		document.querySelector(
+			`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.last_name }`
+		)?.value || ''
 	}`.trim();
 	if (
 		! name &&
@@ -435,14 +436,15 @@ export const isBillingInformationMissing = ( form ) => {
 	const country = billingFieldsToValidate.includes(
 		SHORTCODE_BILLING_ADDRESS_FIELDS.country
 	)
-		? form.querySelector( `#${ SHORTCODE_BILLING_ADDRESS_FIELDS.country }` )
-				?.value
+		? document.querySelector(
+				`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.country }`
+		  )?.value
 		: null;
 
 	// We need to just find one field with missing information. If even only one is missing, just return early.
 	return Boolean(
 		billingFieldsToValidate.find( ( fieldName ) => {
-			const field = form.querySelector( `#${ fieldName }` );
+			const field = document.querySelector( `#${ fieldName }` );
 			let isRequired = enabledBillingFields[ fieldName ]?.required;
 			const locale = getParsedLocale();
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10133

#### Changes proposed in this Pull Request

This PR reverts part of a previous optimization where billing field queries were scoped to the checkout form element. While this optimization (introduced in #9782) improved performance by limiting DOM queries, it caused issues with custom checkout implementations.

Some theme builders (like Divi) allow merchants to build custom checkout forms where billing fields exist outside the payment form. The assumption while developing WooPayments is based on the shortcode checkout form, which contains all the pieces, including billing and payment fields. Hence, our current form-scoped queries were implemented with these assumptions in mind, but these queries fail to find billing fields when a custom checkout form is built with a different structure.

To address this, we're reverting to document-wide queries for billing fields to ensure compatibility with custom checkout layouts. This ensures billing field detection works regardless of the form structure.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install Divi theme and builder
* Navigate to blocks checkout page editor in admin panel and click the purple `Edit With The Divi Builder` button on the top left
* Add Woo Checkout Billing and Woo Checkout Payment forms to the checkout page, save and visit the page
* The checkout should be successful
* Check out `develop`, repeat all the steps and confirm the error is occurring

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
