### PR TITLE
Remove the statement descriptors from the settings page.

### DIFF
--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -121,42 +121,6 @@ export const useWCPaySubscriptions = () => {
 	];
 };
 
-export const useAccountStatementDescriptor = () => {
-	const { updateAccountStatementDescriptor } = useDispatch( STORE_NAME );
-
-	const accountStatementDescriptor = useSelect( ( select ) =>
-		select( STORE_NAME ).getAccountStatementDescriptor()
-	);
-
-	return [ accountStatementDescriptor, updateAccountStatementDescriptor ];
-};
-
-export const useAccountStatementDescriptorKanji = () => {
-	const { updateAccountStatementDescriptorKanji } = useDispatch( STORE_NAME );
-
-	const accountStatementDescriptorKanji = useSelect( ( select ) =>
-		select( STORE_NAME ).getAccountStatementDescriptorKanji()
-	);
-
-	return [
-		accountStatementDescriptorKanji,
-		updateAccountStatementDescriptorKanji,
-	];
-};
-
-export const useAccountStatementDescriptorKana = () => {
-	const { updateAccountStatementDescriptorKana } = useDispatch( STORE_NAME );
-
-	const accountStatementDescriptorKana = useSelect( ( select ) =>
-		select( STORE_NAME ).getAccountStatementDescriptorKana()
-	);
-
-	return [
-		accountStatementDescriptorKana,
-		updateAccountStatementDescriptorKana,
-	];
-};
-
 export const useAccountBusinessName = () => {
 	const { updateAccountBusinessName } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -53,18 +53,6 @@ export const isDirty = ( state ) => {
 	return getSettingsState( state ).isDirty || false;
 };
 
-export const getAccountStatementDescriptor = ( state ) => {
-	return getSettings( state ).account_statement_descriptor || '';
-};
-
-export const getAccountStatementDescriptorKanji = ( state ) => {
-	return getSettings( state ).account_statement_descriptor_kanji || '';
-};
-
-export const getAccountStatementDescriptorKana = ( state ) => {
-	return getSettings( state ).account_statement_descriptor_kana || '';
-};
-
 export const getAccountBusinessName = ( state ) => {
 	return getSettings( state ).account_business_name || '';
 };

--- a/client/data/settings/test/hooks.js
+++ b/client/data/settings/test/hooks.js
@@ -7,7 +7,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import {
-	useAccountStatementDescriptor,
 	useEnabledPaymentMethodIds,
 	useIsWCPayEnabled,
 	useManualCapture,
@@ -109,34 +108,6 @@ describe( 'Settings hooks tests', () => {
 			expect( actions.updateIsWCPayEnabled ).toHaveBeenCalledWith(
 				false
 			);
-		} );
-	} );
-
-	describe( 'useAccountStatementDescriptor()', () => {
-		test( 'returns the statement description value and a function', () => {
-			actions = {
-				updateAccountStatementDescriptor: jest.fn(),
-			};
-
-			selectors = {
-				getAccountStatementDescriptor: jest
-					.fn()
-					.mockReturnValue( 'statement value' ),
-			};
-
-			const [
-				statementDescriptor,
-				setStatementDescriptor,
-			] = useAccountStatementDescriptor();
-
-			expect( statementDescriptor ).toEqual( 'statement value' );
-			expect( setStatementDescriptor ).toHaveBeenCalledTimes( 0 );
-
-			setStatementDescriptor( 'statement value update' );
-
-			expect(
-				actions.updateAccountStatementDescriptor
-			).toHaveBeenCalledWith( 'statement value update' );
 		} );
 	} );
 

