### PR TITLE
Fix/increase docker php memory limit

### DIFF
--- a/changelog/fix-increase-docker-php-memory-limit
+++ b/changelog/fix-increase-docker-php-memory-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Increased the PHP memory limit for the Docker container

--- a/changelog/fix-increase-docker-php-memory-limit
+++ b/changelog/fix-increase-docker-php-memory-limit
@@ -1,4 +1,5 @@
 Significance: patch
-Type: dev
+Type: fix
+Comment: Increased the PHP memory limit for the Docker container
 
-Increased the PHP memory limit for the Docker container
+

--- a/docker/wc-payments-php.ini
+++ b/docker/wc-payments-php.ini
@@ -1,1 +1,2 @@
 upload_max_filesize = 20M
+memory_limit = 256M


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increases the php memory limit for Docker containers. Setting up PHP tests for the first time can lead to out of memory errors.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
