### PR TITLE
HACK week - Prevent unsaved changes dialog when changes have been saved

### DIFF
--- a/changelog/fix-settings-unsaved-changes-dialog
+++ b/changelog/fix-settings-unsaved-changes-dialog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent unsaved changes dialog when changes have been saved.

--- a/client/settings/fraud-protection/components/protection-levels/index.tsx
+++ b/client/settings/fraud-protection/components/protection-levels/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 import { useState } from '@wordpress/element';
@@ -13,6 +13,8 @@ import { Button } from '@wordpress/components';
 import {
 	useCurrentProtectionLevel,
 	useAdvancedFraudProtectionSettings,
+	useSettings,
+	useGetSettings,
 } from 'wcpay/data';
 import { FraudProtectionHelpText, BasicFraudProtectionModal } from '../index';
 import { getAdminUrl } from 'wcpay/utils';
@@ -24,6 +26,9 @@ import { CurrentProtectionLevelHook } from '../../interfaces';
 const ProtectionLevels: React.FC = () => {
 	const [ isBasicModalOpen, setBasicModalOpen ] = useState( false );
 
+	const initialProtectionLevelRef = useRef< string | null >( null );
+	const initialSettingsRef = useRef< Record< string, any > | null >( null );
+
 	const [
 		currentProtectionLevel,
 		updateProtectionLevel,
@@ -32,6 +37,19 @@ const ProtectionLevels: React.FC = () => {
 	const [
 		advancedFraudProtectionSettings,
 	] = useAdvancedFraudProtectionSettings();
+
+	const { isDirty } = useSettings();
+	const currentSettings = useGetSettings() as Record< string, any >;
+
+	useEffect( () => {
+		if ( initialProtectionLevelRef.current === null ) {
+			initialProtectionLevelRef.current = currentProtectionLevel;
+		}
+
+		if ( initialSettingsRef.current === null && currentSettings ) {
+			initialSettingsRef.current = { ...currentSettings };
+		}
+	}, [ currentProtectionLevel, currentSettings ] );
 
 	const isAdvancedSettingsConfigured =
 		Array.isArray( advancedFraudProtectionSettings ) &&
@@ -47,6 +65,62 @@ const ProtectionLevels: React.FC = () => {
 	const handleBasicModalOpen = () => {
 		recordEvent( 'wcpay_fraud_protection_basic_modal_viewed' );
 		setBasicModalOpen( true );
+	};
+
+	// Check if only the protection level setting has changed
+	const isOnlyProtectionLevelChanged = (): boolean => {
+		if ( ! initialSettingsRef.current || ! currentSettings ) {
+			return false;
+		}
+
+		const allKeys = new Set( [
+			...Object.keys( initialSettingsRef.current ),
+			...Object.keys( currentSettings ),
+		] );
+
+		// Check each key to see if anything other than protection level changed
+		for ( const key of allKeys ) {
+			if ( key === 'current_protection_level' ) {
+				continue;
+			}
+
+			const initialValue =
+				initialSettingsRef.current[ key ] !== undefined
+					? initialSettingsRef.current[ key ]
+					: null;
+			const currentValue =
+				currentSettings[ key ] !== undefined
+					? currentSettings[ key ]
+					: null;
+
+			// If values are different for any key other than protection level, more than one setting changed
+			if (
+				JSON.stringify( initialValue ) !==
+				JSON.stringify( currentValue )
+			) {
+				return false;
+			}
+		}
+
+		// If we got here, only the protection level changed
+		return true;
+	};
+
+	const handleConfigureClick = () => {
+		// Only clear the beforeunload handler if:
+		// 1. The page has unsaved changes (isDirty is true)
+		// 2. The initial protection level was Basic
+		// 3. The current protection level is Advanced
+		// 4. It's the only setting that changed on the page
+		if (
+			isDirty &&
+			initialProtectionLevelRef.current === ProtectionLevel.BASIC &&
+			currentProtectionLevel === ProtectionLevel.ADVANCED &&
+			isOnlyProtectionLevelChanged()
+		) {
+			// When the only change is from Basic to Advanced, prevent the dialog
+			window.onbeforeunload = null;
+		}
 	};
 
 	return (
@@ -141,6 +215,7 @@ const ProtectionLevels: React.FC = () => {
 								path: '/payments/fraud-protection',
 							} ) }
 							isSecondary
+							onClick={ handleConfigureClick }
 							disabled={
 								ProtectionLevel.ADVANCED !==
 								currentProtectionLevel

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useEffect } from 'react';
 import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQuery } from '@woocommerce/navigation';
@@ -144,7 +144,13 @@ const SettingsManager = () => {
 		true
 	);
 
-	const { isLoading } = useSettings();
+	const { isLoading, isDirty } = useSettings();
+
+	useEffect( () => {
+		if ( ! isDirty ) {
+			window.onbeforeunload = null;
+		}
+	}, [ isDirty ] );
 
 	useLayoutEffect( () => {
 		const { anchor } = getQuery();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes solves a long standing problem in the settings where an "unsaved changes" dialog appears when navigating away from the settings page, even when settings have been saved. After a log of debugging, I was able to determine that the "unsaved changes" dialog was being displayed by WooCommerce core. When creating custom WooCommerce settings pages using React, the default unsaved changes handler in [settings.js](https://github.com/woocommerce/woocommerce/blob/c807d2d068125af1607afd22e54c0b13f7f83bc1/plugins/woocommerce/client/legacy/js/admin/settings.js#L125) can conflict with our own form state management. This leads to the "unsaved changes" dialog appearing even after forms have been properly saved.

This PR adds a custom `onbeforeunload` handler that properly respects our settings form state through an `isDirty` flag. The handler is cleaned up when the component unmounts to prevent memory leaks.

The solution directly sets `window.onbeforeunload` since WooCommerce's settings.js uses direct assignment rather than event listeners, making this the most reliable way to override the default behavior.

Additionally, this PR streamlines the fraud settings workflow by removing an unnecessary save step. Previously, enabling Advanced Fraud Settings would trigger the "unsaved changes" dialog when clicking the "Configure" button, forcing merchants to save before they could actually configure any advanced settings. This created an unnecessary step since the advanced settings aren't truly active until configured anyway.

This change prevents the "unsaved changes" dialog from appearing when only the Advanced Fraud setting has been toggled. Merchants can now enable Advanced Fraud Settings and immediately proceed to configuration without an interrupting save step, creating a more intuitive workflow.

<details>
<summary>Before</summary>

<video src="https://github.com/user-attachments/assets/82314068-3aed-4956-9f3b-194ae79d08c1" controls></video>

</details>

<details>
<summary>After</summary>

<video src="https://github.com/user-attachments/assets/51637829-5748-43e3-9455-e3577fec99aa" controls></video>

</details>

### Testing instructions


* Navigate to the WooPayments settings and change any setting.
* Saved the settings.
* Navigate to another page or refresh the page.
* The "Unsaved Changes" warning should not appear.

**Fraud Settings**
* From a clean settings page, toggle from Basic to Advanced Fraud settings.
* Click the "Configure" button.
* The "Unsaved Changes" warning should not appear.
* Reset to Basic fraud settings, save, and refresh the page.
* Change any non-fraud setting.
* Toggle from Basic to Advanced Fraud settings. 
* Click the "Configure" button.
* The "Unsaved Changes" warning **should** appear.

<!--




Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
