### PR TITLE
Fix fraud settings modal styles causing prompt for review modal UI bugs.

### DIFF
--- a/changelog/fix-10556-scope-fraud-settings-modal-styles
+++ b/changelog/fix-10556-scope-fraud-settings-modal-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Insignificant refactor of fraud settings modal CSS to limit global styles affecting merchant feedback prompt
+
+

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -251,52 +251,54 @@
 	}
 }
 
-.components-modal__header {
-	border-bottom: 1px solid #ddd;
-}
-
-.components-modal__body--fraud-protection {
-	padding-top: 24px;
-
-	ul {
-		list-style-type: disc;
-		margin-left: 24px;
+.fraud-protection-level-modal {
+	.components-modal__header {
+		border-bottom: 1px solid #ddd;
 	}
-}
 
-.component-modal__text {
-	&--blocked {
-		color: #b32d2e;
+	.components-modal__body--fraud-protection {
+		padding-top: 24px;
+
+		ul {
+			list-style-type: disc;
+			margin-left: 24px;
+		}
 	}
-	&--review {
-		color: #996800;
+
+	.component-modal__text {
+		&--blocked {
+			color: #b32d2e;
+		}
+		&--review {
+			color: #996800;
+		}
 	}
-}
 
-.component-modal__button {
-	&--confirm {
-		display: block;
-		margin-left: auto;
+	.component-modal__button {
+		&--confirm {
+			display: block;
+			margin-left: auto;
+		}
 	}
-}
 
-.component-notice--is-info {
-	margin-left: 0;
-	margin-right: 0;
-	margin-bottom: 1em;
-	background-color: #f0f6fc;
-	border-left: none;
-}
+	.component-notice--is-info {
+		margin-left: 0;
+		margin-right: 0;
+		margin-bottom: 1em;
+		background-color: #f0f6fc;
+		border-left: none;
+	}
 
-.component-notice__icon {
-	margin-right: 10px;
-	align-self: center;
-}
+	.component-notice__icon {
+		margin-right: 10px;
+		align-self: center;
+	}
 
-.component-notice__content--flex {
-	display: flex;
-	flex-direction: row;
-	align-items: flex-start;
+	.component-notice__content--flex {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+	}
 }
 
 #fraud-protection-welcome-tour-first-step {


### PR DESCRIPTION
Fixes #10556

#### Changes proposed in this Pull Request

This PR limits the scope of the CSS used to override modal styles for the fraud settings modal which were previously being applied to all `.components-modal__*` elements globally.

This fixes a UI bug seen in the prompt for reviews modal, a border-bottom on the modal header (see issue for details #10566).

The styles modified are only being used in this modal: https://github.com/Automattic/woocommerce-payments/blob/9691b285405e12577b68139df13e4195bb6e8753/client/settings/fraud-protection/components/fp-modal/index.tsx which is the 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a build of this branch using the [`Build zip file` GH action](https://github.com/Automattic/woocommerce-payments/actions/workflows/build-zip-and-run-smoke-tests.yml). Local styles using `npm run build` do not seem to load styles in the same way.
* You can use this [woocommerce-payments.zip](https://github.com/user-attachments/files/19221366/woocommerce-payments.zip)
 I [prepared in this way](https://github.com/Automattic/woocommerce-payments/actions/runs/13826214319).


**Fraud settings modal**

* Open Payments → Settings and click the `(?)` next to `Basic` in the Fraud settings section
	<img width="1122" alt="image" src="https://github.com/user-attachments/assets/1cef9eb1-d57f-494c-8def-632a91553afd" />
* Observe the fraud settings modal and ensure it is styled correctly
	<img width="400" src="https://github.com/user-attachments/assets/e5be0be8-232a-493c-bb29-c22623761f94" />

**Merchant feedback prompt modal**

* Ensure your store meets the merchant feedback prompt campaign eligibility criteria
	- Lifetime TPV > $1,000 USD
	- 5+ completed payouts
	- Account in good standing (not suspended/rejected)
* If you've dismissed the prompt earlier, use `delete_user_meta( get_current_user_id(), 'woocommerce_admin_wc_payments_wporg_review_2025_prompt_dismissed')` in WP Console plugin to reset it.
* Visit Payments → Overview.
* Click "Yes" in the snackbar prompt.
* Observe the prompt and ensure the modal header does not have a bottom border
	<img width="400" src="https://github.com/user-attachments/assets/4b4d44ef-4219-4ffa-8c87-7bdf3d05b510" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
