### PR TITLE
Add environment variables to playwright.config.ts

### DIFF
--- a/changelog/dev-playwright-config-import-e2e-env-vars
+++ b/changelog/dev-playwright-config-import-e2e-env-vars
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add E2E environment variables to Playwright config.

--- a/tests/e2e-pw/playwright.config.ts
+++ b/tests/e2e-pw/playwright.config.ts
@@ -3,6 +3,11 @@
  * External dependencies
  */
 import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+import path from 'path';
+
+config( { path: path.resolve( __dirname, '../e2e/config', '.env' ) } );
+config( { path: path.resolve( __dirname, '../e2e/config', 'local.env' ) } );
 
 const { BASE_URL } = process.env;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* This PR adds the e2e environment variables to `playwright.config.ts` so that we can access them.
* We discovered that our [current implementation of `describeif`](https://github.com/Automattic/woocommerce-payments/blob/develop/tests/e2e-pw/utils/helpers.ts#L100) wasn't working to evaluate enviornment variables to determine if Playwright should or should not run subscription tests. [Example usage](https://github.com/Automattic/woocommerce-payments/blob/develop/tests/e2e-pw/specs/merchant/merchant-subscriptions-renew.spec.ts#L28). This was happening b/c our [check of the environment variable](https://github.com/Automattic/woocommerce-payments/blob/develop/tests/e2e-pw/utils/constants.ts#L1) wasn't working since they were undefined. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Setup your e2e environment with the following variable commented out in your `tests/e2e/config/local.env`:

```
# SKIP_WC_SUBSCRIPTIONS_TESTS=1
```

* Then run this subscription test: `npm run test:e2e-pw merchant-subscriptions-renew`
* You should see that all three tests passed:

```
🎭 Running Playwright e2e tests in default headless mode, skipping @todo.

Running 3 tests using 1 worker
[setup] › auth.setup.ts:37:6 › authenticate as admin
Trying to log-in as admin...
Logged-in as admin successfully.
[setup] › auth.setup.ts:83:6 › authenticate as customer
Trying to log-in as customer...
Logged-in as customer successfully.
  3 passed (44.5s)
```

* Now run `npm run test:e2e-down`
* Uncomment the environment variable in `tests/e2e/config/local.env`:

```
SKIP_WC_SUBSCRIPTIONS_TESTS=1
```

* Bring the containers back up: `npm run test:e2e-up`
* Re-run the same test: `npm run test:e2e-pw merchant-subscriptions-renew`
* You should see that the two auth tests pass and the subscription test is skipped:

```
🎭 Running Playwright e2e tests in default headless mode, skipping @todo.

Running 3 tests using 1 worker
[setup] › auth.setup.ts:37:6 › authenticate as admin
Trying to log-in as admin...
Logged-in as admin successfully.
[setup] › auth.setup.ts:83:6 › authenticate as customer
Trying to log-in as customer...
Logged-in as customer successfully.
  1 skipped
  2 passed (9.6s)
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
