### PR TITLE
Add a notice indicating that overview page needs to be reloaded after completing the requirements in the embedded component

### DIFF
--- a/changelog/update-10391-snackbar-when-user-updates-kyc-on-overview-page
+++ b/changelog/update-10391-snackbar-when-user-updates-kyc-on-overview-page
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Add a notice indicating that overview page needs to be reloaded	after completing the requirements in the embedded component.
+Add a notice indicating that overview page needs to be reloaded after completing the requirements in the embedded component.

--- a/changelog/update-10391-snackbar-when-user-updates-kyc-on-overview-page
+++ b/changelog/update-10391-snackbar-when-user-updates-kyc-on-overview-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add a notice indicating that overview page needs to be reloaded	after completing the requirements in the embedded component.

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -98,6 +98,11 @@ const OverviewPage = () => {
 	const [ stripeComponentLoading, setStripeComponentLoading ] = useState(
 		true
 	);
+	// Variable to memoize the count of Stripe notifications.
+	const [
+		stripeNotificationsCountToAddressMemo,
+		setStripeNotificationsCountToAddressMemo,
+	] = useState( 0 );
 
 	const isTestModeOnboarding = wcpaySettings.testModeOnboarding;
 	const { isLoading: settingsIsLoading } = useSettings();
@@ -216,6 +221,19 @@ const OverviewPage = () => {
 			// Do something related to notifications that don't require action.
 			setNotificationsBannerMessage( 'The items below are in review.' );
 		} else {
+			// This is the case where we addressed everything and previously had some notifications to address.
+			// We recommend the merchant to reload the page in this case.
+			if ( stripeNotificationsCountToAddressMemo > 0 ) {
+				dispatch( 'core/notices' ).createSuccessNotice(
+					__(
+						'It takes some time to see updates, so please refresh the page in a minute or so.',
+						'woocommerce-payments'
+					),
+					{
+						explicitDismiss: true,
+					}
+				);
+			}
 			setNotificationsBannerMessage( '' );
 		}
 		if ( response.actionRequired > 0 || response.total > 0 ) {
@@ -224,6 +242,8 @@ const OverviewPage = () => {
 				action_required_count: response.actionRequired,
 				total_count: response.total,
 			} );
+			// Memoize the notifications count to be able to compare it with the fresh count when this function is called one more time.
+			setStripeNotificationsCountToAddressMemo( response.total );
 		}
 		// If the component inits successfully, this function is always called.
 		// It's safe to set the loading false here rather than onLoaderStart, because it happens too early and the UX is not smooth.

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -40,6 +40,7 @@ import {
 } from '@stripe/react-connect-js';
 import { recordEvent } from 'wcpay/tracks';
 import StripeSpinner from 'wcpay/components/stripe-spinner';
+import { getAdminUrl } from 'wcpay/utils';
 
 const OverviewPageError = () => {
 	const queryParams = getQuery();
@@ -230,6 +231,15 @@ const OverviewPage = () => {
 						'woocommerce-payments'
 					),
 					{
+						actions: [
+							{
+								label: __( 'Refresh', 'woocommerce-payments' ),
+								url: getAdminUrl( {
+									page: 'wc-admin',
+									path: '/payments/overview',
+								} ),
+							},
+						],
 						explicitDismiss: true,
 					}
 				);

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -226,7 +226,7 @@ const OverviewPage = () => {
 			if ( stripeNotificationsCountToAddressMemo > 0 ) {
 				dispatch( 'core/notices' ).createSuccessNotice(
 					__(
-						'It takes some time to see updates, so please refresh the page in a minute or so.',
+						'Updates take a moment to appear. Please refresh the page in a minute.',
 						'woocommerce-payments'
 					),
 					{


### PR DESCRIPTION
Fixes #10391 

#### Changes proposed in this Pull Request

Add notice that should be explicitly dismissed by the merchant that lets them know they need to reload the page to see the account updates after dealing with Stripe notifications component.

<img width="626" alt="image" src="https://github.com/user-attachments/assets/2c96d8ee-d964-4985-883a-f43babd002ae" />

#### Testing instructions

* Check out this branch `update/10391-snackbar-when-user-updates-kyc-on-overview-page`
* While following testing instructions of this PR https://github.com/Automattic/woocommerce-payments/pull/10314, take a look the notice is shown when the merchant resolves all the items.

https://github.com/user-attachments/assets/38e00502-f302-48b2-bc32-0b6b5faf30aa

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Added to https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-9.0.0#stripe-embedded-account-notifications-component-on-the-overview-page_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.