### PR TITLE
[WooPayments] Update Payments menu item behavior when WooPayments is not fully onboarded

### DIFF
--- a/changelog/update-10536-remove-duplicated-payments-menu-item-for-not-onboarded-accounts
+++ b/changelog/update-10536-remove-duplicated-payments-menu-item-for-not-onboarded-accounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Payments menu item behavior when WooPayments is not fully onboarded.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -365,13 +365,19 @@ class WC_Payments_Admin {
 
 		$menu_icon = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgdmVyc2lvbj0iMS4xIgogICBpZD0ic3ZnNjciCiAgIHNvZGlwb2RpOmRvY25hbWU9IndjcGF5X21lbnVfaWNvbi5zdmciCiAgIHdpZHRoPSI4NTIiCiAgIGhlaWdodD0iNjg0IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWUsIDIwMjEtMDUtMjQpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnM3MSIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzY5IgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tYm90dG9tPSIwIgogICAgIGlua3NjYXBlOnpvb209IjI1NiIKICAgICBpbmtzY2FwZTpjeD0iLTg0Ljg1NzQyMiIKICAgICBpbmtzY2FwZTpjeT0iLTgzLjI5NDkyMiIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjEzMTIiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iMTA4MSIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMTE2IgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyMDIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMCIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmc2NyIgLz4KICA8cGF0aAogICAgIHRyYW5zZm9ybT0ic2NhbGUoLTEsIDEpIHRyYW5zbGF0ZSgtODUwLCAwKSIKICAgICBkPSJNIDc2OCw4NiBWIDU5OCBIIDg0IFYgODYgWiBtIDAsNTk4IGMgNDgsMCA4NCwtMzggODQsLTg2IFYgODYgQyA4NTIsMzggODE2LDAgNzY4LDAgSCA4NCBDIDM2LDAgMCwzOCAwLDg2IHYgNTEyIGMgMCw0OCAzNiw4NiA4NCw4NiB6IE0gMzg0LDEyOCB2IDQ0IGggLTg2IHYgODQgaCAxNzAgdiA0NCBIIDM0MCBjIC0yNCwwIC00MiwxOCAtNDIsNDIgdiAxMjggYyAwLDI0IDE4LDQyIDQyLDQyIGggNDQgdiA0NCBoIDg0IHYgLTQ0IGggODYgViA0MjggSCAzODQgdiAtNDQgaCAxMjggYyAyNCwwIDQyLC0xOCA0MiwtNDIgViAyMTQgYyAwLC0yNCAtMTgsLTQyIC00MiwtNDIgaCAtNDQgdiAtNDQgeiIKICAgICBmaWxsPSIjYTJhYWIyIgogICAgIGlkPSJwYXRoNjUiIC8+Cjwvc3ZnPgo=';
 
+		$wc_9_9_and_more = false; // TODO.
+		$position        = '55.7'; // After WooCommerce & Product menu items.
+		if ( false === $should_render_full_menu && $wc_9_9_and_more ) {
+			// Remove the menu item for not onboarded accounts only if WC >= 9.9 to avoid missing Payments menu item.
+			$position = null;
+		}
 		wc_admin_register_page(
 			[
 				'id'         => 'wc-payments',
 				'title'      => __( 'Payments', 'woocommerce-payments' ),
 				'capability' => 'manage_woocommerce',
 				'path'       => $top_level_link,
-				'position'   => '55.7', // After WooCommerce & Product menu items.
+				'position'   => $position, // After WooCommerce & Product menu items.
 				'icon'       => $menu_icon,
 				'nav_args'   => [
 					'title'        => 'WooPayments',

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -395,7 +395,7 @@ class WC_Payments_Admin {
 				$menu_title,
 				'manage_woocommerce',
 				$menu_path,
-				null,
+				'',
 				$menu_icon,
 				$menu_position,
 			);

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -363,21 +363,21 @@ class WC_Payments_Admin {
 
 		$top_level_link = $should_render_full_menu ? '/payments/overview' : '/payments/connect';
 
-		$menu_icon = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgdmVyc2lvbj0iMS4xIgogICBpZD0ic3ZnNjciCiAgIHNvZGlwb2RpOmRvY25hbWU9IndjcGF5X21lbnVfaWNvbi5zdmciCiAgIHdpZHRoPSI4NTIiCiAgIGhlaWdodD0iNjg0IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWUsIDIwMjEtMDUtMjQpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnM3MSIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzY5IgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tYm90dG9tPSIwIgogICAgIGlua3NjYXBlOnpvb209IjI1NiIKICAgICBpbmtzY2FwZTpjeD0iLTg0Ljg1NzQyMiIKICAgICBpbmtzY2FwZTpjeT0iLTgzLjI5NDkyMiIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjEzMTIiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iMTA4MSIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMTE2IgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyMDIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMCIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmc2NyIgLz4KICA8cGF0aAogICAgIHRyYW5zZm9ybT0ic2NhbGUoLTEsIDEpIHRyYW5zbGF0ZSgtODUwLCAwKSIKICAgICBkPSJNIDc2OCw4NiBWIDU5OCBIIDg0IFYgODYgWiBtIDAsNTk4IGMgNDgsMCA4NCwtMzggODQsLTg2IFYgODYgQyA4NTIsMzggODE2LDAgNzY4LDAgSCA4NCBDIDM2LDAgMCwzOCAwLDg2IHYgNTEyIGMgMCw0OCAzNiw4NiA4NCw4NiB6IE0gMzg0LDEyOCB2IDQ0IGggLTg2IHYgODQgaCAxNzAgdiA0NCBIIDM0MCBjIC0yNCwwIC00MiwxOCAtNDIsNDIgdiAxMjggYyAwLDI0IDE4LDQyIDQyLDQyIGggNDQgdiA0NCBoIDg0IHYgLTQ0IGggODYgViA0MjggSCAzODQgdiAtNDQgaCAxMjggYyAyNCwwIDQyLC0xOCA0MiwtNDIgViAyMTQgYyAwLC0yNCAtMTgsLTQyIC00MiwtNDIgaCAtNDQgdiAtNDQgeiIKICAgICBmaWxsPSIjYTJhYWIyIgogICAgIGlkPSJwYXRoNjUiIC8+Cjwvc3ZnPgo=';
+		$menu_title    = esc_html__( 'Payments', 'woocommerce-payments' );
+		$menu_icon     = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgdmVyc2lvbj0iMS4xIgogICBpZD0ic3ZnNjciCiAgIHNvZGlwb2RpOmRvY25hbWU9IndjcGF5X21lbnVfaWNvbi5zdmciCiAgIHdpZHRoPSI4NTIiCiAgIGhlaWdodD0iNjg0IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM0ZThmOWUsIDIwMjEtMDUtMjQpIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnM3MSIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzY5IgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGZpdC1tYXJnaW4tdG9wPSIwIgogICAgIGZpdC1tYXJnaW4tbGVmdD0iMCIKICAgICBmaXQtbWFyZ2luLXJpZ2h0PSIwIgogICAgIGZpdC1tYXJnaW4tYm90dG9tPSIwIgogICAgIGlua3NjYXBlOnpvb209IjI1NiIKICAgICBpbmtzY2FwZTpjeD0iLTg0Ljg1NzQyMiIKICAgICBpbmtzY2FwZTpjeT0iLTgzLjI5NDkyMiIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjEzMTIiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iMTA4MSIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMTE2IgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyMDIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMCIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmc2NyIgLz4KICA8cGF0aAogICAgIHRyYW5zZm9ybT0ic2NhbGUoLTEsIDEpIHRyYW5zbGF0ZSgtODUwLCAwKSIKICAgICBkPSJNIDc2OCw4NiBWIDU5OCBIIDg0IFYgODYgWiBtIDAsNTk4IGMgNDgsMCA4NCwtMzggODQsLTg2IFYgODYgQyA4NTIsMzggODE2LDAgNzY4LDAgSCA4NCBDIDM2LDAgMCwzOCAwLDg2IHYgNTEyIGMgMCw0OCAzNiw4NiA4NCw4NiB6IE0gMzg0LDEyOCB2IDQ0IGggLTg2IHYgODQgaCAxNzAgdiA0NCBIIDM0MCBjIC0yNCwwIC00MiwxOCAtNDIsNDIgdiAxMjggYyAwLDI0IDE4LDQyIDQyLDQyIGggNDQgdiA0NCBoIDg0IHYgLTQ0IGggODYgViA0MjggSCAzODQgdiAtNDQgaCAxMjggYyAyNCwwIDQyLC0xOCA0MiwtNDIgViAyMTQgYyAwLC0yNCAtMTgsLTQyIC00MiwtNDIgaCAtNDQgdiAtNDQgeiIKICAgICBmaWxsPSIjYTJhYWIyIgogICAgIGlkPSJwYXRoNjUiIC8+Cjwvc3ZnPgo=';
+		$menu_position = '55.7'; // After WooCommerce & Product menu items.
 
-		$wc_9_9_and_more = false; // TODO.
-		$position        = '55.7'; // After WooCommerce & Product menu items.
-		if ( false === $should_render_full_menu && $wc_9_9_and_more ) {
-			// Remove the menu item for not onboarded accounts only if WC >= 9.9 to avoid missing Payments menu item.
-			$position = null;
-		}
+		// If the account is not onboarded and Payments NOX feature is enabled, show the menu item linking to the Payments settings page. WooPayments menu item will be hidden.
+		// Otherwise, show the Payments menu item linking to the WooPayments connect / overview page.
+		// Important: We still need connect page to be registered in any case to allow onboarding, test drive onboarding etc.
+		$show_payment_settings_menu_item = Features::is_enabled( 'reactify-classic-payments-settings' ) && false === $should_render_full_menu;
 		wc_admin_register_page(
 			[
 				'id'         => 'wc-payments',
-				'title'      => __( 'Payments', 'woocommerce-payments' ),
+				'title'      => $menu_title,
 				'capability' => 'manage_woocommerce',
 				'path'       => $top_level_link,
-				'position'   => $position, // After WooCommerce & Product menu items.
+				'position'   => $show_payment_settings_menu_item ? null : $menu_position,
 				'icon'       => $menu_icon,
 				'nav_args'   => [
 					'title'        => 'WooPayments',
@@ -387,6 +387,19 @@ class WC_Payments_Admin {
 				],
 			]
 		);
+		if ( $show_payment_settings_menu_item ) {
+			$menu_path = 'admin.php?page=wc-settings&tab=checkout';
+
+			add_menu_page(
+				$menu_title,
+				$menu_title,
+				'manage_woocommerce',
+				$menu_path,
+				null,
+				$menu_icon,
+				$menu_position,
+			);
+		}
 
 		// Merchants are unable to see their deposits, transactions, disputes and settings if their account is rejected or under review.
 		// That's expected, because account under review is hard-blocked account that spends in a review pretty short time-frame.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1215,8 +1215,7 @@ class WC_Payments_Admin {
 
 		$badge = self::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( false === strpos( $menu_item[0], $badge )
-				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
+			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1197,7 +1197,8 @@ class WC_Payments_Admin {
 
 		$badge = self::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] || 'wc-settings&tab=checkout' === $menu_item[2] ) ) {
+			if ( false === strpos( $menu_item[0], $badge )
+				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] || 'admin.php?page=wc-settings&tab=checkout' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -400,6 +400,24 @@ class WC_Payments_Admin {
 				$menu_position,
 			);
 			remove_menu_page( 'wc-admin&path=/payments/connect' );
+
+			global $menu;
+			// If there are providers with active incentive, add a notice badge to the Payments menu item.
+			if ( apply_filters( 'woocommerce_admin_allowed_promo_notes', [] ) ) {
+				$badge = ' <span class="wcpay-menu-badge awaiting-mod count-1"><span class="plugin-count">1</span></span>';
+				foreach ( $menu as $index => $menu_item ) {
+					// Only add the badge markup if not already present and the menu item is the Payments menu item.
+					if ( 0 === strpos( $menu_item[0], $menu_title )
+						&& $menu_path === $menu_item[2]
+						&& false === strpos( $menu_item[0], $badge ) ) {
+
+						$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+						// One menu item with a badge is more than enough.
+						break;
+					}
+				}
+			}
 		}
 
 		// Merchants are unable to see their deposits, transactions, disputes and settings if their account is rejected or under review.
@@ -1198,7 +1216,7 @@ class WC_Payments_Admin {
 		$badge = self::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
 			if ( false === strpos( $menu_item[0], $badge )
-				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] || 'admin.php?page=wc-settings&tab=checkout' === $menu_item[2] ) ) {
+				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -399,6 +399,7 @@ class WC_Payments_Admin {
 				$menu_icon,
 				$menu_position,
 			);
+			remove_menu_page( 'wc-admin&path=/payments/connect' );
 		}
 
 		// Merchants are unable to see their deposits, transactions, disputes and settings if their account is rejected or under review.
@@ -1196,7 +1197,7 @@ class WC_Payments_Admin {
 
 		$badge = self::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
+			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] || 'wc-settings&tab=checkout' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -97,7 +97,7 @@ class WC_Payments_Incentives_Service {
 		$badge = WC_Payments_Admin::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
 			if ( false === strpos( $menu_item[0], $badge )
-				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] || 'admin.php?page=wc-settings&tab=checkout' === $menu_item[2] ) ) {
+				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -96,8 +96,7 @@ class WC_Payments_Incentives_Service {
 
 		$badge = WC_Payments_Admin::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( false === strpos( $menu_item[0], $badge )
-				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
+			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -96,7 +96,8 @@ class WC_Payments_Incentives_Service {
 
 		$badge = WC_Payments_Admin::MENU_NOTIFICATION_BADGE;
 		foreach ( $menu as $index => $menu_item ) {
-			if ( false === strpos( $menu_item[0], $badge ) && ( 'wc-admin&path=/payments/connect' === $menu_item[2] ) ) {
+			if ( false === strpos( $menu_item[0], $badge )
+				&& ( 'wc-admin&path=/payments/connect' === $menu_item[2] || 'admin.php?page=wc-settings&tab=checkout' === $menu_item[2] ) ) {
 				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 				// One menu item with a badge is more than enough.


### PR DESCRIPTION
Fixes #10536

#### Changes proposed in this Pull Request

This PR updates the behavior of the Payments menu item in WooCommerce when WooPayments is installed but not fully onboarded. Previously, clicking Payments redirected users to the WooPayments client connect page. Since this page is being deprecated in WooPayments 9.9, the PR modifies the redirection logic:

- If the merchant is fully onboarded, clicking Payments will redirect them to the Payments Overview page.
- If the merchant is not fully onboarded, clicking Payments will redirect them to the Payments Settings page, which is designed to handle all onboarding states.
- These changes ensure that merchants always land on the appropriate screen, improving usability and aligning with the upcoming deprecation of the connect page.

#### Testing instructions

##### NOX feature flag is enabled

1. [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce-payments-dev-tools&woocommerce&branches.woocommerce=update/10536-remove-duplicated-payments-menu-item-for-not-onboarded-accounts) 🚀
1. Navigate to WooCommerce -> Home, Skip guided setup picking US as a store country.
1. Click Payments menu item. You should be redirected to the Payments -> Settings.

##### NOX feature flag is NOT enabled
1. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
