### PR TITLE
Fix incorrect default value for advanced options in FRT

### DIFF
--- a/changelog/fix-10393-frt-advanced-settings
+++ b/changelog/fix-10393-frt-advanced-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the default value of the FRT advanced options.

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          Orders from outside of the following countries will be screened by the filter: 
+                          Orders from outside of the following countries will be blocked by the filter: 
                           <strong>
                             Canada, United States
                           </strong>
@@ -1345,7 +1345,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be screened by the filter: 
+                        Orders from outside of the following countries will be blocked by the filter: 
                         <strong>
                           Canada, United States
                         </strong>
@@ -2119,7 +2119,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
+              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
     </div>
     <div>
       <div>
@@ -2415,7 +2415,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          Orders from outside of the following countries will be screened by the filter: 
+                          Orders from outside of the following countries will be blocked by the filter: 
                           <strong>
                             Canada, United States
                           </strong>
@@ -3277,7 +3277,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be screened by the filter: 
+                        Orders from outside of the following countries will be blocked by the filter: 
                         <strong>
                           Canada, United States
                         </strong>
@@ -3925,7 +3925,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
+              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
     </div>
     <div>
       <div
@@ -4186,7 +4186,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be screened by the filter: 
+                        Orders from outside of the following countries will be blocked by the filter: 
                         <strong>
                           Canada, United States
                         </strong>
@@ -5012,7 +5012,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                       data-wp-c16t="true"
                       data-wp-component="FlexItem"
                     >
-                      Orders from outside of the following countries will be screened by the filter: 
+                      Orders from outside of the following countries will be blocked by the filter: 
                       <strong>
                         Canada, United States
                       </strong>
@@ -5659,7 +5659,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-                For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked.  Learn more   
+              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
     </div>
     <div>
       <div>
@@ -5938,7 +5938,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           data-wp-c16t="true"
                           data-wp-component="FlexItem"
                         >
-                          Orders from outside of the following countries will be screened by the filter: 
+                          Orders from outside of the following countries will be blocked by the filter: 
                           <strong>
                             Canada, United States
                           </strong>
@@ -6863,7 +6863,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                         data-wp-c16t="true"
                         data-wp-component="FlexItem"
                       >
-                        Orders from outside of the following countries will be screened by the filter: 
+                        Orders from outside of the following countries will be blocked by the filter: 
                         <strong>
                           Canada, United States
                         </strong>

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -73,6 +73,7 @@ declare const global: {
 			}
 		>;
 		isMultiCurrencyEnabled: string;
+		isFRTReviewFeatureActive: boolean;
 	};
 };
 
@@ -143,6 +144,7 @@ describe( 'Advanced fraud protection settings', () => {
 				},
 			},
 			isMultiCurrencyEnabled: '1',
+			isFRTReviewFeatureActive: false,
 		};
 
 		mockUseAdvancedFraudProtectionSettings.mockReturnValue( [

--- a/client/settings/fraud-protection/advanced-settings/test/utils.test.ts
+++ b/client/settings/fraud-protection/advanced-settings/test/utils.test.ts
@@ -16,6 +16,37 @@ const defaultUIConfig = {
 		enabled: false,
 	},
 	address_mismatch: {
+		block: true,
+		enabled: false,
+	},
+	ip_address_mismatch: {
+		block: true,
+		enabled: false,
+	},
+	international_ip_address: {
+		block: true,
+		enabled: false,
+	},
+	order_items_threshold: {
+		block: true,
+		enabled: false,
+		max_items: null,
+		min_items: null,
+	},
+	purchase_price_threshold: {
+		block: true,
+		enabled: false,
+		max_amount: null,
+		min_amount: null,
+	},
+};
+
+const defaultUIConfigWithReviewEnabled = {
+	avs_verification: {
+		block: false,
+		enabled: false,
+	},
+	address_mismatch: {
 		block: false,
 		enabled: false,
 	},
@@ -57,6 +88,7 @@ declare const global: {
 				precision: number;
 			};
 		};
+		isFRTReviewFeatureActive: boolean;
 	};
 	wcSettings: {
 		admin: {
@@ -88,15 +120,42 @@ describe( 'Ruleset adapter utilities test', () => {
 					precision: 2,
 				},
 			},
+			isFRTReviewFeatureActive: false,
 		};
 	} );
 
