### PR TITLE
Update payout failure messages for clarity and accuracy

### DIFF
--- a/changelog/fix-10564-payout-failure-messagin-improvements
+++ b/changelog/fix-10564-payout-failure-messagin-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve payout failure messages for better clarity and accuracy

--- a/client/deposits/details/test/index.tsx
+++ b/client/deposits/details/test/index.tsx
@@ -119,7 +119,7 @@ describe( 'Deposit overview', () => {
 		expect( getByText( 'Failure reason:' ) ).toBeInTheDocument();
 		expect(
 			getByText(
-				'Your account has insufficient funds to cover the transfer.'
+				'Your account has insufficient funds to cover your negative balance.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/deposits/strings.ts
+++ b/client/deposits/strings.ts
@@ -38,7 +38,7 @@ export const depositStatusLabels: Record<
  */
 export const payoutFailureMessages: Record< PayoutFailureCode, string > = {
 	insufficient_funds: __(
-		'Your account has insufficient funds to cover the transfer.',
+		'Your account has insufficient funds to cover your negative balance.',
 		'woocommerce-payments'
 	),
 	bank_account_restricted: __(
@@ -46,15 +46,15 @@ export const payoutFailureMessages: Record< PayoutFailureCode, string > = {
 		'woocommerce-payments'
 	),
 	debit_not_authorized: __(
-		'Debit transactions are not approved on the destination bank account. Bank accounts need to be set up for both credit and debit transfers.',
+		'Debit transactions are not approved on your bank account. Bank accounts need to be set up for both credit and debit transfers.',
 		'woocommerce-payments'
 	),
 	invalid_card: __(
-		'The card used was invalid. This usually means the card number is invalid or the account has been closed. Please verify the card details before retrying.',
+		'The card used was invalid. This usually means the card number is invalid or the account has been closed.',
 		'woocommerce-payments'
 	),
 	declined: __(
-		'The bank has declined this transfer. Please contact the bank before retrying.',
+		'The bank has declined this transfer. Please contact the bank for more information.',
 		'woocommerce-payments'
 	),
 	invalid_transaction: __(
@@ -62,7 +62,7 @@ export const payoutFailureMessages: Record< PayoutFailureCode, string > = {
 		'woocommerce-payments'
 	),
 	refer_to_card_issuer: __(
-		'The transfer was refused by the card issuer. Please contact the issuing bank for clarification before trying again.',
+		'The transfer was refused by the card issuer. Please contact the issuing bank for clarification.',
 		'woocommerce-payments'
 	),
 	unsupported_card: __(
@@ -74,11 +74,11 @@ export const payoutFailureMessages: Record< PayoutFailureCode, string > = {
 		'woocommerce-payments'
 	),
 	invalid_issuer: __(
-		'The issuer specified by the card number does not exist. Please verify card details before retrying.',
+		'The issuer specified by the card number does not exist. Please verify card details.',
 		'woocommerce-payments'
 	),
 	expired_card: __(
-		'The card used has expired. Please switch to a different card or payment method. Contact the issuing bank for clarification before trying again.',
+		'The card used has expired. Please switch to a different card or payment method. Contact the issuing bank for clarification.',
 		'woocommerce-payments'
 	),
 	could_not_process: __(
@@ -111,7 +111,7 @@ export const payoutFailureMessages: Record< PayoutFailureCode, string > = {
 		'woocommerce-payments'
 	),
 	issuer_unavailable: __(
-		'The issuing bank is currently unavailable. Please wait a bit before trying again, or switch to a different payment method or card.',
+		'The issuing bank is currently unavailable. Our system will automatically try again on your next payout date, or you can switch to a different payout method.',
 		'woocommerce-payments'
 	),
 	invalid_currency: __(


### PR DESCRIPTION
Fixes #10564

#### Changes proposed in this Pull Request

This PR improves payout failure messages shown in the payout details screen to correct some inaccuracies and misleading instructions.

See issue or code review comments (https://github.com/Automattic/woocommerce-payments/pull/10565/files) for details on changes.

Failure code messages modified:

1. `insufficient_funds`
2. `debit_not_authorized`
3. `invalid_card`
4. `declined`
5. `refer_to_card_issuer`
6. `invalid_issuer`
7. `expired_card`
8. `issuer_unavailable`


**Example of `insufficient_funds` notice:**
![image](https://github.com/user-attachments/assets/b579a97f-d348-4dfa-ae95-417ed87a6738)



#### Testing instructions

* **Observing the text changes in the code is sufficient for this PR.** 💡
* Alternatively, to see these messages in the UI, navigate to Payments → Payouts and click on any payouts with a `failed` status
* If you have a site with failed Payouts for each `failure_code`, you can observe the notices there.
* Alternatively, manually change a payout's `failure_code` using browser devtools → network → right click `po_xxx` → and override content.
	<img width="318" alt="image" src="https://github.com/user-attachments/assets/c9421444-87e7-4ec1-85de-92f8129d334f" />
	* Use a payout code from above.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
