### PR TITLE
fix: ECE script dependencies with WC 9.7

### DIFF
--- a/changelog/fix-wc9.7-ece-script-dependencies
+++ b/changelog/fix-wc9.7-ece-script-dependencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: GooglePay/ApplePay script dependencies with WooCommerce 9.7

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -307,6 +307,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 		}
 
 		wp_localize_script( 'WCPAY_EXPRESS_CHECKOUT_ECE', 'wcpayExpressCheckoutParams', $express_checkout_params );
+		wp_localize_script( 'WCPAY_BLOCKS_CHECKOUT', 'wcpayExpressCheckoutParams', $express_checkout_params );
 
 		wp_set_script_translations( 'WCPAY_EXPRESS_CHECKOUT_ECE', 'woocommerce-payments' );
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

In WC 9.7.0 there's been some optimizations implemented, which make the `canMakePayment` function being executed earlier in the page's lifecycle, compared to prior versions of WC.

The ECE (both "tokenized" ECE and non-tokenized ECE) on blocks cart/checkout pages are dependent on the `wcpayExpressCheckoutParams` global variable, which is enqueued by the backend.

The problem is that WC 9.7.0 will execute the `canMakePayment` function before the `wcpayExpressCheckoutParams` is evaluated on the page.
This results on the GooglePay/ApplePay buttons not being visible on the cart/checkout pages on first load, unless the customer interacts with the cart (or checkout): changing product quantities, adding a coupon, changing billing or shipping address, changing the selected shipping rate make the button re-appear.
Sometimes, even refreshing or re-visiting cart/checkout works.

This solution ensures that the `wcpayExpressCheckoutParams` is added to the page as a direct dependency of our blocks scripts, so that it can already be present when evaluated in the `canMakePayment` function.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have a block-based cart (or checkout) pages
- Ensure you have GooglePay/ApplePay enabled in the WooPayments settings
- Ensure you have WC Core 9.7.0
- As a customer, add one or more products to the cart
- Visit a block-based cart (or checkout) page
- The GooglePay/ApplePay button(s) should consistently be visible on the page
- Go back to the store, add new products to the cart
- Visit again the block-based cart (or checkout) page
- Once again, the GooglePay/ApplePay button(s) should be visible on the page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
