### PR TITLE
Adds a job to notify product ambassadors of next release

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -141,3 +141,42 @@ jobs:
                 }
               ]
             }
+
+  notify-product-ambassadors:
+    name: "Notify Product Ambassadors"
+    needs: [check-code-freeze, create-release-pr]
+    if: needs.check-code-freeze.outputs.freeze == 1 && needs.create-release-pr.outputs.release-pr-id != ''
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.check-code-freeze.outputs.nextReleaseVersion }}
+    steps:
+      - name: "Ping Product Ambassadors on Release PR"
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const prNumber = parseInt('${{ needs.create-release-pr.outputs.release-pr-id }}');
+              const productAmbassadors = '${{ secrets.PRODUCT_AMBASSADOR_GITHUB_HANDLE }}';
+
+              const commentBody = `
+              👋 Hey ${productAmbassadors}!
+
+              This is an automated notification for the release ${process.env.RELEASE_VERSION}. Could you please:
+              1. Review the scope of changes in this release from a Happiness Engineer's perspective
+              2. Let us know if any additional actions are needed to prepare HEs for this upcoming release
+              3. Provide your final checkoff, confirming whether anything needs to be announced to other HEs
+
+              Thanks for helping ensure our HE team is well-prepared for this release! 🙌`;
+
+              const response = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              console.log(`Product Ambassador notification posted at: ${response.data.html_url}`);
+            } catch (error) {
+              core.setFailed(`Failed to notify Product Ambassador: ${error.message}`);
+            }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This draft represents my attempt to automate the step of pinging the product ambassadors to review the next release from a HE's perspective. I missed this step during my last release, so I thought automating the process could help us not miss this step again in the future.

Note I'm not familiar with Github Actions so I asked Cursor to help me with the implementation.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Will add them in case we decide to move forward with this draft.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
