### PR TITLE
Remove annoying merchant feedback prompt animation on navigation

### DIFF
--- a/changelog/fix-10482-remove-merchant-feedback-prompt-animations
+++ b/changelog/fix-10482-remove-merchant-feedback-prompt-animations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Behind a feature flag: this modified the behaviour of the merchant feedback prompt which is in development. Changelog entry coming for this feature when release planned.
+
+

--- a/client/merchant-feedback-prompt/style.scss
+++ b/client/merchant-feedback-prompt/style.scss
@@ -9,6 +9,19 @@
 	margin-bottom: $gap-small;
 	width: auto;
 
+	// Prevent SnackbarList animations to reduce annoying animations on each page transition.
+	// Required due to the React portal workaround used to render the prompt in the WC footer.
+	&.components-snackbar-list {
+		&__notice-container,
+		> div {
+			transition: none !important;
+			animation: none !important;
+			transform: none !important;
+			opacity: 1 !important;
+			height: auto !important;
+		}
+	}
+
 	.wcpay-merchant-feedback-prompt {
 		&__action.components-button {
 			color: inherit;

--- a/client/merchant-feedback-prompt/style.scss
+++ b/client/merchant-feedback-prompt/style.scss
@@ -9,7 +9,7 @@
 	margin-bottom: $gap-small;
 	width: auto;
 
-	// Prevent SnackbarList animations to reduce annoying animations on each page transition.
+	// Prevent SnackbarList animations to reduce annoyance on each page transition.
 	// Required due to the React portal workaround used to render the prompt in the WC footer.
 	&.components-snackbar-list {
 		&__notice-container,


### PR DESCRIPTION
Fixes #10482

#### Changes proposed in this Pull Request

This PR stops the merchant feedback prompt snackbar entry/exist animation, reducing the distraction/annoyance that occurs when navigating through WooPayments pages.

Removing this animation reduces the risk of the merchant dismissing the prompt due to annoyance.

One tradeoff with disabling animation entirely is that the presence of the snackbar may not be as obvious to a user.

An **alternate/extension to this approach** could be to allow animation of first render, temporarily storing this "rendered" state as a global var, and removing animation if this "rendered" state exists. This may be overly complex for the problem at hand, therefore I've opted for a simple complete animation removal in this PR.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the dev feature flag `_wcpay_feature_prompt_merchant_for_review`.
	* `update_option( '_wcpay_feature_prompt_merchant_for_review', '1' )`
* Ensure your store meets the campaign eligibility criteria, or manually set `'wporgReview2025' => true` [here](https://github.com/Automattic/woocommerce-payments/blob/61fc121aec4d5718734f5a720517e694875c70de/includes/class-wc-payments-account.php#L378)
	- Lifetime TPV > $1,000 USD
	- 5+ completed payouts
	- Account in good standing (not suspended/rejected)
* Visit Payments → Overview.
* Ensure you see the new snackbar prompt and it does not animate on entry (no size / position / opacity transition.
* Navigate to Payments  → Transactions. Ensure the snackbar prompt remains visible, but does not animate.
* Ensure other snackbar animations are not affected (e.g. Transactions List → Download).


#### Before

https://github.com/user-attachments/assets/a42090fe-4fcb-474e-b301-835dc18e0817

#### After 

https://github.com/user-attachments/assets/3e7b4ce7-f26e-4195-9846-904e2380712d



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A**
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : **QA Testing Not Applicable** since eligibility is difficult to prepare, manual internal testing is suitable.
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **Not a critical flow**
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. **What's new in 9.1.0 post: paJDYF-gXj-p2**
