### PR TITLE
Fix multicurrency e2e test failing with WooCommerce beta version

### DIFF
--- a/changelog/fix-10551-multicurrency-e2e-test-for-wc-beta-version
+++ b/changelog/fix-10551-multicurrency-e2e-test-for-wc-beta-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Small fix to a single e2e test.
+
+

--- a/tests/e2e/specs/wcpay/shopper/multi-currency-checkout.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/multi-currency-checkout.spec.ts
@@ -77,9 +77,9 @@ test.describe( 'Multi-currency checkout', () => {
 							currenciesOrders[ currency ]
 						);
 						await expect(
-							shopperPage.locator(
-								'.woocommerce-table--order-details tfoot tr:last-child td'
-							)
+							shopperPage.getByRole( 'cell', {
+								name: /\$?\d\d[\.,]\d\d\s€?\s?[A-Z]{3}/,
+							} )
 						).toHaveText( new RegExp( currency ) );
 					}
 				);


### PR DESCRIPTION
Fixes #10551 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR updates the locator used in the `Multi-currency checkout > Checkout with multiple currencies` test used to find the order total on the My Account > Order page. The test now uses the `page.getByRole` locator. Previously the test used a CSS locator to find the data cell of last row of the order details table. This approach started failing in the beta tests because the order details table order was changed in [Woo Core PR 54440](https://github.com/woocommerce/woocommerce/pull/54440). The order details table order change was shipped behind a feature flag in Woo version `9.7.0`. In `9.8.0 `it becomes the default order for new installations. If all goes well, it will be the default order for all Woo stores in `9.9.0`. See the issue this PR fixes for additional details.

_Order details table in WooCommerce version `9.7.1`_

![woo-v9 7 1-order-details](https://github.com/user-attachments/assets/954dcdb1-14a4-4b89-9943-75314b976110)

_Order details table in WooCommerce version `9.8.0-beta.1`_

![woo-v9 8 0-beta 1-order-details](https://github.com/user-attachments/assets/8bbbb33f-8a7b-4b8f-8a13-b9794740f015)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Code changes should make sense.
* All GH tests on this PR should be passing.
* Visit the [E2E Tests - All action page](https://github.com/Automattic/woocommerce-payments/actions/workflows/e2e-test.yml).
* Click the run workflow button.
* Then click the branch button and select this PR branch: `fix/10551-multicurrency-e2e-test-for-wc-beta-version`.
* Then click the run workflow button.
* Confirm that all tests pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
