### PR TITLE
WooPay: Skip email input search in pay for order flow and use email provided in order data

### DIFF
--- a/changelog/fix-woopay-in-pay-for-order-flow
+++ b/changelog/fix-woopay-in-pay-for-order-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Skip email input search in pay for order flow and use email provided in order data for WooPay iframe.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -22,6 +22,12 @@ export const handleWooPayEmailInput = async (
 	api,
 	isBlocksCheckout = false
 ) => {
+	const isPayForOrder = window.wcpayConfig?.pay_for_order === 'true';
+
+	if ( isPayForOrder ) {
+		return;
+	}
+
 	let timer;
 	const waitTime = 500;
 	const woopayEmailInput = await getTargetElement( field );

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -20,8 +20,19 @@ import { getTracksIdentity } from 'tracks';
 import { getAppearance } from 'wcpay/checkout/upe-styles';
 import { getAppearanceType } from 'wcpay/checkout/utils';
 
+const getEmailValue = async ( emailSelector ) => {
+	const isPayForOrder = window.wcpayConfig?.pay_for_order === 'true';
+
+	if ( isPayForOrder ) {
+		return window.wcpayCustomerData?.email;
+	}
+
+	const emailInput = await getTargetElement( emailSelector );
+
+	return emailInput?.value;
+};
+
 export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
-	const woopayEmailInput = await getTargetElement( emailSelector );
 	const tracksUserID = await getTracksIdentity();
 	let userEmail = '';
 
@@ -289,5 +300,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 	}
 
-	openIframe( woopayEmailInput?.value || getConfig( 'woopaySessionEmail' ) );
+	const email = await getEmailValue( emailSelector );
+
+	openIframe( email || getConfig( 'woopaySessionEmail' ) );
 };

--- a/client/checkout/woopay/express-button/test/express-checkout-iframe.test.js
+++ b/client/checkout/woopay/express-button/test/express-checkout-iframe.test.js
@@ -27,6 +27,12 @@ describe( 'expressCheckoutIframe', () => {
 		getConfig.mockReturnValue( 'http://example.com' );
 	} );
 
+	afterEach( () => {
+		document.body.removeChild(
+			document.querySelector( '.woopay-otp-iframe-wrapper' )
+		);
+	} );
+
 	test( 'should open the iframe', async () => {
 		expressCheckoutIframe( api, null, '#email' );
 
@@ -35,6 +41,75 @@ describe( 'expressCheckoutIframe', () => {
 
 			expect( woopayIframe.className ).toContain( 'woopay-otp-iframe' );
 			expect( woopayIframe.src ).toContain( 'http://example.com/otp/' );
+		} );
+	} );
+
+	describe( 'when an email input is present', () => {
+		beforeEach( () => {
+			const emailInput = document.createElement( 'input' );
+			emailInput.setAttribute( 'id', 'email' );
+			emailInput.value = 'test@example.com';
+			document.body.appendChild( emailInput );
+		} );
+
+		afterEach( () => {
+			document.body.removeChild( document.querySelector( '#email' ) );
+		} );
+
+		test( 'should open the iframe when an email is present', async () => {
+			expressCheckoutIframe( api, null, '#email' );
+
+			await waitFor( () => {
+				const woopayIframe = document.querySelector( 'iframe' );
+
+				expect( woopayIframe.className ).toContain(
+					'woopay-otp-iframe'
+				);
+				expect( woopayIframe.src ).toContain(
+					'http://example.com/otp/'
+				);
+				expect( woopayIframe.src ).toContain(
+					'email=test%40example.com'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'pay for order flow is used', () => {
+		let oldWcpayConfig;
+		let oldWcpayCustomerData;
+		beforeEach( () => {
+			oldWcpayConfig = window.wcpayConfig;
+			oldWcpayCustomerData = window.wcpayCustomerData;
+			window.wcpayConfig = {
+				pay_for_order: 'true',
+			};
+			window.wcpayCustomerData = {
+				email: 'payfororder@example.com',
+			};
+		} );
+
+		afterEach( () => {
+			window.wcpayConfig = oldWcpayConfig;
+			window.wcpayCustomerData = oldWcpayCustomerData;
+		} );
+
+		test( 'should open the iframe when an email is present', async () => {
+			expressCheckoutIframe( api, null, '#email' );
+
+			await waitFor( () => {
+				const woopayIframe = document.querySelector( 'iframe' );
+
+				expect( woopayIframe.className ).toContain(
+					'woopay-otp-iframe'
+				);
+				expect( woopayIframe.src ).toContain(
+					'http://example.com/otp/'
+				);
+				expect( woopayIframe.src ).toContain(
+					'email=payfororder%40example.com'
+				);
+			} );
 		} );
 	} );
 } );

--- a/client/checkout/woopay/express-button/test/express-checkout-iframe.test.js
+++ b/client/checkout/woopay/express-button/test/express-checkout-iframe.test.js
@@ -111,5 +111,17 @@ describe( 'expressCheckoutIframe', () => {
 				);
 			} );
 		} );
+
+		test( 'should handle missing email in wcpayCustomerData', async () => {
+			// Remove email from customer data
+			window.wcpayCustomerData = {};
+
+			expressCheckoutIframe( api, null, '#email' );
+
+			await waitFor( () => {
+				const woopayIframe = document.querySelector( 'iframe' );
+				expect( woopayIframe.src ).not.toContain( 'email=' );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #10408

#### Changes proposed in this Pull Request

Since email inputs don't exist in the Pay For Order flow, we should be able to skip them and use the order data directly. This also prevents a bug when Blocks Checkout is enabled that caused the iframe to never open.

#### Testing instructions
- Enable WooPay in the WooPayments settings.
- Use blocks checkout in your checkout page. If you have multiple checkout pages, make sure that the one using blocks is set in WooCommerce > Settings > Advanced > Checkout page.
- In WP Admin, manually add a new order, in the billing information set any email address.
- When the order is created, it should be in the Pending Payment status, click on the `Customer payment page` click (if you have issues you can copy the link and open it in an incognito window).
![Image](https://github.com/user-attachments/assets/e2648fbc-14e2-4005-b12d-e72b8e75c23f)

### Previous behavior
- Once Pay For Order loads, click on the WooPay button.
- Even if you click it multiple times, nothing will happen.
![Image](https://github.com/user-attachments/assets/73042211-23cb-4169-bef2-39e38d464101)

### Fixed behavior
- Once Pay For Order loads, click on the WooPay button.
- The WooPay iframe should load in a modal.
- The provided email address in the order should be pre-loaded.
![Image](https://github.com/user-attachments/assets/583a088b-afc4-40c7-948d-8a9d519847d5)
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
