### PR TITLE
Remove deprecated `wcpay_exit_survey_dismissed` option from the ALLOWED_OPTIONS list

### DIFF
--- a/changelog/remove-bosolete-option-from-allow-list
+++ b/changelog/remove-bosolete-option-from-allow-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Removed the deprecated wcpay_exit_survey_dismissed option from the ALLOWED_OPTIONS list.

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -28,7 +28,6 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 		'wcpay_connection_success_modal_dismissed',
 		'wcpay_next_deposit_notice_dismissed',
 		'wcpay_duplicate_payment_method_notices_dismissed',
-		'wcpay_exit_survey_dismissed',
 		'wcpay_instant_deposit_notice_dismissed',
 	];
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR removes the obsolete `wcpay_exit_survey_dismissed` from the `ALLOWED_OPTIONS` list of allowed option names that can be updated via the REST API.

#### Testing instructions
- The change should make sense.
- Unit tests should pass.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
