### PR TITLE
poc: avoid re-mount of ece on shortcode cart

### DIFF
--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { addAction, removeAction } from '@wordpress/hooks';
+import { addAction, doAction, removeAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -41,8 +41,10 @@ import {
 	transformCartDataForShippingRates,
 	transformPrice,
 } from './transformers/wc-to-stripe';
+import debounce from './debounce';
 
 let cachedCartData = null;
+let isEceInitialized = false;
 const noop = () => null;
 const fetchNewCartData = async () => {
 	if ( getExpressCheckoutData( 'button_context' ) !== 'product' ) {
@@ -211,6 +213,7 @@ jQuery( ( $ ) => {
 		 * @param {Object} creationOptions ECE initialization options.
 		 */
 		startExpressCheckoutElement: async ( creationOptions ) => {
+			isEceInitialized = false;
 			let addToCartPromise = Promise.resolve();
 			const stripe = await api.getStripe();
 			// https://docs.stripe.com/js/elements_object/create_without_intent
@@ -234,6 +237,10 @@ jQuery( ( $ ) => {
 				if ( ! document.getElementById( 'wcpay-woopay-button' ) ) {
 					expressCheckoutButtonUi.getButtonSeparator().hide();
 				}
+			} );
+
+			eceButton.on( 'ready', () => {
+				isEceInitialized = true;
 			} );
 
 			eceButton.on( 'click', function ( event ) {
@@ -434,7 +441,11 @@ jQuery( ( $ ) => {
 			addAction(
 				'wcpay.express-checkout.update-button-data',
 				'automattic/wcpay/express-checkout',
-				async () => {
+				debounce( 250, async () => {
+					if ( ! isEceInitialized ) {
+						return;
+					}
+
 					// if the product cannot be added to cart (because of missing variation selection, etc),
 					// don't try to add it to the cart to get new data - the call will likely fail.
 					if (
@@ -483,26 +494,20 @@ jQuery( ( $ ) => {
 					} catch ( e ) {
 						expressCheckoutButtonUi.hideContainer();
 					}
-				}
+				} )
 			);
 		},
 	};
 
-	// We don't need to initialize ECE on the checkout page now because it will be initialized by updated_checkout event.
-	if (
-		getExpressCheckoutData( 'button_context' ) !== 'checkout' ||
-		getExpressCheckoutData( 'button_context' ) === 'pay_for_order'
-	) {
-		wcpayECE.init();
-	}
+	wcpayECE.init();
 
 	// We need to refresh ECE data when total is updated.
 	$( document.body ).on( 'updated_cart_totals', () => {
-		wcpayECE.init();
+		doAction( 'wcpay.express-checkout.update-button-data' );
 	} );
 
 	// We need to refresh ECE data when total is updated.
 	$( document.body ).on( 'updated_checkout', () => {
-		wcpayECE.init();
+		doAction( 'wcpay.express-checkout.update-button-data' );
 	} );
 } );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

POC as a follow-up of this conversation: p1740781771968949/1740779023.860979-slack-CU6SYV31A

This doesn't seem to be working right, because the back-end will provide a new DOM element where the ECE will be loaded. It's not the case that it's just the ECE is re-initialized by our code. The ECE needs to be re-initialized because WC Core will provide a brand new wrapper.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.