### PR TITLE
Add multi-currency widget setup e2e tests

### DIFF
--- a/changelog/add-7348-multi-currency-widget-setup-e2e-tests
+++ b/changelog/add-7348-multi-currency-widget-setup-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add e2e tests for the multi-currency widget setup.

--- a/tests/e2e-pw/specs/merchant/multi-currency-widget.spec.ts
+++ b/tests/e2e-pw/specs/merchant/multi-currency-widget.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * External dependencies
+ */
+import { test, expect, Page } from '@playwright/test';
+/**
+ * Internal dependencies
+ */
+import { getMerchant, getShopper } from '../../utils/helpers';
+import {
+	activateMulticurrency,
+	addMulticurrencyWidget,
+	deactivateMulticurrency,
+	removeMulticurrencyWidget,
+} from '../../utils/merchant';
+import * as navigation from '../../utils/shopper-navigation';
+
+test.describe( 'Multi-currency widget setup', () => {
+	let merchantPage: Page;
+	let shopperPage: Page;
+	let wasMulticurrencyEnabled: boolean;
+	// Values to test against. Defining nonsense values to ensure they are applied correctly.
+	const settings = {
+		borderRadius: '15',
+		fontSize: '40',
+		lineHeight: '2.3',
+		textColor: 'rgb(155, 81, 224)',
+		borderColor: 'rgb(252, 185, 0)',
+	};
+
+	test.beforeAll( async ( { browser } ) => {
+		shopperPage = ( await getShopper( browser ) ).shopperPage;
+		merchantPage = ( await getMerchant( browser ) ).merchantPage;
+		wasMulticurrencyEnabled = await activateMulticurrency( merchantPage );
+
+		await addMulticurrencyWidget( merchantPage, true );
+	} );
+
+	test.afterAll( async () => {
+		await removeMulticurrencyWidget( merchantPage, true );
+
+		if ( ! wasMulticurrencyEnabled ) {
+			await deactivateMulticurrency( merchantPage );
+		}
+
+		await merchantPage.close();
+	} );
+
+	test( 'displays enabled currencies correctly in the admin', async () => {
+		await expect(
+			merchantPage
+				.locator( 'select[name="currency"]' )
+				.getByRole( 'option' )
+		).toHaveCount( 3 );
+		await expect(
+			merchantPage
+				.locator( 'select[name="currency"]' )
+				.getByRole( 'option', { name: 'USD' } )
+		).toBeAttached();
+		await expect(
+			merchantPage
+				.locator( 'select[name="currency"]' )
+				.getByRole( 'option', { name: 'EUR' } )
+		).toBeAttached();
+		await expect(
+			merchantPage
+				.locator( 'select[name="currency"]' )
+				.getByRole( 'option', { name: 'GBP' } )
+		).toBeAttached();
+	} );
+
+	test( 'can update widget properties', async () => {
+		await test.step( 'opens widget settings', async () => {
+			await merchantPage
+				.getByRole( 'button', { name: 'Settings' } )
+				.click();
+			await merchantPage
+				.locator( '[data-title="Currency Switcher Block"]' )
+				.click();
+		} );
+
+		await test.step( 'checks display flags', async () => {
+			await merchantPage
+				.getByRole( 'checkbox', { name: 'Display flags' } )
+				.check();
+			await expect(
+				await merchantPage
+					.getByRole( 'checkbox', { name: 'Display flags' } )
+					.isChecked()
+			).toBeTruthy();
+		} );
+
+		await test.step( 'checks display currency symbols', async () => {
+			await merchantPage
+				.getByRole( 'checkbox', { name: 'Display currency symbols' } )
+				.check();
+			await expect(
+				await merchantPage
+					.getByRole( 'checkbox', {
+						name: 'Display currency symbols',
+					} )
+					.isChecked()
+			).toBeTruthy();
+		} );
+
+		await test.step( 'checks border', async () => {
+			await merchantPage
+				.getByRole( 'checkbox', { name: 'Border' } )
+				.check();
+			await expect(
+				await merchantPage
+					.getByRole( 'checkbox', { name: 'Border' } )
+					.isChecked()
+			).toBeTruthy();
+		} );
+
+		await test.step( 'updates border radius', async () => {
+			await merchantPage
+				.getByRole( 'spinbutton', { name: 'Border radius' } )
+				.fill( settings.borderRadius );
+		} );
+
+		await test.step( 'updates font size', async () => {
+			await merchantPage
+				.getByRole( 'spinbutton', { name: 'Size' } )
+				.fill( settings.fontSize );
+		} );
+
+		await test.step( 'updates line height', async () => {
+			await merchantPage
+				.getByRole( 'spinbutton', { name: 'Line height' } )
+				.fill( settings.lineHeight );
+		} );
+
+		await test.step( 'updates text color', async () => {
+			await merchantPage
+				.locator( 'fieldset', { hasText: 'Text' } )
+				.getByRole( 'listbox', { name: 'Custom color picker' } )
+				.getByRole( 'option', { name: 'Vivid purple' } )
+				.click();
+		} );
+
+		await test.step( 'updates border color', async () => {
+			await merchantPage
+				.locator( 'fieldset', { hasText: 'Border' } )
+				.getByRole( 'listbox', { name: 'Custom color picker' } )
+				.getByRole( 'option', { name: 'Luminous vivid amber' } )
+				.click();
+		} );
+
+		await test.step( 'saves changes', async () => {
+			await expect(
+				merchantPage.getByRole( 'button', { name: 'Update' } )
+			).toBeEnabled();
+			await merchantPage
+				.getByRole( 'button', { name: 'Update' } )
+				.click();
+			await expect(
+				merchantPage.getByLabel( 'Dismiss this notice' )
+			).toBeVisible( {
+				timeout: 10000,
+			} );
+		} );
+	} );
+
+	test( 'displays enabled currencies correctly in the frontend', async () => {
+		await navigation.goToShop( shopperPage );
+
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder' )
+		).toBeVisible();
+		await expect(
+			shopperPage
+				.locator( '.currency-switcher-holder' )
+				.getByRole( 'option' )
+		).toHaveCount( 3 );
+		await expect(
+			shopperPage
+				.locator( '.currency-switcher-holder' )
+				.getByRole( 'option', { name: 'USD' } )
+		).toBeAttached();
+		await expect(
+			shopperPage
+				.locator( '.currency-switcher-holder' )
+				.getByRole( 'option', { name: 'EUR' } )
+		).toBeAttached();
+		await expect(
+			shopperPage
+				.locator( '.currency-switcher-holder' )
+				.getByRole( 'option', { name: 'GBP' } )
+		).toBeAttached();
+	} );
+
+	test( 'widget settings are applied in the frontend', async () => {
+		await navigation.goToShop( shopperPage );
+
+		// Asserts flags are displayed.
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toContainText( '🇺🇸' );
+		// Asserts currency symbols are displayed.
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toContainText( '$' );
+		// Asserts border is set.
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toHaveCSS( 'border-top-width', '1px' );
+		// Asserts border radius is set.
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toHaveCSS( 'border-top-left-radius', `${ settings.borderRadius }px` );
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toHaveCSS( 'font-size', `${ settings.fontSize }px` );
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder' )
+		).toHaveAttribute( 'style', `line-height: ${ settings.lineHeight }; ` ); // Trailing space is expected.
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toHaveCSS( 'color', settings.textColor );
+		// Asserts border color is set.
+		await expect(
+			await shopperPage.locator( '.currency-switcher-holder select' )
+		).toHaveCSS( 'border-top-color', settings.borderColor );
+	} );
+} );

