### PR TITLE
Render Multibanco Payment Instructions in Order Details page

### DIFF
--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -66,7 +66,12 @@ class WC_Payments_Order_Success_Page {
 						<img src="<?php echo esc_url_raw( plugins_url( 'assets/images/payment-methods/multibanco-instructions.svg', WCPAY_PLUGIN_FILE ) ); ?>" alt="<?php esc_attr_e( 'Multibanco', 'woocommerce-payments' ); ?>">
 					</div>
 					<div class="payment-details">
-						<div class="payment-header"><?php echo $formatted_order_total; ?></div>
+						<div class="payment-header">
+							<?php
+							/* translators: %s: order number */
+							printf( esc_html__( 'Order #%s', 'woocommerce-payments' ), $order->get_order_number() );
+							?>
+						</div>
 						<div class="payment-expiry">
 						<?php
 							printf(

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -42,6 +42,11 @@ class WC_Payments_Order_Success_Page {
 	 * @param int $order_id The order ID.
 	 */
 	public function maybe_render_multibanco_payment_instructions( $order_id ) {
+		if ( is_order_received_page() && current_filter() === 'woocommerce_order_details_before_order_table' ) {
+			// Prevent rendering twice on order received page.
+			return;
+		}
+
 		$order = wc_get_order( $order_id );
 
 		if ( ! $order || $order->get_payment_method() !== 'woocommerce_payments_' . Payment_Method::MULTIBANCO || 'on-hold' !== $order->get_status() ) {

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -22,6 +22,7 @@ class WC_Payments_Order_Success_Page {
 		add_action( 'woocommerce_before_thankyou', [ $this, 'register_payment_method_override' ] );
 		add_action( 'woocommerce_before_thankyou', [ $this, 'maybe_render_multibanco_payment_instructions' ] );
 		add_action( 'woocommerce_order_details_before_order_table', [ $this, 'unregister_payment_method_override' ] );
+		add_action( 'woocommerce_order_details_before_order_table', [ $this, 'maybe_render_multibanco_payment_instructions' ] );
 		add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'add_notice_previous_paid_order' ], 11 );
 		add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'add_notice_previous_successful_intent' ], 11 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
@@ -345,7 +346,7 @@ class WC_Payments_Order_Success_Page {
 	 * Enqueue style to the order success page
 	 */
 	public function enqueue_scripts() {
-		if ( ! is_order_received_page() ) {
+		if ( ! is_order_received_page() && ! is_view_order_page() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #10139

#### Changes proposed in this Pull Request

This PR adds the Multibanco Payment Instructions to the Order Details page.

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/3b0b6b99-b125-4d80-9bac-a13be720e6f4" />


#### Testing instructions

1. Follow instructions from Automattic/transact-platform-server#7179
1. Enable Multibanco in WooPayments settings
1. Add an item to your cart and go to the checkout
2. Change the currency to EUR and billing country to Portugal
3. As a logged user, place an order using Multibanco
4. Go to My Account >> Orders and open the Order Details page for the order you just created
5. Ensure you can see the Payment Instructions in the Order Details page
7. The payment is automatically confirmed after a couple minutes so it is not an issue if you can't see the instructions after a few minutes

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
