### PR TITLE
refactor: delete ECE temporary cart after request

### DIFF
--- a/changelog/fix-10488-delete-cart-after-request
+++ b/changelog/fix-10488-delete-cart-after-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+refactor: delete temporary Google Pay/Apple Pay cart contents right after making the request, to improve performance and avoiding bots sending wrong session data in subsequent requests.

--- a/client/tokenized-express-checkout/cart-api.js
+++ b/client/tokenized-express-checkout/cart-api.js
@@ -115,6 +115,15 @@ export default class ExpressCheckoutCartApi {
 	}
 
 	/**
+	 * Ensures that the cart is emptied right after making the request.
+	 */
+	deleteAfterRequest() {
+		this.cartRequestHeaders = {
+			'X-WooPayments-Tokenized-Cart-Is-Ephemeral-Cart': '1',
+		};
+	}
+
+	/**
 	 * Update customer data and return the full cart response, or an error.
 	 * See https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/docs/cart.md#update-customer
 	 *

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -43,7 +43,6 @@ import {
 } from './transformers/wc-to-stripe';
 
 let cachedCartData = null;
-const noop = () => null;
 const fetchNewCartData = async () => {
 	if ( getExpressCheckoutData( 'button_context' ) !== 'product' ) {
 		return await getCartApiHandler().getCart();
@@ -54,14 +53,9 @@ const fetchNewCartData = async () => {
 	// preventing other customers from purchasing.
 	const temporaryCart = new ExpressCheckoutCartApi();
 	temporaryCart.useSeparateCart();
+	temporaryCart.deleteAfterRequest();
 
-	const cartData = await temporaryCart.addProductToCart();
-
-	// no need to wait for the request to end, it can be done asynchronously.
-	// using `.finally( noop )` to avoid annoying IDE warnings.
-	temporaryCart.emptyCart().finally( noop );
-
-	return cartData;
+	return await temporaryCart.addProductToCart();
 };
 
 const getTotalAmount = () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10488
Fixes WOOPMNT-4827

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

While investigating #10488, I noticed that the vast majority (all but one in the last 30 days) of the requests are coming from bots.
What I think it's happening is that the `POST /cart/remove-item` is being called with some different headers than expected, causing the custom session handler to reject the request and throw an exception.
I think that crawlers might be parsing the page (esp. from variable products), which makes a request to the backend via the `fetchNewCartData()` function.
This function will:
1. Create a new cart by adding an item to it
2. Fetch its data again
3. Remove the item added on Step 1

I modified the `fetchNewCartData()` function, so that it will create a new cart & remove the item from the cart within the same request.

The reason I have been explicitly removing the item from the cart is that I wanted to avoid issues with items with limited availability or limited stock - where their stock might be decreased (or held) during the `POST /cart/add-item` call (I'll clarify that WC Core behavior will hold the stock only when the checkout has been attempted).

I think that removing the subsequent requests that delete the item from the cart (which are erroneously made by crawlers) will limit the number of exceptions thrown by the `WC_Payments_Payment_Request_Session_Handler` session handler class.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1️⃣  Test from a product page
1. Ensure you have Google Pay/Apple Pay enabled
3. Navigate to the page for a variable product
4. Open the network tab
5. Change the product variation selection
6. Once you selected all the required variation attributes, you should see a `POST /cart/add-item` Store API call in the console
	7. There should no longer be a `POST /cart/remove-item` call

Before (notice the multiple calls on variation change):
![2025-03-31 16 14 50](https://github.com/user-attachments/assets/97bdce98-c024-4b7d-8a4f-54dfe5a0a7c0)

After (notice only the `add-item` call on variation change):
![2025-03-31 16 21 45](https://github.com/user-attachments/assets/0c126698-ec3a-487f-95b1-8736849b9b6e)

2️⃣ Test of the API - cart is cleared
In this test, we'll ensure the header is clearing the cart.
- Navigate to a simple product page (to make things easier)
- Open the browser's console
- Add the product to the cart: 
```
const response = await wp.apiFetch({
    parse: false,
    method: 'POST',
    path: '/wc/store/v1/cart/add-item',
    headers: {
        // creates a new cart for the current customer
        'X-WooPayments-Tokenized-Cart-Session': '',
        // ensures that the cart is cleared after the request is made
        'X-WooPayments-Tokenized-Cart-Is-Ephemeral-Cart': '1',
        'X-WooPayments-Tokenized-Cart-Session-Nonce': window.wcpayExpressCheckoutParams.nonce.tokenized_cart_session_nonce
    },
    data: {
        variation: [],
        id: parseInt(document.querySelector('.single_add_to_cart_button').value, 10),
        quantity: parseInt(document.querySelector('.quantity .qty').value, 10),
    },
});
```

- Subsequently, make a `GET` of the cart from the previous request, to get the cart contents:
```
const session = response.headers.get('X-WooPayments-Tokenized-Cart-Session');
const response = await wp.apiFetch({
    method: 'GET',
    path: '/wc/store/v1/cart',
    headers: {
        // creates a new cart for the current customer
        'X-WooPayments-Tokenized-Cart-Session': session,
        'X-WooPayments-Tokenized-Cart-Session-Nonce': window.wcpayExpressCheckoutParams.nonce.tokenized_cart_session_nonce
    }
});
```

- The response should contain no cart items

Compare it with this, which won't send the `'X-WooPayments-Tokenized-Cart-Is-Ephemeral-Cart': '1',` header - the response should contain one item (the product on the page):
```
const response = await wp.apiFetch({
    parse: false,
    method: 'POST',
    path: '/wc/store/v1/cart/add-item',
    headers: {
        // creates a new cart for the current customer
        'X-WooPayments-Tokenized-Cart-Session': '',
        'X-WooPayments-Tokenized-Cart-Session-Nonce': window.wcpayExpressCheckoutParams.nonce.tokenized_cart_session_nonce
    },
    data: {
        variation: [],
        id: parseInt(document.querySelector('.single_add_to_cart_button').value, 10),
        quantity: parseInt(document.querySelector('.quantity .qty').value, 10),
    },
});
const session = response.headers.get('X-WooPayments-Tokenized-Cart-Session');
await wp.apiFetch({
    method: 'GET',
    path: '/wc/store/v1/cart',
    headers: {
        // creates a new cart for the current customer
        'X-WooPayments-Tokenized-Cart-Session': session,
        'X-WooPayments-Tokenized-Cart-Session-Nonce': window.wcpayExpressCheckoutParams.nonce.tokenized_cart_session_nonce
    }
});
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
