### PR TITLE
chore: remove unused arguments from usePaymentCompleteHandler

### DIFF
--- a/changelog/chore-usePaymentCompleteHandler-unused-arguments
+++ b/changelog/chore-usePaymentCompleteHandler-unused-arguments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: remove unused arguments from usePaymentCompleteHandler
+
+

--- a/client/checkout/blocks/hooks.js
+++ b/client/checkout/blocks/hooks.js
@@ -14,8 +14,6 @@ import {
 
 export const usePaymentCompleteHandler = (
 	api,
-	stripe,
-	elements,
 	onCheckoutSuccess,
 	emitResponse,
 	shouldSavePayment
@@ -33,7 +31,7 @@ export const usePaymentCompleteHandler = (
 			),
 		// not sure if we need to disable this, but kept it as-is to ensure nothing breaks. Please consider passing all the deps.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ elements, stripe, api, shouldSavePayment ]
+		[ api, shouldSavePayment ]
 	);
 };
 

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	PaymentElement,
-	useElements,
-	useStripe,
-} from '@stripe/react-stripe-js';
+import { PaymentElement, useElements } from '@stripe/react-stripe-js';
 import {
 	getPaymentMethods,
 	// eslint-disable-next-line import/no-unresolved
@@ -70,7 +66,6 @@ const PaymentProcessor = ( {
 	onLoadError = noop,
 	theme,
 } ) => {
-	const stripe = useStripe();
 	const elements = useElements();
 	const hasLoadErrorRef = useRef( false );
 	const linkCleanupRef = useRef( null );
@@ -269,8 +264,6 @@ const PaymentProcessor = ( {
 
 	usePaymentCompleteHandler(
 		api,
-		stripe,
-		elements,
 		onCheckoutSuccess,
 		emitResponse,
 		shouldSavePayment

--- a/client/checkout/blocks/saved-token-handler.js
+++ b/client/checkout/blocks/saved-token-handler.js
@@ -8,8 +8,6 @@ import { removeLinkButton } from '../stripe-link';
 
 export const SavedTokenHandler = ( {
 	api,
-	stripe,
-	elements,
 	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 } ) => {
@@ -38,8 +36,6 @@ export const SavedTokenHandler = ( {
 	// Once the server has completed payment processing, confirm the intent of necessary.
 	usePaymentCompleteHandler(
 		api,
-		stripe,
-		elements,
 		onCheckoutSuccess,
 		emitResponse,
 		false // No need to save a payment that has already been saved.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that `usePaymentCompleteHandler` receives two arguments that it never uses: `stripe` and `elements`.

Since it doesn't use those arguments, we can clean them up and further clean up its consumers.

If you look at `SavedTokenHandler`, it should receive `stripe` and `elements`, but they're not arguments that are being provided anywhere, neither from us, nor from the checkout blocks.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This change should only affect the block-based checkout.

I think we can reduce the scope to testing the block-based checkout process with (and without) saved cards.
Which is what I tested. But please let me know if further attention should be needed elsewhere!

- Add some products to the cart
- Navigate to the block-based checkout
- Click on the "Cards" payment method
- Use the `4000000000000002` card
  - Checkout should fail with "Your card was declined"
- Use the `4000002760003184` card
  - Click on "Save payment information to my account for future purchases" to mark the checkbox as checked
  - Place the order
  - Click "confirm" on the dialog
  - Checkout should succeed
- Add more products to the cart
- Navigate to the block-based checkout
- Use the saved `3184` Visa card from earlier
  - Place the order
  - Click on "Fail"
  - Checkout should fail with "We are unable to authenticate your payment method. Please choose a different payment method and try again"
  - Place the order again
  - Click on "Complete"
  - Checkout should succeed

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
