### PR TITLE
Check the array type the dismissed notices for duplicated payment methods

### DIFF
--- a/changelog/chore-add-array-type-checking
+++ b/changelog/chore-add-array-type-checking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Chore: check the array type in dismissed noticeces component.

--- a/client/components/duplicate-notice/index.tsx
+++ b/client/components/duplicate-notice/index.tsx
@@ -28,7 +28,7 @@ function DuplicateNotice( {
 
 	const handleDismiss = useCallback( () => {
 		const updatedNotices = { ...dismissedNotices };
-		if ( updatedNotices[ paymentMethod ] ) {
+		if ( Array.isArray( updatedNotices[ paymentMethod ] ) ) {
 			// If there are existing dismissed notices for the payment method, append to the current array.
 			updatedNotices[ paymentMethod ] = [
 				...new Set( [
@@ -53,7 +53,7 @@ function DuplicateNotice( {
 		updateOptions,
 	] );
 
-	if ( dismissedNotices?.[ paymentMethod ] ) {
+	if ( Array.isArray( dismissedNotices?.[ paymentMethod ] ) ) {
 		const isNoticeDismissedForEveryGateway = gatewaysEnablingPaymentMethod.every(
 			( value ) => dismissedNotices[ paymentMethod ].includes( value )
 		);


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request
Add some type checking for arrays when working with dismissed duplicated payment method notices.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
Let's perform a sanity check of the feature

* Install another gateway e.g. Stripe and enable `Apple Pay / Google Pay` in both WooPayments and Stripe gateway
* Confirm that upon settings page opening, the duplicate notices appear on the page for card and Apple Pay/Google Pay
* Dismiss one notice e.g. for the Apple Pay/Google Pay payment method, refresh the page and confirm the notice is not appearing anymore

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
