### PR TITLE
Add GrabPay details to the view transaction page

### DIFF
--- a/changelog/add-grabpay-pm-details
+++ b/changelog/add-grabpay-pm-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add GrabPay payment method details to the View Transaction page.

--- a/client/payment-details/payment-method/grabpay/index.tsx
+++ b/client/payment-details/payment-method/grabpay/index.tsx
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+
+/**
+ * Internal dependencies.
+ */
+import Detail from '../detail';
+import { PaymentMethodDetails } from 'wcpay/payment-details/types';
+import { Charge } from 'wcpay/types/charges';
+
+interface GrabPayPaymentMethodDetails extends PaymentMethodDetails {
+	grabPayTransactionId: string;
+}
+
+/**
+ * Extracts and formats payment method details from a charge.
+ *
+ * @param {Charge} charge The charge object.
+ * @return {GrabPayPaymentMethodDetails} A flat hash of all necessary values.
+ */
+const formatPaymentMethodDetails = (
+	charge: Charge
+): GrabPayPaymentMethodDetails => {
+	const { billing_details: billingDetails, payment_method: id } = charge;
+	const { name, email, formatted_address: formattedAddress } = billingDetails;
+
+	const grabPayTransactionId =
+		charge.payment_method_details.grabpay?.grabpay_id;
+
+	return {
+		id,
+		grabPayTransactionId,
+		name,
+		email,
+		formattedAddress,
+	};
+};
+
+interface GrabPayDetailsProps {
+	charge: Charge;
+	isLoading: boolean;
+}
+
+const GrabPayDetails: React.FC< GrabPayDetailsProps > = ( {
+	charge,
+	isLoading,
+} ) => {
+	const {
+		id,
+		grabPayTransactionId,
+		name,
+		email,
+		formattedAddress,
+	} = formatPaymentMethodDetails( charge );
+
+	return (
+		<div className="payment-method-details">
+			<div className="payment-method-details__column">
+				<Detail
+					isLoading={ isLoading }
+					label={ __( 'ID', 'woocommerce-payments' ) }
+				>
+					{ !! id ? id : '–' }
+				</Detail>
+
+				<Detail
+					isLoading={ isLoading }
+					label={ __(
+						'GrabPay Transaction ID',
+						'woocommerce-payments'
+					) }
+				>
+					{ !! grabPayTransactionId ? grabPayTransactionId : '–' }
+				</Detail>
+			</div>
+
+			<div className="payment-method-details__column">
+				<Detail
+					isLoading={ isLoading }
+					label={ __( 'Owner', 'woocommerce-payments' ) }
+				>
+					{ name || '–' }
+				</Detail>
+
+				<Detail
+					isLoading={ isLoading }
+					label={ __( 'Owner email', 'woocommerce-payments' ) }
+				>
+					{ email || '–' }
+				</Detail>
+
+				<Detail
+					isLoading={ isLoading }
+					label={ __( 'Address', 'woocommerce-payments' ) }
+				>
+					<span
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ {
+							__html: formattedAddress || '–',
+						} }
+					/>
+				</Detail>
+			</div>
+		</div>
+	);
+};
+
+export default GrabPayDetails;

