### PR TITLE
Update merchant feedback prompt text to emphasise a 5-star review request

### DIFF
--- a/changelog/add-10544-merchant-feedback-prompt-explicit-5-star-wording
+++ b/changelog/add-10544-merchant-feedback-prompt-explicit-5-star-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Behind feature flag: Update merchant feedback prompt text to emphasise 5-star review request
+
+

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -46,7 +46,7 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 		>
 			<p>
 				{ __(
-					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a quick review on WordPress.org?',
+					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a 5-star review and quick review on WordPress.org?',
 					'woocommerce-payments'
 				) }
 			</p>

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -46,7 +46,7 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 		>
 			<p>
 				{ __(
-					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a 5-star rating and quick review on WordPress.org?',
+					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a 5-star rating and a quick review on WordPress.org?',
 					'woocommerce-payments'
 				) }
 			</p>

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -46,7 +46,7 @@ export const PositiveFeedbackModal: React.FC< PositiveFeedbackModalProps > = ( {
 		>
 			<p>
 				{ __(
-					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a 5-star review and quick review on WordPress.org?',
+					'Thanks for sharing your feedback on WooPayments! Would you mind leaving us a 5-star rating and quick review on WordPress.org?',
 					'woocommerce-payments'
 				) }
 			</p>

--- a/client/merchant-feedback-prompt/test/index.test.tsx
+++ b/client/merchant-feedback-prompt/test/index.test.tsx
@@ -253,7 +253,7 @@ describe( 'MerchantFeedbackPrompt', () => {
 		// The positive feedback modal should be rendered
 		expect( screen.getByText( 'Share your feedback' ) ).toBeInTheDocument();
 		expect(
-			screen.getByText( /Would you mind leaving us a quick review/ )
+			screen.getByText( /Would you mind leaving us a 5-star review/ )
 		).toBeInTheDocument();
 	} );
 

--- a/client/merchant-feedback-prompt/test/index.test.tsx
+++ b/client/merchant-feedback-prompt/test/index.test.tsx
@@ -253,7 +253,7 @@ describe( 'MerchantFeedbackPrompt', () => {
 		// The positive feedback modal should be rendered
 		expect( screen.getByText( 'Share your feedback' ) ).toBeInTheDocument();
 		expect(
-			screen.getByText( /Would you mind leaving us a 5-star review/ )
+			screen.getByText( /Would you mind leaving us a 5-star rating/ )
 		).toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
Fixes #10544

#### Changes proposed in this Pull Request

This PR updates the wording in the merchant feedback prompt positive modal to explicitly encourage a 5-star rating.


Addition in bold: "Thanks for sharing your feedback on WooPayments! Would you mind leaving us **a 5 star rating and** a quick review on WordPress.org?"

![image](https://github.com/user-attachments/assets/c7392728-d111-44d8-a76b-e347ba40cb52)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the dev feature flag `_wcpay_feature_prompt_merchant_for_review`.
	* `update_option( '_wcpay_feature_prompt_merchant_for_review', '1' )`
* Ensure your store meets the campaign eligibility criteria, or manually set `'wporgReview2025' => true` [here](https://github.com/Automattic/woocommerce-payments/blob/61fc121aec4d5718734f5a720517e694875c70de/includes/class-wc-payments-account.php#L378)
	- Lifetime TPV > $1,000 USD
	- 5+ completed payouts
	- Account in good standing (not suspended/rejected)
* If you've dismissed the prompt earlier, use `delete_user_meta( get_current_user_id(), 'woocommerce_admin_wc_payments_wporg_review_2025_prompt_dismissed')` to reset it.
* Visit Payments → Overview.
* Click "Yes" in the snackbar prompt.
* Observe the new text in the modal.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : **QA Testing Not Applicable** since eligibility is difficult to prepare, manual internal testing is suitable.
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. **Not a critical flow**
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. **What's new in 9.1.0 post: paJDYF-gXj-p2**
