### PR TITLE
fix: php 8.1 warning for undefined key

### DIFF
--- a/changelog/fix-undefined-required-key
+++ b/changelog/fix-undefined-required-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: avoid PHP 8.1 warning when required key is not defined.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -246,7 +246,7 @@ class WC_Payments_Checkout {
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
 			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
 				$enabled_billing_fields[ $billing_field ] = [
-					'required' => is_array( $billing_field_options ) ? ( $billing_field_options['required'] ?? false ) : false,
+					'required' => isset( $billing_field_options['required'] ) ? $billing_field_options['required'] : false,
 				];
 			}
 		}

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -246,7 +246,7 @@ class WC_Payments_Checkout {
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
 			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
 				$enabled_billing_fields[ $billing_field ] = [
-					'required' => $billing_field_options['required'] ?? false,
+					'required' => is_array( $billing_field_options ) ? ( $billing_field_options['required'] ?? false ) : false,
 				];
 			}
 		}

--- a/includes/core/server/class-response.php
+++ b/includes/core/server/class-response.php
@@ -58,6 +58,7 @@ class Response implements ArrayAccess {
 	 * @param mixed $value               The value.
 	 * @throws Server_Response_Exception It is not possible.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ): void {
 		throw new Server_Response_Exception( 'Server responses cannot be mutated.', 'wcpay_core_server_response_malformed' );
 	}
@@ -68,6 +69,7 @@ class Response implements ArrayAccess {
 	 * @param mixed $offset                The offset to remove.
 	 * @throws Server_Response_Exception   It is not possible.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ): void {
 		throw new Server_Response_Exception( 'Server responses cannot be mutated.', 'wcpay_core_server_response_malformed' );
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