--- a/client/payment-details/payment-method/grabpay/index.tsx
+++ b/client/payment-details/payment-method/grabpay/index.tsx
@@ -28,7 +28,7 @@ const formatPaymentMethodDetails = (
 	const { name, email, formatted_address: formattedAddress } = billingDetails;
 
 	const grabPayTransactionId =
-		charge.payment_method_details.grabpay?.grabpay_id;
+		charge.payment_method_details.grabpay?.transaction_id;
 
 	return {
 		id,

--- a/client/payment-details/payment-method/grabpay/index.tsx
+++ b/client/payment-details/payment-method/grabpay/index.tsx
@@ -11,28 +11,18 @@ import Detail from '../detail';
 import { PaymentMethodDetails } from 'wcpay/payment-details/types';
 import { Charge } from 'wcpay/types/charges';
 
-interface GrabPayPaymentMethodDetails extends PaymentMethodDetails {
-	grabPayTransactionId: string;
-}
-
 /**
  * Extracts and formats payment method details from a charge.
  *
  * @param {Charge} charge The charge object.
- * @return {GrabPayPaymentMethodDetails} A flat hash of all necessary values.
+ * @return {PaymentMethodDetails} A flat hash of all necessary values.
  */
-const formatPaymentMethodDetails = (
-	charge: Charge
-): GrabPayPaymentMethodDetails => {
+const formatPaymentMethodDetails = ( charge: Charge ): PaymentMethodDetails => {
 	const { billing_details: billingDetails, payment_method: id } = charge;
 	const { name, email, formatted_address: formattedAddress } = billingDetails;
 
-	const grabPayTransactionId =
-		charge.payment_method_details.grabpay?.transaction_id;
-
 	return {
 		id,
-		grabPayTransactionId,
 		name,
 		email,
 		formattedAddress,
@@ -48,13 +38,9 @@ const GrabPayDetails: React.FC< GrabPayDetailsProps > = ( {
 	charge,
 	isLoading,
 } ) => {
-	const {
-		id,
-		grabPayTransactionId,
-		name,
-		email,
-		formattedAddress,
-	} = formatPaymentMethodDetails( charge );
+	const { id, name, email, formattedAddress } = formatPaymentMethodDetails(
+		charge
+	);
 
 	return (
 		<div className="payment-method-details">
@@ -64,16 +50,6 @@ const GrabPayDetails: React.FC< GrabPayDetailsProps > = ( {
 					label={ __( 'ID', 'woocommerce-payments' ) }
 				>
 					{ !! id ? id : '–' }
-				</Detail>
-
-				<Detail
-					isLoading={ isLoading }
-					label={ __(
-						'GrabPay Transaction ID',
-						'woocommerce-payments'
-					) }
-				>
-					{ !! grabPayTransactionId ? grabPayTransactionId : '–' }
 				</Detail>
 			</div>
 

--- a/client/payment-details/payment-method/index.js
+++ b/client/payment-details/payment-method/index.js
@@ -19,6 +19,7 @@ import CardDetails from './card';
 import CardPresentDetails from './card-present';
 import EpsDetails from './eps';
 import GiropayDetails from './giropay';
+import GrabPayDetails from './grabpay';
 import IdealDetails from './ideal';
 import KlarnaDetails from './klarna';
 import P24Details from './p24';
@@ -35,6 +36,7 @@ const detailsComponentMap = {
 	card_present: CardPresentDetails,
 	eps: EpsDetails,
 	giropay: GiropayDetails,
+	grabpay: GrabPayDetails,
 	ideal: IdealDetails,
 	klarna: KlarnaDetails,
 	p24: P24Details,

--- a/client/types/charges.d.ts
+++ b/client/types/charges.d.ts
@@ -29,6 +29,7 @@ interface ChargeRefunds {
 
 export interface PaymentMethodDetails {
 	card?: any;
+	grabpay?: any;
 	type:
 		| 'affirm'
 		| 'afterpay_clearpay'


### PR DESCRIPTION
Fixes #10375

#### Changes proposed in this Pull Request

Display the Payment Method details in the view transaction page. Unfortunately, [Stripe's documentation](https://docs.stripe.com/api/payment_methods/object#payment_method_object-grabpay) doesn't go into detail about what specific information will be provided for each payment method, in the case of GrabPay it is only described as:
> grabpay nullable object
> If this is a grabpay PaymentMethod, this hash contains details about the GrabPay payment method.

In the test environment, that particular object contained the following information:
```
grabpay: {transaction_id: null}
```

So I'll move forward with the assumption that said `transaction_id` will be available in the live environment, and that it is the only specific detail we can show (besides the standard name, email, and address fields).

Note: I decided to remove the transaction_id in a later commit since it doesn't seem to contain any useful information.

#### Testing instructions

Pre-requisite: follow the instructions defined in the following server PR to enable GrabPay payments locally 7231-gh-Automattic/transact-platform-server

- Enable GrabPay in the WooPayments settings page (need an onboarded Stripe account with SG as the country)
- Set the store currency to SGD.
- Make a purchase using GrabPay
- Go to WP Admin > Payments > Transactions, click on the latest GrabPay transaction.
- Payment method details should be displayed at the bottom of the page.

![image](https://github.com/user-attachments/assets/ac6eb9a1-ed06-44b3-b0c2-284f195ad26a)



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
