### PR TITLE
WOOPLUG-3493 WooPay on Multisite: Fix intent sanitization

### DIFF
--- a/changelog/fix-woopay-intent-id-sanitization
+++ b/changelog/fix-woopay-intent-id-sanitization
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Changed WooPay intent ID sanitizaiton to allow WooPay to work on multisites.
+
+

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1560,8 +1560,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$this->order_service->mark_payment_failed( $order, $intent_id, $status, $charge_id );
 			}
 		} else {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$woopay_intent_id = sanitize_user( wp_unslash( $_POST['platform-checkout-intent'] ?? '' ), true );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$woopay_intent_id = WooPay_Utilities::sanitize_intent_id( wp_unslash( $_POST['platform-checkout-intent'] ?? '' ) );
 
 			if ( ! empty( $woopay_intent_id ) ) {
 				// If the setup intent is included in the request use that intent.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1446,10 +1446,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				throw new Exception( WC_Payments_Utils::get_filtered_error_message( $e ) );
 			}
 
-			// The sanitize_user call here is deliberate: it seems the most appropriate sanitization function
-			// for a string that will only contain latin alphanumeric characters and underscores.
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$woopay_intent_id = sanitize_user( wp_unslash( $_POST['platform-checkout-intent'] ?? '' ), true );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$woopay_intent_id = WooPay_Utilities::sanitize_intent_id( wp_unslash( $_POST['platform-checkout-intent'] ?? '' ) );
 
 			// Initializing the intent variable here to ensure we don't try to use an undeclared
 			// variable later.

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -149,6 +149,16 @@ class WooPay_Utilities {
 	}
 
 	/**
+	 * Sanitizes an intent ID by stripping everything by underscores, characters and digits.
+	 *
+	 * @param string $intent_id ID of the intent.
+	 * @return string Sanitized value.
+	 */
+	public static function sanitize_intent_id( string $intent_id ) {
+		return preg_replace( '/[^\w_]+/', '', $intent_id );
+	}
+
+	/**
 	 * Get if WooPay is available on the store country.
 	 *
 	 * @return boolean

--- a/src/Internal/Payment/PaymentRequest.php
+++ b/src/Internal/Payment/PaymentRequest.php
@@ -14,6 +14,7 @@ use WCPay\Internal\Payment\PaymentMethod\NewPaymentMethod;
 use WCPay\Internal\Payment\PaymentMethod\PaymentMethodInterface;
 use WCPay\Internal\Payment\PaymentMethod\SavedPaymentMethod;
 use WCPay\Internal\Proxy\LegacyProxy;
+use WCPay\WooPay\WooPay_Utilities;
 
 /**
  * Class for loading, sanitizing, and escaping data from payment requests.
@@ -72,7 +73,7 @@ class PaymentRequest {
 	 */
 	public function get_woopay_intent_id(): ?string {
 		return isset( $this->request['platform-checkout-intent'] )
-			? sanitize_text_field( wp_unslash( ( $this->request['platform-checkout-intent'] ) ) )
+			? WooPay_Utilities::sanitize_intent_id( wp_unslash( ( $this->request['platform-checkout-intent'] ) ) )
 			: null;
 	}
 

--- a/tests/unit/src/Internal/Payment/PaymentRequestTest.php
+++ b/tests/unit/src/Internal/Payment/PaymentRequestTest.php
@@ -52,15 +52,6 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 	/**
 	 * @dataProvider provider_text_string_param
 	 */
-	public function test_get_woopay_intent_id( ?string $value, ?string $expected ) {
-		$request   = is_null( $value ) ? [] : [ 'platform-checkout-intent' => $value ];
-		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
-		$this->assertSame( $expected, $this->sut->get_woopay_intent_id() );
-	}
-
-	/**
-	 * @dataProvider provider_text_string_param
-	 */
 	public function test_get_intent_id( ?string $value, ?string $expected ) {
 		$request   = is_null( $value ) ? [] : [ 'intent_id' => $value ];
 		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
@@ -93,6 +84,36 @@ class PaymentRequestTest extends WCPAY_UnitTestCase {
 			'string will be changed after sanitization' => [
 				'value'    => " \n<tag>String-with_special_chars__@.#$%^&*()",
 				'expected' => 'String-with_special_chars__@.#$%^&*()',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provider_get_woopay_intent_id
+	 */
+	public function test_get_woopay_intent_id( ?string $value, ?string $expected ) {
+		$request   = is_null( $value ) ? [] : [ 'platform-checkout-intent' => $value ];
+		$this->sut = new PaymentRequest( $this->mock_legacy_proxy, $request );
+		$this->assertSame( $expected, $this->sut->get_woopay_intent_id() );
+	}
+
+	public function provider_get_woopay_intent_id(): array {
+		return [
+			'Param is not set'                          => [
+				'value'    => null,
+				'expected' => null,
+			],
+			'empty string'                              => [
+				'value'    => '',
+				'expected' => '',
+			],
+			'normal string'                             => [
+				'value'    => 'String-with-dash_and_underscore',
+				'expected' => 'Stringwithdash_and_underscore',
+			],
+			'string will be changed after sanitization' => [
+				'value'    => " \n<tag>String-with_special_chars__@.#$%^&*()",
+				'expected' => 'tagStringwith_special_chars__',
 			],
 		];
 	}


### PR DESCRIPTION
Fixes WOOPLUG-3493 ([link](https://linear.app/a8c/issue/WOOPLUG-3493))

#### Changes proposed in this Pull Request

Checking a demo site, WooPay is facing errors while trying to complete the order on the client side:

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/e9e186c4-90fc-474a-8ad1-af9f022b476b" />

Turns out that this was because the intent ID gets converted to lowercase, and Stripe cannot find the intent. After a bit of digging, it appears that this was happening because the demo site was a multisite, and the following line was executed:

https://github.com/WordPress/wordpress-develop/blob/eded4748b390893384ad39a36deca5767230c1e8/src/wp-includes/ms-default-filters.php#L33

Since we used `sanitize_user` to sanitize the incoming intent ID, the intent ID went through `strtolower`. AFAICT, this means that WooPay never worked on a multisite setup.

This PR replaces `sanitize_user` and `sanitize_text_field` with a bespoke method that strips everything but digits, characters, and underscores. This will allow us to safely call Stripe to retrieve the intent, thus allowing WooPay to function on a multisite.

#### Testing instructions

Simply confirm that checking out with WooPay through the _Buy with WooPay_ button on checkout works. If this PR does not break anything, the order should appear as completed (ex. Processing) on the client site.

Ideally, the client site should be a part of a Multisite network. However, the updated solution here should not depend on that.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good r