### PR TITLE
Fix potential fatal in the WooPay express checkout button

### DIFF
--- a/changelog/fix-10193-woopay-express-button-fatal
+++ b/changelog/fix-10193-woopay-express-button-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent potential fatal when initializing the WooPay express checkout button.

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -125,8 +125,7 @@ class WC_Payments_WooPay_Button_Handler {
 
 		// Create WooPay button location option if it doesn't exist and enable all locations by default.
 		if ( ! array_key_exists( self::BUTTON_LOCATIONS, get_option( 'woocommerce_woocommerce_payments_settings' ) ) ) {
-			if ( array_key_exists( self::BUTTON_LOCATIONS, $this->gateway->form_fields )
-				&& isset( $this->gateway->form_fields[ self::BUTTON_LOCATIONS ]['options'] ) ) {
+			if ( isset( $this->gateway->form_fields[ self::BUTTON_LOCATIONS ]['options'] ) ) {
 				$all_locations = $this->gateway->form_fields[ self::BUTTON_LOCATIONS ]['options'];
 
 				$this->gateway->update_option( self::BUTTON_LOCATIONS, array_keys( $all_locations ) );

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -125,12 +125,13 @@ class WC_Payments_WooPay_Button_Handler {
 
 		// Create WooPay button location option if it doesn't exist and enable all locations by default.
 		if ( ! array_key_exists( self::BUTTON_LOCATIONS, get_option( 'woocommerce_woocommerce_payments_settings' ) ) ) {
+			if ( array_key_exists( self::BUTTON_LOCATIONS, $this->gateway->form_fields )
+				&& isset( $this->gateway->form_fields[ self::BUTTON_LOCATIONS ]['options'] ) ) {
+				$all_locations = $this->gateway->form_fields[ self::BUTTON_LOCATIONS ]['options'];
 
-			$all_locations = $this->gateway->form_fields[ self::BUTTON_LOCATIONS ]['options'];
-
-			$this->gateway->update_option( self::BUTTON_LOCATIONS, array_keys( $all_locations ) );
-
-			WC_Payments::woopay_tracker()->woopay_locations_updated( $all_locations, array_keys( $all_locations ) );
+				$this->gateway->update_option( self::BUTTON_LOCATIONS, array_keys( $all_locations ) );
+				WC_Payments::woopay_tracker()->woopay_locations_updated( $all_locations, array_keys( $all_locations ) );
+			}
 		}
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is related to #10193 and, as the issue indicates, there's a chance a fatal error is raised [here](https://github.com/Automattic/woocommerce-payments/blob/573a5b3f75e1ef0bb2b18fc125e23c647255c091/includes/class-wc-payments-woopay-button-handler.php#L131). We haven't been able to reproduce so far, but this PR prevents the fatal from happening by adding a couple checks and I'm going to address the root cause in a separate PR.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Reproduce the issue**

1. Checkout to `develop`.
2. Add `true ||` to [this condition](https://github.com/Automattic/woocommerce-payments/blob/573a5b3f75e1ef0bb2b18fc125e23c647255c091/includes/class-wc-payments-woopay-button-handler.php#L127):
```php
if (true || ! array_key_exists( self::BUTTON_LOCATIONS, get_option( 'woocommerce_woocommerce_payments_settings' ) ) ) {
```
3. Add a product to the cart and navigate to checkout.
4. The same fatal error indicated in the issue should be triggered:
`Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given`

**Test: No fatal error is triggered**

1. Checkout to this branch.
2. Keep the condition change you did in step 2 above.
3. Refresh the checkout page.
4. You should not see any errors and page should load successfully.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
