### PR TITLE
Fixes undefined constant WC_Install::STORE_ID_OPTION error

### DIFF
--- a/changelog/fix-woopay-tracker-undefined-wc-store-id
+++ b/changelog/fix-woopay-tracker-undefined-wc-store-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes incorrect defined statement for WC_Install::STORE_ID_OPTION constant.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -387,7 +387,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @return string|null
 	 */
 	public function get_wc_store_id() {
-		if ( defined( \WC_Install::STORE_ID_OPTION ) ) {
+		if ( defined( '\WC_Install::STORE_ID_OPTION' ) ) {
 			return get_option( \WC_Install::STORE_ID_OPTION, null );
 		}
 		return null;

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -14,7 +14,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	/**
 	 * @var WooPay_Tracker
 	 */
-	private $mock_tracker;
+	private $tracker;
 
 	/**
 	 * @var WC_Payments_Http
@@ -43,12 +43,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->http_client_stub->method( 'is_user_connected' )->willReturn( true );
 		$this->http_client_stub->method( 'get_connected_user_data' )->willReturn( [ 'ID' => 1234 ] );
 
-		$this->mock_tracker = $this->getMockBuilder( WooPay_Tracker::class )
-			->setConstructorArgs( [ $this->http_client_stub ] )
-			->onlyMethods( [ 'get_wc_store_id' ] )
-			->getMock();
-		$this->mock_tracker->method( 'get_wc_store_id' )
-			->willReturn( 'mock_store_id' );
+		$this->tracker = new WooPay_Tracker( $this->http_client_stub );
 
 		$this->cache      = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
@@ -68,7 +63,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_account_connected = true;
 
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
-		$this->assertFalse( $this->mock_tracker->should_enable_tracking() );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
 	public function test_does_not_track_admin_pages(): void {
@@ -76,7 +71,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_account_connected = true;
 		$is_admin_page        = true;
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected, $is_admin_page );
-		$this->assertFalse( $this->mock_tracker->should_enable_tracking() );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
 	public function test_does_track_non_admins(): void {
@@ -89,7 +84,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 
 		foreach ( $all_roles as $role ) {
 			wp_get_current_user()->set_role( $role );
-			$this->assertTrue( $this->mock_tracker->should_enable_tracking() );
+			$this->assertTrue( $this->tracker->should_enable_tracking() );
 		}
 	}
 
@@ -97,7 +92,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_woopay_eligible   = true;
 		$is_account_connected = false;
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
-		$this->assertFalse( $this->mock_tracker->should_enable_tracking() );
+		$this->assertFalse( $this->tracker->should_enable_tracking() );
 	}
 
 	public function test_tracks_build_event_obj_for_admin_events(): void {
@@ -105,10 +100,9 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$event_name = 'wcadmin_test_event';
 		$properties = [ 'test_property' => 'value' ];
 
-		$event_obj = $this->invoke_method( $this->mock_tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
+		$event_obj = $this->invoke_method( $this->tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
 		$this->assertEquals( 'value', $event_obj->test_property );
 		$this->assertEquals( 1234, $event_obj->_ui );
-		$this->assertEquals( 'mock_store_id', $event_obj->store_id );
 		$this->assertEquals( $event_name, $event_obj->_en );
 	}
 
@@ -117,12 +111,11 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$event_name = 'wcpay_test_event';
 		$properties = [ 'test_property' => 'value' ];
 
-		$event_obj = $this->invoke_method( $this->mock_tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
+		$event_obj = $this->invoke_method( $this->tracker, 'tracks_build_event_obj', [ wp_get_current_user(), $event_name, $properties ] );
 
 		$this->assertInstanceOf( Jetpack_Tracks_Event::class, $event_obj );
 		$this->assertEquals( 'value', $event_obj->test_property );
 		$this->assertEquals( 1234, $event_obj->_ui );
-		$this->assertEquals( 'mock_store_id', $event_obj->store_id );
 		$this->assertEquals( $event_name, $event_obj->_en );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Fixes undefined constant WC_Install::STORE_ID_OPTION error
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR fixes the below error due to incorrect usage of the `defined` function in a conditional, prior to including this constant in the body of a `WooPay_Tracker` event. `\WC_Install::STORE_ID_OPTION` was introduced in WC 8.4, so we must check that this constant is defined for earlier versions of WC, before using this property in the tracker request. 

```log
CRITICAL Uncaught Error: Undefined constant WC_Install::STORE_ID_OPTION in /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-woopay-tracker.php:390
```

This PR also removes some not particularly helpful unit tests and avoids mocking the `WooPay_Tracker` system under test.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure that your site is using a version of WC prior to 8.4 (WC 7.7 was failing on our E2E tests.)
2. Pull the changes in this PR.
3. Trigger a tracker event by enabling or disabling WooPay from Payments settings.
4. No errors should be logged.
5. To optionally, also confirm tracker functionality, see the testing steps in #10412. Note that on WC <8.4, the `store_id` value should now be `null`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
