### PR TITLE
chore: port ECE changes into tokenized ECE

### DIFF
--- a/changelog/chore-port-express-checkout-changes-to-tokenized-ece
+++ b/changelog/chore-port-express-checkout-changes-to-tokenized-ece
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: chore: port express checkout changes to tokenized ECE
+
+

--- a/client/tokenized-express-checkout/blocks/index.js
+++ b/client/tokenized-express-checkout/blocks/index.js
@@ -39,9 +39,7 @@ export const tokenizedExpressCheckoutElementApplePay = ( api ) => ( {
 			return false;
 		}
 
-		return new Promise( ( resolve ) => {
-			checkPaymentMethodIsAvailable( 'applePay', cart, resolve );
-		} );
+		return checkPaymentMethodIsAvailable( 'applePay', cart );
 	},
 } );
 
@@ -77,9 +75,7 @@ export const tokenizedExpressCheckoutElementGooglePay = ( api ) => {
 				return false;
 			}
 
-			return new Promise( ( resolve ) => {
-				checkPaymentMethodIsAvailable( 'googlePay', cart, resolve );
-			} );
+			return checkPaymentMethodIsAvailable( 'googlePay', cart );
 		},
 	};
 };

--- a/client/tokenized-express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/tokenized-express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -14,71 +14,75 @@ import WCPayAPI from 'wcpay/checkout/api';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 
 export const checkPaymentMethodIsAvailable = memoize(
-	( paymentMethod, cart, resolve ) => {
-		// Create the DIV container on the fly
-		const containerEl = document.createElement( 'div' );
+	( paymentMethod, cart ) => {
+		return new Promise( ( resolve ) => {
+			// Create the DIV container on the fly
+			const containerEl = document.createElement( 'div' );
 
-		// Ensure the element is hidden and doesn’t interfere with the page layout.
-		containerEl.style.display = 'none';
+			// Ensure the element is hidden and doesn’t interfere with the page layout.
+			containerEl.style.display = 'none';
 
-		document.querySelector( 'body' ).appendChild( containerEl );
+			document.querySelector( 'body' ).appendChild( containerEl );
 
-		const root = ReactDOM.createRoot( containerEl );
+			const root = ReactDOM.createRoot( containerEl );
 
-		const api = new WCPayAPI(
-			{
-				publishableKey: getUPEConfig( 'publishableKey' ),
-				accountId: getUPEConfig( 'accountId' ),
-				forceNetworkSavedCards: getUPEConfig(
-					'forceNetworkSavedCards'
-				),
-				locale: getUPEConfig( 'locale' ),
-				isStripeLinkEnabled: isLinkEnabled(
-					getUPEConfig( 'paymentMethodsConfig' )
-				),
-			},
-			request
-		);
+			const api = new WCPayAPI(
+				{
+					publishableKey: getUPEConfig( 'publishableKey' ),
+					accountId: getUPEConfig( 'accountId' ),
+					forceNetworkSavedCards: getUPEConfig(
+						'forceNetworkSavedCards'
+					),
+					locale: getUPEConfig( 'locale' ),
+					isStripeLinkEnabled: isLinkEnabled(
+						getUPEConfig( 'paymentMethodsConfig' )
+					),
+				},
+				request
+			);
 
-		root.render(
-			<Elements
-				stripe={ api.loadStripeForExpressCheckout() }
-				options={ {
-					mode: 'payment',
-					paymentMethodCreation: 'manual',
-					amount: Number( cart.cartTotals.total_price ),
-					currency: cart.cartTotals.currency_code.toLowerCase(),
-				} }
-			>
-				<ExpressCheckoutElement
-					onLoadError={ () => resolve( false ) }
+			root.render(
+				<Elements
+					stripe={ api.loadStripeForExpressCheckout() }
 					options={ {
-						paymentMethods: {
-							amazonPay: 'never',
-							applePay:
-								paymentMethod === 'applePay'
-									? 'always'
-									: 'never',
-							googlePay:
-								paymentMethod === 'googlePay'
-									? 'always'
-									: 'never',
-							link: 'never',
-							paypal: 'never',
-						},
+						mode: 'payment',
+						paymentMethodCreation: 'manual',
+						amount: Number( cart.cartTotals.total_price ),
+						currency: cart.cartTotals.currency_code.toLowerCase(),
 					} }
-					onReady={ ( event ) => {
-						let canMakePayment = false;
-						if ( event.availablePaymentMethods ) {
-							canMakePayment =
-								event.availablePaymentMethods[ paymentMethod ];
-						}
-						resolve( canMakePayment );
-						root.unmount();
-						containerEl.remove();
-					} }
-				/>
-			</Elements>
-		);
+				>
+					<ExpressCheckoutElement
+						onLoadError={ () => resolve( false ) }
+						options={ {
+							paymentMethods: {
+								amazonPay: 'never',
+								applePay:
+									paymentMethod === 'applePay'
+										? 'always'
+										: 'never',
+								googlePay:
+									paymentMethod === 'googlePay'
+										? 'always'
+										: 'never',
+								link: 'never',
+								paypal: 'never',
+							},
+						} }
+						onReady={ ( event ) => {
+							let canMakePayment = false;
+							if ( event.availablePaymentMethods ) {
+								canMakePayment =
+									event.availablePaymentMethods[
+										paymentMethod
+									];
+							}
+							resolve( canMakePayment );
+							root.unmount();
+							containerEl.remove();
+						} }
+					/>
+				</Elements>
+			);
+		} );
 	}
 );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In https://github.com/Automattic/woocommerce-payments/pull/9927 , some changes were applied to the `client/express-checkout` directory, but not in the `client/tokenized-express-checkout` directory.

This PR ports those changes from `client/express-checkout` into `client/tokenized-express-checkout`, so that they won't get lost once we remove it.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
