### PR TITLE
Fix: Tokenized ECE availability check

### DIFF
--- a/changelog/fix-tokenized-ece-availability-check
+++ b/changelog/fix-tokenized-ece-availability-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix Tokenized ECE async availability check.

--- a/client/tokenized-express-checkout/blocks/index.js
+++ b/client/tokenized-express-checkout/blocks/index.js
@@ -39,9 +39,7 @@ export const tokenizedExpressCheckoutElementApplePay = ( api ) => ( {
 			return false;
 		}
 
-		return new Promise( ( resolve ) => {
-			checkPaymentMethodIsAvailable( 'applePay', cart, resolve );
-		} );
+		return checkPaymentMethodIsAvailable( 'applePay', cart );
 	},
 } );
 
@@ -77,9 +75,7 @@ export const tokenizedExpressCheckoutElementGooglePay = ( api ) => {
 				return false;
 			}
 
-			return new Promise( ( resolve ) => {
-				checkPaymentMethodIsAvailable( 'googlePay', cart, resolve );
-			} );
+			return checkPaymentMethodIsAvailable( 'googlePay', cart );
 		},
 	};
 };

--- a/client/tokenized-express-checkout/utils/checkPaymentMethodIsAvailable.js
+++ b/client/tokenized-express-checkout/utils/checkPaymentMethodIsAvailable.js
@@ -14,71 +14,75 @@ import WCPayAPI from 'wcpay/checkout/api';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 
 export const checkPaymentMethodIsAvailable = memoize(
-	( paymentMethod, cart, resolve ) => {
-		// Create the DIV container on the fly
-		const containerEl = document.createElement( 'div' );
+	( paymentMethod, cart ) => {
+		return new Promise( ( resolve ) => {
+			// Create the DIV container on the fly
+			const containerEl = document.createElement( 'div' );
 
-		// Ensure the element is hidden and doesn’t interfere with the page layout.
-		containerEl.style.display = 'none';
+			// Ensure the element is hidden and doesn’t interfere with the page layout.
+			containerEl.style.display = 'none';
 
-		document.querySelector( 'body' ).appendChild( containerEl );
+			document.querySelector( 'body' ).appendChild( containerEl );
 
-		const root = ReactDOM.createRoot( containerEl );
+			const root = ReactDOM.createRoot( containerEl );
 
-		const api = new WCPayAPI(
-			{
-				publishableKey: getUPEConfig( 'publishableKey' ),
-				accountId: getUPEConfig( 'accountId' ),
-				forceNetworkSavedCards: getUPEConfig(
-					'forceNetworkSavedCards'
-				),
-				locale: getUPEConfig( 'locale' ),
-				isStripeLinkEnabled: isLinkEnabled(
-					getUPEConfig( 'paymentMethodsConfig' )
-				),
-			},
-			request
-		);
+			const api = new WCPayAPI(
+				{
+					publishableKey: getUPEConfig( 'publishableKey' ),
+					accountId: getUPEConfig( 'accountId' ),
+					forceNetworkSavedCards: getUPEConfig(
+						'forceNetworkSavedCards'
+					),
+					locale: getUPEConfig( 'locale' ),
+					isStripeLinkEnabled: isLinkEnabled(
+						getUPEConfig( 'paymentMethodsConfig' )
+					),
+				},
+				request
+			);
 
-		root.render(
-			<Elements
-				stripe={ api.loadStripeForExpressCheckout() }
-				options={ {
-					mode: 'payment',
-					paymentMethodCreation: 'manual',
-					amount: Number( cart.cartTotals.total_price ),
-					currency: cart.cartTotals.currency_code.toLowerCase(),
-				} }
-			>
-				<ExpressCheckoutElement
-					onLoadError={ () => resolve( false ) }
+			root.render(
+				<Elements
+					stripe={ api.loadStripeForExpressCheckout() }
 					options={ {
-						paymentMethods: {
-							amazonPay: 'never',
-							applePay:
-								paymentMethod === 'applePay'
-									? 'always'
-									: 'never',
-							googlePay:
-								paymentMethod === 'googlePay'
-									? 'always'
-									: 'never',
-							link: 'never',
-							paypal: 'never',
-						},
+						mode: 'payment',
+						paymentMethodCreation: 'manual',
+						amount: Number( cart.cartTotals.total_price ),
+						currency: cart.cartTotals.currency_code.toLowerCase(),
 					} }
-					onReady={ ( event ) => {
-						let canMakePayment = false;
-						if ( event.availablePaymentMethods ) {
-							canMakePayment =
-								event.availablePaymentMethods[ paymentMethod ];
-						}
-						resolve( canMakePayment );
-						root.unmount();
-						containerEl.remove();
-					} }
-				/>
-			</Elements>
-		);
+				>
+					<ExpressCheckoutElement
+						onLoadError={ () => resolve( false ) }
+						options={ {
+							paymentMethods: {
+								amazonPay: 'never',
+								applePay:
+									paymentMethod === 'applePay'
+										? 'always'
+										: 'never',
+								googlePay:
+									paymentMethod === 'googlePay'
+										? 'always'
+										: 'never',
+								link: 'never',
+								paypal: 'never',
+							},
+						} }
+						onReady={ ( event ) => {
+							let canMakePayment = false;
+							if ( event.availablePaymentMethods ) {
+								canMakePayment =
+									event.availablePaymentMethods[
+										paymentMethod
+									];
+							}
+							resolve( canMakePayment );
+							root.unmount();
+							containerEl.remove();
+						} }
+					/>
+				</Elements>
+			);
+		} );
 	}
 );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

This same problem was previously found in non-tokenized ECE and was already fixed in https://github.com/Automattic/woocommerce-payments/pull/9927, here are the details taken from that PR:

> It was discovered that for some reason, canMakePayment for payment methods (non-express checkout payment methods) is executed only upon page load, but not executed on subsequent actions like e.g. billing country update. This applies to Blocks checkout only.
> This PR resolves the issue by caching the promise itself instead of its resolved value. Previously, memoize cached the resolved boolean, causing subsequent calls to bypass the promise logic. Now, the memoized function returns and caches the promise, ensuring that subsequent calls return the cached resolved promise which is handled by Blocks.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For Blocks checkout

* Make sure the feature flag `Enable Cart-Token implementation for ECE` is enabled using the WCPay Dev tool.
* check on `develop` that dynamical filtering upon billing country change is not working
* check out this branch and make sure that dynamical filtering of payment methods works 
    * enable e.g. Klarna
    * while opening the page, confirm this payment method is visible or invisible (depending on the country selected) 
    * switch the country and confirm Klarna is appearing and disappearing as expected depending on the country

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
