### PR TITLE
Fixed possible race condition on the WooPay optin trunk

### DIFF
--- a/changelog/fix-woopay-opt-in-race-condition
+++ b/changelog/fix-woopay-opt-in-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed WooPay opt-in race condition

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -275,17 +275,34 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		isBlocksCheckout,
 	] );
 
+	useEffect( () => {
+		if (
+			! getConfig( 'forceNetworkSavedCards' ) ||
+			! isWCPayWithNewTokenChosen ||
+			isRegisteredUser
+		) {
+			// Clicking the place order button sets the extension data in backend. If user changes the payment method
+			// due to an error, we need to clear the extension data in backend.
+			if ( isBlocksCheckout && userDataSent ) {
+				sendExtensionData( true );
+			}
+			clearValidationError( errorId );
+		}
+	}, [
+		clearValidationError,
+		errorId,
+		isBlocksCheckout,
+		isRegisteredUser,
+		isWCPayWithNewTokenChosen,
+		sendExtensionData,
+		userDataSent,
+	] );
+
 	if (
 		! getConfig( 'forceNetworkSavedCards' ) ||
 		! isWCPayWithNewTokenChosen ||
 		isRegisteredUser
 	) {
-		// Clicking the place order button sets the extension data in backend. If user changes the payment method
-		// due to an error, we need to clear the extension data in backend.
-		if ( isBlocksCheckout && userDataSent ) {
-			sendExtensionData( true );
-		}
-		clearValidationError( errorId );
 		return null;
 	}
 


### PR DESCRIPTION
Related to p1739870652155429-slack-C022WMN88KG
#### Changes proposed in this Pull Request
This PR moves the checks for clearing the checkout errors to a `useEffect` to prevent a race condition where the error is created after being clered

#### Testing instructions
I'm not sure how to simulate the bug but make sure it's possible to place the order

**Using WooPayments**
- Checkout to this branch on your merchant site
- As a shopper add products to your cart
- Go to the blocks checkout page
- Select WooPayments as the payment method
- Select the `Securely save my information for 1-click checkout` option
- Make sure the phone number is empty
- Try to place the order
- Make sure the error shows up
- Now repeat the process but fill in the phone number
- This time the order should be placed
- Repeat on Shortcode checkout

**Using another payment gateway**
- Checkout to this branch on your merchant site
- As a shopper add products to your cart
- Go to the blocks checkout page
- Select another payment method that is not WooPayments
- Try to place the order
- Make sure no error shows up and the order is placed

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.