### PR TITLE
Fix success page qit security watnings

### DIFF
--- a/assets/css/success.rtl.css
+++ b/assets/css/success.rtl.css
@@ -148,7 +148,7 @@
 	color: #4d3716;
 	justify-self: start;
 	width: max-content;
-	margin-left: 5px;
+	margin-right: 5px;
 }
 
 #wc-payment-gateway-multibanco-instructions-container .payment-box-value {

--- a/changelog/order-success-qit-warnings
+++ b/changelog/order-success-qit-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This change only fixes phpcs warnings
+
+

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -87,23 +87,30 @@ class WC_Payments_Order_Success_Page {
 						<div class="payment-header">
 							<?php
 							/* translators: %s: order number */
-							printf( esc_html__( 'Order #%s', 'woocommerce-payments' ), $order->get_order_number() );
+							echo esc_html( sprintf( __( 'Order #%s', 'woocommerce-payments' ), $order->get_order_number() ) );
 							?>
 						</div>
 						<div class="payment-expiry">
 						<?php
-							printf(
-								/* translators: %s: expiry date */
-								esc_html__( 'Expires %s', 'woocommerce-payments' ),
-								'<strong>' . $expiry_date . '</strong>'
-							);
+						printf(
+							WC_Payments_Utils::esc_interpolated_html( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							/* translators: %s: expiry date */
+								__( 'Expires <strong>%s</strong>', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+								]
+							),
+							esc_html( $expiry_date )
+						);
 						?>
 							<span class="badge">
 							<?php
-							printf(
-							/* translators: %d: number of days */
-								_n( '%d day', '%d days', $days_remaining, 'woocommerce-payments' ),
-								$days_remaining
+							echo esc_html(
+								sprintf(
+									/* translators: %d: number of days */
+									_n( '%d day', '%d days', $days_remaining, 'woocommerce-payments' ),
+									$days_remaining
+								)
 							);
 							?>
 							</span>
@@ -131,7 +138,7 @@ class WC_Payments_Order_Success_Page {
 					</div>
 					<div class="payment-box-row">
 						<span class="payment-box-label"><?php esc_html_e( 'Amount', 'woocommerce-payments' ); ?></span>
-						<button type="button" class="payment-box-value copy-btn" data-copy-value="<?php echo esc_attr( wp_strip_all_tags( $formatted_order_total ) ); ?>"><?php echo wp_strip_all_tags( $formatted_order_total ); ?><i class="copy-icon"></i></button>
+						<button type="button" class="payment-box-value copy-btn" data-copy-value="<?php echo esc_attr( wp_strip_all_tags( $formatted_order_total ) ); ?>"><?php echo esc_html( wp_strip_all_tags( $formatted_order_total ) ); ?><i class="copy-icon"></i></button>
 					</div>
 				</div>
 
@@ -510,18 +517,18 @@ class WC_Payments_Order_Success_Page {
 
 		if ( $plain_text ) {
 			echo "----------------------------------------\n";
-			echo __( 'Multibanco Payment instructions', 'woocommerce-payments' ) . "\n\n";
+			echo esc_html__( 'Multibanco Payment instructions', 'woocommerce-payments' ) . "\n\n";
 			printf(
 			/* translators: %s: expiry date */
-				__( 'Expires %s', 'woocommerce-payments' ) . "\n\n",
-				$expiry_date
+				esc_html__( 'Expires %s', 'woocommerce-payments' ) . "\n\n",
+				esc_html( $expiry_date )
 			);
-			echo '1. ' . __( 'In your online bank account or from an ATM, choose "Payment and other services".', 'woocommerce-payments' ) . "\n";
-			echo '2. ' . __( 'Click "Payments of services/shopping".', 'woocommerce-payments' ) . "\n";
-			echo '3. ' . __( 'Enter the entity number, reference number, and amount.', 'woocommerce-payments' ) . "\n\n";
-			echo __( 'Entity', 'woocommerce-payments' ) . ': ' . $multibanco_info['entity'] . "\n";
-			echo __( 'Reference', 'woocommerce-payments' ) . ': ' . $multibanco_info['reference'] . "\n";
-			echo __( 'Amount', 'woocommerce-payments' ) . ': ' . wp_strip_all_tags( $formatted_order_total ) . "\n";
+			echo '1. ' . esc_html__( 'In your online bank account or from an ATM, choose "Payment and other services".', 'woocommerce-payments' ) . "\n";
+			echo '2. ' . esc_html__( 'Click "Payments of services/shopping".', 'woocommerce-payments' ) . "\n";
+			echo '3. ' . esc_html__( 'Enter the entity number, reference number, and amount.', 'woocommerce-payments' ) . "\n\n";
+			echo esc_html__( 'Entity', 'woocommerce-payments' ) . ': ' . esc_html( $multibanco_info['entity'] ) . "\n";
+			echo esc_html__( 'Reference', 'woocommerce-payments' ) . ': ' . esc_html( $multibanco_info['reference'] ) . "\n";
+			echo esc_html__( 'Amount', 'woocommerce-payments' ) . ': ' . esc_html( wp_strip_all_tags( $formatted_order_total ) ) . "\n";
 			echo "----------------------------------------\n\n";
 		} else {
 			?>
@@ -542,7 +549,7 @@ class WC_Payments_Order_Success_Page {
 								<td style="font-size: 20px; padding: 0;">
 									<?php
 									/* translators: %s: order number */
-									printf( esc_html__( 'Order #%s', 'woocommerce-payments' ), $order->get_order_number() );
+									echo esc_html( sprintf( __( 'Order #%s', 'woocommerce-payments' ), $order->get_order_number() ) );
 									?>
 								</td>
 							</tr>
@@ -550,14 +557,14 @@ class WC_Payments_Order_Success_Page {
 								<td style="padding: 0;">
 									<?php
 									printf(
-										WC_Payments_Utils::esc_interpolated_html(
+										WC_Payments_Utils::esc_interpolated_html( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 											/* translators: %s: expiry date */
 											__( 'Expires <strong>%s</strong>', 'woocommerce-payments' ),
 											[
 												'strong' => '<strong>',
 											]
 										),
-										$expiry_date
+										esc_html( $expiry_date )
 									);
 									?>
 								</td>
@@ -584,7 +591,7 @@ class WC_Payments_Order_Success_Page {
 							</tr>
 							<tr>
 								<th class="td"><?php esc_html_e( 'Amount', 'woocommerce-payments' ); ?></th>
-								<td class="td"><?php echo wp_strip_all_tags( $formatted_order_total ); ?></td>
+								<td class="td"><?php echo esc_html( wp_strip_all_tags( $formatted_order_total ) ); ?></td>
 							</tr>
 							</tbody>
 						</table>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,7 +36,6 @@
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8434 is closed. -->
 		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped" />
-		<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated" />
 
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8436 is closed. -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#10227 introduced a few QIT security warnings p1742844655283119-slack-CU6SYV31A. This not too concerning since none of this information is entered by the user, so we don't need to release a patch. This PR fixes those issues and removes the phpcs exclude rule to prevent this from happening again.

#### Testing instructions

1. Follow testing instructions from #10418.
1. Follow testing instructions from #10469.
1. Follow testing instructions from #10484.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.