### PR TITLE
Pass the business name to the express checkout options

### DIFF
--- a/changelog/add-pass-business-name-express-checkout
+++ b/changelog/add-pass-business-name-express-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Pass the business name to the express checkout handler.

--- a/client/express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/express-checkout/blocks/hooks/use-express-checkout.js
@@ -92,6 +92,9 @@ export const useExpressCheckout = ( {
 			}
 
 			const options = {
+				business: {
+					name: getExpressCheckoutData( 'store_name' ),
+				},
 				lineItems: normalizeLineItems( billing?.cartTotalItems ),
 				emailRequired: true,
 				shippingAddressRequired,

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -313,6 +313,9 @@ jQuery( ( $ ) => {
 				}
 
 				const clickOptions = {
+					business: {
+						name: getExpressCheckoutData( 'store_name' ),
+					},
 					lineItems: normalizeLineItems( options.displayItems ),
 					emailRequired: true,
 					shippingAddressRequired: options.requestShipping,

--- a/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
@@ -92,6 +92,9 @@ export const useExpressCheckout = ( {
 			}
 
 			const options = {
+				business: {
+					name: getExpressCheckoutData( 'store_name' ),
+				},
 				lineItems: normalizeLineItems( billing?.cartTotalItems ),
 				emailRequired: true,
 				shippingAddressRequired,

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -269,6 +269,9 @@ jQuery( ( $ ) => {
 					// The "real" values will be updated once the button loads.
 					// They are preemptively initialized because the `event.resolve({})`
 					// needs to be called within 1 second of the `click` event.
+					business: {
+						name: getExpressCheckoutData( 'store_name' ),
+					},
 					lineItems: options.displayItems,
 					emailRequired: true,
 					shippingAddressRequired: options.requestShipping,

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -260,6 +260,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 			'has_block'          => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
 			'product'            => $this->express_checkout_helper->get_product_data(),
 			'total_label'        => $this->express_checkout_helper->get_total_label(),
+			'store_name'         => get_bloginfo( 'name' ),
 		];
 
 		if ( WC_Payments_Features::is_tokenized_cart_ece_enabled() ) {

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -214,15 +214,12 @@ class WC_Payments_Express_Checkout_Button_Handler {
 	}
 
 	/**
-	 * Load public scripts and styles.
+	 * Gets the parameters needed for Express Checkout functionality.
+	 *
+	 * @return array Parameters for Express Checkout.
 	 */
-	public function scripts() {
-		// Don't load scripts if page is not supported.
-		if ( ! $this->express_checkout_helper->should_show_express_checkout_button() ) {
-			return;
-		}
-
-		$express_checkout_params = [
+	public function get_express_checkout_params() {
+		return [
 			'ajax_url'           => admin_url( 'admin-ajax.php' ),
 			'wc_ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'             => [
@@ -262,6 +259,18 @@ class WC_Payments_Express_Checkout_Button_Handler {
 			'total_label'        => $this->express_checkout_helper->get_total_label(),
 			'store_name'         => get_bloginfo( 'name' ),
 		];
+	}
+
+	/**
+	 * Load public scripts and styles.
+	 */
+	public function scripts() {
+		// Don't load scripts if page is not supported.
+		if ( ! $this->express_checkout_helper->should_show_express_checkout_button() ) {
+			return;
+		}
+
+		$express_checkout_params = $this->get_express_checkout_params();
 
 		if ( WC_Payments_Features::is_tokenized_cart_ece_enabled() ) {
 			WC_Payments::register_script_with_dependencies(

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
@@ -133,4 +133,20 @@ class WC_Payments_Express_Checkout_Button_Handler_Test extends WCPAY_UnitTestCas
 		remove_filter( 'woocommerce_shipping_method_count', '__return_zero' );
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 	}
+
+	public function test_get_express_checkout_params() {
+		$this->mock_ece_button_helper
+			->method( 'get_common_button_settings' )
+			->willReturn(
+				[
+					'type'   => 'buy',
+					'theme'  => 'white',
+					'height' => '30',
+					'radius' => '10',
+				]
+			);
+		$params = $this->system_under_test->get_express_checkout_params();
+		$this->assertArrayHasKey( 'store_name', $params );
+		$this->assertEquals( get_bloginfo( 'name' ), $params['store_name'] );
+	}
 }


### PR DESCRIPTION
Fixes #9816

#### Changes proposed in this Pull Request

Pass the Store/Site name as the `business.name` in the express checkout options after the ECE button is clicked.

The reason for this change is explained in the linked issue:

> In the current ECE implementation of Apple Pay and Google Pay, the business name displayed in the payment sheet is sourced from the business name entered during merchant onboarding. Often times this information doesn't match the site's go live name. Changing the name requires a merchant to either edit the name in the Stripe Express Dashboard or they must first open an HE ticket who then have to ask Stripe to update the business name. Self-serve edits for Individual type businesses is not possible.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the WooPayments settings enable Apple Pay/Google Pay
* In WP Admin go to Settings > General, and change the site title using special characters and numbers. E.g. `Seller's Store-🏬`
* You'll need to serve your page through HTTPS in order to render the express checkout buttons. Use jurassic tube, ngrok, or a similar solution.
* Test the following in the Product, Cart and Checkout pages.
* Click the Express Checkout buttons
* Verify that the Site name is being used in the Payment Sheet:
![Screenshot 2025-02-05 at 10 25 49 a m](https://github.com/user-attachments/assets/3aad163d-8cdd-48d9-8b09-becb77c7845b)
![Screenshot 2025-02-05 at 10 25 26 a m](https://github.com/user-attachments/assets/38972ab1-222f-4247-8422-10c5239f5d00)
* Verify that orders can still be placed using Express Checkout.
* In the General Settings, clear the site name so it becomes an empty string, save the changes.
* Verify that the business name in the payment sheets for Google Pay and Apple Pay (requires Safari) is set to the name used to setup the Stripe account.
![Screenshot 2025-02-05 at 10 29 23 a m](https://github.com/user-attachments/assets/655f8c14-4b0c-4063-acfe-23035e60dc6b)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