--- a/tests/e2e-pw/specs/merchant/multi-currency.spec.ts
+++ b/tests/e2e-pw/specs/merchant/multi-currency.spec.ts
@@ -11,6 +11,7 @@ import {
 	addMulticurrencyWidget,
 	deactivateMulticurrency,
 	disableAllEnabledCurrencies,
+	removeMulticurrencyWidget,
 	restoreCurrencies,
 } from '../../utils/merchant';
 import * as navigation from '../../utils/merchant-navigation';
@@ -30,6 +31,7 @@ test.describe( 'Multi-currency', () => {
 	} );
 
 	test.afterAll( async () => {
+		await removeMulticurrencyWidget( page );
 		await restoreCurrencies( page );
 		if ( ! wasMulticurrencyEnabled ) {
 			await deactivateMulticurrency( page );

--- a/tests/e2e-pw/utils/merchant.ts
+++ b/tests/e2e-pw/utils/merchant.ts
@@ -135,6 +135,54 @@ export const addMulticurrencyWidget = async (
 	}
 };
 
+export const removeMulticurrencyWidget = async (
+	page: Page,
+	blocksVersion = false
+) => {
+	await navigation.goToWidgets( page );
+	// Wait for all widgets to load. This is important to prevent flakiness.
+	await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
+
+	if ( await page.getByRole( 'button', { name: 'Close' } ).isVisible() ) {
+		await page.getByRole( 'button', { name: 'Close' } ).click();
+	}
+
+	// At this point, widgets might still be loading individually.
+	await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
+
+	const widgetName = blocksVersion
+		? 'Currency Switcher Block'
+		: 'Currency Switcher Widget';
+	const isWidgetAdded = blocksVersion
+		? await page.locator( `[data-title="${ widgetName }"]` ).isVisible()
+		: await page.getByRole( 'heading', { name: widgetName } ).isVisible();
+
+	if ( isWidgetAdded ) {
+		if ( blocksVersion ) {
+			await page.locator( `[data-title="${ widgetName }"]` ).click();
+		} else {
+			await page
+				.locator( '.wp-block.wp-block-legacy-widget' )
+				.filter( {
+					has: page.getByRole( 'heading', { name: widgetName } ),
+				} )
+				.click();
+		}
+
+		await page.getByLabel( 'Block tools' ).getByLabel( 'Options' ).click();
+		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+		await page.waitForTimeout( 2000 );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Update' } )
+		).toBeEnabled();
+		await page.getByRole( 'button', { name: 'Update' } ).click();
+		await expect( page.getByLabel( 'Dismiss this notice' ) ).toBeVisible( {
+			timeout: 10000,
+		} );
+	}
+};
+
 export const getActiveThemeSlug = async ( page: Page ) => {
 	await navigation.goToThemes( page );
 

--- a/tests/e2e-pw/utils/merchant.ts
+++ b/tests/e2e-pw/utils/merchant.ts
@@ -90,26 +90,33 @@ export const deactivateMulticurrency = async ( page: Page ) => {
 	await saveWooPaymentsSettings( page );
 };
 
-export const addMulticurrencyWidget = async ( page: Page ) => {
+export const addMulticurrencyWidget = async (
+	page: Page,
+	blocksVersion = false
+) => {
 	await navigation.goToWidgets( page );
 	// Wait for all widgets to load. This is important to prevent flakiness.
-	await page.locator( '.components-spinner' ).first().waitFor();
 	await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
 
 	if ( await page.getByRole( 'button', { name: 'Close' } ).isVisible() ) {
 		await page.getByRole( 'button', { name: 'Close' } ).click();
 	}
 
-	const isWidgetAdded = await page
-		.locator( 'iframe[srcdoc*=currency]' )
-		.first()
-		.isVisible();
+	// At this point, widgets might still be loading individually.
+	await expect( page.locator( '.components-spinner' ) ).toHaveCount( 0 );
+
+	const widgetName = blocksVersion
+		? 'Currency Switcher Block'
+		: 'Currency Switcher Widget';
+	const isWidgetAdded = blocksVersion
+		? await page.locator( `[data-title="${ widgetName }"]` ).isVisible()
+		: await page.getByRole( 'heading', { name: widgetName } ).isVisible();
 
 	if ( ! isWidgetAdded ) {
 		await page.getByRole( 'button', { name: 'Add block' } ).click();
 		await page
 			.locator( 'input[placeholder="Search"]' )
-			.pressSequentially( 'switcher', { delay: 20 } );
+			.pressSequentially( widgetName, { delay: 20 } );
 		await expect(
 			page.locator( 'button.components-button[role="option"]' ).first()
 		).toBeVisible( { timeout: 5000 } );


### PR DESCRIPTION
Resolves #7348.

#### Changes proposed in this Pull Request

- Creates the new multi-currency widget setup spec testing against all items mentioned in #7348.
- Adds Blocks support to the `addMulticurrencyWidget` helper. That means the helper now supports adding the Blocks version of the multi-currency widget, which is the version used in the new widget setup spec.
- Prevents flakiness in the `addMulticurrencyWidget` by adding another check for the loading spinners in a second moment.
- Adds the `removeMulticurrencyWidget` helper to remove widgets once they're added during the tests. I also made sure the widget gets removed in the older specs.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**

1. Checkout to this branch.
2. Have your e2e environment up: `npm run test:e2e-up` or `npm run test:e2e-setup`.

**Test: All e2e tests pass locally**

> [!TIP]
> You may run the commands multiple times to confirm tests are not flaky.

1. Run `npm run test:e2e-pw merchant/multi-currency-widget` to confirm the new spec passes.
2. Run `npm run test:e2e-pw multi-currency` to confirm all multi-currency tests are still passing.
3. Run `npm run test:e2e-pw` to confirm all e2e tests are still passing.

**Confirm: All e2e tests are passing in the GitHub check**

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
