### PR TITLE
fix: Manual capture fails in the transaction detail screen with a customized order number

### DIFF
--- a/changelog/fix-10395-order-number-manual-capture
+++ b/changelog/fix-10395-order-number-manual-capture
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Manual capture fails in the transaction detail screen with a customized order number

--- a/client/data/payment-intents/actions.ts
+++ b/client/data/payment-intents/actions.ts
@@ -55,7 +55,7 @@ export function* refundCharge(
 				charge_id: charge.id,
 				amount: charge.amount,
 				reason: reason,
-				order_id: charge?.order?.number,
+				order_id: charge?.order?.id,
 			},
 		} );
 

--- a/client/data/payment-intents/test/hooks.ts
+++ b/client/data/payment-intents/test/hooks.ts
@@ -54,6 +54,7 @@ export const chargeMock: Charge = {
 	dispute: null,
 	disputed: false,
 	order: {
+		id: 123,
 		number: Number( '67' ),
 		url: 'http://order.url',
 		customer_url: 'customer.url',
@@ -88,6 +89,7 @@ export const paymentIntentMock: PaymentIntent = {
 	payment_method: 'pm_mock',
 	status: 'requires_capture',
 	order: {
+		id: 123,
 		number: 123,
 		url: 'http://order.url',
 		customer_url: 'customer.url',

--- a/client/data/payment-intents/test/hooks.ts
+++ b/client/data/payment-intents/test/hooks.ts
@@ -55,7 +55,7 @@ export const chargeMock: Charge = {
 	disputed: false,
 	order: {
 		id: 123,
-		number: Number( '67' ),
+		number: 'custom-67',
 		url: 'http://order.url',
 		customer_url: 'customer.url',
 		customer_name: '',
@@ -90,7 +90,7 @@ export const paymentIntentMock: PaymentIntent = {
 	status: 'requires_capture',
 	order: {
 		id: 123,
-		number: 123,
+		number: 'custom-123',
 		url: 'http://order.url',
 		customer_url: 'customer.url',
 		customer_name: '',

--- a/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`Order details page should match the snapshot - Charge without payment i
                       data-link-type="external"
                       href="http://wcpay.test/wp-admin/post.php?post=776&action=edit"
                     >
-                      776
+                      custom-776
                     </a>
                   </span>
                 </div>

--- a/client/payment-details/order-details/test/index.test.tsx
+++ b/client/payment-details/order-details/test/index.test.tsx
@@ -63,6 +63,7 @@ const chargeFromOrderMock = {
 	disputed: false,
 	outcome: null,
 	order: {
+		id: 776,
 		number: 776,
 		url: 'http://wcpay.test/wp-admin/post.php?post=776&action=edit',
 		customer_url:

--- a/client/payment-details/order-details/test/index.test.tsx
+++ b/client/payment-details/order-details/test/index.test.tsx
@@ -64,7 +64,7 @@ const chargeFromOrderMock = {
 	outcome: null,
 	order: {
 		id: 776,
-		number: 776,
+		number: 'custom-776',
 		url: 'http://wcpay.test/wp-admin/post.php?post=776&action=edit',
 		customer_url:
 			'admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=55',

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -199,7 +199,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 
 	const { authorization } = useAuthorization(
 		charge.payment_intent as string,
-		charge.order?.number as number,
+		charge.order?.id as number,
 		shouldFetchAuthorization
 	);
 

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -702,7 +702,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 						>
 							{ createInterpolateElement(
 								__(
-									'You must <a>capture</a> this charge within the next testinggg',
+									'You must <a>capture</a> this charge within the next',
 									'woocommerce-payments'
 								),
 								{

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -458,7 +458,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 							{ ! isLoading && isFraudOutcomeReview && (
 								<div className="payment-details-summary__fraud-outcome-action">
 									<CancelAuthorizationButton
-										orderId={ charge.order?.number || 0 }
+										orderId={ charge.order?.id || 0 }
 										paymentIntentId={
 											charge.payment_intent || ''
 										}
@@ -484,7 +484,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 
 									<CaptureAuthorizationButton
 										buttonIsPrimary
-										orderId={ charge.order?.number || 0 }
+										orderId={ charge.order?.id || 0 }
 										paymentIntentId={
 											charge.payment_intent || ''
 										}
@@ -599,7 +599,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 																	charge.payment_intent,
 																order_id:
 																	charge.order
-																		?.number,
+																		?.id,
 															}
 														);
 														window.location =
@@ -679,7 +679,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 							actions={
 								! isFraudOutcomeReview ? (
 									<CaptureAuthorizationButton
-										orderId={ charge.order?.number || 0 }
+										orderId={ charge.order?.id || 0 }
 										paymentIntentId={
 											charge.payment_intent || ''
 										}
@@ -702,7 +702,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 						>
 							{ createInterpolateElement(
 								__(
-									'You must <a>capture</a> this charge within the next',
+									'You must <a>capture</a> this charge within the next testinggg',
 									'woocommerce-payments'
 								),
 								{

--- a/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.test.tsx.snap
@@ -2264,7 +2264,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
                     data-link-type="external"
                     href="https://example.com/subscription/246"
                   >
-                    246
+                    custom-246
                   </a>
                 </span>
               </div>

--- a/client/payment-details/summary/test/index.test.tsx
+++ b/client/payment-details/summary/test/index.test.tsx
@@ -287,7 +287,7 @@ describe( 'PaymentDetailsSummary', () => {
 		if ( charge.order ) {
 			charge.order.subscriptions = [
 				{
-					number: 246,
+					number: 'custom-246',
 					url: 'https://example.com/subscription/246',
 				},
 			];

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -568,7 +568,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       data-link-type="external"
                       href="https://example.com/order/123"
                     >
-                      123
+                      custom-123
                     </a>
                   </td>
                   <td
@@ -749,7 +749,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       data-link-type="external"
                       href="https://example.com/order/125"
                     >
-                      125
+                      custom-125
                     </a>
                   </td>
                   <td
@@ -897,7 +897,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       data-link-type="external"
                       href="https://example.com/order/335"
                     >
-                      335
+                      custom-335
                     </a>
                   </td>
                   <td
@@ -1561,7 +1561,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/123"
                     >
-                      123
+                      custom-123
                     </a>
                   </td>
                   <td
@@ -1742,7 +1742,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/125"
                     >
-                      125
+                      custom-125
                     </a>
                   </td>
                   <td
@@ -1890,7 +1890,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/335"
                     >
-                      335
+                      custom-335
                     </a>
                   </td>
                   <td
@@ -2558,7 +2558,7 @@ exports[`Transactions list renders correctly when filtered by payout 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/125"
                     >
-                      125
+                      custom-125
                     </a>
                   </td>
                   <td
@@ -3248,7 +3248,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/123"
                     >
-                      123
+                      custom-123
                     </a>
                   </td>
                   <td
@@ -3258,7 +3258,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/subscription/246"
                     >
-                      246
+                      custom-246
                     </a>
                   </td>
                   <td
@@ -3439,7 +3439,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/125"
                     >
-                      125
+                      custom-125
                     </a>
                   </td>
                   <td
@@ -3590,7 +3590,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/335"
                     >
-                      335
+                      custom-335
                     </a>
                   </td>
                   <td
@@ -4299,7 +4299,7 @@ exports[`Transactions list when not filtered by payout renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/123"
                     >
-                      123
+                      custom-123
                     </a>
                   </td>
                   <td
@@ -4480,7 +4480,7 @@ exports[`Transactions list when not filtered by payout renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/125"
                     >
-                      125
+                      custom-125
                     </a>
                   </td>
                   <td
@@ -4628,7 +4628,7 @@ exports[`Transactions list when not filtered by payout renders correctly 1`] = `
                       data-link-type="external"
                       href="https://example.com/order/335"
                     >
-                      335
+                      custom-335
                     </a>
                   </td>
                   <td
@@ -5334,7 +5334,7 @@ exports[`Transactions list when not filtered by payout renders table summary onl
                       data-link-type="external"
                       href="https://example.com/order/123"
                     >
-                      123
+                      custom-123
                     </a>
                   </td>
                   <td
@@ -5515,7 +5515,7 @@ exports[`Transactions list when not filtered by payout renders table summary onl
                       data-link-type="external"
                       href="https://example.com/order/125"
                     >
-                      125
+                      custom-125
                     </a>
                   </td>
                   <td
@@ -5663,7 +5663,7 @@ exports[`Transactions list when not filtered by payout renders table summary onl
                       data-link-type="external"
                       href="https://example.com/order/335"
                     >
-                      335
+                      custom-335
                     </a>
                   </td>
                   <td

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -109,7 +109,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		source: 'visa',
 		order: {
 			id: 123,
-			number: 123,
+			number: 'custom-123',
 			url: 'https://example.com/order/123',
 			// eslint-disable-next-line camelcase
 			customer_url: 'https://example.com/customer/my-name',
@@ -141,7 +141,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		source: 'mastercard',
 		order: {
 			id: 123,
-			number: 125,
+			number: 'custom-125',
 			url: 'https://example.com/order/125',
 			// eslint-disable-next-line camelcase
 			customer_url: 'https://example.com/customer/my-name',
@@ -173,7 +173,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		source: 'visa',
 		order: {
 			id: 123,
-			number: 335,
+			number: 'custom-335',
 			url: 'https://example.com/order/335',
 			// eslint-disable-next-line camelcase
 			customer_url: 'https://example.com/customer/my-name',

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -427,7 +427,7 @@ describe( 'Transactions list', () => {
 		const mockTransactions = getMockTransactions();
 		mockTransactions[ 0 ].order.subscriptions = [
 			{
-				number: 246,
+				number: 'custom-246',
 				url: 'https://example.com/subscription/246',
 			},
 		];

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -108,6 +108,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		type: 'refund',
 		source: 'visa',
 		order: {
+			id: 123,
 			number: 123,
 			url: 'https://example.com/order/123',
 			// eslint-disable-next-line camelcase
@@ -139,6 +140,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		type: 'charge',
 		source: 'mastercard',
 		order: {
+			id: 123,
 			number: 125,
 			url: 'https://example.com/order/125',
 			// eslint-disable-next-line camelcase
@@ -170,6 +172,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		type: 'charge',
 		source: 'visa',
 		order: {
+			id: 123,
 			number: 335,
 			url: 'https://example.com/order/335',
 			// eslint-disable-next-line camelcase

--- a/client/types/orders.d.ts
+++ b/client/types/orders.d.ts
@@ -12,6 +12,7 @@ interface SubscriptionDetails {
 }
 
 interface OrderDetails {
+	id: number;
 	number: number;
 	url: string;
 	customer_url: null | string;

--- a/client/types/orders.d.ts
+++ b/client/types/orders.d.ts
@@ -7,7 +7,7 @@
  */
 
 interface SubscriptionDetails {
-	number: number;
+	number: string; // Comment for OderDetails.number below applies here as well.
 	url: string;
 }
 

--- a/client/types/orders.d.ts
+++ b/client/types/orders.d.ts
@@ -13,7 +13,12 @@ interface SubscriptionDetails {
 
 interface OrderDetails {
 	id: number;
-	number: number;
+	/**
+	 * The order number for display.
+	 * By default, it's order ID but a plugin can customize it.
+	 * See PHP method WC_Order::get_order_number().
+	 */
+	number: string;
 	url: string;
 	customer_url: null | string;
 	customer_email: null | string;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2598,6 +2598,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	 */
 	public function build_order_info( WC_Order $order ): array {
 		$order_info = [
+			'id'                  => $order->get_id(),
 			'number'              => $order->get_order_number(),
 			'url'                 => $order->get_edit_order_url(),
 			'customer_url'        => $this->get_customer_url( $order ),


### PR DESCRIPTION
Fixes #10395

#### Changes proposed in this Pull Request

- Added `OrderDatils.id` in file `client/types/orders.d.ts` and used it in the proper places to fix the main issue.
- Additional improvement changes: 
  - Changed type handling for `OrderDetails.number` to be consistently treated as string
  - Updated `SubscriptionDetails.number` type to string
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Install and activate a sequential order number plugin (like [Sequential Order Numbers for WooCommerce](https://wordpress.org/plugins/sequential-order-numbers-for-woocommerce/) or [Sequential Order Numbers Pro for WooCommerce](https://woocommerce.com/products/sequential-order-numbers-pro/), which can be downloaded from here by any Automattic staff)
2. Create a new order with a payment that requires manual capture
3. Try to capture the payment from the transaction detail screen
4. Verify that the capture succeeds and no errors occur
5. Verify that order and subscription numbers are displayed correctly in the transactions list

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
