### PR TITLE
Revert using reversed_url for wpcom_url provided by Jetpack

### DIFF
--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -355,15 +355,6 @@ function wcpay_get_jetpack_idc_custom_content(): array {
 	$urls = Automattic\Jetpack\Identity_Crisis::get_mismatched_urls();
 	if ( false !== $urls ) {
 		$current_url = untrailingslashit( $urls['current_url'] );
-		/**
-		 * Undo the reverse the Jetpack IDC library is doing since we want to display the URL.
-		 *
-		 * @see https://github.com/Automattic/jetpack-identity-crisis/blob/trunk/src/class-identity-crisis.php#L471
-		 */
-		$idc_sync_error = Automattic\Jetpack\Identity_Crisis::check_identity_crisis();
-		if ( is_array( $idc_sync_error ) && ! empty( $idc_sync_error['reversed_url'] ) ) {
-			$urls['wpcom_url'] = strrev( $urls['wpcom_url'] );
-		}
 		$wpcom_url = untrailingslashit( $urls['wpcom_url'] );
 
 		$custom_content['migrateCardBodyText'] = sprintf(


### PR DESCRIPTION

Fixes #

Looking at [Jetpack code](https://github.com/Automattic/jetpack/blob/06cda771335eca520400af8dd2c13a3769b75e9f/projects/packages/connection/src/identity-crisis/class-identity-crisis.php#L501-L506), we expect that Jetpack should return reversed URLs but it seems Jetpack is no longer do so. 

If #10511 is applied properly, the reversed URL is being used for the original site address: 

![Markup on 2025-03-10 at 10:51:26](https://github.com/user-attachments/assets/57e6e5e0-2a21-4002-b467-6eeefe516cc9)


#### Changes proposed in this Pull Request

This actually reverts PR #8033 as we no longer need this anymore. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
