### PR TITLE
Fix non-rendering PMME container on cart block for specific scenario

### DIFF
--- a/changelog/fix-pmme-on-cart-block
+++ b/changelog/fix-pmme-on-cart-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Init PMME container in cart block so that it can be dynamically rendered once the requirements are met.

--- a/client/cart/blocks/index.js
+++ b/client/cart/blocks/index.js
@@ -2,26 +2,10 @@
  * Internal dependencies
  */
 import { renderBNPLCartMessaging } from './product-details';
-import { getUPEConfig } from 'wcpay/utils/checkout';
 
 const { registerPlugin } = window.wp.plugins;
 
-const paymentMethods = getUPEConfig( 'paymentMethodsConfig' ) || {};
-
-const BNPL_PAYMENT_METHODS = {
-	AFFIRM: 'affirm',
-	AFTERPAY: 'afterpay_clearpay',
-	KLARNA: 'klarna',
-};
-
-const bnplPaymentMethods = Object.values( BNPL_PAYMENT_METHODS ).filter(
-	( method ) => method in paymentMethods
-);
-
-if ( bnplPaymentMethods.length ) {
-	// Register BNPL site messaging on the cart block.
-	registerPlugin( 'bnpl-site-messaging', {
-		render: renderBNPLCartMessaging,
-		scope: 'woocommerce-checkout',
-	} );
-}
+registerPlugin( 'bnpl-site-messaging', {
+	render: renderBNPLCartMessaging,
+	scope: 'woocommerce-checkout',
+} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10448

#### Changes proposed in this Pull Request


#### Testing instructions

> 1️⃣  Enable Affirm in your store
> 2️⃣  Ensure the country used in checkout is a country that supports Affirm (e.g. United States)

##### From below-the-limit to within-the-limit
* add a product with the price lower than $50 to the cart 
* open the _**cart block**_ and confirm no PMME on the page
* start increasing the quantity of the product in the cart so that the cart total is >= $50
* confirm PMME appears on the page
* go in/out the limit by changing the quantity and confirm expected dynamic PMME render


##### From within-the-limit to below-the-limit
* add multiple products to the cart so that the total is $50 or higher
* confirm PMME appears on the cart block page
* decrease the quantity/remove some products from the cart
* confirm that PMME disappears once the cart total is lower than $50


> Change the checkout country to an unsupported one (e.g. Poland)

* navigate to the cart block page and confirm no user or console errors
* change the quantity to enter/exit the $50 cart total limit and confirm the PMME is not appearing (due to unsupported country) and no errors


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
