### PR TITLE
Handle fatal errors when subscription plugin gets deactivated due to outdated version

### DIFF
--- a/changelog/fix-5623-handle-fatal-errors-on-wc-subscriptions-deactivated-due-outdated-version
+++ b/changelog/fix-5623-handle-fatal-errors-on-wc-subscriptions-deactivated-due-outdated-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors when subscription is deactivated due outdated version.

--- a/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
@@ -69,6 +69,9 @@ trait WC_Payments_Subscriptions_Utilities {
 	 * @return bool Indicates whether the save payment method checkbox should be displayed or not.
 	 */
 	public function display_save_payment_method_checkbox( $display ) {
+		if ( ! class_exists( 'WC_Subscriptions_Cart' ) ) {
+			return false;
+		}
 		if ( WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
 			return false;
 		}
@@ -83,7 +86,7 @@ trait WC_Payments_Subscriptions_Utilities {
 	 * @return bool
 	 */
 	public function is_subscription_item_in_cart() {
-		if ( $this->is_subscriptions_enabled() ) {
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && $this->is_subscriptions_enabled() ) {
 			return WC_Subscriptions_Cart::cart_contains_subscription() || $this->cart_contains_renewal();
 		}
 		return false;

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -459,7 +459,7 @@ class WC_Payments_Product_Service {
 	 * @param int $product_id ID of the product that's being saved.
 	 */
 	public function limit_subscription_product_intervals( $product_id ) {
-		if ( $this->is_subscriptions_plugin_active() ) {
+		if ( $this->is_subscriptions_plugin_active() || ! class_exists( 'WC_Subscriptions_Product' ) ) {
 			return;
 		}
 
@@ -500,7 +500,7 @@ class WC_Payments_Product_Service {
 	 * @param int $index Variation index in the incoming array.
 	 */
 	public function limit_subscription_variation_intervals( $product_id, $index ) {
-		if ( $this->is_subscriptions_plugin_active() ) {
+		if ( $this->is_subscriptions_plugin_active() || ! class_exists( 'WC_Subscriptions_Product' ) ) {
 			return;
 		}
 
@@ -792,6 +792,10 @@ class WC_Payments_Product_Service {
 	public function get_wcpay_price_id( WC_Product $product, $test_mode = null ): string {
 		wc_deprecated_function( __FUNCTION__, '3.3.0' );
 		$price_id = $product->get_meta( self::get_wcpay_price_id_option( $test_mode ), true );
+
+		if ( ! class_exists( 'WC_Subscriptions_Product' ) ) {
+			return $price_id;
+		}
 
 		// If the subscription product doesn't have a WC Pay price ID, create one now.
 		if ( empty( $price_id ) && WC_Subscriptions_Product::is_subscription( $product ) ) {


### PR DESCRIPTION
Fixes #5623 

#### Changes proposed in this Pull Request

This PR fixes an issue where the subscription plugin gets deactivated if minimum requirements are not met.


#### Testing instructions

- Ensure the subscription plugin is activated.  
- Switch to the `develop` branch.  
- Manually update the `$wc_minimum_supported_version` variable in `woocommerce-subscriptions/woocommerce-subscriptions.php` to a version higher than your current WooCommerce version (even a non-existent future version will do a trick).  
- Refresh the page and the fatal error will occur.  
- Switch to this branch.  
- Verify that the change in the subscription file is still there. If not, update the minimum supported version as in earlier step.  
- Refresh the page and confirm that the fatal error no longer occurs.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
