### PR TITLE
Add a searchable flag and notes to some existing lists of payment method IDs

### DIFF
--- a/changelog/update-10517-add-notes-to-payment-method-details-and-logos
+++ b/changelog/update-10517-add-notes-to-payment-method-details-and-logos
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Again, this is related to the work in 10517 and a changelog entry will be made during the PR to close that issue.
+
+

--- a/client/components/payment-method-details/index.js
+++ b/client/components/payment-method-details/index.js
@@ -43,12 +43,6 @@ const formatDetails = ( payment ) => {
 					{ paymentMethod.iban_last4 }
 				</Fragment>
 			);
-		case 'alipay':
-		case 'affirm':
-		case 'afterpay_clearpay':
-		case 'klarna':
-		case 'multibanco':
-		case 'wechat_pay':
 		default:
 			return <Fragment />;
 	}

--- a/client/components/payment-method-details/index.js
+++ b/client/components/payment-method-details/index.js
@@ -15,6 +15,15 @@ import { PAYMENT_METHOD_TITLES } from 'wcpay/constants/payment-method';
  */
 const formatDetails = ( payment ) => {
 	const paymentMethod = payment[ payment.type ];
+	/**
+	 * FLAG: PAYMENT_METHODS_LIST
+	 *
+	 * When adding a payment method, if you need to display a specific detail, you can
+	 * add it here. If not, you don't need to list it here.
+	 *
+	 * If you're removing a payment method, you'll probably want to leave this section
+	 * section alone because we still need to display the details of existing transactions.
+	 */
 	switch ( payment.type ) {
 		case 'card':
 		case 'au_becs_debit':

--- a/client/components/payment-method-logos/index.tsx
+++ b/client/components/payment-method-logos/index.tsx
@@ -31,6 +31,11 @@ import Przelewy24 from 'assets/images/payment-methods/przelewy24.svg?asset';
 import WeChatPay from 'assets/images/payment-method-icons/wechat-pay.svg?asset';
 import './style.scss';
 
+/**
+ * FLAG: PAYMENT_METHODS_LIST
+ * If you're adding a new payment method that needs to be displayed on the
+ * connect account page, you'll need to add it here.
+ */
 const PaymentMethods = [
 	{
 		name: 'visa',

--- a/client/data/transactions/hooks.ts
+++ b/client/data/transactions/hooks.ts
@@ -44,6 +44,8 @@ export interface Transaction {
 	// Usually last 4 digits for card payments, bank name for bank transfers...
 	source_identifier: string;
 	source_device?: string;
+	// FLAG: PAYMENT_METHODS_LIST
+	// This source could be the network, brand, or payment method ID.
 	source:
 		| 'ach_credit_transfer'
 		| 'ach_debit'


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This is part of the work being done in #10517 but does not complete it.

This PR removes an unnecessary listing of payment methods above the `default` case in a `switch` statement to be more clear that a payment method does not necessarily need to be listed there. I'm also implementing the use of `FLAG: PAYMENT_METHODS_LIST` to highlight anywhere there is a static list of payment methods. This is to help highlight areas of the code that may need to be updated when adding/removing payment methods from the plugin.

#### Testing instructions
This is mostly adding comments, but to be extra safe, you can look at the transaction details of a transaction made with Affirm or Klarna and make sure that the "Payment Method" column looks the same before and after this PR is applied.

<img width="800" alt="Screenshot 2025-03-19 at 4 48 39 PM" src="https://github.com/user-attachments/assets/595f46e8-7c47-493e-885c-7e6c0c8ac242" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
