### PR TITLE
feat: tokenized ECE flag via server-side control

### DIFF
--- a/changelog/feat-tokenized-ece-account-meta-control
+++ b/changelog/feat-tokenized-ece-account-meta-control
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: dev: ability to disable the Tokenized ECE via server-side flag
+
+

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -49,7 +49,9 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_tokenized_cart_ece_enabled(): bool {
-		return '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '0' );
+		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
+
+		return is_array( $account ) && ! ( $account['is_tokenized_ece_disabled'] ?? false ) && '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '0' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -296,6 +296,34 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->clear_feature_flag_options( [ 'wcpay_frt_review_feature_active' ] );
 	}
 
+	public function test_is_tokenized_cart_ece_enabled_returns_true_when_site_flag_is_true() {
+		$this->mock_cache->method( 'get' )->willReturn( [] );
+		$this->set_feature_flag_option( '_wcpay_feature_tokenized_cart_ece', '1' );
+		$this->assertTrue( WC_Payments_Features::is_tokenized_cart_ece_enabled() );
+		$this->clear_feature_flag_options( [ '_wcpay_feature_tokenized_cart_ece' ] );
+	}
+
+	public function test_is_tokenized_cart_ece_enabled_returns_false_when_site_flag_is_false() {
+		$this->mock_cache->method( 'get' )->willReturn( [] );
+		$this->set_feature_flag_option( '_wcpay_feature_tokenized_cart_ece', '0' );
+		$this->assertFalse( WC_Payments_Features::is_tokenized_cart_ece_enabled() );
+		$this->clear_feature_flag_options( [ '_wcpay_feature_tokenized_cart_ece' ] );
+	}
+
+	public function test_is_tokenized_cart_ece_enabled_returns_false_when_account_flag_is_true() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'is_tokenized_ece_disabled' => true ] );
+		$this->set_feature_flag_option( '_wcpay_feature_tokenized_cart_ece', '1' );
+		$this->assertFalse( WC_Payments_Features::is_tokenized_cart_ece_enabled() );
+		$this->clear_feature_flag_options( [ '_wcpay_feature_tokenized_cart_ece' ] );
+	}
+
+	public function test_is_tokenized_cart_ece_enabled_returns_true_when_account_flag_is_false() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'is_tokenized_ece_disabled' => false ] );
+		$this->set_feature_flag_option( '_wcpay_feature_tokenized_cart_ece', '1' );
+		$this->assertTrue( WC_Payments_Features::is_tokenized_cart_ece_enabled() );
+		$this->clear_feature_flag_options( [ '_wcpay_feature_tokenized_cart_ece' ] );
+	}
+
 	public function test_is_frt_review_feature_active_returns_false_when_flag_is_not_set() {
 		$this->assertFalse( WC_Payments_Features::is_frt_review_feature_active() );
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

To be used in combination with the server-side PR.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have GooglePay/ApplePay enabled
- Disable the site's own ECE feature flag: `wp option update _wcpay_feature_tokenized_cart_ece 0`
- Go to the product page for a simple physical product
- Click on the GooglePay/ApplePay button
- There should be an AJAX call to the `wcpay_ece_get_shipping_options` endpoint
- Enable the site's own ECE feature flag: `wp option update _wcpay_feature_tokenized_cart_ece 1`
- Refresh the product page
- Click on the GooglePay/ApplePay button
- There should be an AJAX call to the `/wp-json/wc/store/v1/cart/add-item` endpoint
- Disable the feature flag server-side
- Refresh the account data
- Refresh the product page
- Click on the GooglePay/ApplePay button
- There should be an AJAX call to the `wcpay_ece_get_shipping_options` endpoint

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
