### PR TITLE
Send the store's URL to Stripe when the coming soon flag is removed

### DIFF
--- a/changelog/add-inform-stripe-when-site-goes-live
+++ b/changelog/add-inform-stripe-when-site-goes-live
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Inform Stripe when a store switch from coming soon to live mode

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -198,7 +198,10 @@ class WC_Payments_Admin {
 		// If the store is transitioning from coming soon to live, Stripe should be notified.
 		// This is triggered by updating the account business URL.
 		if ( 'no' === $coming_soon_new_value && $coming_soon_value !== $coming_soon_new_value ) {
-			$this->wcpay_gateway->update_account_settings( [ 'account_business_url' => $this->account->get_business_url() ] );
+			$response = $this->wcpay_gateway->update_account_settings( [ 'account_business_url' => $this->account->get_business_url() ] );
+			if ( is_wp_error( $response ) ) {
+				Logger::error( 'Failed to update account business URL.' );
+			}
 		}
 	}
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Identity_Crisis as Jetpack_Identity_Crisis;
+use Automattic\WooCommerce\Admin\Features\Features;
 use WCPay\Constants\Intent_Status;
 use WCPay\Core\Server\Request;
 use WCPay\Database_Cache;
@@ -169,6 +170,36 @@ class WC_Payments_Admin {
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_woopay_payment_method_name_admin' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_wcpay_transaction_fee' ] );
 		add_action( 'admin_init', [ $this, 'redirect_deposits_to_payouts' ] );
+		add_action( 'woocommerce_update_options_site-visibility', [ $this, 'inform_stripe_when_store_goes_live' ] );
+	}
+
+	/**
+	 * When a store transitions to live mode, we need to notify Stripe to trigger necessary verification checks.
+	 *
+	 * @return void
+	 */
+	public function inform_stripe_when_store_goes_live() {
+
+		$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
+		// New Settings API uses wp_rest nonce.
+		$nonce_string = Features::is_enabled( 'settings' ) ? 'wp_rest' : 'woocommerce-settings';
+		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, $nonce_string ) ) {
+			return;
+		}
+
+		// If an account is not connected, we can skip this.
+		if ( ! $this->account->is_stripe_connected() ) {
+			return;
+		}
+
+		$coming_soon_value     = get_option( 'woocommerce_coming_soon' );
+		$coming_soon_new_value = sanitize_text_field( wp_unslash( $_POST['woocommerce_coming_soon'] ) );
+
+		// If the store is transitioning from coming soon to live, Stripe should be notified.
+		// This is triggered by updating the account business URL.
+		if ( 'no' === $coming_soon_new_value && $coming_soon_value !== $coming_soon_new_value ) {
+			$this->wcpay_gateway->update_account_settings( [ 'account_business_url' => $this->account->get_business_url() ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes 7297-gh-Automattic/transact-platform-server

#### Changes proposed in this Pull Request
For Stripe to run their KYC, they need access to a public store. The WooCommerce "coming soon" flag makes the store private, which makes it impossible for Stripe to run the KYC.
In this PR a trigger is implemented for Stripe to run their checks. We do this by re-seding the account business URL to Stripe.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Onboard an account
* Go to Site visibility ( /wp-admin/admin.php?page=wc-settings&tab=site-visibility )
* Set the store  to "Coming soon" and save the settings
* Go to Stripe dashboard and modify the website in the "Contact information" section of the account
* Switch back to live mode
* Check the platform logs, you should see an update account request with the account business url param. 
* Check the Stripe dashboard. The Website field should be updated with the previous URL.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