--- a/client/data/settings/test/reducer.js
+++ b/client/data/settings/test/reducer.js
@@ -6,7 +6,6 @@ import {
 	updateSettings,
 	updateIsSavingSettings,
 	updateIsManualCaptureEnabled,
-	updateAccountStatementDescriptor,
 	updatePaymentRequestLocations,
 	updateIsPaymentRequestEnabled,
 	updateAccountBusinessName,
@@ -162,52 +161,6 @@ describe( 'Settings reducer tests', () => {
 				foo: 'bar',
 				data: {
 					is_manual_capture_enabled: true,
-					baz: 'quux',
-				},
-			} );
-		} );
-	} );
-
-	describe( 'SET_ACCOUNT_STATEMENT_DESCRIPTOR', () => {
-		test( 'toggles `data.account_statement_descriptor`', () => {
-			const oldState = {
-				data: {
-					account_statement_descriptor: 'Statement',
-				},
-			};
-
-			const state = reducer(
-				oldState,
-				updateAccountStatementDescriptor( 'New Statement' )
-			);
-
-			expect( state.data.account_statement_descriptor ).toEqual(
-				'New Statement'
-			);
-		} );
-
-		test( 'leaves other fields unchanged', () => {
-			const oldState = {
-				isDirty: false,
-				foo: 'bar',
-				data: {
-					account_statement_descriptor: 'Statement',
-					baz: 'quux',
-				},
-				savingError: {},
-			};
-
-			const state = reducer(
-				oldState,
-				updateAccountStatementDescriptor( 'New Statement' )
-			);
-
-			expect( state ).toEqual( {
-				isDirty: true,
-				foo: 'bar',
-				savingError: null,
-				data: {
-					account_statement_descriptor: 'New Statement',
 					baz: 'quux',
 				},
 			} );

--- a/client/data/settings/test/selectors.js
+++ b/client/data/settings/test/selectors.js
@@ -6,7 +6,6 @@ import {
 	getIsWCPayEnabled,
 	getEnabledPaymentMethodIds,
 	getIsManualCaptureEnabled,
-	getAccountStatementDescriptor,
 	isSavingSettings,
 	getPaymentRequestLocations,
 	getIsPaymentRequestEnabled,
@@ -132,31 +131,6 @@ describe( 'Settings selectors tests', () => {
 			[ { settings: { data: {} } } ],
 		] )( 'returns false if missing (tested state: %j)', ( state ) => {
 			expect( getIsManualCaptureEnabled( state ) ).toBeFalsy();
-		} );
-	} );
-
-	describe( 'getAccountStatementDescriptor()', () => {
-		test( 'returns the value of state.settings.data.account_statement_descriptor', () => {
-			const state = {
-				settings: {
-					data: {
-						account_statement_descriptor: 'my account statement',
-					},
-				},
-			};
-
-			expect( getAccountStatementDescriptor( state ) ).toEqual(
-				'my account statement'
-			);
-		} );
-
-		test.each( [
-			[ undefined ],
-			[ {} ],
-			[ { settings: {} } ],
-			[ { settings: { data: {} } } ],
-		] )( 'returns false if missing (tested state: %j)', ( state ) => {
-			expect( getAccountStatementDescriptor( state ) ).toEqual( '' );
 		} );
 	} );
 

--- a/client/settings/transactions/index.js
+++ b/client/settings/transactions/index.js
@@ -2,56 +2,23 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CheckboxControl,
-	Notice,
-	TextControl,
-} from '@wordpress/components';
+import { Card, CheckboxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import CardBody from '../card-body';
-import {
-	useAccountStatementDescriptor,
-	useAccountStatementDescriptorKanji,
-	useAccountStatementDescriptorKana,
-	useGetSavingError,
-	useSavedCards,
-} from '../../data';
+import { useSavedCards } from '../../data';
 import './style.scss';
 import ManualCaptureControl from 'wcpay/settings/transactions/manual-capture-control';
 import SupportPhoneInput from 'wcpay/settings/support-phone-input';
 import SupportEmailInput from 'wcpay/settings/support-email-input';
 import React, { useEffect, useState } from 'react';
-import { select } from '@wordpress/data';
-import { STORE_NAME } from 'wcpay/data/constants';
-
-const ACCOUNT_STATEMENT_MAX_LENGTH = 22;
-const ACCOUNT_STATEMENT_MAX_LENGTH_KANJI = 17;
-const ACCOUNT_STATEMENT_MAX_LENGTH_KANA = 22;
 
 const Transactions = ( { setTransactionInputsValid } ) => {
 	const [ isSavedCardsEnabled, setIsSavedCardsEnabled ] = useSavedCards();
-	const [
-		accountStatementDescriptor,
-		setAccountStatementDescriptor,
-	] = useAccountStatementDescriptor();
-	const [
-		accountStatementDescriptorKanji,
-		setAccountStatementDescriptorKanji,
-	] = useAccountStatementDescriptorKanji();
-	const [
-		accountStatementDescriptorKana,
-		setAccountStatementDescriptorKana,
-	] = useAccountStatementDescriptorKana();
-	const customerBankStatementErrorMessage = useGetSavingError()?.data?.details
-		?.account_statement_descriptor?.message;
-
 	const [ isEmailInputValid, setEmailInputValid ] = useState( true );
 	const [ isPhoneInputValid, setPhoneInputValid ] = useState( true );
-	const settings = select( STORE_NAME ).getSettings();
 
 	useEffect( () => {
 		if ( setTransactionInputsValid ) {
@@ -86,101 +53,6 @@ const Transactions = ( { setTransactionInputsValid } ) => {
 						'woocommerce-payments'
 					) }
 				</p>
-
-				<div className="transactions__customer-statements">
-					{ customerBankStatementErrorMessage && (
-						<Notice status="error" isDismissible={ false }>
-							<span
-								dangerouslySetInnerHTML={ {
-									__html: customerBankStatementErrorMessage,
-								} }
-							/>
-						</Notice>
-					) }
-					<TextControl
-						className="transactions__account-statement-input"
-						help={
-							settings.account_country === 'JP' &&
-							__(
-								'Use only latin characters.',
-								'woocommerce-payments'
-							)
-						}
-						label={ __(
-							'Customer bank statement',
-							'woocommerce-payments'
-						) }
-						value={ accountStatementDescriptor }
-						onChange={ setAccountStatementDescriptor }
-						maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
-						data-testid={ 'store-name-bank-statement' }
-					/>
-					<span className="input-help-text" aria-hidden="true">
-						{ `${ accountStatementDescriptor.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH }` }
-					</span>
-					{ settings.account_country === 'JP' && (
-						<>
-							<div className="transactions__customer-support">
-								<TextControl
-									className="transactions__account-statement-input"
-									help={ __(
-										'Use only kanji characters.',
-										'woocommerce-payments'
-									) }
-									label={ __(
-										'Customer bank statement (kanji)',
-										'woocommerce-payments'
-									) }
-									value={ accountStatementDescriptorKanji }
-									onChange={
-										setAccountStatementDescriptorKanji
-									}
-									maxLength={
-										ACCOUNT_STATEMENT_MAX_LENGTH_KANJI
-									}
-									data-testid={
-										'store-name-bank-statement-kanji'
-									}
-								/>
-								<span
-									className="input-help-text"
-									aria-hidden="true"
-								>
-									{ `${ accountStatementDescriptorKanji.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH_KANJI }` }
-								</span>
-							</div>
-							<div className="transactions__customer-support">
-								<TextControl
-									className="transactions__account-statement-input"
-									help={ __(
-										'Use only kana characters.',
-										'woocommerce-payments'
-									) }
-									label={ __(
-										'Customer bank statement (kana)',
-										'woocommerce-payments'
-									) }
-									value={ accountStatementDescriptorKana }
-									onChange={
-										setAccountStatementDescriptorKana
-									}
-									maxLength={
-										ACCOUNT_STATEMENT_MAX_LENGTH_KANA
-									}
-									data-testid={
-										'store-name-bank-statement-kana'
-									}
-								/>
-								<span
-									className="input-help-text"
-									aria-hidden="true"
-								>
-									{ `${ accountStatementDescriptorKana.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH_KANA }` }
-								</span>
-							</div>
-						</>
-					) }
-				</div>
 
 				<h4>{ __( 'Customer support', 'woocommerce-payments' ) }</h4>
 

--- a/client/settings/transactions/test/index.test.js
+++ b/client/settings/transactions/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -9,9 +9,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import Transactions from '..';
 import {
 	useGetSavingError,
-	useAccountStatementDescriptor,
-	useAccountStatementDescriptorKanji,
-	useAccountStatementDescriptorKana,
 	useAccountBusinessSupportEmail,
 	useAccountBusinessSupportPhone,
 	useManualCapture,
@@ -32,9 +29,6 @@ select.mockReturnValue( {
 } );
 
 jest.mock( 'wcpay/data', () => ( {
-	useAccountStatementDescriptor: jest.fn(),
-	useAccountStatementDescriptorKanji: jest.fn(),
-	useAccountStatementDescriptorKana: jest.fn(),
 	useAccountBusinessSupportEmail: jest.fn(),
 	useAccountBusinessSupportPhone: jest.fn(),
 	useManualCapture: jest.fn(),
@@ -47,9 +41,6 @@ jest.mock( 'wcpay/data', () => ( {
 
 describe( 'Settings - Transactions', () => {
 	beforeEach( () => {
-		useAccountStatementDescriptor.mockReturnValue( [ '', jest.fn() ] );
-		useAccountStatementDescriptorKanji.mockReturnValue( [ '', jest.fn() ] );
-		useAccountStatementDescriptorKana.mockReturnValue( [ '', jest.fn() ] );
 		useAccountBusinessSupportEmail.mockReturnValue( [
 			'test@test.com',
 			jest.fn(),
@@ -67,58 +58,6 @@ describe( 'Settings - Transactions', () => {
 				country: 'US',
 			},
 		};
-	} );
-
-	it( 'displays the length of the bank statement input', async () => {
-		const updateAccountStatementDescriptor = jest.fn();
-		useAccountStatementDescriptor.mockReturnValue( [
-			'Statement Name',
-			updateAccountStatementDescriptor,
-		] );
-
-		render( <Transactions /> );
-
-		expect( screen.getByText( '14 / 22' ) ).toBeInTheDocument();
-
-		fireEvent.change( screen.getByLabelText( 'Customer bank statement' ), {
-			target: { value: 'New Statement Name' },
-		} );
-
-		expect( updateAccountStatementDescriptor ).toHaveBeenCalledWith(
-			'New Statement Name'
-		);
-	} );
-
-	it( 'displays the error message for the statement input', async () => {
-		useAccountStatementDescriptor.mockReturnValue( [ '111', jest.fn() ] );
-		useGetSavingError.mockReturnValue( {
-			code: 'rest_invalid_param',
-			message: 'Invalid parameter(s): account_statement_descriptor',
-			data: {
-				status: 400,
-				params: {
-					account_statement_descriptor:
-						'Customer bank statement is invalid. It should not contain special characters: \' " * &lt; &gt;',
-				},
-				details: {
-					account_statement_descriptor: {
-						code: 'rest_invalid_pattern',
-						message:
-							'Customer bank statement is invalid. It should not contain special characters: \' " * &lt; &gt;',
-						data: null,
-					},
-				},
-			},
-		} );
-
-		render( <Transactions /> );
-
-		expect( screen.getByText( '3 / 22' ) ).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				`Customer bank statement is invalid. It should not contain special characters: ' " * < >`
-			)
-		).toBeInTheDocument();
 	} );
 
 	it( 'display ipp payment notice', async () => {
@@ -155,26 +94,5 @@ describe( 'Settings - Transactions', () => {
 			screen.getByLabelText( 'Support phone number' )
 		).toBeInTheDocument();
 		expect( screen.getByLabelText( 'Support email' ) ).toBeInTheDocument();
-	} );
-
-	it( 'display customer bank statements for JP', async () => {
-		const settingsMockCountryJP = {
-			account_country: 'JP',
-		};
-
-		select.mockReturnValue( {
-			getSettings: () => settingsMockCountryJP,
-		} );
-		render( <Transactions /> );
-
-		expect(
-			await screen.findByText( 'Use only latin characters.' )
-		).toBeInTheDocument();
-		expect(
-			await screen.findByText( 'Use only kanji characters.' )
-		).toBeInTheDocument();
-		expect(
-			await screen.findByText( 'Use only kana characters.' )
-		).toBeInTheDocument();
 	} );
 } );

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -140,15 +140,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'account_statement_descriptor'         => [
-						'description'       => sprintf(
-							/* translators: %s: WooPayments */
-							__( '%s bank account descriptor to be displayed in customers\' bank accounts.', 'woocommerce-payments' ),
-							'WooPayments'
-						),
-						'type'              => 'string',
-						'validate_callback' => [ $this, 'validate_statement_descriptor' ],
-					],
 					'account_business_name'                => [
 						'description' => __( 'The customer-facing business name.', 'woocommerce-payments' ),
 						'type'        => 'string',
@@ -317,34 +308,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
-	}
-
-	/**
-	 * Validate the statement descriptor argument.
-	 *
-	 * @since 4.7.0
-	 *
-	 * @param mixed           $value The value being validated.
-	 * @param WP_REST_Request $request The request made.
-	 * @param string          $param The parameter name, used in error messages.
-	 * @return true|WP_Error
-	 */
-	public function validate_statement_descriptor( $value, $request, $param ) {
-		$string_validation_result = rest_validate_request_arg( $value, $request, $param );
-		if ( true !== $string_validation_result ) {
-			return $string_validation_result;
-		}
-
-		try {
-			$this->wcpay_gateway->validate_account_statement_descriptor_field( 'account_statement_descriptor', $value );
-		} catch ( Exception $exception ) {
-			return new WP_Error(
-				'rest_invalid_pattern',
-				$exception->getMessage()
-			);
-		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #10392

#### Changes proposed in this Pull Request
This PR is a follow-up to the Account Management embedded component implementation, which already provides the statement descriptor field. Since the settings page currently includes fields that duplicate this functionality, this update removes the redundant fields to ensure consistency and avoid unnecessary duplication.

#### Testing instructions
- To-Do

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
