### PR TITLE
Improve handling for HTTPs errors.

### DIFF
--- a/changelog/dev-error-handling-updates
+++ b/changelog/dev-error-handling-updates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Better handling of HTTPs errors.

--- a/changelog/dev-error-handling-updates
+++ b/changelog/dev-error-handling-updates
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Better handling of HTTPs errors.
+Better handling of HTTPs errors in embedded components.

--- a/client/embedded-components/index.tsx
+++ b/client/embedded-components/index.tsx
@@ -67,7 +67,9 @@ const useInitializeStripe = (
 		stripeConnectInstance,
 		setStripeConnectInstance,
 	] = useState< StripeConnectInstance | null >( null );
-	const [ error, setError ] = useState< string | null >( null );
+	const [ initializationError, setInitializationError ] = useState<
+		string | null
+	>( null );
 	const [ loading, setLoading ] = useState< boolean >( true );
 
 	useEffect( () => {
@@ -107,7 +109,7 @@ const useInitializeStripe = (
 
 				setStripeConnectInstance( instance );
 			} catch ( err ) {
-				setError(
+				setInitializationError(
 					err instanceof Error ? err.message : 'Unknown error'
 				);
 			} finally {
@@ -118,7 +120,7 @@ const useInitializeStripe = (
 		initializeStripe();
 	}, [ isOnboarding, onboardingData, isPoEligible ] );
 
-	return { stripeConnectInstance, error, loading };
+	return { stripeConnectInstance, initializationError, loading };
 };
 
 /**
@@ -143,7 +145,7 @@ export const EmbeddedAccountOnboarding: React.FC< EmbeddedAccountOnboardingProps
 	isPoEligible = false,
 	collectPayoutRequirements = false,
 } ) => {
-	const { stripeConnectInstance, error } = useInitializeStripe(
+	const { stripeConnectInstance, initializationError } = useInitializeStripe(
 		true,
 		onboardingData,
 		isPoEligible
@@ -151,8 +153,12 @@ export const EmbeddedAccountOnboarding: React.FC< EmbeddedAccountOnboardingProps
 
 	return (
 		<>
-			{ error && <BannerNotice status="error">{ error }</BannerNotice> }
-			{ ! error && stripeConnectInstance && (
+			{ initializationError && (
+				<BannerNotice status="error">
+					{ initializationError }
+				</BannerNotice>
+			) }
+			{ stripeConnectInstance && (
 				<ConnectComponentsProvider
 					connectInstance={ stripeConnectInstance }
 				>
@@ -190,17 +196,21 @@ export const EmbeddedConnectNotificationBanner: React.FC< EmbeddedAccountNotific
 	onLoadError,
 	onNotificationsChange,
 } ) => {
-	const { stripeConnectInstance, error, loading } = useInitializeStripe(
-		false,
-		null,
-		false
-	);
+	const {
+		stripeConnectInstance,
+		initializationError,
+		loading,
+	} = useInitializeStripe( false, null, false );
 
 	return (
 		<>
 			{ ( loading || ! stripeConnectInstance ) && <StripeSpinner /> }
-			{ error && <BannerNotice status="error">{ error }</BannerNotice> }
-			{ ! error && stripeConnectInstance && (
+			{ initializationError && (
+				<BannerNotice status="error">
+					{ initializationError }
+				</BannerNotice>
+			) }
+			{ stripeConnectInstance && (
 				<ConnectComponentsProvider
 					connectInstance={ stripeConnectInstance }
 				>

--- a/client/onboarding/steps/embedded-kyc.tsx
+++ b/client/onboarding/steps/embedded-kyc.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import { LoadError } from '@stripe/connect-js';
 
 /**
  * Internal dependencies
@@ -12,6 +14,7 @@ import { finalizeOnboarding, isPoEligible } from 'wcpay/onboarding/utils';
 import { getConnectUrl, getOverviewUrl } from 'wcpay/utils';
 import { trackEmbeddedStepChange } from 'wcpay/onboarding/tracking';
 import { EmbeddedAccountOnboarding } from 'wcpay/embedded-components';
+import BannerNotice from 'wcpay/components/banner-notice';
 
 interface Props {
 	continueKyc?: boolean;
@@ -26,6 +29,11 @@ const EmbeddedKyc: React.FC< Props > = ( {
 	const [ finalizingAccount, setFinalizingAccount ] = useState( false );
 	const [ isEligible, setIsEligible ] = useState< boolean | null >( null );
 	const [ loading, setLoading ] = useState( true );
+	const [ loadError, setLoadError ] = useState< LoadError | null >( null );
+
+	const urlParams = new URLSearchParams( window.location.search );
+	const urlSource =
+		urlParams.get( 'source' )?.replace( /[^\w-]+/g, '' ) || 'unknown';
 
 	// Fetch whether the account is eligible for progressive onboarding
 	useEffect( () => {
@@ -46,10 +54,6 @@ const EmbeddedKyc: React.FC< Props > = ( {
 	};
 
 	const handleOnExit = async () => {
-		const urlParams = new URLSearchParams( window.location.search );
-		const urlSource =
-			urlParams.get( 'source' )?.replace( /[^\w-]+/g, '' ) || 'unknown';
-
 		setFinalizingAccount( true );
 
 		try {
@@ -82,6 +86,10 @@ const EmbeddedKyc: React.FC< Props > = ( {
 		}
 	};
 
+	const handleLoadError = ( err: LoadError ) => {
+		setLoadError( err );
+	};
+
 	return (
 		<>
 			{ loading && (
@@ -94,6 +102,47 @@ const EmbeddedKyc: React.FC< Props > = ( {
 					<StripeSpinner />
 				</div>
 			) }
+			{ loadError &&
+				( loadError.error.type === 'invalid_request_error' ? (
+					<BannerNotice
+						className={ 'wcpay-banner-notice--embedded-kyc' }
+						status="warning"
+						isDismissible={ false }
+						actions={ [
+							{
+								label: 'Learn more',
+								variant: 'primary',
+								url:
+									'https://woocommerce.com/document/woopayments/startup-guide/#requirements',
+								urlTarget: '_blank',
+							},
+							{
+								label: 'Cancel',
+								variant: 'link',
+								url: getConnectUrl(
+									{
+										'wcpay-connection-error': '1',
+										source: urlSource,
+									},
+									'WCPAY_ONBOARDING_WIZARD'
+								),
+							},
+						] }
+					>
+						{ __(
+							'Payment activation through our financial partner requires HTTPS and cannot be completed.',
+							'woocommerce-payments'
+						) }
+					</BannerNotice>
+				) : (
+					<BannerNotice
+						className={ 'wcpay-banner-notice--embedded-kyc' }
+						status="error"
+						isDismissible={ false }
+					>
+						{ loadError.error.message }
+					</BannerNotice>
+				) ) }
 			{
 				// Only render the embedded onboarding component once the PO eligibility has been determined.
 				isEligible !== null && (
@@ -101,6 +150,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 						onExit={ handleOnExit }
 						onStepChange={ handleStepChange }
 						onLoaderStart={ () => setLoading( false ) }
+						onLoadError={ handleLoadError }
 						isPoEligible={ isEligible }
 						onboardingData={ data }
 						collectPayoutRequirements={ collectPayoutRequirements }

--- a/client/onboarding/style.scss
+++ b/client/onboarding/style.scss
@@ -168,6 +168,16 @@ body.wcpay-onboarding__body {
 			}
 		}
 
+		.wcpay-banner-notice--embedded-kyc {
+			&.is-warning {
+				background-color: lighten( $alert-yellow, 35% );
+			}
+
+			&.is-error {
+				background-color: lighten( $alert-red, 35% );
+			}
+		}
+
 		.wcpay-onboarding__tos {
 			font-size: 12px;
 		}

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -6,8 +6,10 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Notice } from '@wordpress/components';
 import { getQuery } from '@woocommerce/navigation';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { dispatch } from '@wordpress/data';
+import interpolateComponents from '@automattic/interpolate-components';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies.
@@ -83,6 +85,10 @@ const OverviewPage = () => {
 	const [
 		stripeNotificationsBannerErrorMessage,
 		setStripeNotificationsBannerErrorMessage,
+	] = useState( '' );
+	const [
+		stripeNotificationsBannerErrorType,
+		setStripeNotificationsBannerErrorType,
 	] = useState( '' );
 	const [
 		notificationsBannerMessage,
@@ -297,6 +303,39 @@ const OverviewPage = () => {
 					actions={ [] }
 				/>
 			) }
+			{ stripeNotificationsBannerErrorMessage &&
+				stripeNotificationsBannerErrorType ===
+					'invalid_request_error' && (
+					<BannerNotice
+						status="warning"
+						icon={ true }
+						isDismissible={ false }
+					>
+						{ interpolateComponents( {
+							mixedString: sprintf(
+								__(
+									// eslint-disable-next-line max-len
+									'Some account related notifications require HTTPS and cannot be displayed. View them on our financial partner’s website. {{seeDetailsLink}}See details{{/seeDetailsLink}}',
+									'woocommerce-payments'
+								)
+							),
+							components: {
+								seeDetailsLink: (
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<Link
+										href={
+											// eslint-disable-next-line max-len
+											'https://woocommerce.com/document/woopayments/startup-guide/#requirements'
+										}
+										target="_blank"
+										rel="noreferrer"
+										type="external"
+									/>
+								),
+							},
+						} ) }
+					</BannerNotice>
+				) }
 			<ErrorBoundary>
 				<FRTDiscoverabilityBanner />
 			</ErrorBoundary>
@@ -327,6 +366,9 @@ const OverviewPage = () => {
 									setStripeNotificationsBannerErrorMessage(
 										loadError.error.message ||
 											'Unknown error'
+									);
+									setStripeNotificationsBannerErrorType(
+										loadError.error.type
 									);
 									setStripeComponentLoading( false );
 								} }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@automattic/interpolate-components": "1.2.1",
         "@fingerprintjs/fingerprintjs": "3.4.1",
         "@stripe/connect-js": "3.3.16",
-        "@stripe/react-connect-js": "3.3.17",
+        "@stripe/react-connect-js": "3.3.21",
         "@stripe/react-stripe-js": "2.5.1",
         "@stripe/stripe-js": "1.15.1",
         "@woocommerce/explat": "2.3.0",
@@ -5539,11 +5539,11 @@
       "integrity": "sha512-lMUKJJaDl6qzjp+czNn+N6wMwFXwLawmB2jNNgds8SeR+bXCVCXevzJ8dfF92KfmexKg++hBYagF9e99sEMBJQ=="
     },
     "node_modules/@stripe/react-connect-js": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/@stripe/react-connect-js/-/react-connect-js-3.3.17.tgz",
-      "integrity": "sha512-uxCh6ACcSWS/t0kBeqvvRieBI9pRxh2rPxt6NpjrTg3Ft1ZDleUfg9OAjkfoOT3Ta+FTomouA19l2ju7If2h5A==",
+      "version": "3.3.21",
+      "resolved": "https://registry.npmjs.org/@stripe/react-connect-js/-/react-connect-js-3.3.21.tgz",
+      "integrity": "sha512-b2M9S9QhdIR7suF0VYWwG0+H7SV+X7Y4y/mfJcsVUU/oyrUPZ1V6HIP9z07C33JDcR5I5ULIiwIBRytgPhr09g==",
       "peerDependencies": {
-        "@stripe/connect-js": ">=3.3.16",
+        "@stripe/connect-js": ">=3.3.20",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@automattic/interpolate-components": "1.2.1",
     "@fingerprintjs/fingerprintjs": "3.4.1",
     "@stripe/connect-js": "3.3.16",
-    "@stripe/react-connect-js": "3.3.17",
+    "@stripe/react-connect-js": "3.3.21",
     "@stripe/react-stripe-js": "2.5.1",
     "@stripe/stripe-js": "1.15.1",
     "@woocommerce/explat": "2.3.0",


### PR DESCRIPTION
Fixes server/7298 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Add error handling for https errors from Stripe.
* Some styling updates to match the designs

### Designs

Account Overview: ahxjzp9zZSn1PuCmNpVTQx-fi-242_3560
Account Settings (not implemented in this PR): UnzlEjiLDScC60xGG9OC2v-fi-4004_2666 
Onboarding: xO8YdpKfaVoP2d8NvweZ5I-fi-7421_44904 

### Screenshots:

**Overview Page**
<img width="728" alt="Screenshot 2025-03-11 at 11 53 46" src="https://github.com/user-attachments/assets/bca340fc-981d-43a7-a0bb-bb02eea95004" />

**Onboarding Page (MOX)**
 
<img width="1497" alt="Screenshot 2025-03-11 at 12 16 45" src="https://github.com/user-attachments/assets/e5779b97-4b41-43ad-86cf-0e164eac72af" />

### Notes 

cc @orcungogus / @timmy5685 , would be great to get your feedback on this!

- Originally, we discussed implementing an option to switch to test mode on the onboarding embedded component error. However, it will require some additional work for refactoring in order to make this possible. Because of the limited time we have to complete this (aiming to land it in the next release, meaning the code freeze is on Friday), I opted for an interim solution of just having the warning appear, with either the option to go back to the Connect page (or payment settings, for the NOX), and a link which will go to a documentation page informing users about the HTTPs requirements. 
- Account settings piece is not implemented yet because the component is not live yet (it is on a separate branch) - we will implement it before that goes live (cc @mordeth) 


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(Note: must be tested locally)

**Onboarding** 

* `npm install` and `npm run watch`
* Reset or disconnect your current account.
* Replace these lines as follows
https://github.com/Automattic/woocommerce-payments/blob/249d4f8b4477edc24328935705851ca87ef80a35/client/onboarding/steps/embedded-kyc.tsx#L105-L106

```react
{ true ? (
```

* Start the onboarding. When you get to the second step (the embedded component) you should see the notice. You will probably also see the embedded component load underneath (this is okay, because in production the notice will only show when a load error occurs).
* Verify that the learn more button takes you to a documentation page (real page isn't in place yet). Verify the cancel button takes you back to the Connect page.
* Revert the change so that you can onboard for the next step.

** Account management **

* Follow the instructions in [this PR](https://github.com/Automattic/woocommerce-payments/pull/10314) to allow you to see the account notifications component
* Replace these lines as follows:
https://github.com/Automattic/woocommerce-payments/blob/249d4f8b4477edc24328935705851ca87ef80a35/client/overview/index.js#L306-L307
```react
true && (
```

* Refresh the page. Verify you can see the https warning, and it looks as expected matching the designs.
* The see details link should lead to a documentation page (which doesn't exist yet).

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.