### PR TITLE
Track action complete event in Stripe Notification embedded component

### DIFF
--- a/changelog/add-10548-tracking-event-for-notification-banner-complete
+++ b/changelog/add-10548-tracking-event-for-notification-banner-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Track action complete event in Stripe Notification embedded component.

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -244,6 +244,10 @@ const OverviewPage = () => {
 						explicitDismiss: true,
 					}
 				);
+				// No need to add extra params, we are interested in the total amount of actions here.
+				recordEvent(
+					'wcpay_overview_stripe_notifications_banner_action_completed'
+				);
 			}
 			setNotificationsBannerMessage( '' );
 		}


### PR DESCRIPTION
Fixes #10548 

#### Changes proposed in this Pull Request

Add action complete event tracking in Stripe Notification embedded component.

#### Testing instructions

* Check out this branch locally
* Make sure you have the Tracks Vigilante (p7H4VZ-3cB-p2) browser extension installed and set up. Open up the Tracks Vigilante browser extension and put it in standalone mode (click on the "Standalone popup" button).
* Follow the steps described in https://github.com/Automattic/woocommerce-payments/pull/10417
* You should see the following event:`wcpay_overview_stripe_notifications_banner_action_completed` alongside with the snackbar notice

![image](https://github.com/user-attachments/assets/e364e86c-a549-4550-838f-6171bd923f3f)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
