### PR TITLE
feat: enable tokenized ECE by default - round 2

### DIFF
--- a/changelog/feat-enable-tokenized-ece-by-default-round-2
+++ b/changelog/feat-enable-tokenized-ece-by-default-round-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+feat: GooglePay/ApplePay refactor to leverage Store API is enabled by default - second try.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -51,7 +51,7 @@ class WC_Payments_Features {
 	public static function is_tokenized_cart_ece_enabled(): bool {
 		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 
-		return is_array( $account ) && ! ( $account['is_tokenized_ece_disabled'] ?? false ) && '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '0' );
+		return is_array( $account ) && ! ( $account['is_tokenized_ece_disabled'] ?? false ) && '1' === get_option( self::TOKENIZED_CART_ECE_FLAG_NAME, '1' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Enabling the tokenized ECE by default.
It can be disabled locally via a filter, until we remove the feature flag:
```php
add_filter( 'pre_option__wcpay_feature_tokenized_cart_ece', function ( $v ) {
    // ensures that once the next version of WCPay is released, this filter can be automatically ignored
    if ( version_compare( WCPAY_VERSION_NUMBER, '9.0.1', '<' ) ) {
        return '0';
    }
 
    return $v;
}, 100 );
```

Enabling it for GlobalStep testing. We'll disable the feature flag server-side after the GlobalStep testing while we wait for the SkyVerge patch to be released.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have GooglePay/ApplePay enabled in WooCommerce > Settings > Payments > WooPayments 
- Go to the product page for a simple product
- Click on the GooglePay/ApplePay button
- In your browser's network tab, you should see calls to `/wp-json/wc/store/v1/cart/add-item` (for example)
- Apply the filter above (e.g.: via Code Snippets)
- Refresh the product page from earlier
- Click on the GooglePay/ApplePay button
- In your browser's network tab, you should now see calls to `/?wc-ajax=wcpay_add_to_cart` (for example) and no longer to the Store API

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
