### PR TITLE
Remove fraud protection discoverability leftovers

### DIFF
--- a/changelog/remove-fraud-discover-banner-leftovers
+++ b/changelog/remove-fraud-discover-banner-leftovers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Remove code leftovers from a recent PR
+
+

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -114,7 +114,6 @@ declare global {
 		dismissedDuplicateNotices: PaymentMethodToPluginsMap;
 		accountDefaultCurrency: string;
 		isFRTReviewFeatureActive: boolean;
-		frtDiscoverBannerSettings: string;
 		onboardingFieldsData?: {
 			business_types: Country[];
 			mccs_display_tree: MccsDisplayTreeItem[];

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -112,11 +112,6 @@ describe( 'Overview page', () => {
 				accountOverviewTaskList: true,
 			},
 			accountLoans: {},
-			frtDiscoverBannerSettings: JSON.stringify( {
-				remindMeCount: 0,
-				remindMeAt: null,
-				dontShowAgain: false,
-			} ),
 		};
 		getQuery.mockReturnValue( {} );
 		getTasks.mockReturnValue( [] );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1012,7 +1012,6 @@ class WC_Payments_Admin {
 			'enabledPaymentMethods'              => $this->get_enabled_payment_method_ids(),
 			'progressiveOnboarding'              => $this->account->get_progressive_onboarding_details(),
 			'accountDefaultCurrency'             => $this->account->get_account_default_currency(),
-			'frtDiscoverBannerSettings'          => get_option( 'wcpay_frt_discover_banner_settings', '' ),
 			'storeCurrency'                      => get_option( 'woocommerce_currency' ),
 			'isWooPayStoreCountryAvailable'      => WooPay_Utilities::is_store_country_available(),
 			'woopayLastDisableDate'              => $this->wcpay_gateway->get_option( 'platform_checkout_last_disable_date' ),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1967,7 +1967,6 @@ class WC_Payments {
 	public static function add_wcpay_options_to_woocommerce_permissions_list( $permissions ) {
 		$wcpay_permissions_list = array_fill_keys(
 			[
-				'wcpay_frt_discover_banner_settings',
 				'wcpay_multi_currency_setup_completed',
 				'woocommerce_dismissed_todo_tasks',
 				'woocommerce_remind_me_later_todo_tasks',


### PR DESCRIPTION
Follow-up from #10558

#### Changes proposed in this Pull Request
Remove fraud protection discoverability leftovers

#### Testing instructions
Code changes make sense and tests pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
