### PR TITLE
Fix fraud prevention token not available on blocks checkout

### DIFF
--- a/changelog/fix-fraud-prevention-token-blocks-checkout
+++ b/changelog/fix-fraud-prevention-token-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed fraud prevention token not available on blocks checkout

--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -89,7 +89,7 @@ class Fraud_Prevention_Service {
 
 		// Don't add the token if the user isn't on the cart, checkout, product or pay for order page.
 		// Checking the product and cart page too because the user can pay quickly via the payment buttons on that page.
-		if ( ! is_checkout() && ! is_cart() && ! is_product() && ! $instance->is_pay_for_order_page() ) {
+		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) && ! is_cart() && ! is_product() && ! $instance->is_pay_for_order_page() ) {
 			return;
 		}
 


### PR DESCRIPTION
p1736864658021229-slack-CU6SYV31A

#### Changes proposed in this Pull Request

This PR fixed the fraud prevention token not available on blocks checkout by adding `has_block( 'woocommerce/checkout' )` as `is_checkout()` does not return true in blocks checkout when it is not the default checkout page.

#### Testing instructions

1. In devtools enable "Force the WCPay plugin to act with **Card testing mitigations enabled on the Transact Platform Server**"
2. Make sure your test site checkout page is set to a different page than the blocks checkout page.
3. Try to purchase anything using the blocks checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.