### PR TITLE
Update the copy of the set up live payments task

### DIFF
--- a/changelog/fix-wc-54302-fix-set-up-live-payments-task-copy
+++ b/changelog/fix-wc-54302-fix-set-up-live-payments-task-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update set up live payments task list item copy

--- a/client/overview/task-list/strings.tsx
+++ b/client/overview/task-list/strings.tsx
@@ -423,7 +423,7 @@ export default {
 			),
 		},
 		go_live: {
-			title: __( 'Set up live payments', 'woocommerce-payments' ),
+			title: __( 'Activate payments', 'woocommerce-payments' ),
 			time: __( '10 minutes', 'woocommerce-payments' ),
 		},
 	},


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/54302

#### Changes proposed in this Pull Request

Update the copy of the set up live payments task.

#### Testing instructions

* Check out to `fix/wc-54302-fix-set-up-live-payments-task-copy` locally.
* Onboard the sandbox account if you don't have one.
* Navigate to WooCommerce -> Home and check that the set up live payment task was renamed.

![image](https://github.com/user-attachments/assets/72b6b4fb-9167-4ac6-bd87-8b04d54d08ae)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable - since it's small copy change.
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. Done in https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows/_compare/0c9df5448c429f7c32730b2dfa3a2bf38133c0e5...482b3ae4bcac51ab9820c3d4fc0cec016709e427
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
