### PR TITLE
Make Survey Deactivation Modal Scrollable

### DIFF
--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -67,6 +67,10 @@
 	background-image: url( '../images/cards/visa.svg' );
 }
 
+.payment-method__brand--alipay {
+	background-image: url( '../images/payment-methods/alipay-logo.svg' );
+}
+
 .payment-method__brand--cartes_bancaires {
 	background-image: url( '../images/cards/cartes_bancaires.svg' );
 }
@@ -133,6 +137,14 @@
 
 .payment-method__brand--klarna {
 	background-image: url( '../images/payment-methods/klarna.svg' );
+}
+
+.payment-method__brand--grabpay {
+	background-image: url( '../images/payment-methods/grabpay.svg' );
+}
+
+.payment-method__brand--wechat_pay {
+	background-image: url( '../images/payment-methods/wechat-pay.svg' );
 }
 
 .wc_gateways tr[data-gateway_id='woocommerce_payments'] .payment-method__icon {

--- a/changelog/dev-fix-broken-survey
+++ b/changelog/dev-fix-broken-survey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where survey modal is not scrollable on smaller screen sizes.

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -225,6 +225,10 @@ declare global {
 		siteTitle: string;
 	};
 
+	const wcpayPluginSettings: {
+		exitSurveyLastShown: string | null;
+	};
+
 	interface WcSettings {
 		ece_data?: WCPayExpressCheckoutParams;
 		woocommerce_payments_data: typeof wcpaySettings;
@@ -245,5 +249,6 @@ declare global {
 		wc: typeof wc;
 		wcTracks: typeof wcTracks;
 		wcSettings: typeof wcSettings;
+		wcpayPluginSettings?: typeof wcpayPluginSettings;
 	}
 }

--- a/client/plugins-page/deactivation-survey/index.tsx
+++ b/client/plugins-page/deactivation-survey/index.tsx
@@ -12,11 +12,20 @@ import './style.scss';
 import Loadable from 'wcpay/components/loadable';
 import WooPaymentsIcon from 'assets/images/woopayments.svg?asset';
 
-const PluginDisableSurvey = ( { onRequestClose } ) => {
+interface PluginDisableSurveyProps {
+	/**
+	 * Callback to close the modal.
+	 */
+	onRequestClose: () => void;
+}
+const PluginDisableSurvey = ( {
+	onRequestClose,
+}: PluginDisableSurveyProps ) => {
 	const [ isLoading, setIsLoading ] = useState( true );
 
 	return (
 		<Modal
+			// @ts-expect-error - The Modal component expects a string but we're intentionally using a React element.
 			title={
 				<img
 					src={ WooPaymentsIcon }

--- a/client/plugins-page/deactivation-survey/style.scss
+++ b/client/plugins-page/deactivation-survey/style.scss
@@ -5,7 +5,6 @@
 
 	.components-modal__content {
 		padding: 0;
-		overflow: hidden;
 	}
 
 	&-iframe {


### PR DESCRIPTION
Fixes #9352 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update to fix an issue where the survey modal is not scrollable, preventing the survey from being submitted on smaller screens.

https://github.com/user-attachments/assets/1bcadd72-e0b6-434f-ac62-ad66ed64fad9

#### Testing instructions

* Spin up a new JN site from this branch.
* Go to `Plugins` and click `Deactivate` on the WooPayments plugin.
* The modal should show. Reduce the window size of your browser until the content does not fit. Ensure you can scroll to see the full modal content. 
* Submit the modal survey, and ensure that it is able to be submitted.
* Refresh the page, reactivate WooPayments, then try and disable it again. The modal should no longer show (because it's already been submitted or dismissed recently).
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
