### PR TITLE
WooPay blocks default terms and conditions text

### DIFF
--- a/changelog/fix-blocks-terms-conditions
+++ b/changelog/fix-blocks-terms-conditions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooPay blocks checkout terms and condition default text

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -975,9 +975,11 @@ class WooPay_Session {
 				}
 			}
 
-			$fields_block        = self::get_inner_block( $checkout_page_blocks[ $checkout_block_index ], 'woocommerce/checkout-fields-block' );
-			$terms_block         = self::get_inner_block( $fields_block, 'woocommerce/checkout-terms-block' );
-			$show_terms_checkbox = isset( $terms_block['attrs']['checkbox'] ) && $terms_block['attrs']['checkbox'];
+			$fields_block                  = self::get_inner_block( $checkout_page_blocks[ $checkout_block_index ], 'woocommerce/checkout-fields-block' );
+			$terms_block                   = self::get_inner_block( $fields_block, 'woocommerce/checkout-terms-block' );
+			$show_terms_checkbox           = isset( $terms_block['attrs']['checkbox'] ) && $terms_block['attrs']['checkbox'];
+			$below_place_order_button_text = self::get_blocks_terms_and_conditions_text( $terms_block );
+
 		}
 
 		return [
@@ -987,6 +989,41 @@ class WooPay_Session {
 			'terms_checkbox' => $show_terms_checkbox,
 			'custom_terms'   => $below_place_order_button_text,
 		];
+	}
+
+	/**
+	 * Gets the blocks terms and conditions text.
+	 *
+	 * @param array $terms_block the terms block.
+	 * @return string
+	 */
+	private static function get_blocks_terms_and_conditions_text( $terms_block ) {
+
+		if ( isset( $terms_block['attrs']['text'] ) ) {
+			return $terms_block['attrs']['text'];
+		}
+
+		$privacy_page_link = get_privacy_policy_url();
+		$privacy_page_link = $privacy_page_link
+			? '<a href="' . $privacy_page_link . '" target="_blank">' . __( 'Privacy Policy', 'woocommerce-payments' ) . '</a>'
+			: __( 'Privacy Policy', 'woocommerce-payments' );
+
+		$terms_page_id   = wc_terms_and_conditions_page_id();
+		$terms_page_link = '';
+		if ( $terms_page_id ) {
+			$terms_page_link = get_permalink( $terms_page_id );
+		}
+
+		$terms_page_link = $terms_page_link
+			? '<a href="' . $terms_page_link . '" target="_blank">' . __( 'Terms and Conditions', 'woocommerce-payments' ) . '</a>'
+			: __( 'Terms and Conditions', 'woocommerce-payments' );
+
+		return sprintf(
+			/* translators: %1$s terms page link, %2$s privacy page link. */
+			__( 'You must accept our %1$s and %2$s to continue with your purchase.', 'woocommerce-payments' ),
+			$terms_page_link,
+			$privacy_page_link
+		);
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a bug that would prevent loading the default text from the terms and conditions block.

#### Testing instructions
**Default text**
- Recreate the blocks checkout page
- Go to /wp-admin > WooCommerce > Settings > Advanced
- Make sure the blocks checkout page is being used
- Make sure the terms and conditions page is set
- Go to /wp-admin > Payments > Settings > WooPay > Customize and remove the checkout policies
- Save
- As a shopper buy a product using WooPay
- Make sure the text below the place order button is set to `You must accept our [Terms and Conditions](http://woopaymerchant.test/sample-page/) and [Privacy Policy](http://woopaymerchant.test/sample-page/) to continue with your purchase.`
- Make sure the links work

**Edited text**
- Edit the blocks checkout page and change the terms and conditions text
- Save
- As a shopper buy a product using WooPay
- Make sure the text below the place order button is set to the text you added above

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
