### PR TITLE
Optimise memory usage when formatting logger entries

### DIFF
--- a/changelog/dev-10021-logging-memory-optimisations
+++ b/changelog/dev-10021-logging-memory-optimisations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Optimise memory consumption when formatting log entries.

--- a/src/Internal/LoggerContext.php
+++ b/src/Internal/LoggerContext.php
@@ -125,12 +125,13 @@ class LoggerContext {
 		}
 
 		$formatted_lines = [];
-		$entry           = array_shift( $entries );
-		while ( null !== $entry ) {
-			foreach ( explode( "\n", $entry ) as $line ) {
+		$log_entry       = array_shift( $entries );
+		while ( null !== $log_entry ) {
+			foreach ( explode( "\n", $log_entry ) as $line ) {
 				$formatted_lines[] = $line_prefix . $line;
 			}
-			unset( $entry );
+			unset( $log_entry );
+			$log_entry = array_shift( $entries );
 		}
 
 		return implode( "\n", $formatted_lines );

--- a/src/Internal/LoggerContext.php
+++ b/src/Internal/LoggerContext.php
@@ -109,10 +109,10 @@ class LoggerContext {
 			return $entry;
 		}
 
-		$entry_number  = ++$this->entry_number;
-		$time_string   = gmdate( 'c', $context['timestamp'] );
-		$level_string  = strtoupper( $context['level'] );
-		$format_string = sprintf( '%s %s %s-%04d %%s', $time_string, $level_string, $this->request_id, $entry_number );
+		$entry_number = ++$this->entry_number;
+		$time_string  = gmdate( 'c', $context['timestamp'] );
+		$level_string = strtoupper( $context['level'] );
+		$line_prefix  = sprintf( '%s %s %s-%04d ', $time_string, $level_string, $this->request_id, $entry_number );
 
 		$entries = [ $context['message'] ];
 
@@ -124,23 +124,16 @@ class LoggerContext {
 			$this->context_updated = false;
 		}
 
-		return implode(
-			"\n",
-			array_map(
-				function ( $entry ) use ( $format_string ) {
-					return implode(
-						"\n",
-						array_map(
-							function ( $line ) use ( $format_string ) {
-								return sprintf( $format_string, $line );
-							},
-							explode( "\n", $entry )
-						)
-					);
-				},
-				$entries
-			)
-		);
+		$formatted_lines = [];
+		$entry           = array_shift( $entries );
+		while ( null !== $entry ) {
+			foreach ( explode( "\n", $entry ) as $line ) {
+				$formatted_lines[] = $line_prefix . $line;
+			}
+			unset( $entry );
+		}
+
+		return implode( "\n", $formatted_lines );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #10201 

#### Changes proposed in this Pull Request

Optimizations to the memory consumption when formatting a logger entry:

 - Reduce number of stacked function calls
 - Unset entries once those are formatted for the logging

#### Testing instructions

* All E2E tests should complete successfully.
* Manual run of "E2E Tests - All" workflow can be found [here](https://github.com/Automattic/woocommerce-payments/actions/runs/12912242716). Reported tests were successful for this branch.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
