### PR TITLE
Add useReportExport hook to encapsulate polling logic for PR 10211

### DIFF
--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -88,16 +88,15 @@ export function* getTransactions( query ) {
 	}
 }
 
+export const transactionsDownloadEndpoint = `${ NAMESPACE }/transactions/download`;
 export function getTransactionsCSVRequestURL( query ) {
 	const path = addQueryArgs(
-		`${ NAMESPACE }/transactions/download`,
+		transactionsDownloadEndpoint,
 		formatQueryFilters( query )
 	);
 
 	return path;
 }
-
-export const transactionsCSVFileAvailabilityEndpoint = `${ NAMESPACE }/transactions/download`;
 
 /**
  * Retrieves the transactions summary from the summary API.

--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -88,7 +88,7 @@ export function* getTransactions( query ) {
 	}
 }
 
-export function getTransactionsCSV( query ) {
+export function getTransactionsCSVRequestURL( query ) {
 	const path = addQueryArgs(
 		`${ NAMESPACE }/transactions/download`,
 		formatQueryFilters( query )
@@ -97,9 +97,7 @@ export function getTransactionsCSV( query ) {
 	return path;
 }
 
-export function getTransactionsDownloadURL( query ) {
-	return `${ NAMESPACE }/transactions/download/${ query.exportId }`;
-}
+export const transactionsCSVFileAvailabilityEndpoint = `${ NAMESPACE }/transactions/download`;
 
 /**
  * Retrieves the transactions summary from the summary API.

--- a/client/hooks/use-report-export.ts
+++ b/client/hooks/use-report-export.ts
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useState } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+
+interface ExportResponse {
+	export_id?: string;
+}
+
+const maxRetries = 5;
+
+/**
+ * Hook for requesting and polling for a CSV export. E.g. Transactions, Payouts, Disputes.
+ *
+ * @example
+ * const { requestReportExport, isDownloading } = useReportExport();
+ * requestReportExport( {
+ * 	exportRequestURL: '/wc/v3/payments/transactions/download?queryParam=value',
+ * 	exportFileAvailabilityEndpoint: '/wc/v3/payments/transactions/download',
+ * 	userEmail: 'test@example.com',
+ * } );
+ */
+export const useReportExport = () => {
+	const [ isDownloading, setIsDownloading ] = useState( false );
+	const { createNotice } = useDispatch( 'core/notices' );
+	const timeoutIdRef = useRef< NodeJS.Timeout | null >( null );
+	const retryCountRef = useRef( 0 );
+
+	useEffect( () => {
+		// Cancel the timeout if the component unmounts.
+		return () => {
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
+	}, [ timeoutIdRef ] );
+
+	interface PollForFileProps {
+		/**
+		 * The URL to check for the exported file. E.g. "/wc/v3/payments/transactions/download/{export_id}"
+		 */
+		checkFileURL: string;
+		/**
+		 * The email address the export will be sent to.
+		 */
+		userEmail: string;
+		/**
+		 * The interval in milliseconds to poll the server.
+		 */
+		interval?: number;
+	}
+
+	/**
+	 * Polls the server to check if the exported file is ready.
+	 */
+	async function pollForFile( {
+		checkFileURL,
+		userEmail,
+		interval = 1000,
+	}: PollForFileProps ) {
+		timeoutIdRef.current = setTimeout( async () => {
+			retryCountRef.current++;
+			const exportedFileURL = await apiFetch< string >( {
+				path: checkFileURL,
+				method: 'GET',
+			} );
+
+			if ( exportedFileURL ) {
+				// The file is available, so we can download it.
+				// Create a link element to trigger the download.
+				const link = document.createElement( 'a' );
+				// Add force_download=true to the URL to force the download, which adds the appropriate `Content-Disposition: attachment` header when using production server.
+				link.href = exportedFileURL + '?force_download=true';
+				link.click();
+
+				createNotice(
+					'success',
+					sprintf(
+						__(
+							'Your CSV export is ready to download. It will also be emailed to %s',
+							'woocommerce-payments'
+						),
+						userEmail
+					)
+				);
+
+				setIsDownloading( false );
+
+				return;
+			}
+
+			if ( retryCountRef.current < maxRetries ) {
+				// If the file is not available, check again after 1 second.
+				pollForFile( {
+					checkFileURL,
+					userEmail,
+				} );
+			} else {
+				// If the file is not available after the maximum number of retries, show an error notice.
+				setIsDownloading( false );
+				createNotice(
+					'error',
+					__(
+						'There was a problem generating your CSV export. Please try again later.',
+						'woocommerce-payments'
+					)
+				);
+			}
+		}, interval );
+	}
+
+	interface RequestReportExportProps {
+		/**
+		 * The URL for requesting the export. E.g. "/wc/v3/payments/transactions/download?param=value"
+		 */
+		exportRequestURL: string;
+		/**
+		 * The endpoint for retrieving the file's download URL. E.g. "/wc/v3/payments/transactions/download/"
+		 */
+		exportFileAvailabilityEndpoint: string;
+		/**
+		 * The email address to send the export to.
+		 */
+		userEmail: string;
+	}
+
+	/**
+	 * Requests a CSV export to be prepared.
+	 */
+	async function requestReportExport( {
+		exportRequestURL,
+		exportFileAvailabilityEndpoint,
+		userEmail,
+	}: RequestReportExportProps ) {
+		try {
+			setIsDownloading( true );
+
+			// Request the report download.
+			const response = await apiFetch< ExportResponse >( {
+				path: exportRequestURL,
+				method: 'POST',
+			} );
+
+			// If the export request was successful, start polling to see if the exported file is ready.
+			if ( response.export_id ) {
+				const checkFileURL = `${ exportFileAvailabilityEndpoint }/${ response.export_id }`;
+				pollForFile( {
+					checkFileURL,
+					userEmail,
+				} );
+			}
+		} catch ( error ) {
+			setIsDownloading( false );
+			createNotice(
+				'error',
+				__(
+					'There was a problem generating your export.',
+					'woocommerce-payments'
+				)
+			);
+		}
+	}
+
+	return {
+		/**
+		 * Requests a report export to be prepared and starts polling for the exported file.
+		 */
+		requestReportExport,
+		/**
+		 * Whether a report download request has been made and polling is in progress.
+		 */
+		isDownloading,
+	};
+};

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -47,7 +47,7 @@ import { recordEvent } from 'tracks';
 import DownloadButton from 'components/download-button';
 import {
 	getTransactionsCSVRequestURL,
-	transactionsCSVFileAvailabilityEndpoint,
+	transactionsDownloadEndpoint,
 } from '../../data/transactions/resolvers';
 import p24BankList from '../../payment-details/payment-method/p24/bank-list';
 import { HoverTooltip } from 'components/tooltip';
@@ -669,7 +669,7 @@ export const TransactionsList = (
 		) {
 			requestReportExport( {
 				exportRequestURL,
-				exportFileAvailabilityEndpoint: transactionsCSVFileAvailabilityEndpoint,
+				exportFileAvailabilityEndpoint: transactionsDownloadEndpoint,
 				userEmail,
 			} );
 		}

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 import { uniq } from 'lodash';
-import { useDispatch } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import {
@@ -19,7 +18,6 @@ import {
 	getQuery,
 	updateQueryString,
 } from '@woocommerce/navigation';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -48,14 +46,15 @@ import Page from '../../components/page';
 import { recordEvent } from 'tracks';
 import DownloadButton from 'components/download-button';
 import {
-	getTransactionsCSV,
-	getTransactionsDownloadURL,
+	getTransactionsCSVRequestURL,
+	transactionsCSVFileAvailabilityEndpoint,
 } from '../../data/transactions/resolvers';
 import p24BankList from '../../payment-details/payment-method/p24/bank-list';
 import { HoverTooltip } from 'components/tooltip';
 import { PAYMENT_METHOD_TITLES } from 'wcpay/constants/payment-method';
 import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 import { usePersistedColumnVisibility } from 'wcpay/hooks/use-persisted-table-column-visibility';
+import { useReportExport } from 'wcpay/hooks/use-report-export';
 
 interface TransactionsListProps {
 	depositId?: string;
@@ -81,11 +80,6 @@ interface Column extends TableCardColumn {
 	visible?: boolean;
 	cellClassName?: string;
 	labelInCsv?: string;
-}
-
-interface TransactionExportResponse {
-	export_id?: string;
-	exported_transactions: number;
 }
 
 const getPaymentSourceDetails = ( txn: Transaction ) => {
@@ -297,8 +291,6 @@ const getColumns = (
 export const TransactionsList = (
 	props: TransactionsListProps
 ): JSX.Element => {
-	const [ isDownloading, setIsDownloading ] = useState( false );
-	const { createNotice } = useDispatch( 'core/notices' );
 	const { transactions, isLoading } = useTransactions(
 		getQuery(),
 		props.depositId ?? ''
@@ -307,6 +299,8 @@ export const TransactionsList = (
 		transactionsSummary,
 		isLoading: isSummaryLoading,
 	} = useTransactionsSummary( getQuery(), props.depositId ?? '' );
+
+	const { requestReportExport, isDownloading } = useReportExport();
 
 	const { onColumnsChange, columnsToDisplay } = usePersistedColumnVisibility<
 		Column
@@ -583,23 +577,17 @@ export const TransactionsList = (
 
 	const downloadable = !! rows.length;
 
-	const successNotice = ( userEmail: string, downloadURL: string ) => {
-		const noticeMessage = downloadURL
-			? __(
-					'Your export is downloaded. It will also be emailed to %s',
-					'woocommerce-payments'
-			  )
-			: __( 'Your export will be emailed to %s', 'woocommerce-payments' );
-		createNotice( 'success', sprintf( noticeMessage, userEmail ) );
-	};
+	const onDownload = async () => {
+		recordEvent( 'wcpay_transactions_download_csv_click', {
+			location: props.depositId ? 'deposit_details' : 'transactions',
+			exported_transactions: rows.length,
+			total_transactions: transactionsSummary.count,
+		} );
 
-	const endpointExport = async () => {
-		// We destructure page and path to get the right params.
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { page, path, ...params } = getQuery();
 		const userEmail = wcpaySettings.currentUserEmail;
-
 		const userLocale = wcpaySettings.userLocale.code;
+		const depositId = props.depositId;
+
 		const {
 			date_after: dateAfter,
 			date_before: dateBefore,
@@ -620,8 +608,32 @@ export const TransactionsList = (
 			customer_currency_is_not: customerCurrencyIsNot,
 			source_is: sourceIs,
 			source_is_not: sourceIsNot,
-		} = params;
-		const depositId = props.depositId;
+		} = getQuery();
+
+		const exportRequestURL = getTransactionsCSVRequestURL( {
+			userEmail,
+			userLocale,
+			dateAfter,
+			dateBefore,
+			dateBetween,
+			match,
+			search,
+			typeIs,
+			typeIsNot,
+			sourceDeviceIs,
+			sourceDeviceIsNot,
+			customerCurrencyIs,
+			customerCurrencyIsNot,
+			sourceIs,
+			sourceIsNot,
+			channelIs,
+			channelIsNot,
+			customerCountryIs,
+			customerCountryIsNot,
+			riskLevelIs,
+			riskLevelIsNot,
+			depositId,
+		} );
 
 		const isFiltered =
 			!! dateAfter ||
@@ -655,79 +667,12 @@ export const TransactionsList = (
 			totalRows < confirmThreshold ||
 			window.confirm( confirmMessage )
 		) {
-			try {
-				const response = await apiFetch< TransactionExportResponse >( {
-					path: getTransactionsCSV( {
-						userEmail,
-						userLocale,
-						dateAfter,
-						dateBefore,
-						dateBetween,
-						match,
-						search,
-						typeIs,
-						typeIsNot,
-						sourceDeviceIs,
-						sourceDeviceIsNot,
-						customerCurrencyIs,
-						customerCurrencyIsNot,
-						sourceIs,
-						sourceIsNot,
-						channelIs,
-						channelIsNot,
-						customerCountryIs,
-						customerCountryIsNot,
-						riskLevelIs,
-						riskLevelIsNot,
-						depositId,
-					} ),
-					method: 'POST',
-				} );
-
-				if ( response.export_id ) {
-					setTimeout( async () => {
-						const URL = await apiFetch< string >( {
-							path: getTransactionsDownloadURL( {
-								exportId: response.export_id,
-							} ),
-							method: 'GET',
-						} );
-						if ( URL ) {
-							const link = document.createElement( 'a' );
-							// Add force_download=true to the URL to force the download, which adds the appropriate `Content-Disposition: attachment` header when using production server.
-							link.href = URL + '?force_download=true';
-							link.click();
-						}
-						setIsDownloading( false );
-						successNotice( userEmail, URL );
-					}, 2000 ); // Waiting for the download to be available
-				}
-			} catch {
-				createNotice(
-					'error',
-					__(
-						'There was a problem generating your export.',
-						'woocommerce-payments'
-					)
-				);
-			}
+			requestReportExport( {
+				exportRequestURL,
+				exportFileAvailabilityEndpoint: transactionsCSVFileAvailabilityEndpoint,
+				userEmail,
+			} );
 		}
-	};
-
-	const onDownload = async () => {
-		setIsDownloading( true );
-
-		// We destructure page and path to get the right params.
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { page, path, ...params } = getQuery();
-
-		recordEvent( 'wcpay_transactions_download_csv_click', {
-			location: props.depositId ? 'deposit_details' : 'transactions',
-			exported_transactions: rows.length,
-			total_transactions: transactionsSummary.count,
-		} );
-
-		endpointExport();
 	};
 
 	if ( ! wcpaySettings.featureFlags.customSearch ) {


### PR DESCRIPTION
This PR is based on #10211

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Moves report export and polling logic into a separate react hook
* Easier to reuse across disputes, payouts, etc
* Easier to separate and test the polling logic (tests TBD)

Transactions/disputes/payouts list pages will call:

```ts
requestReportExport( {
	// this is the prepared URL for the request to `{transactions|disputes|payouts}/download?query`
	exportRequestURL,
	// this is the endpoint that will be used to check if the file is ready to download
	exportFileAvailabilityEndpoint,
	// this is the email recipient, used for notices
   userEmail,
} );
```

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
