### PR TITLE
Fix PHP Deprecated: Hook woocommerce_rest_api_option_permissions

### DIFF
--- a/changelog/fix-7864-deprecated-woocommerce_rest_api_option_permissions
+++ b/changelog/fix-7864-deprecated-woocommerce_rest_api_option_permissions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix deprecated hook woocommerce_rest_api_option_permissions

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { useDispatch } from '@wordpress/data';
 import { Card, CardBody, CardHeader, Flex } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
@@ -26,10 +25,10 @@ import { ClickTooltip } from '../tooltip';
 import { formatCurrency } from 'multi-currency/interface/functions';
 import { useAllDepositsOverviews } from 'wcpay/data';
 import { useSelectedCurrency } from 'wcpay/overview/hooks';
+import { saveOption } from 'wcpay/data/settings/actions';
 import './style.scss';
 
 const useInstantDepositNoticeState = () => {
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 	const [ isDismissed, setIsDismissed ] = useState(
 		wcpaySettings.isInstantDepositNoticeDismissed
 	);
@@ -37,7 +36,7 @@ const useInstantDepositNoticeState = () => {
 	const setInstantDepositNoticeDismissed = () => {
 		setIsDismissed( true );
 		wcpaySettings.isInstantDepositNoticeDismissed = true;
-		updateOptions( { wcpay_instant_deposit_notice_dismissed: true } );
+		saveOption( 'wcpay_instant_deposit_notice_dismissed', true );
 	};
 
 	return {

--- a/client/components/duplicate-notice/index.tsx
+++ b/client/components/duplicate-notice/index.tsx
@@ -5,8 +5,12 @@ import React, { useCallback } from 'react';
 import InlineNotice from '../inline-notice';
 import interpolateComponents from '@automattic/interpolate-components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { getAdminUrl } from 'wcpay/utils';
-import { useDispatch } from '@wordpress/data';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 export type PaymentMethodToPluginsMap = { [ key: string ]: string[] };
 interface DuplicateNoticeProps {
@@ -24,8 +28,6 @@ function DuplicateNotice( {
 	dismissedNotices,
 	setDismissedDuplicateNotices,
 }: DuplicateNoticeProps ): JSX.Element | null {
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
-
 	const handleDismiss = useCallback( () => {
 		const updatedNotices = { ...dismissedNotices };
 		if ( updatedNotices[ paymentMethod ] ) {
@@ -41,16 +43,16 @@ function DuplicateNotice( {
 		}
 
 		setDismissedDuplicateNotices( updatedNotices );
-		updateOptions( {
-			wcpay_duplicate_payment_method_notices_dismissed: updatedNotices,
-		} );
+		saveOption(
+			'wcpay_duplicate_payment_method_notices_dismissed',
+			updatedNotices
+		);
 		wcpaySettings.dismissedDuplicateNotices = updatedNotices;
 	}, [
 		paymentMethod,
 		gatewaysEnablingPaymentMethod,
 		dismissedNotices,
 		setDismissedDuplicateNotices,
-		updateOptions,
 	] );
 
 	if ( dismissedNotices?.[ paymentMethod ] ) {

--- a/client/components/duplicate-notice/tests/index.test.tsx
+++ b/client/components/duplicate-notice/tests/index.test.tsx
@@ -3,25 +3,20 @@
  */
 import React from 'react';
 import { render, fireEvent, screen, cleanup } from '@testing-library/react';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import DuplicateNotice from '..';
+import { saveOption } from 'wcpay/data/settings/actions';
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
+jest.mock( 'wcpay/data/settings/actions', () => ( {
+	saveOption: jest.fn(),
 } ) );
 
-const mockUseDispatch = useDispatch as jest.MockedFunction< any >;
+const mockSaveOption = saveOption as jest.MockedFunction< any >;
 
 describe( 'DuplicateNotice', () => {
-	const mockDispatch = jest.fn();
-	mockUseDispatch.mockReturnValue( {
-		updateOptions: mockDispatch,
-	} );
-
 	afterEach( () => {
 		cleanup();
 	} );
@@ -108,11 +103,12 @@ describe( 'DuplicateNotice', () => {
 		expect( props.setDismissedDuplicateNotices ).toHaveBeenCalledWith( {
 			[ paymentMethod ]: [ 'woocommerce_payments' ],
 		} );
-		expect( mockDispatch ).toHaveBeenCalledWith( {
-			wcpay_duplicate_payment_method_notices_dismissed: {
-				[ paymentMethod ]: [ 'woocommerce_payments' ],
-			},
-		} );
+		expect(
+			mockSaveOption
+		).toHaveBeenCalledWith(
+			'wcpay_duplicate_payment_method_notices_dismissed',
+			{ [ paymentMethod ]: [ 'woocommerce_payments' ] }
+		);
 	} );
 
 	test( 'clicking on the Review extensions link navigates correctly', () => {

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -283,9 +283,9 @@ export function* submitStripeBillingSubscriptionMigration() {
 	);
 }
 
-export function saveOption( optionKey, value ) {
+export function saveOption( optionName, value ) {
 	directApiFetch( {
-		path: `${ NAMESPACE }/settings/${ optionKey }`,
+		path: `${ NAMESPACE }/settings/${ optionName }`,
 		method: 'post',
 		data: { value },
 	} ).catch( () => {} );

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -288,5 +288,9 @@ export function saveOption( optionName, value ) {
 		path: `${ NAMESPACE }/settings/${ optionName }`,
 		method: 'post',
 		data: { value },
-	} ).catch( () => {} );
+	} ).catch( () => {
+		dispatch( 'core/notices' ).createErrorNotice(
+			__( 'Error saving option', 'woocommerce-payments' )
+		);
+	} );
 }

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -5,6 +5,7 @@
  */
 import { dispatch, select } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
+import directApiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -280,4 +281,12 @@ export function* submitStripeBillingSubscriptionMigration() {
 	yield dispatch( STORE_NAME ).finishResolution(
 		'scheduleStripeBillingMigration'
 	);
+}
+
+export function saveOption( optionKey, value ) {
+	directApiFetch( {
+		path: `${ NAMESPACE }/settings/${ optionKey }`,
+		method: 'post',
+		data: { value },
+	} ).catch( () => {} );
 }

--- a/client/deposits/index.tsx
+++ b/client/deposits/index.tsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { useDispatch } from '@wordpress/data';
 import { ExternalLink } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -23,9 +22,9 @@ import DepositsList from './list';
 import { hasAutomaticScheduledDeposits } from 'wcpay/deposits/utils';
 import { recordEvent } from 'wcpay/tracks';
 import { MaybeShowMerchantFeedbackPrompt } from 'wcpay/merchant-feedback-prompt';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 const useNextDepositNoticeState = () => {
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 	const [ isDismissed, setIsDismissed ] = useState(
 		wcpaySettings.isNextDepositNoticeDismissed
 	);
@@ -33,9 +32,7 @@ const useNextDepositNoticeState = () => {
 	const setNextDepositNoticeDismissed = () => {
 		setIsDismissed( true );
 		wcpaySettings.isNextDepositNoticeDismissed = true;
-		updateOptions( {
-			wcpay_next_deposit_notice_dismissed: true,
-		} );
+		saveOption( 'wcpay_next_deposit_notice_dismissed', true );
 	};
 
 	return {

--- a/client/overview/modal/connection-success/index.tsx
+++ b/client/overview/modal/connection-success/index.tsx
@@ -23,7 +23,7 @@ export const ConnectionSuccessModal = () => {
 		setIsDismissed( true );
 
 		// Update the option to mark the modal as dismissed.
-		await saveOption( 'wcpay_connection_success_modal_dismissed', true );
+		saveOption( 'wcpay_connection_success_modal_dismissed', true );
 	};
 
 	return (

--- a/client/overview/modal/connection-success/index.tsx
+++ b/client/overview/modal/connection-success/index.tsx
@@ -3,13 +3,13 @@
  */
 import React from 'react';
 import { Modal, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import strings from './strings';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 /**
  * A modal component displayed when a live account is successfully connected.
@@ -18,15 +18,12 @@ export const ConnectionSuccessModal = () => {
 	const [ isDismissed, setIsDismissed ] = React.useState(
 		wcpaySettings.isConnectionSuccessModalDismissed
 	);
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 
 	const onDismiss = async () => {
 		setIsDismissed( true );
 
 		// Update the option to mark the modal as dismissed.
-		await updateOptions( {
-			wcpay_connection_success_modal_dismissed: true,
-		} );
+		await saveOption( 'wcpay_connection_success_modal_dismissed', true );
 	};
 
 	return (

--- a/client/overview/modal/connection-success/test/index.test.tsx
+++ b/client/overview/modal/connection-success/test/index.test.tsx
@@ -10,8 +10,8 @@ import user from '@testing-library/user-event';
  */
 import ConnectionSuccessModal from '../index';
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn().mockReturnValue( { updateOptions: jest.fn() } ),
+jest.mock( 'wcpay/data/settings/actions', () => ( {
+	saveOption: jest.fn(),
 } ) );
 
 declare const global: {

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -6,7 +6,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { Button, Modal } from '@wordpress/components';
 import { Icon, store, currencyDollar } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -14,6 +14,7 @@ import interpolateComponents from '@automattic/interpolate-components';
  */
 import { trackEligibilityModalClosed } from 'onboarding/tracking';
 import ConfettiAnimation from 'components/confetti-animation';
+import { saveOption } from 'wcpay/data/settings/actions';
 import './style.scss';
 
 const ProgressiveOnboardingEligibilityModal: React.FC = () => {
@@ -21,8 +22,6 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 	const [ modalDismissed, setModalDismissed ] = useState(
 		wcpaySettings.progressiveOnboarding?.isEligibilityModalDismissed
 	);
-
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 
 	const urlParams = new URLSearchParams( window.location.search );
 	const urlSource =
@@ -32,9 +31,7 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 		setModalDismissed( true );
 
 		// Update the option to mark the modal as dismissed.
-		await updateOptions( {
-			wcpay_onboarding_eligibility_modal_dismissed: true,
-		} );
+		saveOption( 'wcpay_onboarding_eligibility_modal_dismissed', true );
 	};
 
 	const handleSetup = () => {

--- a/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/test/index.test.tsx
@@ -10,8 +10,8 @@ import user from '@testing-library/user-event';
  */
 import ProgressiveOnboardingEligibilityModal from '../index';
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn().mockReturnValue( { updateOptions: jest.fn() } ),
+jest.mock( 'wcpay/data/settings/actions', () => ( {
+	saveOption: jest.fn(),
 } ) );
 
 declare const global: {

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -13,10 +13,10 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { TIME } from 'wcpay/constants/time';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 	const [ visibleTasks, setVisibleTasks ] = useState( tasks );
 	const {
 		deletedTodoTasks,
@@ -52,9 +52,7 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		dismissedTasks.splice( dismissedTodoTasks.indexOf( key ), 1 );
 		setVisibleTasks( getVisibleTasks() );
 
-		await updateOptions( {
-			[ optionName ]: updatedDismissedTasks,
-		} );
+		await saveOption( optionName, updatedDismissedTasks );
 	};
 
 	const dismissSelectedTask = async ( {
@@ -68,9 +66,7 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		dismissedTasks.push( key );
 		setVisibleTasks( getVisibleTasks() );
 
-		await updateOptions( {
-			[ optionName ]: [ ...dismissedTasks ],
-		} );
+		await saveOption( optionName, [ ...dismissedTasks ] );
 
 		createNotice( 'success', noticeMessage, {
 			actions: [
@@ -120,9 +116,10 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		delete remindMeLaterTodoTasks[ key ];
 		setVisibleTasks( getVisibleTasks() );
 
-		await updateOptions( {
-			woocommerce_remind_me_later_todo_tasks: updatedRemindMeLaterTasks,
-		} );
+		await saveOption(
+			'woocommerce_remind_me_later_todo_tasks',
+			updatedRemindMeLaterTasks
+		);
 	};
 
 	const remindTaskLater = async ( { key, onDismiss } ) => {
@@ -130,11 +127,9 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		remindMeLaterTodoTasks[ key ] = dismissTime;
 		setVisibleTasks( getVisibleTasks() );
 
-		await updateOptions( {
-			woocommerce_remind_me_later_todo_tasks: {
-				...remindMeLaterTodoTasks,
-				[ key ]: dismissTime,
-			},
+		saveOption( 'woocommerce_remind_me_later_todo_tasks', {
+			...remindMeLaterTodoTasks,
+			[ key ]: dismissTime,
 		} );
 
 		createNotice(

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -52,7 +52,7 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		dismissedTasks.splice( dismissedTodoTasks.indexOf( key ), 1 );
 		setVisibleTasks( getVisibleTasks() );
 
-		await saveOption( optionName, updatedDismissedTasks );
+		saveOption( optionName, updatedDismissedTasks );
 	};
 
 	const dismissSelectedTask = async ( {
@@ -66,7 +66,7 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		dismissedTasks.push( key );
 		setVisibleTasks( getVisibleTasks() );
 
-		await saveOption( optionName, [ ...dismissedTasks ] );
+		saveOption( optionName, [ ...dismissedTasks ] );
 
 		createNotice( 'success', noticeMessage, {
 			actions: [
@@ -116,7 +116,7 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		delete remindMeLaterTodoTasks[ key ];
 		setVisibleTasks( getVisibleTasks() );
 
-		await saveOption(
+		saveOption(
 			'woocommerce_remind_me_later_todo_tasks',
 			updatedRemindMeLaterTasks
 		);

--- a/client/plugins-page/index.js
+++ b/client/plugins-page/index.js
@@ -2,17 +2,15 @@
  * External dependencies
  */
 import React, { useState, useEffect, useCallback } from 'react';
-import { useDispatch } from '@wordpress/data';
 import ReactDOM from 'react-dom';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import PluginDisableSurvey from './deactivation-survey';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 const PluginsPage = () => {
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const [ modalOpen, setModalOpen ] = useState( false );
 	const surveyModalTimestamp =
 		window.wcpayPluginsSettings?.exitSurveyLastShown ?? null;
@@ -41,9 +39,7 @@ const PluginsPage = () => {
 		const currentDate = new Date();
 
 		// Update modal dismissed option.
-		await updateOptions( {
-			wcpay_exit_survey_last_shown: currentDate,
-		} );
+		await saveOption( 'wcpay_exit_survey_last_shown', currentDate );
 
 		window.wcpayPluginsSettings.exitSurveyLastShown = currentDate;
 

--- a/client/plugins-page/index.js
+++ b/client/plugins-page/index.js
@@ -39,7 +39,7 @@ const PluginsPage = () => {
 		const currentDate = new Date();
 
 		// Update modal dismissed option.
-		await saveOption( 'wcpay_exit_survey_last_shown', currentDate );
+		saveOption( 'wcpay_exit_survey_last_shown', currentDate );
 
 		window.wcpayPluginsSettings.exitSurveyLastShown = currentDate;
 

--- a/client/settings/fraud-protection/tour/index.tsx
+++ b/client/settings/fraud-protection/tour/index.tsx
@@ -2,15 +2,15 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { useDispatch } from '@wordpress/data';
 import { TourKit } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
-import { useSettings } from '../../../data';
+import { useSettings } from 'wcpay/data';
 import { steps } from './steps';
 import { recordEvent } from 'tracks';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 const options = {
 	effects: {
@@ -35,7 +35,6 @@ const FraudProtectionTour: React.FC = () => {
 	const { isWelcomeTourDismissed } = wcpaySettings.fraudProtection;
 
 	const { isLoading } = useSettings();
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 	const [ showTour, setShowTour ] = useState( false );
 
 	useEffect( () => {
@@ -61,9 +60,7 @@ const FraudProtectionTour: React.FC = () => {
 		currentIndex: number,
 		element: string
 	) => {
-		updateOptions( {
-			wcpay_fraud_protection_welcome_tour_dismissed: true,
-		} );
+		saveOption( 'wcpay_fraud_protection_welcome_tour_dismissed', true );
 		wcpaySettings.fraudProtection.isWelcomeTourDismissed = true;
 
 		setShowTour( false );

--- a/client/settings/payment-methods-list/capability-request/capability-request-notice.tsx
+++ b/client/settings/payment-methods-list/capability-request/capability-request-notice.tsx
@@ -15,6 +15,7 @@ import apiFetch from '@wordpress/api-fetch';
 import DismissConfirmationModal from './capability-request-dismiss-modal';
 import { CapabilityNoticeProps } from './types';
 import { Action } from 'wcpay/types/notices';
+import { saveOption } from 'wcpay/data/settings/actions';
 
 const CapabilityNotice = ( {
 	id,
@@ -22,7 +23,6 @@ const CapabilityNotice = ( {
 	country,
 	states,
 }: CapabilityNoticeProps ): JSX.Element | null => {
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { capabilityRequestNotices } = wcpaySettings;
 	const [ isDismissed, setIsDismissed ] = useState(
@@ -115,16 +115,15 @@ const CapabilityNotice = ( {
 	};
 
 	const dismissNotice = () => {
-		updateOptions( {
-			wcpay_capability_request_dismissed_notices: {
-				...capabilityRequestNotices,
-				[ id ]: true,
-			},
-		} );
-		wcpaySettings.capabilityRequestNotices = {
+		const updatedNotices = {
 			...capabilityRequestNotices,
 			[ id ]: true,
 		};
+		saveOption(
+			'wcpay_capability_request_dismissed_notices',
+			updatedNotices
+		);
+		wcpaySettings.capabilityRequestNotices = updatedNotices;
 
 		setIsDismissed( true );
 	};

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -999,7 +999,7 @@ class WC_Payments_Admin {
 			'showUpdateDetailsTask'              => $this->get_should_show_update_business_details_task( $account_status_data ),
 			'wpcomReconnectUrl'                  => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
 			'multiCurrencySetup'                 => [
-				'isSetupCompleted' => get_option( 'wcpay_multi_currency_setup_completed' ),
+				'isSetupCompleted' => filter_var( get_option( 'wcpay_multi_currency_setup_completed' ), FILTER_VALIDATE_BOOLEAN ) ? 'yes' : 'no,',
 			],
 			'isMultiCurrencyEnabled'             => WC_Payments_Features::is_customer_multi_currency_enabled(),
 			'shouldUseExplicitPrice'             => WC_Payments_Explicit_Price_Formatter::should_output_explicit_price(),

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -96,7 +96,7 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	 * Update the option value.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_option( WP_REST_Request $request ) {
 		$option_name = $request->get_param( 'option_name' );

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Controller {
 
 	/**
-	 * List of allowed option keys that can be updated via the REST API.
+	 * List of allowed option names that can be updated via the REST API.
 	 *
 	 * @var array
 	 */
@@ -47,18 +47,19 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<option_key>[a-zA-Z0-9_-]+)',
+			'/' . $this->rest_base . '/(?P<option_name>[a-zA-Z0-9_-]+)',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'update_option' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'option_key' => [
+					'option_name' => [
 						'required'          => true,
-						'validate_callback' => [ $this, 'validate_option_key' ],
+						'validate_callback' => [ $this, 'validate_option_name' ],
 					],
-					'value'      => [
-						'required' => true,
+					'value'       => [
+						'required'          => true,
+						'validate_callback' => [ $this, 'validate_value' ],
 					],
 				],
 			]
@@ -66,22 +67,30 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	}
 
 	/**
-	 * Verify access.
+	 * Validate the option name.
 	 *
+	 * @param string $option_name The option name to validate.
 	 * @return bool
 	 */
-	public function check_permission(): bool {
-		return current_user_can( 'manage_woocommerce' );
+	public function validate_option_name( string $option_name ): bool {
+		return in_array( $option_name, self::ALLOWED_OPTIONS, true );
 	}
 
 	/**
-	 * Validate the option key.
+	 * Validate the value parameter.
 	 *
-	 * @param string $option_key The option key to validate.
-	 * @return bool
+	 * @param mixed $value The value to validate.
+	 * @return bool|WP_Error True if valid, WP_Error if invalid.
 	 */
-	public function validate_option_key( string $option_key ): bool {
-		return in_array( $option_key, self::ALLOWED_OPTIONS, true );
+	public function validate_value( $value ) {
+		if ( is_bool( $value ) || is_array( $value ) ) {
+			return true;
+		}
+		return new WP_Error(
+			'rest_invalid_param',
+			__( 'Invalid value type; must be either boolean or array', 'woocommerce-payments' ),
+			[ 'status' => 400 ]
+		);
 	}
 
 	/**
@@ -91,10 +100,10 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	 * @return WP_REST_Response
 	 */
 	public function update_option( WP_REST_Request $request ) {
-		$option_key = $request->get_param( 'option_key' );
-		$value      = $request->get_param( 'value' );
+		$option_name = $request->get_param( 'option_name' );
+		$value       = $request->get_param( 'value' );
 
-		update_option( $option_key, $value );
+		update_option( $option_name, $value );
 
 		return rest_ensure_response(
 			[

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -18,7 +18,6 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	 * @var array
 	 */
 	private const ALLOWED_OPTIONS = [
-		'wcpay_frt_discover_banner_settings',
 		'wcpay_multi_currency_setup_completed',
 		'woocommerce_dismissed_todo_tasks',
 		'woocommerce_remind_me_later_todo_tasks',

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Class WC_REST_Payments_Settings_Option_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for settings options.
+ */
+class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Controller {
+
+	/**
+	 * List of allowed option keys that can be updated via the REST API.
+	 *
+	 * @var array
+	 */
+	private const ALLOWED_OPTIONS = [
+		'wcpay_frt_discover_banner_settings',
+		'wcpay_multi_currency_setup_completed',
+		'woocommerce_dismissed_todo_tasks',
+		'woocommerce_remind_me_later_todo_tasks',
+		'woocommerce_deleted_todo_tasks',
+		'wcpay_fraud_protection_welcome_tour_dismissed',
+		'wcpay_capability_request_dismissed_notices',
+		'wcpay_onboarding_eligibility_modal_dismissed',
+		'wcpay_connection_success_modal_dismissed',
+		'wcpay_next_deposit_notice_dismissed',
+		'wcpay_duplicate_payment_method_notices_dismissed',
+		'wcpay_exit_survey_dismissed',
+		'wcpay_instant_deposit_notice_dismissed',
+		'wcpay_date_format_notice_dismissed',
+	];
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/settings';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<option_key>[a-zA-Z0-9_-]+)',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'update_option' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'option_key' => [
+						'required' => true,
+						'enum'     => self::ALLOWED_OPTIONS,
+					],
+					'value'      => [
+						'required' => true,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Verify access.
+	 *
+	 * @return bool
+	 */
+	public function check_permission() {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Update the option value.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_option( $request ) {
+		$option_key = $request->get_param( 'option_key' );
+		$value      = $request->get_param( 'value' );
+
+		update_option( $option_key, $value );
+
+		return rest_ensure_response(
+			[
+				'success' => true,
+				'value'   => $value,
+			]
+		);
+	}
+}

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -35,13 +35,6 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	];
 
 	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc/v3';
-
-	/**
 	 * Endpoint path.
 	 *
 	 * @var string
@@ -61,8 +54,8 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
 					'option_key' => [
-						'required' => true,
-						'enum'     => self::ALLOWED_OPTIONS,
+						'required'          => true,
+						'validate_callback' => [ $this, 'validate_option_key' ],
 					],
 					'value'      => [
 						'required' => true,
@@ -77,17 +70,27 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	 *
 	 * @return bool
 	 */
-	public function check_permission() {
+	public function check_permission(): bool {
 		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Validate the option key.
+	 *
+	 * @param string $option_key The option key to validate.
+	 * @return bool
+	 */
+	public function validate_option_key( string $option_key ): bool {
+		return in_array( $option_key, self::ALLOWED_OPTIONS, true );
 	}
 
 	/**
 	 * Update the option value.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response|WP_Error
+	 * @return WP_REST_Response
 	 */
-	public function update_option( $request ) {
+	public function update_option( WP_REST_Request $request ) {
 		$option_key = $request->get_param( 'option_key' );
 		$value      = $request->get_param( 'value' );
 
@@ -96,7 +99,6 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 		return rest_ensure_response(
 			[
 				'success' => true,
-				'value'   => $value,
 			]
 		);
 	}

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -30,7 +30,6 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 		'wcpay_duplicate_payment_method_notices_dismissed',
 		'wcpay_exit_survey_dismissed',
 		'wcpay_instant_deposit_notice_dismissed',
-		'wcpay_date_format_notice_dismissed',
 	];
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -679,7 +679,6 @@ class WC_Payments {
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );
 		add_filter( 'option_woocommerce_gateway_order', [ __CLASS__, 'order_woopayments_gateways' ], 2 );
 		add_filter( 'default_option_woocommerce_gateway_order', [ __CLASS__, 'order_woopayments_gateways' ], 3 );
-		add_filter( 'woocommerce_rest_api_option_permissions', [ __CLASS__, 'add_wcpay_options_to_woocommerce_permissions_list' ], 5 );
 		add_filter( 'woocommerce_admin_get_user_data_fields', [ __CLASS__, 'add_user_data_fields' ] );
 
 		// Add note query support for source.
@@ -1963,43 +1962,6 @@ class WC_Payments {
 			wp_enqueue_script( 'WCPAY_RUNTIME', plugins_url( 'dist/runtime.js', WCPAY_PLUGIN_FILE ), [], self::get_file_version( 'dist/runtime.js' ), true );
 		}
 	}
-
-	/**
-	 * Adds WCPay options to Woo Core option allow list.
-	 *
-	 * @param   array $permissions Array containing the permissions.
-	 *
-	 * @return  array              An array containing the modified permissions.
-	 */
-	public static function add_wcpay_options_to_woocommerce_permissions_list( $permissions ) {
-		$wcpay_permissions_list = array_fill_keys(
-			[
-				'wcpay_multi_currency_setup_completed',
-				'woocommerce_dismissed_todo_tasks',
-				'woocommerce_remind_me_later_todo_tasks',
-				'woocommerce_deleted_todo_tasks',
-				'wcpay_fraud_protection_welcome_tour_dismissed',
-				'wcpay_capability_request_dismissed_notices',
-				'wcpay_onboarding_eligibility_modal_dismissed',
-				'wcpay_connection_success_modal_dismissed',
-				'wcpay_next_deposit_notice_dismissed',
-				'wcpay_duplicate_payment_method_notices_dismissed',
-				'wcpay_exit_survey_dismissed',
-				'wcpay_instant_deposit_notice_dismissed',
-			],
-			true
-		);
-
-		if ( is_array( $permissions ) ) {
-			return array_merge(
-				$permissions,
-				$wcpay_permissions_list
-			);
-		}
-
-		return $wcpay_permissions_list;
-	}
-
 
 	/**
 	 * Creates a new request object for a server call.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1119,6 +1119,10 @@ class WC_Payments {
 		$settings_controller = new WC_REST_Payments_Settings_Controller( self::$api_client, self::get_gateway(), self::$account );
 		$settings_controller->register_routes();
 
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-settings-option-controller.php';
+		$settings_option_controller = new WC_REST_Payments_Settings_Option_Controller( self::$api_client );
+		$settings_option_controller->register_routes();
+
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-reader-controller.php';
 		$charges_controller = new WC_REST_Payments_Reader_Controller( self::$api_client, self::get_gateway(), self::$in_person_payments_receipts_service );
 		$charges_controller->register_routes();

--- a/includes/multi-currency/client/data/actions.js
+++ b/includes/multi-currency/client/data/actions.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import directApiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -144,4 +145,12 @@ export function* submitStoreSettingsUpdate(
 			__( 'Error saving store settings.', 'woocommerce-payments' )
 		);
 	}
+}
+
+export function saveOption( optionName, value ) {
+	directApiFetch( {
+		path: `${ NAMESPACE }/settings/${ optionName }`,
+		method: 'post',
+		data: { value },
+	} ).catch( () => {} );
 }

--- a/includes/multi-currency/client/data/actions.js
+++ b/includes/multi-currency/client/data/actions.js
@@ -152,5 +152,9 @@ export function saveOption( optionName, value ) {
 		path: `${ NAMESPACE }/settings/${ optionName }`,
 		method: 'post',
 		data: { value },
-	} ).catch( () => {} );
+	} ).catch( () => {
+		dispatch( 'core/notices' ).createErrorNotice(
+			__( 'Error saving option', 'woocommerce-payments' )
+		);
+	} );
 }

--- a/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
@@ -5,7 +5,6 @@ import React from 'react';
 import { useEffect, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,26 +18,26 @@ import { WizardTaskContext } from 'multi-currency/interface/functions';
 import './index.scss';
 
 import { useDefaultCurrency } from 'multi-currency/data';
+import { saveOption } from '../../../data/actions';
 
 const SetupComplete = () => {
 	const { isActive } = useContext( WizardTaskContext );
 	const defaultCurrency = useDefaultCurrency();
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
 
 	useEffect( () => {
 		if ( ! isActive ) {
 			return;
 		}
 
-		updateOptions( {
+		saveOption( {
 			// eslint-disable-next-line camelcase
-			wcpay_multi_currency_setup_completed: 'yes',
+			wcpay_multi_currency_setup_completed: true,
 		} );
 
 		// Set the local `isSetupCompleted` to `yes` so that task appears completed on the list.
 		// Please note that marking an item as "completed" is different from "dismissing" it.
 		window.wcpaySettings.multiCurrencySetup.isSetupCompleted = 'yes';
-	}, [ isActive, updateOptions ] );
+	}, [ isActive ] );
 
 	return (
 		<WizardTaskItem

--- a/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
@@ -18,7 +18,7 @@ import { WizardTaskContext } from 'multi-currency/interface/functions';
 import './index.scss';
 
 import { useDefaultCurrency } from 'multi-currency/data';
-import { saveOption } from '../../../data/actions';
+import { saveOption } from 'multi-currency/data/actions';
 
 const SetupComplete = () => {
 	const { isActive } = useContext( WizardTaskContext );

--- a/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
@@ -29,10 +29,7 @@ const SetupComplete = () => {
 			return;
 		}
 
-		saveOption( {
-			// eslint-disable-next-line camelcase
-			wcpay_multi_currency_setup_completed: true,
-		} );
+		saveOption( 'wcpay_multi_currency_setup_completed', true );
 
 		// Set the local `isSetupCompleted` to `yes` so that task appears completed on the list.
 		// Please note that marking an item as "completed" is different from "dismissing" it.

--- a/includes/multi-currency/client/setup/tasks/setup-complete-task/test/index.test.js
+++ b/includes/multi-currency/client/setup/tasks/setup-complete-task/test/index.test.js
@@ -9,8 +9,8 @@ import { render } from '@testing-library/react';
 import { WizardTaskContext } from 'multi-currency/interface/functions';
 import SetupCompleteTask from '../../setup-complete-task';
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn().mockReturnValue( { updateOptions: jest.fn() } ),
+jest.mock( 'multi-currency/data/actions', () => ( {
+	saveOption: jest.fn(),
 } ) );
 
 jest.mock( 'multi-currency/interface/data', () => ( {} ) );

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Class WC_REST_Payments_Settings_Option_Controller_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_REST_Payments_Settings_Option_Controller unit tests.
+ */
+class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var WC_REST_Payments_Settings_Option_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Set the user so that we can pass the authentication.
+		wp_set_current_user( 1 );
+
+		$this->controller = new WC_REST_Payments_Settings_Option_Controller( $this->createMock( WC_Payments_API_Client::class ) );
+	}
+
+	public function test_update_option_success() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'option_name', 'wcpay_multi_currency_setup_completed' );
+		$request->set_param( 'value', true );
+
+		$response = $this->controller->update_option( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['success'] );
+	}
+
+	private function provider_option_names(): array {
+		return [
+			'valid option: wcpay_multi_currency_setup_completed' => [
+				'wcpay_multi_currency_setup_completed',
+				true,
+			],
+			'valid option: woocommerce_dismissed_todo_tasks' => [
+				'woocommerce_dismissed_todo_tasks',
+				true,
+			],
+			'valid option: wcpay_fraud_protection_welcome_tour_dismissed' => [
+				'wcpay_fraud_protection_welcome_tour_dismissed',
+				true,
+			],
+			'invalid option: invalid_option'       => [
+				'invalid_option',
+				false,
+			],
+			'invalid option: wcpay_invalid_option' => [
+				'wcpay_invalid_option',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provider_option_names
+	 */
+	public function test_validate_option_name( string $option, bool $expected_result ) {
+		$this->assertSame( $expected_result, $this->controller->validate_option_name( $option ) );
+	}
+
+	public function test_validate_value_with_valid_values() {
+		$valid_values = [
+			true,
+			false,
+			[],
+			[ 'key' => 'value' ],
+			[ 'key' => [ 'nested_key' => 'nested_value' ] ],
+		];
+
+		foreach ( $valid_values as $value ) {
+			$result = $this->controller->validate_value( $value );
+			$this->assertTrue( $result );
+		}
+	}
+
+	public function test_validate_value_with_invalid_values() {
+		$invalid_values = [
+			'string',
+			123,
+			null,
+			(object) [],
+		];
+
+		foreach ( $invalid_values as $value ) {
+			$result = $this->controller->validate_value( $value );
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertEquals( 'rest_invalid_param', $result->get_error_code() );
+			$this->assertEquals( 400, $result->get_error_data()['status'] );
+		}
+	}
+}

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
@@ -40,7 +40,7 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 		$this->assertTrue( $response->get_data()['success'] );
 	}
 
-	private function provider_option_names(): array {
+	public function provider_option_names(): array {
 		return [
 			'valid option: wcpay_multi_currency_setup_completed' => [
 				'wcpay_multi_currency_setup_completed',

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -85,6 +85,7 @@ function _manually_load_plugin() {
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-terminal-locations-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-tos-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-settings-controller.php';
+	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-settings-option-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-survey-controller.php';
 	require_once $_plugin_dir . 'includes/admin/tracks/class-tracker.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-reader-controller.php';


### PR DESCRIPTION
Fixes #7864

## TODOs: 

- [x] Implement changes for other options. 
- [x] Remove the hook completely
- [x] Fix and add tests 
#### Changes proposed in this Pull Request

- Add a separate controller for endpoint: `/wp-json/wc/v3/payments/settings/{option_key}`
- Add `saveOption` in JS code so that we can send the direct REST API request to the endpoint above. This will replace `updateOptions` provided by Woo core, which uses the Woo core Options REST API. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow to test the Fraud Protection Tour https://github.com/Automattic/woocommerce-payments/pull/10558

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
