### PR TITLE
Revert "Adds WC store_id to body of woopay tracker requests (#10412)"

### DIFF
--- a/changelog/add-10382-adds-store-id-to-tracker-request-body
+++ b/changelog/add-10382-adds-store-id-to-tracker-request-body
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adds store_id property to body of WooPay tracker events.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -344,7 +344,6 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		$properties['blog_url']  = $site_url;
 		$properties['blog_id']   = \Jetpack_Options::get_option( 'id' );
 		$properties['user_lang'] = $user->get( 'WPLANG' );
-		$properties['store_id']  = $this->get_wc_store_id();
 
 		// Add event property for test mode vs. live mode events.
 		$properties['test_mode']     = WC_Payments::mode()->is_test() ? 1 : 0;
@@ -378,19 +377,6 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 				]
 			)
 		);
-	}
-
-	/**
-	 * Returns WC store_id value, if available.
-	 * store_id introduced in WC 8.4.
-	 *
-	 * @return string|null
-	 */
-	public function get_wc_store_id() {
-		if ( defined( \WC_Install::STORE_ID_OPTION ) ) {
-			return get_option( \WC_Install::STORE_ID_OPTION, null );
-		}
-		return null;
 	}
 
 	/**

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -14,7 +14,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	/**
 	 * @var WooPay_Tracker
 	 */
-	private $mock_tracker;
+	private $tracker;
 
 	/**
 	 * @var WC_Payments_Http
@@ -43,12 +43,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->http_client_stub->method( 'is_user_connected' )->willReturn( true );
 		$this->http_client_stub->method( 'get_connected_user_data' )->willReturn( [ 'ID' => 1234 ] );
 
-		$this->mock_tracker = $this->getMockBuilder( WooPay_Tracker::class )
-			->setConstructorArgs( [ $this->http_client_stub ] )
-			->onlyMethods( [ 'get_wc_store_id' ] )
-			->getMock();
-		$this->mock_tracker->method( 'get_wc_store_id' )
-			->willReturn( 'mock_store_id' );
+		$this->tracker = new WooPay_Tracker( $this->http_client_stub );
 
 		$this->cache      = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
@@ -68,7 +63,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_account_connected = true;
 
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
-		$this->assertFalse( $this->mock_tracker->should_enable_tracking() );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
 	public function test_does_not_track_admin_pages(): void {
@@ -76,7 +71,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_account_connected = true;
 		$is_admin_page        = true;
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected, $is_admin_page );
-		$this->assertFalse( $this->mock_tracker->should_enable_tracking() );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
 	public function test_does_track_non_admins(): void {
@@ -89,7 +84,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 
 		foreach ( $all_roles as $role ) {
 			wp_get_current_user()->set_role( $role );
-			$this->assertTrue( $this->mock_tracker->should_enable_tracking() );
+			$this->assertTrue( $this->tracker->should_enable_tracking() );
 		}
 	}
 
@@ -97,7 +92,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_woopay_eligible   = true;
 		$is_account_connected = false;
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
-		$this->assertFalse( $this->mock_tracker->should_enable_tracking() );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
 	public function test_tracks_build_event_obj_for_admin_events(): void {
@@ -105,10 +100,9 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$event_name = 'wcadmin_test_event';
 		$properties = [ 'test_property' => 'value' ];
 
-		$event_obj = $this->invoke_method( $this->mock_tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
+		$event_obj = $this->invoke_method( $this->tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
 		$this->assertEquals( 'value', $event_obj->test_property );
 		$this->assertEquals( 1234, $event_obj->_ui );
-		$this->assertEquals( 'mock_store_id', $event_obj->store_id );
 		$this->assertEquals( $event_name, $event_obj->_en );
 	}
 
@@ -117,12 +111,11 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$event_name = 'wcpay_test_event';
 		$properties = [ 'test_property' => 'value' ];
 
-		$event_obj = $this->invoke_method( $this->mock_tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
+		$event_obj = $this->invoke_method( $this->tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
 
 		$this->assertInstanceOf( Jetpack_Tracks_Event::class, $event_obj );
 		$this->assertEquals( 'value', $event_obj->test_property );
 		$this->assertEquals( 1234, $event_obj->_ui );
-		$this->assertEquals( 'mock_store_id', $event_obj->store_id );
 		$this->assertEquals( $event_name, $event_obj->_en );
 	}
 


### PR DESCRIPTION
This reverts commit fd6b5401620300ad04636a53016dc01a7dc43fb7. 

Fixes the failures reported in https://github.com/Automattic/woocommerce-payments/actions/runs/13488302489. Those need to be resolved differently, but reverting for now.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

[E2E tests result. ](https://github.com/Automattic/woocommerce-payments/actions/runs/13499264554)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
