### PR TITLE
Avoid duplicates detection notice on new stores

### DIFF
--- a/changelog/fix-prbs-gateway-scope-for-duplicates-detection
+++ b/changelog/fix-prbs-gateway-scope-for-duplicates-detection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Avoid duplicated payment methods detection notice on new stores.

--- a/includes/class-duplicates-detection-service.php
+++ b/includes/class-duplicates-detection-service.php
@@ -143,7 +143,7 @@ class Duplicates_Detection_Service {
 					if ( strpos( $gateway->id, $keyword ) !== false ) {
 						$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
 						break;
-					} elseif ( 'yes' === $gateway->get_option( 'payment_request' ) ) {
+					} elseif ( 'yes' === $gateway->get_option( 'payment_request' ) && in_array( $gateway->id, [ 'woocommerce_payments', 'stripe' ], true ) ) {
 						$this->gateways_qualified_by_duplicates_detector[ $prb_payment_method ][] = $gateway->id;
 						break;
 					} elseif ( 'yes' === $gateway->get_option( 'express_checkout_enabled' ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10145

#### Changes proposed in this Pull Request
We removed the card gateway-specific check when working on fixing the Stripe plugin integration at https://github.com/Automattic/woocommerce-payments/pull/9663, which caused non-card gateways to be identified as those enabling PRBs.

The duplicate detection mechanism is fragile and relies on our assumptions about gateways' inner workings and some hardcoded keywords. Therefore, I believe we might encounter similar issues in the future, especially if we decide to expand the current solution. With that said, I think we should resolve this specific problem with the simplest approach but focus on https://github.com/woocommerce/woocommerce/issues/45218 as a more stable method moving forward. Another option for fixing the problem is to remove PRB-related settings from non-card gateways, but since those settings are used in many places, the risks of impacting other areas are high. Given that our detection mechanism is something we want to replace anyway, I would prefer the simplest solution that this PR implements.

I brought the WooPayments gateway check back and also added the Stripe gateway check into the list to ensure that acceptance criteria of https://github.com/Automattic/woocommerce-payments/pull/9663 are still met. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Check out `develop`
* Re-onboard your account locally (see Pe4Hk0-3f-p2 for the steps)
* Navigate to settings and see the duplicates notice under PRBs 
* Check out `fix/prbs-gateway-scope-for-duplicates-detection`, refresh the settings page and confirm the duplicates notice is gone
* Install some other plugins like e.g. [Klarna](https://wordpress.org/plugins/klarna-payments-for-woocommerce/) and verify whether the detection mechanism works as expected
    * By this, I mean checking if e.g. Klarna enabled in WooPayments and Klarna plugin will lead to a notice
    * After this, checking if turning off Klarna from the separate plugin will resolve the notice on our settings screen
* Make sure there is no regression for the scenario https://github.com/Automattic/woocommerce-payments/pull/9663 is addressing

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.