### PR TITLE
Add order note if payment tokens are missing or invalid on subscription orders

### DIFF
--- a/changelog/fix-8894-add-order-note-if-payment-tokens-are-missing
+++ b/changelog/fix-8894-add-order-note-if-payment-tokens-are-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add an order note when a recurring payment fails or when updating the payment method fails due to a missing or invalid payment token.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -325,7 +325,9 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		}
 
 		$token = $this->get_payment_token( $renewal_order );
+		$token = null;
 		if ( is_null( $token ) && ! WC_Payments::is_network_saved_cards_enabled() ) {
+			$renewal_order->add_order_note( 'Subscription renewal failed: No saved payment method found.' );
 			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );
 			// TODO: Update to use Order_Service->mark_payment_failed.
 			$renewal_order->update_status( 'failed' );
@@ -380,6 +382,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
 		$renewal_token = $this->get_payment_token( $renewal_order );
 		if ( is_null( $renewal_token ) ) {
+			$renewal_order->add_order_note( 'Unable to update subscription payment method: No valid payment token or method found.' );
 			Logger::error( 'Failing subscription could not be updated: there is no saved payment token for order #' . $renewal_order->get_id() );
 			return;
 		}

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -325,7 +325,6 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		}
 
 		$token = $this->get_payment_token( $renewal_order );
-		$token = null;
 		if ( is_null( $token ) && ! WC_Payments::is_network_saved_cards_enabled() ) {
 			$renewal_order->add_order_note( 'Subscription renewal failed: No saved payment method found.' );
 			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -265,7 +265,15 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 
 	public function test_update_failing_payment_method_does_not_copy_method_if_renewal_has_no_method() {
 		$subscription  = WC_Helper_Order::create_order( self::USER_ID );
-		$renewal_order = WC_Helper_Order::create_order( self::USER_ID );
+		$renewal_order = $this->createMock( WC_Order::class );
+
+		$renewal_order->expects( $this->once() )
+			->method( 'get_payment_tokens' )
+			->willReturn( [] );
+
+		$renewal_order->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with( 'Unable to update subscription payment method: No valid payment token or method found.' );
 
 		$this->wcpay_gateway->update_failing_payment_method( $subscription, $renewal_order );
 


### PR DESCRIPTION
Fixes #8894  

#### Changes proposed in this Pull Request  

This PR adds an order note when a recurring payment fails or when updating the payment method fails due to a missing or invalid payment token.  

#### Testing instructions  

1. Ensure all tests pass.  
2. Verify that you have an active subscription.  
3. In the database, delete the payment method token linked to the subscription or set `$token` to `null` on this [line](https://github.com/Automattic/woocommerce-payments/pull/10438/files#diff-66bbfee02f23d61d5be427672d6f26214263718f1dcd3e5162c1e95bfdd7ad53L327).  
4. Navigate to **WooCommerce > Status > Scheduled Actions**, find the pending subscription renewal action for that subscription, and manually execute it.  
5. Confirm that the order fails and a new order note is added, explaining the failure.  

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
