### PR TITLE
Use a constant to define all currencies support

### DIFF
--- a/includes/payment-methods/class-cc-payment-method.php
+++ b/includes/payment-methods/class-cc-payment-method.php
@@ -26,7 +26,7 @@ class CC_Payment_Method extends UPE_Payment_Method {
 		parent::__construct( $token_service );
 		$this->stripe_id   = self::PAYMENT_METHOD_STRIPE_ID;
 		$this->is_reusable = true;
-		$this->currencies  = [];// All currencies are supported.
+		$this->currencies  = [ self::ALL_CURRENCIES_SUPPORTED ];
 		$this->icon_url    = plugins_url( 'assets/images/payment-methods/generic-card.svg', WCPAY_PLUGIN_FILE );
 	}
 

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -113,6 +113,13 @@ class UPE_Payment_Method {
 	protected $countries = [];
 
 	/**
+	 * Constant for all currencies supported
+	 *
+	 * @var string
+	 */
+	protected const ALL_CURRENCIES_SUPPORTED = 'ALL_CURRENCIES';
+
+	/**
 	 * Create instance of payment method
 	 *
 	 * @param WC_Payments_Token_Service $token_service Instance of WC_Payments_Token_Service.
@@ -279,9 +286,13 @@ class UPE_Payment_Method {
 			}
 		}
 
+		if ( $this->are_all_currencies_supported() ) {
+			return true;
+		}
+
 		$supported_currencies = $this->get_currencies();
 
-		return empty( $supported_currencies ) || in_array( $current_store_currency, $supported_currencies, true );
+		return ! empty( $supported_currencies ) && in_array( $current_store_currency, $supported_currencies, true );
 	}
 
 	/**
@@ -365,6 +376,15 @@ class UPE_Payment_Method {
 		$account_country = isset( $account['country'] ) ? strtoupper( $account['country'] ) : '';
 
 		return $this->has_domestic_transactions_restrictions() ? [ $account_country ] : $this->countries;
+	}
+
+	/**
+	 * Returns true if all currencies are supported
+	 *
+	 * @return bool
+	 */
+	private function are_all_currencies_supported() {
+		return [ self::ALL_CURRENCIES_SUPPORTED ] === $this->get_currencies();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request
Switch from array emptiness to a constant to define the support of any currencies. Currently, only card payment method is the one supported all the currencies, so the constant was applied there too. 

Going forward, we can use an empty array to return from `get_currencies` to flag no currencies supported. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
