### PR TITLE
Fix flaky PW test: Shopper can save and delete cards

### DIFF
--- a/changelog/dev-10271-shopper-cards-flaky-test
+++ b/changelog/dev-10271-shopper-cards-flaky-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky Shopper saved cards test.

--- a/tests/e2e-pw/specs/shopper/shopper-myaccount-saved-cards.spec.ts
+++ b/tests/e2e-pw/specs/shopper/shopper-myaccount-saved-cards.spec.ts
@@ -218,7 +218,9 @@ test.describe( 'Shopper can save and delete cards', () => {
 				test.afterAll( async () => {
 					const cardKeys = Object.keys( cards );
 					if ( cardName !== cardKeys[ cardKeys.length - 1 ] ) {
-						waitTwentySecondsSinceLastCardAdded( shopperPage );
+						await waitTwentySecondsSinceLastCardAdded(
+							shopperPage
+						);
 					}
 				} );
 			} );


### PR DESCRIPTION
Fixes #10271

#### Changes proposed in this Pull Request

This PR aims to fix the flaky tests on the `Shopper can save and delete cards` test suite. The main idea is that the 20-second wait wasn't being respected after each card test due to the lack of `await` before calling the `waitTwentySecondsSinceLastCardAdded()` function.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- The CI shouldn't contain flaky errors related to this spec
- Clear your E2E test env: `npm run test:e2e-reset && npm run test:e2e-setup`
- The tests should be passing: `npm run test:e2e-pw shopper-myaccount-saved-cards.spec.ts`

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
