### PR TITLE
Update the size of Woo logo on the test drive onboarding page

### DIFF
--- a/changelog/fix-10379-woo-logo-size-test-drive-onboarding
+++ b/changelog/fix-10379-woo-logo-size-test-drive-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update the size of Woo logo on the test drive onboarding page.

--- a/client/connect-account-page/style.scss
+++ b/client/connect-account-page/style.scss
@@ -260,10 +260,9 @@
 
 			img.logo {
 				position: absolute;
-				height: 40px;
-				width: 40px;
-				top: 18px;
-				left: 36px;
+				width: 64px;
+				top: 24px;
+				left: 24px;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #10379 

#### Changes proposed in this Pull Request

Update the size of Woo logo on the test drive onboarding page according to the Figma design.

#### Testing instructions

* Check out the branch `fix/10379-woo-logo-size-test-drive-onboarding` locally
* Reset the account if you have one
* Go to WooCommerce -> Settings -> Payments and kick off new account creation
![image](https://github.com/user-attachments/assets/3a1a0f00-47f6-4d98-9d4b-cdbc91bcc26c)
* Choose some payment methods and click continue 
![image](https://github.com/user-attachments/assets/80944659-be22-4a13-8787-cf6b4139f0ff)
* Observe that Woo logo on the test drive onboarding page is updated
![image](https://github.com/user-attachments/assets/bf6ff7c7-2e54-429c-ae08-301a6b4733d9)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
