### PR TITLE
Change self assessment data url key name

### DIFF
--- a/changelog/dev-10580-change-self-assessment-url-key-name
+++ b/changelog/dev-10580-change-self-assessment-url-key-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+We switch to using site instead of url as the key in the self assessment data to avoid XSS firewall false-positives.

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -65,7 +65,7 @@ const getComingSoonShareKey = () => {
 const initialData = {
 	business_name: wcSettings?.siteTitle,
 	mcc: getMccFromIndustry(),
-	url:
+	site:
 		location.hostname === 'localhost'
 			? 'https://wcpay.test'
 			: wcSettings?.homeUrl + getComingSoonShareKey(),

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -91,9 +91,9 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 								'description' => 'The timeframe bucket for the estimated first live transaction.',
 								'required'    => true,
 							],
-							'url'               => [
+							'site'              => [
 								'type'        => 'string',
-								'description' => 'The URL of the store.',
+								'description' => 'The URL of the site.',
 								'required'    => true,
 							],
 						],

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -510,7 +510,7 @@ class WC_Payments_Onboarding_Service {
 					'country'       => $self_assessment_data['country'] ?? null,
 					'email'         => $self_assessment_data['email'] ?? null,
 					'business_name' => $self_assessment_data['business_name'] ?? null,
-					'url'           => $self_assessment_data['url'] ?? null,
+					'url'           => $self_assessment_data['site'] ?? null,
 					'mcc'           => $self_assessment_data['mcc'] ?? null,
 					'business_type' => $business_type,
 					'company'       => [


### PR DESCRIPTION
Fixes #10580

#### Changes proposed in this Pull Request

We replace the `url` key in the `self_assessment` data we receive from the frontend with `site` to avoid the request being blocked by certain firewalls due to XSS false-positive.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new Jurassic Ninja site from this branch.
* Open the network tab of your browser and turn on recording ("Preserve log" checkbox in Chrome).
![Screenshot 2025-03-18 at 11 50 24](https://github.com/user-attachments/assets/afd6f049-896c-4d77-b7cb-7642fa2ae85c)
* Start an onboarding. Use `United States`, `Individual` and a high value for the estimated revenue/time to launch store.
* In your browser's network tab look for a GET request to `payments/onboarding/kyc/session`. In its query parameters, you should have a `self_assessment%5Bsite%5D=` part and no `self_assessment%5Burl%5D=` part:
```
http://localhost:8082/wp-json/wc/v3/payments/onboarding/kyc/session?self_assessment%5Bbusiness_name%5D=WooCommerce%20Payments%20Dev&self_assessment%5Bmcc%5D=retail__clothing_and_apparel&self_assessment%5Bsite%5D=https%3A%2F%2Fwcpay.test&self_assessment%5Bcountry%5D=US&self_assessment%5Bbusiness_type%5D=individual&self_assessment%5Bannual_revenue%5D=from_20m_to_100m&self_assessment%5Bgo_live_timeframe%5D=more_than_6months&capabilities=&progressive=false&_locale=user
```
* Verify you see the embedded onboarding. Complete the phone number verification using the test code.
* Verify you see the personal details step. Click the X at the top of the page to leave the embedded flow and go back to the connect page.
* On the Connect page, click the prompt to re-enter the onboarding. You should land on the personal details step of the embedded onboarding.
* Continue the onboarding. Complete it as normal, but enter `1111` as the social security number, and `111-111-1111` as the full SSN. This will trigger an identity mismatch error.
* Complete the onboarding.
* You should be redirected to the overview page, and you should see the account notification component with a prompt to update business details.
* Complete the business details update via the prompt. It will take a minute or so to update, but when it does, the notification component will disappear and the account status will become Complete.
* Refresh the page. The component should no longer appear.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