-	test( 'converts an empty ruleset to default UI config', () => {
+	test( 'converts an empty ruleset to default UI config with isFRTReviewFeatureActive disabled', () => {
 		const ruleset: FraudProtectionRule[] = [];
 		const expected = defaultUIConfig;
 		const output = readRuleset( ruleset );
 		expect( output ).toEqual( expected );
 	} );
+
+	test( 'converts an empty ruleset to default UI config with isFRTReviewFeatureActive enabled', () => {
+		global.wcpaySettings = {
+			storeCurrency: 'USD',
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+			isFRTReviewFeatureActive: true,
+		};
+
+		const ruleset: FraudProtectionRule[] = [];
+		const expected = defaultUIConfigWithReviewEnabled;
+		const output = readRuleset( ruleset );
+		expect( output ).toEqual( expected );
+	} );
+
 	test( 'converts an address mismatch ruleset to matching UI config', () => {
 		const ruleset = [
 			{
@@ -111,7 +170,7 @@ describe( 'Ruleset adapter utilities test', () => {
 		];
 		const expected = Object.assign( {}, defaultUIConfig, {
 			address_mismatch: {
-				block: false,
+				block: true,
 				enabled: true,
 			},
 		} );
@@ -288,7 +347,7 @@ describe( 'Ruleset adapter utilities test', () => {
 		const expected = Object.assign( {}, defaultUIConfig, {
 			[ Rules.RULE_PURCHASE_PRICE_THRESHOLD ]: {
 				enabled: true,
-				block: false,
+				block: true,
 				min_amount: 1,
 				max_amount: '',
 			},
@@ -371,7 +430,7 @@ describe( 'Ruleset adapter utilities test', () => {
 		const expected = Object.assign( {}, defaultUIConfig, {
 			[ Rules.RULE_PURCHASE_PRICE_THRESHOLD ]: {
 				enabled: true,
-				block: false,
+				block: true,
 				min_amount: 0.01,
 				max_amount: '',
 			},

--- a/client/settings/fraud-protection/advanced-settings/utils.ts
+++ b/client/settings/fraud-protection/advanced-settings/utils.ts
@@ -233,36 +233,44 @@ export const writeRuleset = (
 	return rulesetConfig.filter( ( rule ) => rule );
 };
 
+const shouldBlockOutcome = ( outcome: string ) => {
+	const { isFRTReviewFeatureActive } = wcpaySettings;
+
+	if ( ! isFRTReviewFeatureActive ) {
+		return true;
+	}
+
+	return outcome === Outcomes.BLOCK;
+};
+
 export const readRuleset = (
 	rulesetConfig: FraudProtectionRule[] | string
 ): ProtectionSettingsUI => {
+	const { isFRTReviewFeatureActive } = wcpaySettings;
 	const isAVSChecksEnabled =
 		wcpaySettings?.accountStatus?.fraudProtection?.declineOnAVSFailure ||
 		false;
+
+	const defaultEnableConfig = {
+		enabled: false,
+		block: ! isFRTReviewFeatureActive,
+	};
 
 	const defaultUIConfig = {
 		[ Rules.RULE_AVS_VERIFICATION ]: {
 			enabled: isAVSChecksEnabled,
 			block: isAVSChecksEnabled,
 		},
-		[ Rules.RULE_ADDRESS_MISMATCH ]: { enabled: false, block: false },
-		[ Rules.RULE_INTERNATIONAL_IP_ADDRESS ]: {
-			enabled: false,
-			block: false,
-		},
-		[ Rules.RULE_IP_ADDRESS_MISMATCH ]: {
-			enabled: false,
-			block: false,
-		},
+		[ Rules.RULE_ADDRESS_MISMATCH ]: { ...defaultEnableConfig },
+		[ Rules.RULE_INTERNATIONAL_IP_ADDRESS ]: { ...defaultEnableConfig },
+		[ Rules.RULE_IP_ADDRESS_MISMATCH ]: { ...defaultEnableConfig },
 		[ Rules.RULE_ORDER_ITEMS_THRESHOLD ]: {
-			enabled: false,
-			block: false,
+			...defaultEnableConfig,
 			min_items: null,
 			max_items: null,
 		},
 		[ Rules.RULE_PURCHASE_PRICE_THRESHOLD ]: {
-			enabled: false,
-			block: false,
+			...defaultEnableConfig,
 			min_amount: null,
 			max_amount: null,
 		},
@@ -277,25 +285,25 @@ export const readRuleset = (
 				case Rules.RULE_AVS_VERIFICATION:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: rule.outcome === Outcomes.BLOCK,
+						block: shouldBlockOutcome( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_ADDRESS_MISMATCH:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: rule.outcome === Outcomes.BLOCK,
+						block: shouldBlockOutcome( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_INTERNATIONAL_IP_ADDRESS:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: rule.outcome === Outcomes.BLOCK,
+						block: shouldBlockOutcome( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_IP_ADDRESS_MISMATCH:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: rule.outcome === Outcomes.BLOCK,
+						block: shouldBlockOutcome( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_ORDER_ITEMS_THRESHOLD:
@@ -311,7 +319,7 @@ export const readRuleset = (
 					) as FraudProtectionSettingsSingleCheck;
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: rule.outcome === Outcomes.BLOCK,
+						block: shouldBlockOutcome( rule.outcome ),
 						min_items: minItemsCheck.value ?? '',
 						max_items: maxItemsCheck.value ?? '',
 					};
@@ -329,7 +337,7 @@ export const readRuleset = (
 					) as FraudProtectionSettingsSingleCheck;
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: rule.outcome === Outcomes.BLOCK,
+						block: shouldBlockOutcome( rule.outcome ),
 						min_amount: readFormattedRulePrice(
 							minAmountCheck.value
 						),

--- a/client/settings/fraud-protection/advanced-settings/utils.ts
+++ b/client/settings/fraud-protection/advanced-settings/utils.ts
@@ -233,7 +233,7 @@ export const writeRuleset = (
 	return rulesetConfig.filter( ( rule ) => rule );
 };
 
-const shouldBlockOutcome = ( outcome: string ) => {
+const getRuleBlockStatus = ( outcome: string ) => {
 	const { isFRTReviewFeatureActive } = wcpaySettings;
 
 	if ( ! isFRTReviewFeatureActive ) {
@@ -285,25 +285,25 @@ export const readRuleset = (
 				case Rules.RULE_AVS_VERIFICATION:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: shouldBlockOutcome( rule.outcome ),
+						block: getRuleBlockStatus( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_ADDRESS_MISMATCH:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: shouldBlockOutcome( rule.outcome ),
+						block: getRuleBlockStatus( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_INTERNATIONAL_IP_ADDRESS:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: shouldBlockOutcome( rule.outcome ),
+						block: getRuleBlockStatus( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_IP_ADDRESS_MISMATCH:
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: shouldBlockOutcome( rule.outcome ),
+						block: getRuleBlockStatus( rule.outcome ),
 					};
 					break;
 				case Rules.RULE_ORDER_ITEMS_THRESHOLD:
@@ -319,7 +319,7 @@ export const readRuleset = (
 					) as FraudProtectionSettingsSingleCheck;
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: shouldBlockOutcome( rule.outcome ),
+						block: getRuleBlockStatus( rule.outcome ),
 						min_items: minItemsCheck.value ?? '',
 						max_items: maxItemsCheck.value ?? '',
 					};
@@ -337,7 +337,7 @@ export const readRuleset = (
 					) as FraudProtectionSettingsSingleCheck;
 					parsedUIConfig[ rule.key ] = {
 						enabled: true,
-						block: shouldBlockOutcome( rule.outcome ),
+						block: getRuleBlockStatus( rule.outcome ),
 						min_amount: readFormattedRulePrice(
 							minAmountCheck.value
 						),

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -186,22 +186,6 @@
 					&:last-child {
 						margin-bottom: 0;
 					}
-
-					input[type='radio'] {
-						border-color: #757575;
-
-						&:checked {
-							background-color: #fff;
-							border-color: #757575;
-
-							&::before {
-								border: 6px solid #3582c4;
-								width: 12px;
-								height: 12px;
-								transform: translate( 3px, 3px );
-							}
-						}
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #10393

#### Changes proposed in this Pull Request

This change aims to fix the default value for the advanced protection fraud options, by setting it to block transactions by default. A visual fix was also introduced as part of this PR.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before checking out to this branch:**

- Apply the following diff:
```diff
diff --git a/client/settings/fraud-protection/advanced-settings/index.tsx b/client/settings/fraud-protection/advanced-settings/index.tsx
index b39a65970..252b15908 100644
--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -129,6 +129,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 		);
 	}, [ advancedFraudProtectionSettings ] );
 
+	console.log({ protectionSettingsUI });
+
 	useLayoutEffect( () => {
 		const saveButton = document.querySelector(
 			'.fraud-protection-header-save-button'

```

- Go to **Payments > Fraud protection**
- Enable the advanced settings and click on "Configure"
- On the "Advanced fraud protection" page, enable the "Purchase Price Threshold" rule
- Check the console—the `purchase_price_threshold` key should look like this:
```
purchase_price_threshold: 
  block: false
  enabled: true
  max_amount: null
  min_amount: null
```

**Checkout to this branch**

- Run `npm run start` on your client
- Go to **Payments > Fraud protection**
- Enable the advanced settings and click on "Configure"
- On the "Advanced fraud protection" page, enable the "Purchase Price Threshold" rule
- Check the console—the `purchase_price_threshold` key should look like this:
```
purchase_price_threshold: 
  block: true
  enabled: true
  max_amount: null
  min_amount: null
```

### Visual fix:

- Checkout to develop
- Apply the following diff:
```diff
diff --git a/includes/class-wc-payments-features.php b/includes/class-wc-payments-features.php
index 6eefb80fb..fbaa74db0 100644
--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -286,7 +286,7 @@ class WC_Payments_Features {
 	 * @return  bool
 	 */
 	public static function is_frt_review_feature_active(): bool {
-		return '1' === get_option( 'wcpay_frt_review_feature_active', '0' );
+		return true;
 	}
 
 	/**

```
- Run `npm run start` on your client
- Go to the advanced fraud protection page
- Enable "Purchase Price Threshold" rule
- Confirm that it looks like this:
<img width="317" alt="image" src="https://github.com/user-attachments/assets/04d9ca40-b484-4e84-b190-d6b92fc60cb2" />

- Checkout to this branch
- Run `npm run start` on your client
- Go to the advanced fraud protection page
- Enable "Purchase Price Threshold" rule
- Confirm that it looks like this:
<img width="317" alt="image" src="https://github.com/user-attachments/assets/56831b0c-c0a5-450c-b179-c8ee57b8d5d6" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
