### PR TITLE
Remove the subscriptions spec for Puppeteer

### DIFF
--- a/changelog/fix-10249-remove-subscriptions-jest-spec
+++ b/changelog/fix-10249-remove-subscriptions-jest-spec
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove the subscriptions spec for Puppeteer

--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -9,7 +9,6 @@ config( { path: path.resolve( __dirname, 'local.env' ) } );
 // Define paths to look for E2E tests.
 const e2ePaths = {
 	wcpay: path.resolve( __dirname, '../specs/wcpay' ),
-	subscriptions: path.resolve( __dirname, '../specs/subscriptions' ),
 	blocks: path.resolve( __dirname, '../specs/blocks' ),
 };
 


### PR DESCRIPTION
Fixes #10249 

#### Changes proposed in this Pull Request

* Remove the subscriptions spec for Jest/Puppeteer.

#### Testing instructions

* Tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
