### PR TITLE
Fix Multi-currency conversion for WooCommerce Bookings range type cost adjustments

### DIFF
--- a/changelog/fix-8461-multi-currency-doesnt-convert-range-type-cost-adjustments-from-woo-bookings
+++ b/changelog/fix-8461-multi-currency-doesnt-convert-range-type-cost-adjustments-from-woo-bookings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Multi-currency conversion for WooCommerce Bookings range type cost adjustments

--- a/includes/multi-currency/Compatibility/WooCommerceBookings.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBookings.php
@@ -53,6 +53,8 @@ class WooCommerceBookings extends BaseCompatibility {
 				add_filter( 'woocommerce_product_get_resource_base_costs', [ $this, 'get_resource_prices' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_resource_block_costs', [ $this, 'get_resource_prices' ], 50, 1 );
 				add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ], 50, 2 );
+				add_filter( 'woocommerce_bookings_process_cost_rules_cost', [ $this, 'get_price' ], 50, 1 );
+				add_filter( 'woocommerce_bookings_process_cost_rules_base_cost', [ $this, 'get_price' ], 50, 1 );
 				add_action( 'wp_ajax_wc_bookings_calculate_costs', [ $this, 'add_wc_price_args_filter_for_ajax' ], 9 );
 				add_action( 'wp_ajax_nopriv_wc_bookings_calculate_costs', [ $this, 'add_wc_price_args_filter_for_ajax' ], 9 );
 			}


### PR DESCRIPTION
Fixes #8461 

This PR fixes an issue where range type cost adjustments in WooCommerce Bookings were not being properly converted when using multi-currency functionality. The fix adds two new filters to handle the conversion of both cost rules and base costs during the booking cost calculation process.

#### Changes proposed in this Pull Request

The WooCommerce Bookings plugin uses a rule-based system for managing booking costs, where costs can be adjusted based on various factors like person count, block count, or time ranges. These rules are processed in the `WC_Product_Booking_Rule_Manager::process_cost_rules()` method.

Each cost rule can have two types of costs:
1. `base_cost`: A fixed cost that applies to the entire booking
2. `cost`: A variable cost that can be applied per person, block, or time unit

The new filters are added to ensure that both these costs are properly converted when using multi-currency:
- `woocommerce_bookings_process_cost_rules_cost`: Converts the variable cost component of range type rules
- `woocommerce_bookings_process_cost_rules_base_cost`: Converts the base cost component of range type rules

These filters are called during the cost calculation process, ensuring that all price adjustments are properly converted to the selected currency.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. **Setup**
   - Install and activate WooCommerce Bookings
   - Configure WCPay multi-currency with at least one non-default currency
   - Create a bookable product with range type cost adjustments (e.g., person count or block count)

2. **Test Range Type Cost Adjustments**
   - Create a bookable product with a base cost.
   - Set up range rules (e.g., 1-2 people = $100, 3-4 people = $180)
   - View the product on the frontend
   - Select different quantities within the ranges
   - Switch between currencies
   - Verify that the prices are correctly converted in all scenarios

4. **Verify Cart and Checkout**
   - Add a booking to cart 
   - Switch currencies in cart
   - Verify prices update correctly
   - Proceed to checkout
   - Verify final prices are in the correct currency

### Expected Results
- All range type cost adjustments should be properly converted when switching currencies
- Prices should update dynamically when switching currencies
- Cart and checkout should display correct converted prices

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
