### PR TITLE
feat: add order notes to tokenized ECE on blocks checkout

### DIFF
--- a/changelog/feat-add-order-notes-to-tokenized-ece
+++ b/changelog/feat-add-order-notes-to-tokenized-ece
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+feat: add order notes to tokenized ECE GooglePay/ApplePay on blocks checkout

--- a/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/tokenized-express-checkout/blocks/hooks/use-express-checkout.js
@@ -124,7 +124,12 @@ export const useExpressCheckout = ( {
 			elements,
 			completePayment,
 			abortPayment,
-			event
+			{
+				...event,
+				order_comments: wp?.data
+					?.select( 'wc/store/checkout' )
+					?.getOrderNotes(),
+			}
 		);
 	};
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Allowing to pass the order notes from the blocks checkout page to the tokenized ECE, so that they can be persisted.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product to the cart
- Go to a block-based checkout
- Enter some order notes on the checkout page
<img width="553" alt="Screenshot 2025-02-05 at 6 33 44 PM" src="https://github.com/user-attachments/assets/625803ce-c0b4-4725-8c8c-982339db70c9" />

- Click on the GooglePay/ApplePay button
- Pay for the order
- The order notes should be captured on the "Order received" page
<img width="909" alt="Screenshot 2025-02-05 at 6 34 04 PM" src="https://github.com/user-attachments/assets/133b71c7-927e-483a-a641-610fb7f2ae48" />


Block-based cart, shortcode-based cart & checkout pages, product pages should remain unaffected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
