### PR TITLE
chore: tokenized ECE tests for product page

### DIFF
--- a/changelog/chore-add-tokenized-express-checkout-unit-tests
+++ b/changelog/chore-add-tokenized-express-checkout-unit-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: add tokenized express checkout unit tests for product page
+
+

--- a/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js
+++ b/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js
@@ -15,8 +15,6 @@ jest.mock( 'lodash', () => ( {
 describe( 'Tokenized Express Checkout Element - Product page logic', () => {
 	let stripeElementMock, stripeInstance;
 	beforeEach( () => {
-		// jest.resetModules();
-
 		// ensuring jQuery is available globally.
 		global.$ = global.jQuery = $;
 		// ensuring that `callback` is immediately invoked on document.ready.

--- a/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js
+++ b/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js
@@ -1,0 +1,206 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import $ from 'jquery';
+import { recordUserEvent } from 'tracks';
+
+jest.mock( 'tracks', () => ( {
+	recordUserEvent: jest.fn(),
+} ) );
+jest.mock( 'lodash', () => ( {
+	debounce: jest.fn( ( callback ) => callback ),
+} ) );
+
+describe( 'Tokenized Express Checkout Element - Product page logic', () => {
+	let stripeElementMock, stripeInstance;
+	beforeEach( () => {
+		// jest.resetModules();
+
+		// ensuring jQuery is available globally.
+		global.$ = global.jQuery = $;
+		// ensuring that `callback` is immediately invoked on document.ready.
+		$.fn.ready = ( callback ) => callback( $ );
+
+		global.wcpayExpressCheckoutParams = {};
+		global.wcpayExpressCheckoutParams.stripe = {
+			accountId: 'acc_id',
+			locale: 'it',
+			publishableKey: 'stripe_public_key',
+		};
+		global.wcpayExpressCheckoutParams.checkout = {
+			country_code: 'US',
+			currency_code: 'usd',
+			currency_decimals: 2,
+			needs_payer_phone: false,
+			needs_shipping: true,
+			allowed_shipping_countries: [ 'US' ],
+		};
+		global.wcpayExpressCheckoutParams.store_name = 'My fancy store';
+		global.wcpayExpressCheckoutParams.button_context = 'product';
+		global.wcpayExpressCheckoutParams.product = {
+			product_type: 'simple',
+			needs_shipping: true,
+			country_code: 'US',
+			currency: 'usd',
+			total: { amount: 1100 },
+			shippingOptions: {
+				id: 'pending',
+				label: 'Pending',
+				detail: '',
+				amount: 0,
+			},
+			displayItems: [
+				{
+					label: 'Beanie',
+					amount: 1000,
+				},
+				{
+					label: 'Tax',
+					amount: 100,
+					pending: false,
+				},
+				{
+					label: 'Shipping',
+					amount: 0,
+					pending: true,
+				},
+			],
+		};
+
+		// just mocking some server-side-provided DOM elements.
+		render(
+			<div>
+				<button className="single_add_to_cart_button">
+					Fake button
+				</button>
+				<div id="wcpay-express-checkout-wrapper">
+					<div
+						id="wcpay-express-checkout-element"
+						data-testid="wcpay-express-checkout-element"
+						style={ { display: 'none' } }
+					/>
+				</div>
+			</div>
+		);
+
+		stripeElementMock = {
+			mount: jest.fn(),
+			unmount: jest.fn(),
+			on: jest.fn( ( event, callback ) => {
+				stripeElementMock[ `__triggerEvent-${ event }` ] = callback;
+			} ),
+		};
+		global.Stripe = jest.fn( () => {
+			stripeInstance = {
+				elements: jest.fn( () => ( {
+					create: jest.fn( () => stripeElementMock ),
+				} ) ),
+			};
+
+			return stripeInstance;
+		} );
+	} );
+
+	afterEach( () => {
+		delete global.Stripe;
+	} );
+
+	it( 'should not initialize Stripe if there is no publishable key', async () => {
+		global.wcpayExpressCheckoutParams.stripe.publishableKey = '';
+
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		expect( global.Stripe ).not.toHaveBeenCalled();
+		expect( recordUserEvent ).not.toHaveBeenCalled();
+		expect(
+			screen.getByTestId( 'wcpay-express-checkout-element' )
+		).not.toBeVisible();
+	} );
+
+	it( 'should not initialize Stripe if the total amount is 0', async () => {
+		global.wcpayExpressCheckoutParams.product.total.amount = 0;
+		global.wcpayExpressCheckoutParams.product.displayItems = [];
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		expect( global.Stripe ).not.toHaveBeenCalled();
+		expect( recordUserEvent ).not.toHaveBeenCalled();
+		expect(
+			screen.getByTestId( 'wcpay-express-checkout-element' )
+		).not.toBeVisible();
+	} );
+
+	it( 'should not track the initialization if no payment methods are available', async () => {
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		expect( global.Stripe ).toHaveBeenCalled();
+		expect( stripeInstance.elements ).toHaveBeenCalledWith( {
+			mode: 'payment',
+			amount: 1100,
+			currency: 'usd',
+			paymentMethodCreation: 'manual',
+			appearance: expect.anything(),
+			locale: 'it',
+		} );
+
+		// triggering the `ready` event on the ECE button, to test its callback.
+		stripeElementMock[ `__triggerEvent-ready` ]( {
+			availablePaymentMethods: {
+				link: false,
+				applePay: false,
+				googlePay: false,
+				paypal: false,
+				amazonPay: false,
+			},
+		} );
+
+		expect( recordUserEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should track the initialization', async () => {
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		expect( global.Stripe ).toHaveBeenCalled();
+		expect( stripeInstance.elements ).toHaveBeenCalledWith( {
+			mode: 'payment',
+			amount: 1100,
+			currency: 'usd',
+			paymentMethodCreation: 'manual',
+			appearance: expect.anything(),
+			locale: 'it',
+		} );
+
+		// triggering the `ready` event on the ECE button, to test its callback.
+		stripeElementMock[ `__triggerEvent-ready` ]( {
+			availablePaymentMethods: {
+				link: false,
+				applePay: true,
+				googlePay: true,
+				paypal: false,
+				amazonPay: false,
+			},
+		} );
+
+		expect( recordUserEvent ).toHaveBeenNthCalledWith(
+			1,
+			'applepay_button_load',
+			expect.objectContaining( { source: 'product' } )
+		);
+		expect( recordUserEvent ).toHaveBeenNthCalledWith(
+			2,
+			'gpay_button_load',
+			expect.objectContaining( { source: 'product' } )
+		);
+		expect(
+			screen.getByTestId( 'wcpay-express-checkout-element' )
+		).toBeVisible();
+	} );
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "iti": "0.6.0",
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
+        "jquery": "3.7.1",
         "lint-staged": "10.5.4",
         "mini-css-extract-plugin": "2.3.0",
         "moment": "2.29.4",
@@ -28017,6 +28018,12 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "dev": true
     },
     "node_modules/js-library-detector": {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "iti": "0.6.0",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
+    "jquery": "3.7.1",
     "lint-staged": "10.5.4",
     "mini-css-extract-plugin": "2.3.0",
     "moment": "2.29.4",


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I'd like to add some basic unit tests for the Tokenized ECE for its product page logic.
The logic can become quite complex, so I'd like to start somewhere :D 

This is just testing some basic logic, but I'd like to eventually extend its test scenarios further.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `npm run test:js -- client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js` (or wait for the GH actions to run?) 😄 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
