### PR TITLE
fix: add ECE incompatibility notice with shipping settings

### DIFF
--- a/changelog/fix-ece-incompatibility-with-shipping-settings
+++ b/changelog/fix-ece-incompatibility-with-shipping-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+update: add incompatibility notice for GooglePay/ApplePay with shipping settings.

--- a/client/components/google-pay-apple-pay-shipping-compatibility-notice/index.tsx
+++ b/client/components/google-pay-apple-pay-shipping-compatibility-notice/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import interpolateComponents from '@automattic/interpolate-components';
+import React from 'react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getAdminUrl } from '../../utils';
+import { STORE_NAME } from 'wcpay/data/constants';
+import InlineNotice from '../inline-notice';
+
+const AppleGooglePayShippingSettingsCompatibilityNotice = () => {
+	const isRequiringFullAddressAtCheckout = useSelect( ( select ) =>
+		select( STORE_NAME ).getIsRequiringFullAddressAtCheckout()
+	);
+
+	if ( ! isRequiringFullAddressAtCheckout ) return null;
+
+	return (
+		<InlineNotice status="warning" icon={ true } isDismissible={ false }>
+			{ interpolateComponents( {
+				mixedString: __(
+					'The your shipping settings can cause conflicts with this payment method. To resolve this issue, please disable the "Hide shipping costs until an address is entered" option {{link}}in the shipping settings page{{/link}}.',
+					'woocommerce-payments'
+				),
+				components: {
+					link: (
+						<a
+							href={ getAdminUrl( {
+								page: 'wc-settings',
+								tab: 'shipping',
+								section: 'options',
+							} ) }
+						>
+							Review extensions
+						</a>
+					),
+				},
+			} ) }
+		</InlineNotice>
+	);
+};
+
+export default AppleGooglePayShippingSettingsCompatibilityNotice;

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -272,3 +272,7 @@ export const getStripeBillingSubscriptionCount = ( state ) => {
 export const getStripeBillingMigratedCount = ( state ) => {
 	return getSettings( state ).stripe_billing_migrated_count || 0;
 };
+
+export const getIsRequiringFullAddressAtCheckout = ( state ) => {
+	return getSettings( state ).is_requiring_full_address_checkout || false;
+};

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -15,6 +15,7 @@ import {
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
 } from 'wcpay/data';
+import AppleGooglePayShippingSettingsCompatibilityNotice from 'wcpay/components/google-pay-apple-pay-shipping-compatibility-notice';
 
 const PaymentRequestSettings = ( { section } ) => {
 	const [
@@ -44,6 +45,7 @@ const PaymentRequestSettings = ( { section } ) => {
 		<Card>
 			{ section === 'enable' && (
 				<CardBody>
+					<AppleGooglePayShippingSettingsCompatibilityNotice />
 					<CheckboxControl
 						checked={ isPaymentRequestEnabled }
 						onChange={ updateIsPaymentRequestEnabled }

--- a/client/settings/express-checkout/apple-google-pay-item.tsx
+++ b/client/settings/express-checkout/apple-google-pay-item.tsx
@@ -15,10 +15,11 @@ import { PaymentRequestEnabledSettingsHook } from './interfaces';
 import { ApplePayIcon, GooglePayIcon } from 'wcpay/payment-methods-icons';
 import DuplicateNotice from 'wcpay/components/duplicate-notice';
 import DuplicatedPaymentMethodsContext from '../settings-manager/duplicated-payment-methods-context';
+import AppleGooglePayShippingSettingsCompatibilityNotice from 'wcpay/components/google-pay-apple-pay-shipping-compatibility-notice';
+
+const id = 'apple_pay_google_pay';
 
 const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
-	const id = 'apple_pay_google_pay';
-
 	const [
 		isPaymentRequestEnabled,
 		updateIsPaymentRequestEnabled,
@@ -171,6 +172,7 @@ const AppleGooglePayExpressCheckoutItem = (): React.ReactElement => {
 					</div>
 				</div>
 			</div>
+			<AppleGooglePayShippingSettingsCompatibilityNotice />
 			{ isDuplicate && (
 				<DuplicateNotice
 					paymentMethod={ id }

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -475,6 +475,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'available_payment_method_ids'           => $available_upe_payment_methods,
 				'payment_method_statuses'                => $this->wcpay_gateway->get_upe_enabled_payment_method_statuses(),
 				'duplicated_payment_method_ids'          => $this->wcpay_gateway->find_duplicates(),
+				'is_requiring_full_address_checkout'     => wc_shipping_enabled() && 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ),
 				'is_wcpay_enabled'                       => $this->wcpay_gateway->is_enabled(),
 				'is_manual_capture_enabled'              => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
 				'is_test_mode_enabled'                   => WC_Payments::mode()->is_test(),


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
