### PR TITLE
Prevent potential fatal in multi-currency widget markup getter

### DIFF
--- a/changelog/fix-10220-multi-currency-widget-markup-getter
+++ b/changelog/fix-10220-multi-currency-widget-markup-getter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure multi-currency widget markup getter don't throw errors.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -528,9 +528,8 @@ class MultiCurrency {
 		if ( ! is_object( $currency_switcher_widget ) ) {
 			Logger::notice(
 				sprintf(
-					'Invalid widget markup. Widget instance must be type object, %s given with value: "%s".',
-					gettype( $currency_switcher_widget ),
-					$currency_switcher_widget
+					'Invalid widget markup. Widget instance must be type object, %s given.',
+					gettype( $currency_switcher_widget )
 				)
 			);
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -526,6 +526,14 @@ class MultiCurrency {
 		$currency_switcher_widget = $this->get_currency_switcher_widget();
 
 		if ( ! is_object( $currency_switcher_widget ) ) {
+			Logger::notice(
+				sprintf(
+					'Invalid widget markup. Widget instance must be type object, %s given with value: "%s".',
+					gettype( $currency_switcher_widget ),
+					$currency_switcher_widget
+				)
+			);
+
 			return ob_get_clean();
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -522,8 +522,15 @@ class MultiCurrency {
 		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
 		 */
 		ob_start();
+
+		$currency_switcher_widget = $this->get_currency_switcher_widget();
+
+		if ( ! is_object( $currency_switcher_widget ) ) {
+			return ob_get_clean();
+		}
+
 		the_widget(
-			spl_object_hash( $this->get_currency_switcher_widget() ),
+			spl_object_hash( $currency_switcher_widget ),
 			apply_filters( self::FILTER_PREFIX . 'theme_widget_instance', $instance ),
 			apply_filters( self::FILTER_PREFIX . 'theme_widget_args', $args )
 		);

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -927,6 +927,18 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertEquals( $expected, $this->multi_currency->get_switcher_widget_markup() );
 	}
 
+	public function test_get_switcher_widget_markup_when_widget_instance_is_null() {
+		$mock_multi_currency = $this
+			->getMockBuilder( WCPay\MultiCurrency\MultiCurrency::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_currency_switcher_widget' ] )
+			->getMock();
+
+		$mock_multi_currency->method( 'get_currency_switcher_widget' )->willReturn( null );
+
+		$this->assertEquals( '', $mock_multi_currency->get_switcher_widget_markup() );
+	}
+
 	public function test_validate_currency_code_returns_existing_currency_code() {
 		$this->assertEquals( 'CAD', $this->multi_currency->validate_currency_code( 'CAD' ) );
 		$this->assertEquals( 'CAD', $this->multi_currency->validate_currency_code( 'cAd' ) );


### PR DESCRIPTION
Fixes #10220.

#### Changes proposed in this Pull Request

This addresses a potential fatal that might happen in the multi-currency widget markup getter when the widget instance is `null`. This fatal is impacting Atomic sites only and based on the logs and this thread p1738351484913529-slack-C01BZUL57SQ, our theory is that this is happening in automated requests only. I haven't been able to reproduce the issue myself.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**

1. As a merchant, ensure your site theme is Storefront.
2. Navigate to **WooCommerce > Settings > Multi-currency** and ensure **Add a currency switcher to the Storefront theme on breadcrumb section** is enabled.

**Reproduce the issue**

1. Checkout to `develop`.
2. Add `return null;` early in [get_currency_switcher_widget()](https://github.com/Automattic/woocommerce-payments/blob/30e1c14084bcad388b9306a13db0cbbe178d453a/includes/multi-currency/MultiCurrency.php).
3. Visit the store and see the fatal error indicated in the issue:
`Fatal error: Uncaught TypeError: spl_object_hash(): Argument #1 ($object) must be of type object, null given`

**Test: Ensure no fatal error is triggered**

1. Checkout to this branch.
2. Keep the early return you added in step 2 above.
3. Refresh the page.
4. You should not see any errors and page should load successfully. Note, however, that the currency switcher widget is no longer displayed in the breadcrumb.

**Regression test: Ensure currency switcher widget is displayed as expected**

1. Remove the early return you added in step 2 above.
2. Refresh the page.
3. You should not see any errors and page should load successfully. The currency switcher widget should be rendered in the breadcrumb and should be working as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.