### PR TITLE
Update disputes CSV download notice.

### DIFF
--- a/changelog/update-disputes-csv-download-notice
+++ b/changelog/update-disputes-csv-download-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor update to disputes CSV download notice. No need extra changelog entry.
+
+

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -409,14 +409,11 @@ export const DisputesList = (): JSX.Element => {
 				'success',
 				sprintf(
 					__(
-						'Now processing your export. The file will download automatically and will be emailed to %s.',
+						'We’re processing your export. 🎉 The file will download automatically and be emailed to %s.',
 						'woocommerce-payments'
 					),
 					userEmail
-				),
-				{
-					icon: '✅',
-				}
+				)
 			);
 		}
 	};


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10356

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Same changes like https://github.com/Automattic/woocommerce-payments/pull/10359 but for disputes. It's minor change to the notice after user clicks the Export button to download the disputes' CSV.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch and rebuild assets
Browse to Payments -> Disputes and click the export button
You should see a notice similar to the one in the screenshot below towards the bottom left of the screen.

![image](https://github.com/user-attachments/assets/c406a5f0-ff7d-44ea-9f8f-226bb6af683f)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
