### PR TITLE
Disables the tokenised cart for ECE integration by default

### DIFF
--- a/changelog/patch-disable-tokenised-carts-by-default
+++ b/changelog/patch-disable-tokenised-carts-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures that the tokenised cart for ECE implementation is disabled by default.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -49,7 +49,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_tokenized_cart_ece_enabled(): bool {
-		return '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '1' );
+		return '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '0' );
 	}
 
 	/**


### PR DESCRIPTION
See p1738882358232039-slack-C08C3ER76E9 for more details. 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Disabling tokenised cart implementation by default
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
We recently identified issues with this integration in place to support express checkout payment methods (EPMs) payments via Store API tokenised carts. While we investigate the cause of these issues further, this PR ensures that the tokenised cart feature flag is disabled by default, so that we will continue relying on the previous implementation in production for the time being instead. 

This PR essentially reverts #10016. 
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Ensure that you do not have the tokenised cart feature flag enabled from your Dev Tools (see screenshot below).
2. On the `develop` branch, go to a product, cart, or checkout page and commence a payment with an EPM (e.g. Apple/Google Pay) by clicking the EPM button.
3. With your browser's network tab open, you should notice requests made to Store API endpoints (e.g. `/wp-json/wc/store/v1/cart/add-item`).
4. Pull the changes from this PR and repeat steps 2-3.
5. You should now no longer see any requests sent to the Store API: these should be replaced by internal AJAX requests instead (e.g. `/?wc-ajax=wcpay_add_to_cart`).
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![Tokenised cart feature flag in dev tools](https://cdn-std.droplr.net/files/acc_1104206/Njko7o)
_Ensure that this checkbox is not selected_

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.