### PR TITLE
Update breadcrumbs back link to wc_back_header / wc_back_link for tertiary+ level pages in WooPayments settings

### DIFF
--- a/changelog/update-add-wc-back-links-in-woopayments-settings
+++ b/changelog/update-add-wc-back-links-in-woopayments-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add back button for tertiary+ level pages in WooPayments settings.

--- a/client/settings/express-checkout-settings/__tests__/index.test.js
+++ b/client/settings/express-checkout-settings/__tests__/index.test.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -97,22 +97,6 @@ describe( 'ExpressCheckoutSettings', () => {
 		expect( errorMessage ).toBeInTheDocument();
 	} );
 
-	test( 'renders payment request breadcrumbs', () => {
-		renderWithSettingsProvider(
-			<ExpressCheckoutSettings methodId="payment_request" />
-		);
-
-		const linkToPayments = screen.getByRole( 'link', {
-			name: 'WooPayments',
-		} );
-		const breadcrumbs = linkToPayments.closest( 'h2' );
-
-		const methodName = within( breadcrumbs ).getByText(
-			'Apple Pay / Google Pay'
-		);
-		expect( breadcrumbs ).toContainElement( methodName );
-	} );
-
 	test( 'renders payment request title and description', () => {
 		renderWithSettingsProvider(
 			<ExpressCheckoutSettings methodId="payment_request" />
@@ -145,20 +129,6 @@ describe( 'ExpressCheckoutSettings', () => {
 				name: 'Enable Apple Pay and Google Pay on selected pages',
 			} )
 		).toBeInTheDocument();
-	} );
-
-	test( 'renders woopay breadcrumbs', () => {
-		renderWithSettingsProvider(
-			<ExpressCheckoutSettings methodId="woopay" />
-		);
-
-		const linkToPayments = screen.getByRole( 'link', {
-			name: 'WooPayments',
-		} );
-		const breadcrumbs = linkToPayments.closest( 'h2' );
-
-		const methodName = within( breadcrumbs ).getByText( 'WooPay' );
-		expect( breadcrumbs ).toContainElement( methodName );
 	} );
 
 	test( 'renders woopay settings and confirm its checkbox label', () => {

--- a/client/settings/express-checkout-settings/index.js
+++ b/client/settings/express-checkout-settings/index.js
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
  */
 import './index.scss';
 import SettingsSection from '../settings-section';
-import { getPaymentSettingsUrl } from '../../utils';
 import PaymentRequestSettings from './payment-request-settings';
 import WooPaySettings from './woopay-settings';
 import SettingsLayout from '../settings-layout';
@@ -137,15 +136,10 @@ const ExpressCheckoutSettings = ( { methodId } ) => {
 		} );
 	}
 
