### PR TITLE
fix: ECE parsing of error message to customer

### DIFF
--- a/changelog/chore-ece-parsing-of-error-message
+++ b/changelog/chore-ece-parsing-of-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+fix: parsing of error message for GooglePay/ApplePay buttons to be displayed to customer, instead of displaying generic error message on failure.

--- a/client/tokenized-express-checkout/__tests__/event-handlers.test.js
+++ b/client/tokenized-express-checkout/__tests__/event-handlers.test.js
@@ -1,0 +1,386 @@
+/**
+ * Internal dependencies
+ */
+import {
+	shippingAddressChangeHandler,
+	onConfirmHandler,
+	setCartApiHandler,
+} from '../event-handlers';
+
+describe( 'Express checkout event handlers', () => {
+	let cartApiUpdateCustomerMock;
+	let cartApiPlaceOrderMock;
+	let cartApiSelectShippingRateMock;
+	beforeEach( () => {
+		cartApiUpdateCustomerMock = jest.fn();
+		cartApiPlaceOrderMock = jest.fn();
+		cartApiSelectShippingRateMock = jest.fn();
+		global.window.wcpayFraudPreventionToken = 'token123';
+
+		setCartApiHandler( {
+			updateCustomer: cartApiUpdateCustomerMock,
+			selectShippingRate: cartApiSelectShippingRateMock,
+			placeOrder: cartApiPlaceOrderMock,
+		} );
+	} );
+
+	describe( 'shippingAddressChangeHandler', () => {
+		let event;
+		let elements;
+
+		beforeEach( () => {
+			event = {
+				name: 'John Doe',
+				address: {
+					line1: '123 Main St',
+					city: 'New York',
+					state: 'NY',
+					country: 'US',
+					postal_code: '10001',
+				},
+				resolve: jest.fn(),
+				reject: jest.fn(),
+			};
+			elements = {
+				update: jest.fn(),
+			};
+		} );
+
+		afterEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		test( 'should handle successful response', async () => {
+			cartApiUpdateCustomerMock.mockResolvedValue( {
+				items: [],
+				shipping_rates: [
+					{
+						package_id: 0,
+						name: 'Shipment 1',
+						destination: {},
+						items: [
+							{
+								key: 'aab3238922bcc25a6f606eb525ffdc56',
+								name: 'Beanie',
+								quantity: 2,
+							},
+						],
+						shipping_rates: [
+							{
+								rate_id: 'flat_rate:14',
+								name: 'Standard Shipping',
+								description: '',
+								delivery_time: '',
+								price: '1000',
+								taxes: '300',
+								instance_id: 14,
+								method_id: 'flat_rate',
+								meta_data: [
+									{
+										key: 'Items',
+										value: 'Beanie &times; 2',
+									},
+								],
+								selected: true,
+								currency_code: 'USD',
+								currency_symbol: '$',
+								currency_minor_unit: 2,
+								currency_decimal_separator: '.',
+								currency_thousand_separator: ',',
+								currency_prefix: '$',
+								currency_suffix: '',
+							},
+						],
+					},
+				],
+				totals: {
+					total_price: 1000,
+					currency_minor_unit: 2,
+					currency_code: 'USD',
+					currency_symbol: '$',
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					currency_prefix: '$',
+					currency_suffix: '',
+				},
+			} );
+
+			await shippingAddressChangeHandler( event, elements );
+
+			expect( cartApiUpdateCustomerMock ).toHaveBeenCalledWith( {
+				shipping_address: expect.objectContaining( {
+					first_name: 'John',
+					last_name: 'Doe',
+					company: '',
+					address_1: '123 Main St',
+					address_2: '',
+					city: 'New York',
+					state: 'NY',
+					postcode: '10001',
+					country: 'US',
+				} ),
+			} );
+
+			expect( elements.update ).toHaveBeenCalledWith( { amount: 1000 } );
+			expect( event.resolve ).toHaveBeenCalledWith( {
+				shippingRates: [
+					expect.objectContaining( {
+						id: 'flat_rate:14',
+						displayName: 'Standard Shipping',
+						amount: 1000,
+						deliveryEstimate: '',
+					} ),
+				],
+				lineItems: [],
+			} );
+			expect( event.reject ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should handle zero rates in the response', async () => {
+			cartApiUpdateCustomerMock.mockResolvedValue( {
+				items: [],
+				shipping_rates: [
+					{
+						package_id: 0,
+						name: 'Shipment 1',
+						destination: {},
+						items: [
+							{
+								key: 'aab3238922bcc25a6f606eb525ffdc56',
+								name: 'Beanie',
+								quantity: 2,
+							},
+						],
+						shipping_rates: [],
+					},
+				],
+				totals: {
+					total_price: 1000,
+					currency_minor_unit: 2,
+					currency_code: 'USD',
+					currency_symbol: '$',
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					currency_prefix: '$',
+					currency_suffix: '',
+				},
+			} );
+
+			await shippingAddressChangeHandler( event, elements );
+
+			expect( cartApiUpdateCustomerMock ).toHaveBeenCalled();
+
+			expect( elements.update ).not.toHaveBeenCalled();
+			expect( event.resolve ).not.toHaveBeenCalled();
+			expect( event.reject ).toHaveBeenCalled();
+		} );
+
+		test( 'should handle unsuccessful response', async () => {
+			cartApiUpdateCustomerMock.mockRejectedValue( {} );
+
+			await shippingAddressChangeHandler( event, elements );
+
+			expect( cartApiUpdateCustomerMock ).toHaveBeenCalled();
+
+			expect( elements.update ).not.toHaveBeenCalled();
+			expect( event.resolve ).not.toHaveBeenCalled();
+			expect( event.reject ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'onConfirmHandler', () => {
+		let api;
+		let stripe;
+		let elements;
+		let completePayment;
+		let abortPayment;
+		let event;
+
+		beforeEach( () => {
+			api = {
+				expressCheckoutECECreateOrder: jest.fn(),
+				expressCheckoutECEPayForOrder: jest.fn(),
+				confirmIntent: jest.fn(),
+			};
+			stripe = {
+				createPaymentMethod: jest.fn().mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} ),
+			};
+			elements = {
+				submit: jest.fn().mockResolvedValue( {} ),
+			};
+			completePayment = jest.fn();
+			abortPayment = jest.fn();
+			event = {
+				billingDetails: {
+					name: 'Card Holder Name',
+					email: 'john.doe@example.com',
+					address: {
+						organization: 'Some Company',
+						country: 'US',
+						line1: '123 Main St',
+						line2: 'Apt 4B',
+						city: 'New York',
+						state: 'NY',
+						postal_code: '10001',
+					},
+					phone: '(123) 456-7890',
+				},
+				shippingAddress: {
+					name: 'Card Holder Name',
+					organization: 'Some Company',
+					address: {
+						country: 'US',
+						line1: '123 Main St',
+						line2: 'Apt 4B',
+						city: 'New York',
+						state: 'NY',
+						postal_code: '10001',
+					},
+				},
+				shippingRate: { id: 'rate_1' },
+				expressPaymentType: 'express',
+			};
+		} );
+
+		test( 'should abort payment if elements.submit fails', async () => {
+			elements.submit.mockResolvedValue( {
+				error: { message: 'Submit error' },
+			} );
+
+			await onConfirmHandler(
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event
+			);
+
+			expect( completePayment ).not.toHaveBeenCalled();
+			expect( stripe.createPaymentMethod ).not.toHaveBeenCalled();
+			expect( abortPayment ).toHaveBeenCalledWith( 'Submit error' );
+		} );
+
+		test( 'should abort payment if stripe.createPaymentMethod fails', async () => {
+			stripe.createPaymentMethod.mockResolvedValue( {
+				error: { message: 'Payment method error' },
+			} );
+
+			await onConfirmHandler(
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event
+			);
+
+			expect( completePayment ).not.toHaveBeenCalled();
+			expect( stripe.createPaymentMethod ).toHaveBeenCalledWith( {
+				elements,
+			} );
+			expect( abortPayment ).toHaveBeenCalledWith(
+				'Payment method error'
+			);
+		} );
+
+		test( 'should abort payment if cartApi.placeOrder throws an exception because of a network error', async () => {
+			cartApiPlaceOrderMock.mockRejectedValue( {
+				code: 'fetch_error',
+				message: 'You are probably offline.',
+			} );
+
+			await onConfirmHandler(
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event
+			);
+
+			expect( cartApiPlaceOrderMock ).toHaveBeenCalled();
+			expect( abortPayment ).toHaveBeenCalledWith(
+				'You are probably offline.'
+			);
+			expect( completePayment ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should abort payment if cartApi.placeOrder throws an exception from the store', async () => {
+			cartApiPlaceOrderMock.mockRejectedValue( {
+				status: 400,
+				json: async () => ( {
+					order_id: 1111111,
+					status: 'failed',
+					order_key: 'wc_order_f41lur3',
+					order_number: '1111111',
+					customer_note: '',
+					customer_id: 1,
+					billing_address: {
+						first_name: 'Card',
+						last_name: 'Holder Name',
+						country: 'US',
+						address_1: '123 Main St',
+						address_2: 'Apt 4B',
+						city: 'New York',
+						state: 'NY',
+						postcode: '10001',
+						company: 'Some Company',
+						email: 'john.doe@example.com',
+						phone: '1234567890',
+					},
+					shipping_address: {
+						first_name: 'Card',
+						last_name: 'Holder Name',
+						country: 'US',
+						address_1: '123 Main St',
+						address_2: 'Apt 4B',
+						city: 'New York',
+						state: 'NY',
+						postcode: '10001',
+						company: 'Some Company',
+						phone: '1234567890',
+					},
+					payment_method: 'woocommerce_payments',
+					payment_result: {
+						payment_status: 'failure',
+						payment_details: [
+							{
+								key: 'errorMessage',
+								value: 'Error: Your card was declined.',
+							},
+							{
+								key: 'result',
+								value: 'fail',
+							},
+							{
+								key: 'redirect',
+								value: '',
+							},
+						],
+						redirect_url: '',
+					},
+					additional_fields: [],
+					extensions: {},
+				} ),
+			} );
+
+			await onConfirmHandler(
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event
+			);
+
+			expect( cartApiPlaceOrderMock ).toHaveBeenCalled();
+			expect( abortPayment ).toHaveBeenCalledWith(
+				'Error: Your card was declined.'
+			);
+			expect( completePayment ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/client/tokenized-express-checkout/__tests__/event-handlers.test.js
+++ b/client/tokenized-express-checkout/__tests__/event-handlers.test.js
@@ -311,60 +311,61 @@ describe( 'Express checkout event handlers', () => {
 		it( 'should abort payment if cartApi.placeOrder throws an exception from the store', async () => {
 			cartApiPlaceOrderMock.mockRejectedValue( {
 				status: 400,
-				json: async () => ( {
-					order_id: 1111111,
-					status: 'failed',
-					order_key: 'wc_order_f41lur3',
-					order_number: '1111111',
-					customer_note: '',
-					customer_id: 1,
-					billing_address: {
-						first_name: 'Card',
-						last_name: 'Holder Name',
-						country: 'US',
-						address_1: '123 Main St',
-						address_2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postcode: '10001',
-						company: 'Some Company',
-						email: 'john.doe@example.com',
-						phone: '1234567890',
-					},
-					shipping_address: {
-						first_name: 'Card',
-						last_name: 'Holder Name',
-						country: 'US',
-						address_1: '123 Main St',
-						address_2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postcode: '10001',
-						company: 'Some Company',
-						phone: '1234567890',
-					},
-					payment_method: 'woocommerce_payments',
-					payment_result: {
-						payment_status: 'failure',
-						payment_details: [
-							{
-								key: 'errorMessage',
-								value: 'Error: Your card was declined.',
-							},
-							{
-								key: 'result',
-								value: 'fail',
-							},
-							{
-								key: 'redirect',
-								value: '',
-							},
-						],
-						redirect_url: '',
-					},
-					additional_fields: [],
-					extensions: {},
-				} ),
+				json: () =>
+					Promise.resolve( {
+						order_id: 1111111,
+						status: 'failed',
+						order_key: 'wc_order_f41lur3',
+						order_number: '1111111',
+						customer_note: '',
+						customer_id: 1,
+						billing_address: {
+							first_name: 'Card',
+							last_name: 'Holder Name',
+							country: 'US',
+							address_1: '123 Main St',
+							address_2: 'Apt 4B',
+							city: 'New York',
+							state: 'NY',
+							postcode: '10001',
+							company: 'Some Company',
+							email: 'john.doe@example.com',
+							phone: '1234567890',
+						},
+						shipping_address: {
+							first_name: 'Card',
+							last_name: 'Holder Name',
+							country: 'US',
+							address_1: '123 Main St',
+							address_2: 'Apt 4B',
+							city: 'New York',
+							state: 'NY',
+							postcode: '10001',
+							company: 'Some Company',
+							phone: '1234567890',
+						},
+						payment_method: 'woocommerce_payments',
+						payment_result: {
+							payment_status: 'failure',
+							payment_details: [
+								{
+									key: 'errorMessage',
+									value: 'Error: Your card was declined.',
+								},
+								{
+									key: 'result',
+									value: 'fail',
+								},
+								{
+									key: 'redirect',
+									value: '',
+								},
+							],
+							redirect_url: '',
+						},
+						additional_fields: [],
+						extensions: {},
+					} ),
 			} );
 
 			await onConfirmHandler(

--- a/client/tokenized-express-checkout/__tests__/event-handlers.test.js
+++ b/client/tokenized-express-checkout/__tests__/event-handlers.test.js
@@ -50,7 +50,7 @@ describe( 'Express checkout event handlers', () => {
 			jest.clearAllMocks();
 		} );
 
-		test( 'should handle successful response', async () => {
+		it( 'should handle successful response', async () => {
 			cartApiUpdateCustomerMock.mockResolvedValue( {
 				items: [],
 				shipping_rates: [
@@ -136,7 +136,7 @@ describe( 'Express checkout event handlers', () => {
 			expect( event.reject ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should handle zero rates in the response', async () => {
+		it( 'should handle zero rates in the response', async () => {
 			cartApiUpdateCustomerMock.mockResolvedValue( {
 				items: [],
 				shipping_rates: [
@@ -175,7 +175,7 @@ describe( 'Express checkout event handlers', () => {
 			expect( event.reject ).toHaveBeenCalled();
 		} );
 
-		test( 'should handle unsuccessful response', async () => {
+		it( 'should handle unsuccessful response', async () => {
 			cartApiUpdateCustomerMock.mockRejectedValue( {} );
 
 			await shippingAddressChangeHandler( event, elements );
@@ -244,7 +244,7 @@ describe( 'Express checkout event handlers', () => {
 			};
 		} );
 
-		test( 'should abort payment if elements.submit fails', async () => {
+		it( 'should abort payment if elements.submit fails', async () => {
 			elements.submit.mockResolvedValue( {
 				error: { message: 'Submit error' },
 			} );
@@ -263,7 +263,7 @@ describe( 'Express checkout event handlers', () => {
 			expect( abortPayment ).toHaveBeenCalledWith( 'Submit error' );
 		} );
 
-		test( 'should abort payment if stripe.createPaymentMethod fails', async () => {
+		it( 'should abort payment if stripe.createPaymentMethod fails', async () => {
 			stripe.createPaymentMethod.mockResolvedValue( {
 				error: { message: 'Payment method error' },
 			} );
@@ -286,7 +286,7 @@ describe( 'Express checkout event handlers', () => {
 			);
 		} );
 
-		test( 'should abort payment if cartApi.placeOrder throws an exception because of a network error', async () => {
+		it( 'should abort payment if cartApi.placeOrder throws an exception because of a network error', async () => {
 			cartApiPlaceOrderMock.mockRejectedValue( {
 				code: 'fetch_error',
 				message: 'You are probably offline.',
@@ -308,7 +308,7 @@ describe( 'Express checkout event handlers', () => {
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );
 
-		test( 'should abort payment if cartApi.placeOrder throws an exception from the store', async () => {
+		it( 'should abort payment if cartApi.placeOrder throws an exception from the store', async () => {
 			cartApiPlaceOrderMock.mockRejectedValue( {
 				status: 400,
 				json: async () => ( {

--- a/client/tokenized-express-checkout/event-handlers.js
+++ b/client/tokenized-express-checkout/event-handlers.js
@@ -158,7 +158,7 @@ export const onConfirmHandler = async (
 	} catch ( e ) {
 		// API errors are not parsed, so we need to do it ourselves.
 		if ( e.json ) {
-			e = e.json();
+			e = await Promise.resolve( e.json() );
 		}
 
 		return abortPayment(


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that we show the "fallback" error message when a card failure occurs with the ECE.
Let's show the "correct" error message to the customer - the same one returned by the API.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have GooglePay/ApplePay enabled in the WooPayment's settings
- Go to a product page
- Click on the ECE button
- Select one of the "failure" cards - like "Generic failure" or "Always blocked"
<img width="569" alt="Screenshot 2025-03-17 at 4 19 25 PM" src="https://github.com/user-attachments/assets/24a5c1f1-a2cf-4015-bab0-9cd1b9457d52" />

- Click "pay"
- The ECE sheet should dismiss, and the error message should be displayed in a notice

Before:
<img width="1381" alt="Screenshot 2025-03-17 at 4 20 16 PM" src="https://github.com/user-attachments/assets/dc0424e9-cd3a-45de-b856-1e47631a0b66" />

After:
<img width="1361" alt="Screenshot 2025-03-17 at 4 19 40 PM" src="https://github.com/user-attachments/assets/c0c5e23f-cec5-4daf-91e6-b7743ca8b968" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
