### PR TITLE
update: tokenized ECE log on session mismatch

### DIFF
--- a/changelog/update-tokenized-ece-session-mismatch-logs
+++ b/changelog/update-tokenized-ece-session-mismatch-logs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: update: add debug to help with tokenized ECE session mismatch
+
+

--- a/includes/class-wc-payments-payment-request-session-handler.php
+++ b/includes/class-wc-payments-payment-request-session-handler.php
@@ -51,6 +51,17 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 		$this->init_session_cookie();
 
 		if ( $this->_customer_id !== $this->_data['token_customer_id'] ) {
+			\WCPay\Logger::error(
+				sprintf(
+					'Tokenized ECE cookie and session customer mismatch - customer: %s (%s) , session: %s (%s)',
+					var_export( $this->_customer_id, true ), // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- should only be triggered when logging is enabled.
+					gettype( $this->_customer_id ),
+					var_export( $this->_data['token_customer_id'], true ), // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- should only be triggered when logging is enabled.
+					gettype( $this->_data['token_customer_id'] )
+				)
+			);
+
+			// throwing an exception here to prevent further processing of the request.
 			throw new Exception( __( 'Invalid token: cookie and session customer mismatch', 'woocommerce-payments' ) );
 		}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I'd like to add some logging information to further investigate why https://github.com/Automattic/woocommerce-payments/issues/10488 might be happening.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

We still don't know when the error might be happening. So, manually modify https://github.com/Automattic/woocommerce-payments/blob/ff698a9f56f319517301dd8e007a528e4aa0e3c2/includes/class-wc-payments-payment-request-session-handler.php#L53-L53 to add `true ||` so that the error is triggered

- Go to a product page (it won't be triggered on cart/checkout
- Click on the ECE (Google Pay/ApplePay) button
- Notice the errors in the logs
<img width="1430" alt="Screenshot 2025-03-05 at 7 23 26 PM" src="https://github.com/user-attachments/assets/7c5d6cb2-4080-4006-aa9d-4ace2a95e018" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
