### PR TITLE
Update the progressive parameter in the KYC session creation API to use a boolean type

### DIFF
--- a/changelog/fix-session-creation-eligibility-type
+++ b/changelog/fix-session-creation-eligibility-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Updated the progressive parameter in the KYC session creation API to use a boolean type.

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -228,7 +228,7 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	 */
 	public function get_embedded_kyc_session( WP_REST_Request $request ) {
 		$self_assessment_data = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
-		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && 'true' === $request->get_param( 'progressive' );
+		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && ( 'true' === $request->get_param( 'progressive' ) || true === $request->get_param( 'progressive' ) );
 
 		$account_session = $this->onboarding_service->create_embedded_kyc_session(
 			$self_assessment_data,

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -59,7 +59,9 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 					'progressive'     => [
 						'required'    => false,
 						'description' => 'Whether the session is for progressive onboarding.',
-						'type'        => 'boolean',
+						// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+						// We expect a boolean (true, false, 0, 1, '0', '1', 'true', or 'false'), but will also accept `yes`/`no`.
+						'type'        => [ 'boolean', 'string' ],
 					],
 					'self_assessment' => [
 						'required'    => false,
@@ -228,7 +230,7 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	 */
 	public function get_embedded_kyc_session( WP_REST_Request $request ) {
 		$self_assessment_data = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
-		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && ( 'true' === $request->get_param( 'progressive' ) || true === $request->get_param( 'progressive' ) );
+		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && filter_var( $request->get_param( 'progressive' ), FILTER_VALIDATE_BOOLEAN );
 
 		$account_session = $this->onboarding_service->create_embedded_kyc_session(
 			$self_assessment_data,

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -59,7 +59,7 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 					'progressive'     => [
 						'required'    => false,
 						'description' => 'Whether the session is for progressive onboarding.',
-						'type'        => 'string',
+						'type'        => 'boolean',
 					],
 					'self_assessment' => [
 						'required'    => false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR updates the type of the progressive parameter in the KYC session creation API to boolean. This change ensures compatibility with the implementation introduced in [Add NOX in-context APIs](https://github.com/Automattic/woocommerce-payments/pull/10609), where the parameter is now expected to be a boolean value.

#### Testing instructions
- **The change should make sense.**

1. Spin up a JN site and initiate the MOX onboarding flow.
2. Complete all the MOX fields and click Continue.
3. Confirm that the account session API call is successful.
4. Verify that the Stripe embedded onboarding loads without issues.

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
