### PR TITLE
Disables the tokenised cart for ECE integration by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 *** WooPayments Changelog ***
 
+= 8.9.1 - 2025-02-07 =
+
 = 8.9.0 - 2025-02-04 =
 * Add - Add a popover to WooPayments to present all possible payment methods
 * Add - Added persistent column visibility preferences for reporting tables, allowing merchants to customize and save their preferred table view layouts across sessions.

--- a/changelog/patch-disable-tokenised-carts-by-default
+++ b/changelog/patch-disable-tokenised-carts-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures that the tokenised cart for ECE implementation is disabled by default.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -49,7 +49,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_tokenized_cart_ece_enabled(): bool {
-		return '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '1' );
+		return '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '0' );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-payments",
-  "version": "8.9.0",
+  "version": "8.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-payments",
-      "version": "8.9.0",
+      "version": "8.9.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "8.9.0",
+  "version": "8.9.1",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 7.3
-Stable tag: 8.9.0
+Stable tag: 8.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,6 +86,9 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 4. Manage Disputes
 
 == Changelog ==
+
+= 8.9.1 - 2025-02-07 =
+
 
 = 8.9.0 - 2025-02-04 =
 * Add - Add a popover to WooPayments to present all possible payment methods

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 9.6.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 8.9.0
+ * Version: 8.9.1
  * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
See p1738882358232039-slack-C08C3ER76E9 for more details. 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Disabling tokenised cart implementation by default
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
We recently identified issues with this integration in place to support express checkout payment methods (EPMs) payments via Store API tokenised carts. While we investigate the cause of these issues further, this PR ensures that the tokenised cart feature flag is disabled by default, so that we will continue relying on the previous implementation in production for the time being instead. 

This PR essentially reverts #10016. 
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Ensure that you do not have the tokenised cart feature flag enabled from your Dev Tools (see screenshot below).
2. On the `develop` branch, go to a product, cart, or checkout page and commence a payment with an EPM (e.g. Apple/Google Pay) by clicking the EPM button.
3. With your browser's network tab open, you should notice requests made to Store API endpoints (e.g. `/wp-json/wc/store/v1/cart/add-item`).
4. Pull the changes from this PR and repeat steps 2-3.
5. You should now no longer see any requests sent to the Store API: these should be replaced by internal AJAX requests instead (e.g. `/?wc-ajax=wcpay_add_to_cart`).
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![Tokenised cart feature flag in dev tools](https://cdn-std.droplr.net/files/acc_1104206/Njko7o)
_Ensure that this checkbox is not selected_

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.