### PR TITLE
update: tokenized ECE behavior w/ totals discrepancies

### DIFF
--- a/changelog/fix-tokenized-ece-rounding-of-itemized-items
+++ b/changelog/fix-tokenized-ece-rounding-of-itemized-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: tokenized ECE to exclude itemized items on rounding discrepancies of totals.

--- a/client/express-checkout/blocks/hooks/use-express-checkout.js
+++ b/client/express-checkout/blocks/hooks/use-express-checkout.js
@@ -91,11 +91,27 @@ export const useExpressCheckout = ( {
 				}
 			}
 
+			const lineItems = normalizeLineItems( billing.cartTotalItems );
+			const totalAmountOfLineItems = lineItems.reduce(
+				( acc, lineItem ) => {
+					return acc + lineItem.amount;
+				},
+				0
+			);
+
 			const options = {
 				business: {
 					name: getExpressCheckoutData( 'store_name' ),
 				},
-				lineItems: normalizeLineItems( billing?.cartTotalItems ),
+				// if the `billing.cartTotal.value` is less than the total of `lineItems`, Stripe throws an error
+				// it can sometimes happen that the total is _slightly_ less, due to rounding errors on individual items/taxes/shipping
+				// (or with the `woocommerce_tax_round_at_subtotal` setting).
+				// if that happens, let's just not return any of the line items.
+				// This way, just the total amount will be displayed to the customer.
+				lineItems:
+					billing.cartTotal.value < totalAmountOfLineItems
+						? []
+						: lineItems,
 				emailRequired: true,
 				shippingAddressRequired,
 				phoneNumberRequired:
@@ -115,6 +131,7 @@ export const useExpressCheckout = ( {
 		[
 			onClick,
 			billing.cartTotalItems,
+			billing.cartTotal.value,
 			shippingData.needsShipping,
 			shippingData.shippingRates,
 		]

--- a/client/tokenized-express-checkout/blocks/hooks/__tests__/use-express-checkout.test.js
+++ b/client/tokenized-express-checkout/blocks/hooks/__tests__/use-express-checkout.test.js
@@ -39,6 +39,144 @@ describe( 'useExpressCheckout', () => {
 		global.jQuery = jQueryMock;
 	} );
 
+	it( 'should provide the line items', () => {
+		const onClickMock = jest.fn();
+		const event = { resolve: jest.fn() };
+		const { result } = renderHook( () =>
+			useExpressCheckout( {
+				billing: {
+					cartTotalItems: [
+						{
+							key: 'total_items',
+							label: 'Subtotal:',
+							value: 4000,
+							valueWithTax: 4330,
+						},
+						{
+							key: 'total_fees',
+							label: 'Fees:',
+							value: 0,
+							valueWithTax: 0,
+						},
+						{
+							key: 'total_discount',
+							label: 'Discount:',
+							value: 0,
+							valueWithTax: 0,
+						},
+						{
+							key: 'total_tax',
+							label: 'Taxes:',
+							value: 330,
+							valueWithTax: 330,
+						},
+						{
+							key: 'total_shipping',
+							label: 'Shipping:',
+							value: 0,
+							valueWithTax: 0,
+						},
+					],
+					cartTotal: {
+						label: 'Total',
+						value: 4330,
+					},
+				},
+				shippingData: {
+					needsShipping: false,
+					shippingRates: [],
+				},
+				onClick: onClickMock,
+				onClose: {},
+				setExpressPaymentError: {},
+			} )
+		);
+
+		expect( onClickMock ).not.toHaveBeenCalled();
+
+		result.current.onButtonClick( event );
+
+		expect( event.resolve ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				lineItems: [
+					{ amount: 4000, name: 'Subtotal:' },
+					{ amount: 0, name: 'Fees:' },
+					{ amount: -0, name: 'Discount:' },
+					{ amount: 330, name: 'Taxes:' },
+					{ amount: 0, name: 'Shipping:' },
+				],
+			} )
+		);
+		expect( onClickMock ).toHaveBeenCalled();
+	} );
+
+	it( "should not provide the line items if the totals don't match", () => {
+		const onClickMock = jest.fn();
+		const event = { resolve: jest.fn() };
+		const { result } = renderHook( () =>
+			useExpressCheckout( {
+				billing: {
+					cartTotalItems: [
+						{
+							key: 'total_items',
+							label: 'Subtotal:',
+							value: 4000,
+							valueWithTax: 4330,
+						},
+						{
+							key: 'total_fees',
+							label: 'Fees:',
+							value: 0,
+							valueWithTax: 0,
+						},
+						{
+							key: 'total_discount',
+							label: 'Discount:',
+							value: 0,
+							valueWithTax: 0,
+						},
+						{
+							key: 'total_tax',
+							label: 'Taxes:',
+							value: 330,
+							valueWithTax: 330,
+						},
+						{
+							key: 'total_shipping',
+							label: 'Shipping:',
+							value: 0,
+							valueWithTax: 0,
+						},
+					],
+					cartTotal: {
+						label: 'Total',
+						// simulating a total amount that is lower than the sum of the values of `cartTotalItems`
+						// this scenario happens with the Gift Cards plugin.
+						value: 400,
+					},
+				},
+				shippingData: {
+					needsShipping: false,
+					shippingRates: [],
+				},
+				onClick: onClickMock,
+				onClose: {},
+				setExpressPaymentError: {},
+			} )
+		);
+
+		expect( onClickMock ).not.toHaveBeenCalled();
+
+		result.current.onButtonClick( event );
+
+		expect( event.resolve ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				lineItems: [],
+			} )
+		);
+		expect( onClickMock ).toHaveBeenCalled();
+	} );
+
 	it( 'should provide no shipping rates when not required on click', () => {
 		const onClickMock = jest.fn();
 		const event = { resolve: jest.fn() };
@@ -46,6 +184,10 @@ describe( 'useExpressCheckout', () => {
 			useExpressCheckout( {
 				billing: {
 					cartTotalItems: [],
+					cartTotal: {
+						label: 'Total',
+						value: 448,
+					},
 				},
 				shippingData: {
 					needsShipping: false,
@@ -76,6 +218,10 @@ describe( 'useExpressCheckout', () => {
 			useExpressCheckout( {
 				billing: {
 					cartTotalItems: [],
+					cartTotal: {
+						label: 'Total',
+						value: 448,
+					},
 				},
 				shippingData: {
 					needsShipping: true,
@@ -119,6 +265,10 @@ describe( 'useExpressCheckout', () => {
 			useExpressCheckout( {
 				billing: {
 					cartTotalItems: [],
+					cartTotal: {
+						label: 'Total',
+						value: 448,
+					},
 				},
 				shippingData: {
 					needsShipping: true,

--- a/client/tokenized-express-checkout/transformers/__tests__/wc-to-stripe.test.js
+++ b/client/tokenized-express-checkout/transformers/__tests__/wc-to-stripe.test.js
@@ -136,7 +136,26 @@ describe( 'wc-to-stripe transformers', () => {
 						},
 					],
 					shipping_rates: [],
-					totals: {},
+					totals: {
+						currency_code: 'USD',
+						currency_decimal_separator: '.',
+						currency_minor_unit: 2,
+						currency_prefix: '$',
+						currency_suffix: '',
+						currency_symbol: '$',
+						currency_thousand_separator: ',',
+						tax_lines: [],
+						total_discount: '0',
+						total_discount_tax: '0',
+						total_fees: '0',
+						total_fees_tax: '0',
+						total_items: '6000',
+						total_items_tax: '0',
+						total_price: '6000',
+						total_shipping: '0',
+						total_shipping_tax: '0',
+						total_tax: '0',
+					},
 				} )
 			).toStrictEqual( [
 				{ amount: 4500, name: 'Physical subscription' },
@@ -183,6 +202,113 @@ describe( 'wc-to-stripe transformers', () => {
 			expect(
 				transformCartDataForDisplayItems( {
 					items: [],
+					shipping_rates: [],
+					totals: {
+						total_items: '0',
+						total_items_tax: '0',
+						total_fees: '0',
+						total_fees_tax: '0',
+						total_discount: '0',
+						total_discount_tax: '0',
+						total_shipping: '0',
+						total_shipping_tax: '0',
+						total_price: '0',
+						total_tax: '0',
+						tax_lines: [],
+						currency_code: 'USD',
+						currency_symbol: '$',
+						currency_minor_unit: 2,
+						currency_decimal_separator: '.',
+						currency_thousand_separator: ',',
+						currency_prefix: '$',
+						currency_suffix: '',
+					},
+				} )
+			).toStrictEqual( [] );
+		} );
+
+		it( 'does not return line items when there is a discrepancy with the totals', () => {
+			expect(
+				transformCartDataForDisplayItems( {
+					items: [
+						{
+							key: '6fd9b4da889ae534ceae47561b939f24',
+							id: 214,
+							type: 'simple',
+							quantity: 2,
+							name: 'Deposit',
+							variation: [],
+							item_data: [
+								{
+									name: 'Payment Plan',
+									value: 'Deposit 30',
+									display: '',
+								},
+								{
+									key: 'Payable In Total',
+									value: '&#36;45.00 payable over 20 days',
+								},
+							],
+							prices: {
+								price: '4500',
+								regular_price: '5000',
+								sale_price: '4500',
+								price_range: null,
+								currency_code: 'USD',
+								currency_symbol: '$',
+								currency_minor_unit: 2,
+								currency_decimal_separator: '.',
+								currency_thousand_separator: ',',
+								currency_prefix: '$',
+								currency_suffix: '',
+								raw_prices: {
+									precision: 6,
+									price: '45000000',
+									regular_price: '50000000',
+									sale_price: '45000000',
+								},
+							},
+							totals: {
+								line_subtotal: '1350',
+								line_subtotal_tax: 0,
+								line_total: '4500',
+								line_total_tax: '388',
+								currency_code: 'USD',
+								currency_symbol: '$',
+								currency_minor_unit: 2,
+								currency_decimal_separator: '.',
+								currency_thousand_separator: ',',
+								currency_prefix: '$',
+								currency_suffix: '',
+							},
+							catalog_visibility: 'visible',
+							extensions: {
+								'woocommerce-deposits': {
+									is_deposit: true,
+									has_payment_plan: true,
+									plan_schedule: [
+										{
+											schedule_id: '2',
+											schedule_index: '0',
+											plan_id: '2',
+											amount: '30',
+											interval_amount: '0',
+											interval_unit: '0',
+										},
+										{
+											schedule_id: '3',
+											schedule_index: '1',
+											plan_id: '2',
+											amount: '70',
+											interval_amount: '20',
+											interval_unit: 'day',
+										},
+									],
+								},
+								bundles: [],
+							},
+						},
+					],
 					shipping_rates: [],
 					totals: {
 						total_items: '0',

--- a/client/tokenized-express-checkout/transformers/wc-to-stripe.js
+++ b/client/tokenized-express-checkout/transformers/wc-to-stripe.js
@@ -93,6 +93,24 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 		} );
 	}
 
+	const totalAmount = transformPrice(
+		parseInt( cartData.totals.total_price, 10 ) -
+			parseInt( cartData.totals.total_refund || 0, 10 ),
+		cartData.totals
+	);
+	const totalAmountOfDisplayItems = displayItems.reduce(
+		( acc, { amount } ) => acc + amount,
+		0
+	);
+
+	// if `totalAmount` is less than the total of `displayItems`, Stripe throws an error
+	// it can sometimes happen that the total is _slightly_ less, due to rounding errors on individual items/taxes/shipping
+	// (or with the `woocommerce_tax_round_at_subtotal` setting).
+	// if that happens, let's just not return any of the line items. This way, just the total amount will be displayed to the customer.
+	if ( totalAmount < totalAmountOfDisplayItems ) {
+		return [];
+	}
+
 	return displayItems;
 };
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

There can be scenarios where totals are not congruent with the sum of the individual line items:
- The Gift Cards plugin lowers the total cart amount when gift cards are applied
- The "WooCommerce > Settings > Tax > Round tax at subtotal level, instead of rounding per line" setting might cause a slight (usually around $0.01) difference in price ( p1738792725433579/1738707211.859139-slack-CGGCLBN58 )

The "solution" is to avoid sending the itemized line items when such a discrepancy occurs.
By removing the line items, it means that the little ℹ️ icon next to the price will no longer be visible.
The alternative could be to add a "bogus" line item with the price difference 🤷‍♂️ 

Before:
![2025-02-06 11 09 32](https://github.com/user-attachments/assets/1104dea5-1513-4ee0-b94b-a44fed187d81)

After:
![2025-02-06 11 10 39](https://github.com/user-attachments/assets/8384deff-565d-4c37-943c-985bde771203)



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I think the easiest way to test this is to use the Gift Cards plugin. You can also test the "WooCommerce > Settings > Tax > Round tax at subtotal level, instead of rounding per line" setup, but it requires more setup

1. Install the ["Gift Cards for WooCommerce"](https://woocommerce.com/products/gift-cards/) extension
2. Create a "Gift card" product for $10 - [follow the documentation](https://woocommerce.com/document/gift-cards/store-owners-guide/#creating-gift-card-products)
3. Purchase a gift card
4. Take note of the gift card code
5. Ensure you have GooglePay/ApplePay enabled
6. Add more than $10 worth of products to the cart
7. Go to the checkout page (this applies to both block-based and shortcode-based checkout)
8. Apply the gift card code you noted on the previous step
9. Click on the GooglePay/ApplePay button
10. You should be able to check out without issues (previously, there was an error in the console on click)

PLEASE NOTE: you might render a page with a 0-cart amount if the gift card amount already applied to the cart is greater than the cart amount. If you un-apply the gift card & refresh the page, the GooglePay/ApplePay buttons should appear again.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.