### PR TITLE
Add link to contact support in merchant feedback "No" modal

### DIFF
--- a/changelog/add-10543-merchant-feedback-negative-modal-support-link
+++ b/changelog/add-10543-merchant-feedback-negative-modal-support-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Behind feature flag: adds a support link to the merchant feedback prompt negative modal
+
+

--- a/client/merchant-feedback-prompt/negative-modal.tsx
+++ b/client/merchant-feedback-prompt/negative-modal.tsx
@@ -5,6 +5,8 @@ import React, { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
+import interpolateComponents from '@automattic/interpolate-components';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -69,6 +71,25 @@ export const NegativeFeedbackModal: React.FC< NegativeFeedbackModalProps > = ( {
 						{ __( 'privacy policy', 'woocommerce-payments' ) }
 					</a>
 					.
+				</p>
+				<p>
+					{ interpolateComponents( {
+						// translators: {{a}}: placeholders are opening and closing anchor tags.
+						mixedString: __(
+							`Need help with a specific issue? {{a}}Contact our support team{{/a}} for personalized assistance.`,
+							'woocommerce-payments'
+						),
+						components: {
+							a: (
+								<Link
+									// Link to the WooCommerce support form with WooPayments selected.
+									href="https://woocommerce.com/my-account/contact-support/?select=5278104"
+									type="external"
+									rel="noreferrer noopener"
+								/>
+							),
+						},
+					} ) }
 				</p>
 				<div className="wcpay-merchant-feedback-negative-modal__actions">
 					<button

--- a/client/merchant-feedback-prompt/negative-modal.tsx
+++ b/client/merchant-feedback-prompt/negative-modal.tsx
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -81,11 +80,17 @@ export const NegativeFeedbackModal: React.FC< NegativeFeedbackModalProps > = ( {
 						),
 						components: {
 							a: (
-								<Link
+								// eslint-disable-next-line jsx-a11y/anchor-has-content -- content is provided in the mixedString property above.
+								<a
 									// Link to the WooCommerce support form with WooPayments selected.
 									href="https://woocommerce.com/my-account/contact-support/?select=5278104"
-									type="external"
+									target="_blank"
 									rel="noreferrer noopener"
+									onClick={ () => {
+										recordEvent(
+											'wcpay_merchant_feedback_prompt_negative_modal_contact_support_click'
+										);
+									} }
 								/>
 							),
 						},


### PR DESCRIPTION
Fixes #10543

#### Changes proposed in this Pull Request

This PR adds a support link to the merchant feedback prompt's "No" feedback modal, encouraging merchants to contact support if they have a specific issue.

```
Need help with a specific issue? Contact our support team for personalized assistance.
```

The `Contact our support team` link forwards users to WooCommerce.com support with WooPayments pre-selected: `https://woocommerce.com/my-account/contact-support/?select=5278104`.

On click, a tracks event is recorded: [`wcadmin_wcpay_merchant_feedback_prompt_negative_modal_contact_support_click`](https://mc.a8c.com/tracks/events/event.php?eventname=wcadmin_wcpay_merchant_feedback_prompt_negative_modal_contact_support_click) – registered in PR https://github.com/Automattic/tracks-events-registration/pull/2792.

![image](https://github.com/user-attachments/assets/8f531593-0a8c-49f1-8922-88fc52f7f235)



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the dev feature flag `_wcpay_feature_prompt_merchant_for_review`.
	* `update_option( '_wcpay_feature_prompt_merchant_for_review', '1' )`
* Ensure your store meets the campaign eligibility criteria, or manually set `'wporgReview2025' => true` [here](https://github.com/Automattic/woocommerce-payments/blob/61fc121aec4d5718734f5a720517e694875c70de/includes/class-wc-payments-account.php#L378)
	- Lifetime TPV > $1,000 USD
	- 5+ completed payouts
	- Account in good standing (not suspended/rejected)
* If you've dismissed the prompt earlier, use `delete_user_meta( get_current_user_id(), 'woocommerce_admin_wc_payments_wporg_review_2025_prompt_dismissed')` to reset it.
* Visit Payments → Overview.
* Click "No" in the snackbar prompt.
* Observe the new text in the modal.
* Click the link and ensure it opens the WooCommerce.com support form.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A - minor content change**
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : **QA Testing Not Applicable** since eligibility is difficult to prepare, manual internal testing is suitable.
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **Not a critical flow**
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. **What's new in 9.1.0 post: paJDYF-gXj-p2**
