### PR TITLE
dev - Fix the flaky test in WC_Payments_Incentives_Service_Test

### DIFF
--- a/changelog/dev-fix-unstable-test-WC_Payments_Incentives_Service_Test
+++ b/changelog/dev-fix-unstable-test-WC_Payments_Incentives_Service_Test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix the flaky tests due to using PHP time() in production vs test.
+
+

--- a/tests/unit/test-class-wc-payments-incentives-service.php
+++ b/tests/unit/test-class-wc-payments-incentives-service.php
@@ -406,7 +406,9 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 				$this->assertSame( 'yes', $value );
 
 				// Ensure the cache is set to expire in 90 days - 30 days = 60 days.
-				$this->assertSame( 60 * DAY_IN_SECONDS, $expiration );
+				$expected_expiration = 60 * DAY_IN_SECONDS;
+				// Allowing 5-second difference to avoid flaky tests due to time()  precision.
+				$this->assertLessThanOrEqual( 5, abs( $expected_expiration - $expiration ), 'Expiration time should be within 5 second of expected value' );
 
 				return $value;
 			},


### PR DESCRIPTION
Fixes the following error as seen in 
https://github.com/Automattic/woocommerce-payments/actions/runs/13581864590/job/37969236625

```
1) WC_Payments_Incentives_Service_Test::test_get_connect_incentive_has_orders_is_cached_longer_when_has_orders
Failed asserting that 5183999 is identical to 5184000.

/home/runner/work/woocommerce-payments/woocommerce-payments/tests/unit/test-class-wc-payments-incentives-service.php:409
/tmp/wordpress/wp-includes/class-wp-hook.php:326
/tmp/wordpress/wp-includes/plugin.php:205
/tmp/wordpress/wp-includes/option.php:1517
/home/runner/work/woocommerce-payments/woocommerce-payments/includes/class-wc-payments-incentives-service.php:480
/home/runner/work/woocommerce-payments/woocommerce-payments/includes/class-wc-payments-incentives-service.php:262
/home/runner/work/woocommerce-payments/woocommerce-payments/includes/class-wc-payments-incentives-service.php:203
/home/runner/work/woocommerce-payments/woocommerce-payments/tests/unit/test-class-wc-payments-incentives-service.php:418
phpvfscomposer:///home/runner/work/woocommerce-payments/woocommerce-payments/vendor/phpunit/phpunit/phpunit:97
```

#### Changes proposed in this Pull Request

This PR fixes the flaky test `test_get_connect_incentive_has_orders_is_cached_longer_when_has_orders` in `WC_Payments_Incentives_Service_Test` that was failing intermittently due to timing precision issues. The test was asserting an exact match for cache expiration time (60 days in seconds), but due to the nature of PHP's `time()` function and the slight delays between calculations, this could occasionally fail.

The change modifies the test assertion to allow for a small tolerance (≤ 5 seconds) in the expiration time check, making the test more resilient while still maintaining its effectiveness in catching real issues.

There is an alternative approach by mocking `time` functions like in the server repo but I don't want to make it complicated, and this is still good to address the root cause.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Just run tests for this class WC_Payments_Incentives_Service_Test and confirm there is no issue.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] No need - Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] No need - Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] No need - Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
