### PR TITLE
Increase merchant feedback prompt button label underline offset

### DIFF
--- a/changelog/fix-10542-merchant-feedback-prompt-label-underline-offset
+++ b/changelog/fix-10542-merchant-feedback-prompt-label-underline-offset
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Behind feature flag: fix merchant feedback prompt label text underline offset
+
+

--- a/client/merchant-feedback-prompt/style.scss
+++ b/client/merchant-feedback-prompt/style.scss
@@ -33,6 +33,7 @@
 		&__action-label {
 			margin-left: 0.3em;
 			text-decoration: underline;
+			text-underline-offset: 3px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #10542

#### Changes proposed in this Pull Request

This PR increases the text underline offset for the "Yes" and "No" labels in the merchant feedback prompt since they were too close to the words. This tweaks the prompt, more closely matching the design.

**Before**

<img width="427" alt="image" src="https://github.com/user-attachments/assets/0d41c5d4-041e-4480-9748-2f7ea33939e5" />


**After**


<img width="427" alt="image" src="https://github.com/user-attachments/assets/65f12651-e0a2-46d2-bf7e-f16d97620c31" />

**Design**

<img width="427" alt="image" src="https://github.com/user-attachments/assets/31b2d2fd-bb87-430d-b9fb-ad90879c8cca" />



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the dev feature flag `_wcpay_feature_prompt_merchant_for_review`.
	* `update_option( '_wcpay_feature_prompt_merchant_for_review', '1' )`
* Ensure your store meets the campaign eligibility criteria, or manually set `'wporgReview2025' => true` [here](https://github.com/Automattic/woocommerce-payments/blob/61fc121aec4d5718734f5a720517e694875c70de/includes/class-wc-payments-account.php#L378)
	- Lifetime TPV > $1,000 USD
	- 5+ completed payouts
	- Account in good standing (not suspended/rejected)
* If you've dismissed the prompt earlier, use `delete_user_meta( get_current_user_id(), 'woocommerce_admin_wc_payments_wporg_review_2025_prompt_dismissed')` to reset it.
* Visit Payments → Overview and observe the snackbar prompt.
* Ensure the text underline offset is more suitably spaced.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) **N/A**
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->
- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : **QA Testing Not Applicable** since eligibility is difficult to prepare, manual internal testing is suitable.
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **Not a critical flow**
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. **What's new in 9.1.0 post: paJDYF-gXj-p2**
