### PR TITLE
Add net amount after deducting fees to meta data

### DIFF
--- a/changelog/update-add-net-in-metadata
+++ b/changelog/update-add-net-in-metadata
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Added _wcpay_net to the metadata.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -475,6 +475,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$charges_data  = $this->read_webhook_property( $event_charges, 'data' );
 		$charge_id     = $this->read_webhook_property( $charges_data[0], 'id' );
 		$metadata      = $this->read_webhook_property( $event_object, 'metadata' );
+		$charge_amount = $this->read_webhook_property( $event_object, 'amount' ) ?? $this->read_webhook_property( $charges_data[0], 'amount' );
 
 		$payment_method_id = $charges_data[0]['payment_method'] ?? null;
 		if ( ! $order ) {
@@ -501,10 +502,8 @@ class WC_Payments_Webhook_Processing_Service {
 			$fee = WC_Payments_Utils::interpret_stripe_amount( $application_fee_amount, $currency );
 			$meta_data_to_update['_wcpay_transaction_fee'] = $fee;
 
-			$order_currency = $order->get_currency();
-			if ( $order_currency && strtolower( $currency ) === strtolower( $order_currency ) ) {
-				$meta_data_to_update['_wcpay_net'] = $order->get_total() - $fee;
-			}
+			$charge_amount                     = WC_Payments_Utils::interpret_stripe_amount( $charge_amount, $currency );
+			$meta_data_to_update['_wcpay_net'] = $charge_amount - $fee;
 		}
 
 		foreach ( $meta_data_to_update as $key => $value ) {

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -496,8 +496,15 @@ class WC_Payments_Webhook_Processing_Service {
 		}
 
 		$application_fee_amount = $charges_data[0]['application_fee_amount'] ?? null;
+
 		if ( $application_fee_amount ) {
-			$meta_data_to_update['_wcpay_transaction_fee'] = WC_Payments_Utils::interpret_stripe_amount( $application_fee_amount, $currency );
+			$fee = WC_Payments_Utils::interpret_stripe_amount( $application_fee_amount, $currency );
+			$meta_data_to_update['_wcpay_transaction_fee'] = $fee;
+
+			$order_currency = $order->get_currency();
+			if ( $order_currency && strtolower( $currency ) === strtolower( $order_currency ) ) {
+				$meta_data_to_update['_wcpay_net'] = $order->get_total() - $fee;
+			}
 		}
 
 		foreach ( $meta_data_to_update as $key => $value ) {

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -470,12 +470,10 @@ class WC_Payments_Webhook_Processing_Service {
 		$intent_id     = $this->read_webhook_property( $event_object, 'id' );
 		$currency      = $this->read_webhook_property( $event_object, 'currency' );
 		$order         = $this->get_order_from_event_body( $event_body );
-		$intent_status = $this->read_webhook_property( $event_object, 'status' );
 		$event_charges = $this->read_webhook_property( $event_object, 'charges' );
 		$charges_data  = $this->read_webhook_property( $event_charges, 'data' );
 		$charge_id     = $this->read_webhook_property( $charges_data[0], 'id' );
-		$metadata      = $this->read_webhook_property( $event_object, 'metadata' );
-		$charge_amount = $this->read_webhook_property( $event_object, 'amount' ) ?? $this->read_webhook_property( $charges_data[0], 'amount' );
+		$charge_amount = $this->read_webhook_property( $event_object, 'amount' );
 
 		$payment_method_id = $charges_data[0]['payment_method'] ?? null;
 		if ( ! $order ) {


### PR DESCRIPTION
Fixes #10555 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
- Adds a new key `_wcpay_net` to metadata when handling the payment intent succeeded webhook.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Simulate the webhook and ensure the new key is added in the metadata.
* Tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