-	const { title, sections, controls: Controls } = method;
+	const { sections, controls: Controls } = method;
 
 	return (
 		<SettingsLayout>
-			<h2 className="express-checkout-settings__breadcrumbs">
-				<a href={ getPaymentSettingsUrl() }>{ 'WooPayments' }</a> &gt;{ ' ' }
-				<span>{ title }</span>
-			</h2>
-
 			{ sections.map( ( { section, description } ) => (
 				<SettingsSection key={ section } description={ description }>
 					<LoadableSettingsSection numLines={ 30 }>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -973,6 +973,25 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		global $hide_save_button;
 		$hide_save_button = true;
 
+		$method_title = $this->get_method_title();
+		$return_url   = 'admin.php?page=wc-settings&tab=checkout';
+		if ( ! empty( $_GET['method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// Override the title and return url for method-specific pages in WooPayments settings.
+			$method       = sanitize_text_field( wp_unslash( $_GET['method'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$method_title = 'payment_request' === $method ? 'Apple Pay / Google Pay' : ( 'woopay' === $method ? 'WooPay' : $this->get_method_title() );
+			$return_url   = 'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments';
+		}
+
+		if ( function_exists( 'wc_back_header' ) ) {
+			wc_back_header( $method_title, __( 'Return to payments', 'woocommerce-payments' ), $return_url );
+		} else {
+			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
+			echo '<h2>';
+			echo esc_html( $method_title );
+			wc_back_link( __( 'Return to payments', 'woocommerce-payments' ), $return_url );
+			echo '</h2>';
+		}
+
 		if ( ! empty( $_GET['method'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			?>
 			<div

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2441,7 +2441,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->card_gateway->output_payments_settings_screen();
 		$output = ob_get_clean();
 		$this->assertStringMatchesFormat( '%aid="wcpay-account-settings-container"%a', $output );
-		$this->assertStringMatchesFormat( '%ahref="admin.php?page=wc-settings&tab=checkout"%a', $output );
+		$this->assertStringMatchesFormat( '%ahref="admin.php?page=wc-settings&#038;tab=checkout"%a', $output );
 	}
 
 	public function test_outputs_express_checkout_settings_screen() {
@@ -2451,7 +2451,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertStringMatchesFormat( '%aid="wcpay-express-checkout-settings-container"%a', $output );
 		$this->assertStringMatchesFormat( '%adata-method-id="foo"%a', $output );
-		$this->assertStringMatchesFormat( '%ahref="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"%a', $output );
+		$this->assertStringMatchesFormat( '%ahref="admin.php?page=wc-settings&#038;tab=checkout&#038;section=woocommerce_payments"%a', $output );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2441,6 +2441,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->card_gateway->output_payments_settings_screen();
 		$output = ob_get_clean();
 		$this->assertStringMatchesFormat( '%aid="wcpay-account-settings-container"%a', $output );
+		$this->assertStringMatchesFormat( '%ahref="admin.php?page=wc-settings&tab=checkout"%a', $output );
 	}
 
 	public function test_outputs_express_checkout_settings_screen() {
@@ -2450,6 +2451,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertStringMatchesFormat( '%aid="wcpay-express-checkout-settings-container"%a', $output );
 		$this->assertStringMatchesFormat( '%adata-method-id="foo"%a', $output );
+		$this->assertStringMatchesFormat( '%ahref="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"%a', $output );
 	}
 
 	/**


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce/issues/55738.

#### Changes proposed in this Pull Request

This PR adds the back header (since `wc_back_header` is available in WC 9.9) or the current back link `wc_back_link` into the following pages:

- WooPayments settings
- WooPay settings
- ApplePay / GooglePay settings

#### Testing instructions

##### WC Core has `wc_back_header` published

* Check out `update/55738-update-tertiary-back-button-in-wc-settings` in WC Core
* Run `pnpm install --frozen-lockfile && pnpm run build`
* Onboard a WooPayments account if it's not onboarded (any account, sandbox mode account is fine)
* Navigate to WooPayments settings.
* Navigate to WooPay settings. Click back button and check that you have been navigated to the WooPayments settings.
![image](https://github.com/user-attachments/assets/c1133504-bded-4fe9-ac73-56d203b70cfb)
* Navigate to ApplePay / GooglePay settings. Click back button and check that you have been navigated to the 
WooPayments settings.
![image](https://github.com/user-attachments/assets/f1a08eb6-ffb2-4c51-b2d3-b59087549793)
* Click back button and check that you have been navigated to the Settings -> Payments.
![image](https://github.com/user-attachments/assets/b6e33475-b675-4c0c-bf05-8bc8813fb8cb)

##### WC Core does not have `wc_back_header` published yet

* Check out `trunk` in WC Core
* Run `pnpm install --frozen-lockfile && pnpm run build`
* Navigate to WooPayments settings.
* Navigate to WooPay settings. Click back button and check that you have been navigated to the WooPayments settings.
![image](https://github.com/user-attachments/assets/989422e5-7fdc-4c0e-81d6-fa8dc3448ada)
* Navigate to ApplePay / GooglePay settings. Click back button and check that you have been navigated to the WooPayments settings.
![image](https://github.com/user-attachments/assets/8edcb6cf-194e-4d1c-9052-fe8c56f8c1c8)
* Click back button and check that you have been navigated to the Settings -> Payments.
![image](https://github.com/user-attachments/assets/a67c21ba-4c82-4a77-8f8b-cfcc85b0f980)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-9.2.0#add-back-link-for-tertiary-level-pages-in-woopayments-settings
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
