### PR TITLE
Update copy in the Woopayments Reset account modal

### DIFF
--- a/changelog/update-10317-change-reset-account-modal-copy
+++ b/changelog/update-10317-change-reset-account-modal-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update copy in the Woopayments Reset account modal for incomplete onboarding accounts

--- a/client/overview/modal/reset-account/strings.tsx
+++ b/client/overview/modal/reset-account/strings.tsx
@@ -22,9 +22,13 @@ export default {
 				),
 				'WooPayments'
 		  )
-		: __(
-				'If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.',
-				'woocommerce-payments'
+		: sprintf(
+				/* translators: 1: WooPayments. */
+				__(
+					'When you reset your account, all payment data — including your %1$s account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.',
+					'woocommerce-payments'
+				),
+				'WooPayments'
 		  ),
 	beforeContinue: __( 'Before you continue', 'woocommerce-payments' ),
 	step1: sprintf(

--- a/client/overview/modal/reset-account/test/index.test.tsx
+++ b/client/overview/modal/reset-account/test/index.test.tsx
@@ -28,7 +28,7 @@ describe( 'Reset Account Modal', () => {
 
 		expect(
 			screen.queryByText(
-				'If you are experiencing problems completing account setup, or need to change the email/country associated with your account, you can reset your account and start from the beginning.'
+				'When you reset your account, all payment data — including your WooPayments account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.'
 			)
 		).toBeInTheDocument();
 	} );


### PR DESCRIPTION
Fixes #10317 

#### Changes proposed in this Pull Request
Replace the copy in the Woopayments reset account modal for incomplete onboarded accounts.
Copy: 
`When you reset your account, all payment data — including your WooPayments account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.`
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Onboard a sanbox account
* Go to `Payments -> Overview` and click on activate your Woopayments account

<img width="928" alt="Screenshot 2025-02-18 at 16 11 49" src="https://github.com/user-attachments/assets/ecc7beb4-71b4-4380-af7e-6a918e8546e2" />

* click on `Activate Payments` in the modal
* Start the onboarding, and cancel it after the first step
* Go to `Payments` menu ( http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&source=wcpay-setup-live-payments&from=WCPAY_ONBOARDING_WIZARD )
* click on reset account. You should see the new copy in the modal.
<img width="831" alt="Screenshot 2025-02-18 at 16 15 16" src="https://github.com/user-attachments/assets/edb47ae6-76b5-4c11-9c7e-1d0d6d2f4d90" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
