### PR TITLE
CSV Export - Improve the appearance and message of export notice

### DIFF
--- a/changelog/fix-10356-update-export-snackbar
+++ b/changelog/fix-10356-update-export-snackbar
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a minor follow up task to edit the text within the export notice.
+
+

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -682,14 +682,11 @@ export const TransactionsList = (
 				'success',
 				sprintf(
 					__(
-						'Now processing your export. The file will download automatically and will be emailed to %s.',
+						'We’re processing your export. 🎉 The file will download automatically and be emailed to %s.',
 						'woocommerce-payments'
 					),
 					userEmail
-				),
-				{
-					icon: '✅',
-				}
+				)
 			);
 		}
 	};


### PR DESCRIPTION
Fixes #10356 

#### Changes proposed in this Pull Request

Make the appearance of the export notice aligned with the original snackbar notice WordPress component ( lesser padding ) . Update the wording of the message to make it more 


#### Testing instructions

* Checkout this branch and rebuild assets
* Browse to Payments -> Transactions and click the export button
* You should see a notice similar to the one in the screenshot below towards the bottom left of the screen. 

![image](https://github.com/user-attachments/assets/c406a5f0-ff7d-44ea-9f8f-226bb6af683f)

#### Context

[Feedback on earlier PR](https://github.com/Automattic/woocommerce-payments/pull/10211#discussion_r1950605021) to edit the text and emoji on the notice that appears on CSV export of transactions. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
