### PR TITLE
Avoid PMME init for unavailable BNPL use-cases

### DIFF
--- a/changelog/fix-redundant-pmme-init
+++ b/changelog/fix-redundant-pmme-init
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Avoid PMME init for unavailable BNPL use-cases.

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -83,11 +83,20 @@ const ProductDetail = ( { cart, context } ) => {
 		wcSettings.currency.precision
 	);
 
+	if ( ! window.wcpayStripeSiteMessaging ) {
+		return null;
+	}
+
 	const {
 		country,
 		paymentMethods,
 		currencyCode,
+		shouldInitializePMME,
 	} = window.wcpayStripeSiteMessaging;
+
+	if ( ! shouldInitializePMME ) {
+		return null;
+	}
 
 	const amount = parseInt( cartTotal, 10 ) || 0;
 

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -55,7 +55,6 @@ export const initializeBnplSiteMessaging = async () => {
 		isCart,
 		cartTotal,
 		shouldShowPMME,
-		shouldInitializePMME,
 	} = window.wcpayStripeSiteMessaging;
 
 	let amount;
@@ -63,11 +62,6 @@ export const initializeBnplSiteMessaging = async () => {
 	const paymentMessageContainer = document.getElementById(
 		'payment-method-message'
 	);
-
-	if ( ! shouldInitializePMME ) {
-		paymentMessageContainer.style.setProperty( 'display', 'none' );
-		return;
-	}
 
 	if ( isCart ) {
 		amount = parseInt( cartTotal, 10 ) || 0;

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -54,7 +54,8 @@ export const initializeBnplSiteMessaging = async () => {
 		currencyCode,
 		isCart,
 		cartTotal,
-		isBnplAvailable,
+		shouldShowPMME,
+		shouldInitializePMME,
 	} = window.wcpayStripeSiteMessaging;
 
 	let amount;
@@ -63,13 +64,18 @@ export const initializeBnplSiteMessaging = async () => {
 		'payment-method-message'
 	);
 
+	if ( ! shouldInitializePMME ) {
+		paymentMessageContainer.style.setProperty( 'display', 'none' );
+		return;
+	}
+
 	if ( isCart ) {
 		amount = parseInt( cartTotal, 10 ) || 0;
 		elementLocation = 'bnplClassicCart';
 	} else {
 		amount = parseInt( productVariations.base_product.amount, 10 ) || 0;
 
-		if ( ! isBnplAvailable ) {
+		if ( ! shouldShowPMME ) {
 			paymentMessageContainer.style.setProperty( 'display', 'none' );
 		}
 	}

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -53,7 +53,6 @@ export const initializeBnplSiteMessaging = async () => {
 		paymentMethods,
 		currencyCode,
 		isCart,
-		isCartBlock,
 		cartTotal,
 		isBnplAvailable,
 	} = window.wcpayStripeSiteMessaging;
@@ -64,7 +63,7 @@ export const initializeBnplSiteMessaging = async () => {
 		'payment-method-message'
 	);
 
-	if ( isCart || isCartBlock ) {
+	if ( isCart ) {
 		amount = parseInt( cartTotal, 10 ) || 0;
 		elementLocation = 'bnplClassicCart';
 	} else {
@@ -75,37 +74,33 @@ export const initializeBnplSiteMessaging = async () => {
 		}
 	}
 
-	let paymentMessageElement;
+	const api = new WCPayAPI(
+		{
+			publishableKey: publishableKey,
+			accountId: accountId,
+			locale: locale,
+		},
+		apiRequest
+	);
 
-	if ( ! isCartBlock ) {
-		const api = new WCPayAPI(
-			{
-				publishableKey: publishableKey,
-				accountId: accountId,
-				locale: locale,
-			},
-			apiRequest
-		);
+	const options = {
+		amount: amount,
+		currency: currencyCode || 'USD',
+		paymentMethodTypes: paymentMethods || [],
+		countryCode: country, // Customer's country or base country of the store.
+	};
 
-		const options = {
-			amount: amount,
-			currency: currencyCode || 'USD',
-			paymentMethodTypes: paymentMethods || [],
-			countryCode: country, // Customer's country or base country of the store.
-		};
+	const elementsOptions = {
+		appearance: await initializeAppearance( api, elementLocation ),
+		fonts: getFontRulesFromPage(),
+	};
 
-		const elementsOptions = {
-			appearance: await initializeAppearance( api, elementLocation ),
-			fonts: getFontRulesFromPage(),
-		};
+	const stripe = await api.getStripe();
 
-		const stripe = await api.getStripe();
-
-		paymentMessageElement = stripe
-			.elements( elementsOptions )
-			.create( 'paymentMethodMessaging', options );
-		paymentMessageElement.mount( '#payment-method-message' );
-	}
+	const paymentMessageElement = stripe
+		.elements( elementsOptions )
+		.create( 'paymentMethodMessaging', options );
+	paymentMessageElement.mount( '#payment-method-message' );
 
 	// This function converts relative units (rem/em) to pixels based on the current font size.
 	function convertToPixels( value, baseFontSize ) {

--- a/client/product-details/index.js
+++ b/client/product-details/index.js
@@ -30,6 +30,10 @@ jQuery( async function ( $ ) {
 	const { shouldInitializePMME } = window.wcpayStripeSiteMessaging;
 
 	if ( ! shouldInitializePMME ) {
+		const paymentMessageContainer = document.getElementById(
+			'payment-method-message'
+		);
+		paymentMessageContainer.style.setProperty( 'display', 'none' );
 		return;
 	}
 

--- a/client/product-details/index.js
+++ b/client/product-details/index.js
@@ -27,6 +27,12 @@ jQuery( async function ( $ ) {
 		return;
 	}
 
+	const { shouldInitializePMME } = window.wcpayStripeSiteMessaging;
+
+	if ( ! shouldInitializePMME ) {
+		return;
+	}
+
 	const {
 		productVariations,
 		productId,

--- a/client/product-details/index.js
+++ b/client/product-details/index.js
@@ -81,7 +81,7 @@ jQuery( async function ( $ ) {
 		if ( totalAmount <= 0 || ! currency ) {
 			return;
 		}
-		bnplPaymentMessageElement.update( { amount: totalAmount, currency } );
+		bnplPaymentMessageElement?.update( { amount: totalAmount, currency } );
 	};
 
 	/**

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -126,26 +126,27 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		$country = empty( $billing_country ) ? $store_country : $billing_country;
 
 		$script_data = [
-			'productId'         => 'base_product',
-			'productVariations' => $product_variations,
-			'country'           => $country,
-			'locale'            => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
-			'accountId'         => $this->account->get_stripe_account_id(),
-			'publishableKey'    => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
-			'paymentMethods'    => array_values( $bnpl_payment_methods ),
-			'currencyCode'      => $currency_code,
-			'isCart'            => is_cart(),
-			'isCartBlock'       => $is_cart_block,
-			'cartTotal'         => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
-			'nonce'             => [
+			'productId'            => 'base_product',
+			'productVariations'    => $product_variations,
+			'country'              => $country,
+			'locale'               => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
+			'accountId'            => $this->account->get_stripe_account_id(),
+			'publishableKey'       => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
+			'paymentMethods'       => array_values( $bnpl_payment_methods ),
+			'currencyCode'         => $currency_code,
+			'isCart'               => is_cart(),
+			'isCartBlock'          => $is_cart_block,
+			'cartTotal'            => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
+			'nonce'                => [
 				'get_cart_total'    => wp_create_nonce( 'wcpay-get-cart-total' ),
 				'is_bnpl_available' => wp_create_nonce( 'wcpay-is-bnpl-available' ),
 			],
-			'wcAjaxUrl'         => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'wcAjaxUrl'            => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'shouldInitializePMME' => WC_Payments_Utils::is_any_bnpl_supporting_country( array_values( $bnpl_payment_methods ), $country, $currency_code ),
 		];
 
 		if ( $product ) {
-			$script_data['isBnplAvailable'] = WC_Payments_Utils::is_any_bnpl_method_available( array_values( $bnpl_payment_methods ), $country, $currency_code, $product_price );
+			$script_data['shouldShowPMME'] = WC_Payments_Utils::is_any_bnpl_method_available( array_values( $bnpl_payment_methods ), $country, $currency_code, $product_price );
 		}
 
 		// Create script tag with config.

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -876,6 +876,25 @@ class WC_Payments_Utils {
 	}
 
 	/**
+	 * Check if any BNPL method is available for a given country.
+	 *
+	 * @param array  $enabled_methods Array of enabled BNPL methods.
+	 * @param string $country_code Country code.
+	 * @param string $currency_code Currency code.
+	 * @return bool True if any BNPL method is available, false otherwise.
+	 */
+	public static function is_any_bnpl_supporting_country( array $enabled_methods, string $country_code, string $currency_code ): bool {
+		foreach ( $enabled_methods as $method ) {
+			$limits = self::get_bnpl_limits_per_currency( $method );
+			if ( isset( $limits[ $currency_code ][ $country_code ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Saves the minimum amount required for transactions in a given currency.
 	 *
 	 * @param string $currency The currency.

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -1122,6 +1122,35 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
 	}
 
+	public function test_is_any_bnpl_supporting_country() {
+		// Test supported country and currency combination (US with USD).
+		$this->assertTrue(
+			WC_Payments_Utils::is_any_bnpl_supporting_country(
+				[ 'afterpay_clearpay', 'klarna' ],
+				'US',
+				'USD'
+			)
+		);
+
+		// Test unsupported country and currency combination.
+		$this->assertFalse(
+			WC_Payments_Utils::is_any_bnpl_supporting_country(
+				[ 'afterpay_clearpay', 'klarna' ],
+				'CN',
+				'CNY'
+			)
+		);
+
+		// Test with empty enabled methods.
+		$this->assertFalse(
+			WC_Payments_Utils::is_any_bnpl_supporting_country(
+				[],
+				'US',
+				'USD'
+			)
+		);
+	}
+
 	public function test_is_any_bnpl_method_available() {
 		// Price within range for Afterpay/Clearpay in the US.
 		$this->assertTrue(


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10179

#### Changes proposed in this Pull Request
Product page and cart pages tried to initialize PMME with Stripe for ineligible counties also. This PR re-uses the `isBnplAvailable` flag (while slightly expanding its checks) before attempting to mount the messaging elements.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

----
Confirm that the PMME container is correctly hidden when a country is not supported. This was done before, and this test is to confirm that there is no regression in this area.

* Choose the United States as the billing country on checkout
* Navigate to the product page and confirm the loaded PMME container is visible
* Change the billing country to a BNPL-unsupported one (e.g., `CH`)
* Navigate to the product page and confirm that there's no empty container (like the left screenshot below) and instead it's being wholly hidden (like the right screenshot below)

| This would be unexpected | This is expected |
|--------|-------|
| <img width="608" alt="image" src="https://github.com/user-attachments/assets/6ffd0b17-b81c-48d0-8a0e-64ee5891374c" />  | <img width="614" alt="image" src="https://github.com/user-attachments/assets/961bcd2d-06e5-480b-b5e4-6be8bdf7a09d" />  |

----
Confirm that no console errors occur for classic cart and product page
* Check out `develop`
* Choose the United States as the billing country on checkout
* Navigate to the product page and confirm no user nor console errors
* Change the billing country to a BNPL-unsupported one (e.g., `CH`)
* Confirm there are no user errors visible on the page **but** console errors visible on both pages 
* Check out `fix/redundant-pmme-init` 
* Keep the unsupported checkout billing country
* Refresh product page and classic cart page and confirm the console error is gone
----

Confirm that no intermittent error on cart block is not showing up when refreshing the page. More on that in https://github.com/Automattic/woocommerce-payments/issues/10179#issuecomment-2674245284

----

Confirm that no console errors occur for cart block
* Check out `develop`
* Choose the United States as the billing country on checkout
* Navigate to the product page and confirm no user nor console errors
* Change the billing country to a BNPL-unsupported one (e.g., `CH`)
* Confirm there is user errors visible on the page
* Check out `fix/redundant-pmme-init` 
* Keep the unsupported checkout billing country
* Refresh the cart block page and confirm the error is gone


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
