### PR TITLE
Fix global popover styling

### DIFF
--- a/changelog/fix-global-styling-popover
+++ b/changelog/fix-global-styling-popover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix global styling for popovers

--- a/client/components/payment-method-logos/index.tsx
+++ b/client/components/payment-method-logos/index.tsx
@@ -221,6 +221,7 @@ export const WooPaymentsMethodsLogos: React.VFC< {
 					{ isPopoverVisible && (
 						<Popover
 							position="bottom left"
+							className="connect-account-page__payment-methods--logos-popover"
 							noArrow={ true }
 							onClose={ () => setIsPopoverVisible( false ) }
 							onMouseEnter={ showPopover }

--- a/client/components/payment-method-logos/style.scss
+++ b/client/components/payment-method-logos/style.scss
@@ -37,14 +37,16 @@
 		gap: $gap-smaller;
 		padding: 0;
 	}
-}
 
-.components-popover__content {
-	background: $white;
-	border: 1px solid $gray-100;
-	border-radius: 3px;
-	max-width: 246px;
-	padding: $gap-smaller;
-	box-shadow: none;
-	margin-top: $gap-smaller;
+	&-popover {
+		.components-popover__content {
+			background: $white;
+			border: 1px solid $gray-100;
+			border-radius: 3px;
+			max-width: 246px;
+			padding: $gap-smaller;
+			box-shadow: none;
+			margin-top: $gap-smaller;
+		}
+	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/10372

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This fixes a bug where styling was applied to all popovers. This will only apply the necessary changes to the Popover used in the respective page.

Core fix https://github.com/woocommerce/woocommerce/pull/54723


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure Stripe account is disconnected (or use Dev Tools to "act like disconnected")
* Go to Payments tab
* Make sure to hover over the +X element and that the popover is displayed correctly
<img width="335" alt="Screenshot 2025-01-21 at 13 04 14" src="https://github.com/user-attachments/assets/7aa45080-3716-4afd-8f5d-033de7a2f3e3" />



-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
