### PR TITLE
Add the positive feedback modal to encourage merchants to leave a .org review

### DIFF
--- a/changelog/add-10327-merchant-feedback-prompt-positive-modal
+++ b/changelog/add-10327-merchant-feedback-prompt-positive-modal
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Behind a feature flag: Add a positive feedback modal when users click Yes in the merchant feedback prompt snackbar.
+
+

--- a/client/merchant-feedback-prompt/index.tsx
+++ b/client/merchant-feedback-prompt/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import {
 	Button,
@@ -223,17 +223,13 @@ export function MaybeShowMerchantFeedbackPrompt() {
 		);
 	}
 
-	const isAccountEligible =
-		wcpaySettings?.featureFlags?.isMerchantFeedbackPromptDevFlagEnabled &&
-		wcpaySettings?.accountStatus?.campaigns?.wporgReview2025;
-
-	if ( hasUserDismissed || ! isAccountEligible ) {
+	if ( hasUserDismissedPrompt || ! isAccountEligible ) {
 		return null;
 	}
 
 	return (
 		<MerchantFeedbackPrompt
-			dismissPrompt={ () => setHasUserDismissed( true ) }
+			dismissPrompt={ dismissPrompt }
 			showPositiveFeedbackModal={ () =>
 				setIsPositiveFeedbackModalOpen( true )
 			}

--- a/client/merchant-feedback-prompt/index.tsx
+++ b/client/merchant-feedback-prompt/index.tsx
@@ -209,7 +209,7 @@ export function MaybeShowMerchantFeedbackPrompt() {
 	const [
 		isPositiveFeedbackModalOpen,
 		setIsPositiveFeedbackModalOpen,
-	] = useState( true );
+	] = useState( false );
 
 	if ( isPositiveFeedbackModalOpen ) {
 		return (

--- a/client/merchant-feedback-prompt/index.tsx
+++ b/client/merchant-feedback-prompt/index.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { recordEvent } from 'wcpay/tracks';
+import { PositiveFeedbackModal } from './positive-modal';
 import './style.scss';
 
 /**
@@ -54,6 +55,8 @@ const WCFooterPortal = ( { children }: { children: React.ReactNode } ) => {
 interface MerchantFeedbackPromptProps {
 	/** A function to be called when the user dismisses the prompt and it is to be removed. */
 	dismissPrompt: () => void;
+	/** A function to be called when the user clicks the "Yes" button and the positive feedback modal is to be shown. */
+	showPositiveFeedbackModal: () => void;
 }
 
 /**
@@ -64,6 +67,7 @@ interface MerchantFeedbackPromptProps {
  */
 const MerchantFeedbackPrompt: React.FC< MerchantFeedbackPromptProps > = ( {
 	dismissPrompt,
+	showPositiveFeedbackModal,
 } ) => {
 	// Get the core notices, which we'll use to ensure we're not rendering the prompt if there are other notices being displayed.
 	const coreNotices = useSelect(
@@ -113,6 +117,7 @@ const MerchantFeedbackPrompt: React.FC< MerchantFeedbackPromptProps > = ( {
 											recordEvent(
 												'wcpay_merchant_feedback_prompt_yes_click'
 											);
+											showPositiveFeedbackModal();
 											dismissPrompt();
 										} }
 									>
@@ -201,6 +206,19 @@ export function MaybeShowMerchantFeedbackPrompt() {
 	// TODO: This is a temporary local state to track if the prompt has been dismissed. Move to a user-persistent state in #10329.
 	const [ hasUserDismissed, setHasUserDismissed ] = useState( false );
 
+	const [
+		isPositiveFeedbackModalOpen,
+		setIsPositiveFeedbackModalOpen,
+	] = useState( true );
+
+	if ( isPositiveFeedbackModalOpen ) {
+		return (
+			<PositiveFeedbackModal
+				onRequestClose={ () => setIsPositiveFeedbackModalOpen( false ) }
+			/>
+		);
+	}
+
 	const isAccountEligible =
 		wcpaySettings?.featureFlags?.isMerchantFeedbackPromptDevFlagEnabled &&
 		wcpaySettings?.accountStatus?.campaigns?.wporgReview2025;
@@ -212,6 +230,9 @@ export function MaybeShowMerchantFeedbackPrompt() {
 	return (
 		<MerchantFeedbackPrompt
 			dismissPrompt={ () => setHasUserDismissed( true ) }
+			showPositiveFeedbackModal={ () =>
+				setIsPositiveFeedbackModalOpen( true )
+			}
 		/>
 	);
 }

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -141,7 +141,7 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 				</Button>
 				<Button
 					variant="primary"
-					href="https://wordpress.org/support/plugin/woocommerce-payments/reviews/"
+					href="https://wordpress.org/support/plugin/woocommerce-payments/reviews/#new-post"
 					target="_blank"
 					onClick={ () => {
 						recordEvent(

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -38,7 +38,6 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 			shouldCloseOnClickOutside
 			shouldCloseOnEsc
 			onRequestClose={ () => {
-				// Record tracks event
 				recordEvent(
 					'wcpay_merchant_feedback_prompt_positive_modal_close_click'
 				);
@@ -132,7 +131,6 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 				<Button
 					variant="tertiary"
 					onClick={ () => {
-						// Record tracks event
 						recordEvent(
 							'wcpay_merchant_feedback_prompt_positive_modal_close_click'
 						);
@@ -146,7 +144,6 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 					href="https://wordpress.org/support/plugin/woocommerce-payments/reviews/"
 					target="_blank"
 					onClick={ () => {
-						// Record tracks event
 						recordEvent(
 							'wcpay_merchant_feedback_prompt_positive_modal_leave_review_click'
 						);

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -47,7 +47,7 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 		>
 			<p>
 				{ __(
-					'Thanks for sharing your feedback on WooPayments! Would you mind leave us a quick review on WordPress.org?',
+					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a quick review on WordPress.org?',
 					'woocommerce-payments'
 				) }
 			</p>

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
+import {
+	Icon,
+	commentContent,
+	people,
+	reusableBlock,
+	external,
+} from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'wcpay/tracks';
+import './style.scss';
+
+interface PositiveFeedbackModalProps {
+	onRequestClose: () => void;
+}
+
+export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
+	onRequestClose,
+} ) => {
+	// Record tracks event when the modal is opened.
+	useEffect( () => {
+		recordEvent( 'wcpay_merchant_feedback_prompt_positive_modal_view' );
+	}, [] );
+
+	return (
+		<Modal
+			title={ __( 'Share your feedback', 'woocommerce-payments' ) }
+			className="wcpay-merchant-feedback-positive-modal"
+			isDismissible
+			shouldCloseOnClickOutside
+			shouldCloseOnEsc
+			onRequestClose={ () => {
+				// Record tracks event
+				recordEvent(
+					'wcpay_merchant_feedback_prompt_positive_modal_close_click'
+				);
+				onRequestClose();
+			} }
+		>
+			<p>
+				{ __(
+					'Thanks for sharing your feedback on WooPayments! Would you mind leave us a quick review on WordPress.org?',
+					'woocommerce-payments'
+				) }
+			</p>
+			<p>
+				<strong>
+					{ __(
+						`Here's why your review matters:`,
+						'woocommerce-payments'
+					) }
+				</strong>
+			</p>
+			<Flex justify="flex-start" align="flex-start" gap={ 4 }>
+				<FlexItem>
+					<p>
+						<Icon icon={ reusableBlock } />
+					</p>
+				</FlexItem>
+				<FlexItem>
+					<p>
+						<strong>
+							{ __(
+								'Help other businesses succeed',
+								'woocommerce-payments'
+							) }
+						</strong>
+					</p>
+					<p>
+						{ __(
+							'Your insights guide others in choosing the right payment solution.',
+							'woocommerce-payments'
+						) }
+					</p>
+				</FlexItem>
+			</Flex>
+			<Flex justify="flex-start" align="flex-start" gap={ 4 }>
+				<FlexItem>
+					<p>
+						<Icon icon={ commentContent } />
+					</p>
+				</FlexItem>
+				<FlexItem>
+					<p>
+						<strong>
+							{ __(
+								'Shape our roadmap',
+								'woocommerce-payments'
+							) }
+						</strong>
+					</p>
+					<p>
+						{ __(
+							'Your feedback inspires us to create new features and refine existing ones to better serve you.',
+							'woocommerce-payments'
+						) }
+					</p>
+				</FlexItem>
+			</Flex>
+			<Flex justify="flex-start" align="flex-start" gap={ 4 }>
+				<FlexItem>
+					<p>
+						<Icon icon={ people } />
+					</p>
+				</FlexItem>
+				<FlexItem>
+					<p>
+						<strong>
+							{ __(
+								'Supporting the WooCommerce community',
+								'woocommerce-payments'
+							) }
+						</strong>
+					</p>
+					<p>
+						{ __(
+							'Sharing your experience strengthens the tools that empower your fellow entrepreneurs.',
+							'woocommerce-payments'
+						) }
+					</p>
+				</FlexItem>
+			</Flex>
+			<Flex justify="flex-end" gap={ 2 }>
+				<Button
+					variant="tertiary"
+					onClick={ () => {
+						// Record tracks event
+						recordEvent(
+							'wcpay_merchant_feedback_prompt_positive_modal_close_click'
+						);
+						onRequestClose();
+					} }
+				>
+					{ __( 'Close', 'woocommerce-payments' ) }
+				</Button>
+				<Button
+					variant="primary"
+					href="https://wordpress.org/support/plugin/woocommerce-payments/reviews/"
+					target="_blank"
+					onClick={ () => {
+						// Record tracks event
+						recordEvent(
+							'wcpay_merchant_feedback_prompt_positive_modal_leave_review_click'
+						);
+					} }
+				>
+					{ __( 'Leave a review', 'woocommerce-payments' ) }&nbsp;
+					<Icon icon={ external } size={ 16 } />
+				</Button>
+			</Flex>
+		</Modal>
+	);
+};

--- a/client/merchant-feedback-prompt/style.scss
+++ b/client/merchant-feedback-prompt/style.scss
@@ -23,3 +23,9 @@
 		}
 	}
 }
+
+.wcpay-merchant-feedback-positive-modal {
+	.components-modal__content {
+		max-width: 600px;
+	}
+}

--- a/client/merchant-feedback-prompt/test/index.test.tsx
+++ b/client/merchant-feedback-prompt/test/index.test.tsx
@@ -184,7 +184,7 @@ describe( 'MerchantFeedbackPrompt', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'records event when Yes button is clicked', () => {
+	it( 'opens the positive feedback modal and records event when Yes button is clicked', () => {
 		render( <MaybeShowMerchantFeedbackPrompt /> );
 
 		// Click the Yes button
@@ -200,6 +200,12 @@ describe( 'MerchantFeedbackPrompt', () => {
 		expect(
 			screen.queryByText( 'Are you satisfied with WooPayments?' )
 		).not.toBeInTheDocument();
+
+		// The positive feedback modal should be rendered
+		expect( screen.getByText( 'Share your feedback' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /Would you mind leaving us a quick review/ )
+		).toBeInTheDocument();
 	} );
 
 	it( 'records event when No button is clicked', () => {


### PR DESCRIPTION
Fixes #10327

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR shows the positive feedback modal when a merchants click "Yes" in the merchant feedback snackbar prompt (#10323).

See design in Figma NgNHoJR3z8t8OwxJ5FshIY-fi-11_24061

![image](https://github.com/user-attachments/assets/272c158b-280e-41bc-9104-72e8694e70e5)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the dev feature flag `_wcpay_feature_prompt_merchant_for_review`.
	* `update_option( '_wcpay_feature_prompt_merchant_for_review', '1' )`
* Ensure your store meets the campaign eligibility criteria, or manually set `'wporgReview2025' => true` [here](https://github.com/Automattic/woocommerce-payments/blob/61fc121aec4d5718734f5a720517e694875c70de/includes/class-wc-payments-account.php#L378)
	- Lifetime TPV > $1,000 USD
	- 5+ completed payouts
	- Account in good standing (not suspended/rejected)
* Visit Payments → Overview.
* Ensure you see the new snackbar prompt.
* Click "Yes"
* Ensure the presented modal, icons and wording matches the design closely
* Ensure closing the modal works as expected
* Ensure tracks events are well named and are recorded on all interations
* Click "Write a review" and check that this link is the correct destination for this project's goal.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.