### PR TITLE
chore: remove unnecessary useEffect on settings toggle

### DIFF
--- a/changelog/chore-remove-unneeded-useeffect-in-settings
+++ b/changelog/chore-remove-unneeded-useeffect-in-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: remove unnecessary useEffect on settings toggle
+
+

--- a/client/settings/advanced-settings/multi-currency-toggle.js
+++ b/client/settings/advanced-settings/multi-currency-toggle.js
@@ -3,7 +3,6 @@
  */
 import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,14 +15,6 @@ const MultiCurrencyToggle = () => {
 		isMultiCurrencyEnabled,
 		updateIsMultiCurrencyEnabled,
 	] = useMultiCurrency();
-
-	const headingRef = useRef( null );
-
-	useEffect( () => {
-		if ( ! headingRef.current ) return;
-
-		headingRef.current.focus();
-	}, [] );
 
 	const handleMultiCurrencyStatusChange = ( value ) => {
 		updateIsMultiCurrencyEnabled( value );

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -3,7 +3,6 @@
  */
 import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,14 +16,6 @@ const WCPaySubscriptionsToggle = () => {
 		isWCPaySubscriptionsEligible,
 		updateIsWCPaySubscriptionsEnabled,
 	] = useWCPaySubscriptions();
-
-	const headingRef = useRef( null );
-
-	useEffect( () => {
-		if ( ! headingRef.current ) return;
-
-		headingRef.current.focus();
-	}, [] );
 
 	const handleWCPaySubscriptionsStatusChange = ( value ) => {
 		updateIsWCPaySubscriptionsEnabled( value );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed there's a couple of places where we trigger a `useEffect` on a `ref`. But the `ref` is never assigned. So the `useEffect` would effectively never run 🤷 

I think these components were copy/pasted from this older one https://github.com/Automattic/woocommerce-payments/blob/8f24a5d98c6938d88f537fcdfe5435772bb30379/client/settings/advanced-settings/debug-mode.js without realizing that the `headingRef` was never assigned 🤷 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There should be nothing to test here.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
