### PR TITLE
Implement proper square braces for checks in shell

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -22,9 +22,9 @@ else
 		echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
 
 		DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PLUGIN_PATH && git branch --show-current)
-		if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
+		if [ $DEV_TOOLS_BRANCH = "trunk" ]; then
 			echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
-			if [[ `cd $DEV_TOOLS_PLUGIN_PATH && git status --porcelain` ]]; then
+			if [ `cd $DEV_TOOLS_PLUGIN_PATH && git status --porcelain` ]; then
 				echo "\033[33m  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it.\033[0m"
 			else
 				echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"

--- a/changelog/dev-fix-post-merge-script
+++ b/changelog/dev-fix-post-merge-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix unneeded double square brackets in the post-merge script


### PR DESCRIPTION
Fixes #10621 

#### Changes proposed in this Pull Request

Fix checks in the `post-merge` script.

Single brackets are a POSIX-standard, while double brackets are an extension, provided by `bash` or similar shells. However, the script in question changes the shell interpreter after the start. There is a line in the beginning which calls `.husky/_/husky.sh` and at this point shell changes to `sh` according to the aforementioned script's shebang. And even if this part is fixed, there could be other scripting parts, updated by vendor package, which will change the shell back to `sh`. Therefore, we should be using a portable single-bracket notation in this context.

#### Testing instructions

 - Checkout branch for the pull request
 * Run `sh ./husky/post-merge`
 - No errors should be reported and WCPay Dev tools should be updated if needed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
