### PR TITLE
Remove AddPaymentMethodsTask reliance on upeMethods.

### DIFF
--- a/changelog/update-add-payment-methods-task-upemethods
+++ b/changelog/update-add-payment-methods-task-upemethods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Related to the conversion of Alipay to use a definition and just tweaks that implementation.
+
+

--- a/client/additional-methods-setup/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
@@ -32,7 +32,6 @@ import {
 
 import WCPaySettingsContext from '../../../settings/wcpay-settings-context';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
-import paymentMethodsMap from 'wcpay/payment-methods-map';
 
 jest.mock( '../../../data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
@@ -126,23 +125,6 @@ describe( 'AddPaymentMethodsTask', () => {
 			isMultiCurrencyEnabled: true,
 			storeCurrency: 'USD',
 			accountEmail: 'admin@example.com',
-		};
-		paymentMethodsMap.alipay = {
-			id: 'alipay',
-			label: 'Alipay',
-			description: 'Alipay description mock',
-			icon: ( { className } ) => (
-				<img
-					src="#not-found"
-					alt="Alipay icon mock"
-					className={ className }
-				/>
-			),
-			currencies: [],
-			stripe_key: 'alipay_payments',
-			allows_manual_capture: false,
-			allows_pay_later: false,
-			accepts_only_domestic_payment: false,
 		};
 	} );
 

--- a/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
@@ -37,7 +37,7 @@ import { LoadableBlock } from '../../components/loadable';
 import LoadableSettingsSection from '../../settings/loadable-settings-section';
 import CurrencyInformationForMethods from './currency-information-for-methods';
 import { getMissingCurrenciesTooltipMessage } from 'multi-currency/interface/functions';
-import { upeCapabilityStatuses, upeMethods } from '../constants';
+import { upeCapabilityStatuses } from '../constants';
 import paymentMethodsMap from '../../payment-methods-map';
 import ConfirmPaymentMethodActivationModal from 'wcpay/settings/payment-methods-list/activation-modal';
 import './add-payment-methods-task.scss';
@@ -155,7 +155,9 @@ const AddPaymentMethodsTask = () => {
 
 	useEffect( () => {
 		availablePaymentMethods
-			.filter( ( method ) => upeMethods.includes( method ) )
+			.filter(
+				( method ) => paymentMethodsMap[ method ] && method !== 'card'
+			)
 			.forEach( ( method ) => {
 				handlePaymentMethodChange( method, false );
 			} );
@@ -256,10 +258,15 @@ const AddPaymentMethodsTask = () => {
 		} );
 	};
 
-	const availableBuyNowPayLaterUpeMethods = upeMethods.filter(
-		( id ) =>
-			paymentMethodsMap[ id ].allows_pay_later &&
-			availablePaymentMethods.includes( id )
+	const availableUpeMethods = availablePaymentMethods.filter(
+		( method ) =>
+			paymentMethodsMap[ method ] &&
+			! paymentMethodsMap[ method ].allows_pay_later &&
+			method !== 'card' // Exclude the card payment method since it's rendered separately
+	);
+
+	const availableBuyNowPayLaterUpeMethods = availablePaymentMethods.filter(
+		( method ) => paymentMethodsMap[ method ]?.allows_pay_later
 	);
 
 	return (
@@ -342,11 +349,7 @@ const AddPaymentMethodsTask = () => {
 										name="card"
 									/>
 									{ prepareUpePaymentMethods(
-										upeMethods.filter(
-											( id ) =>
-												! paymentMethodsMap[ id ]
-													.allows_pay_later
-										)
+										availableUpeMethods
 									) }
 								</PaymentMethodCheckboxes>
 							</LoadableSettingsSection>


### PR DESCRIPTION
Fixes #10526 

#### Changes proposed in this Pull Request
It was discovered in #10501 that converting an existing payment method would require mocking that payment method's config in the test for `AddPaymentMethodsTask`. Obviously, this isn't scalable and we want to avoid needing to manually add configs when adding new payment methods (or converting existing ones). Fortunately, `paymentMethodsMap` is already in use in this file and contains enough information so we don't need to rely on the `upeMethods` constant.

This PR alters `AddPaymentMethodsTask` to utilize `paymentMethodsMap` where it was previously using `upeMethods`. One thing to keep in mind is that `paymentMethodsMap` contains the `card` payment method while `upeMethods` does not. So this PR makes sure to exclude `card` when necessary. It also updates the test for `AddPaymentMethodsTask` to not mock the Alipay config.

#### Testing instructions
* Make sure you're using the dev sandbox account on your server - Stripe gated Alipay for us on that account
* Make sure you have an updated payments server, and follow the instructions on PR # 7184
* Refresh the local account data via the dev tools
* I'd also recommend switching your store's currency to JPY (as an example - to ignore any USD/EUR currencies), and
* removing any additional currencies from the multi-currency settings
* Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fadditional-payment-methods`
* You should see Alipay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
