### PR TITLE
Move payment method map definition to the backend

### DIFF
--- a/changelog/update-move-settings-definitions-to-backend
+++ b/changelog/update-move-settings-definitions-to-backend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Move payment method map definition to the backend

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -172,17 +172,7 @@ declare global {
 
 	const wooPaymentsPaymentMethodDefinitions: Record<
 		string,
-		{
-			id: string;
-			stripe_key: string;
-			title: string;
-			description: string;
-			settings_icon_url: string;
-			currencies: string[];
-			allows_manual_capture: boolean;
-			allows_pay_later: boolean;
-			accepts_only_domestic_payment: boolean;
-		}
+		PaymentMethodServerDefinition
 	>;
 
 	const wooPaymentsPaymentMethodsConfig: Record<

--- a/client/payment-methods-icons.tsx
+++ b/client/payment-methods-icons.tsx
@@ -8,23 +8,9 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import BancontactAsset from 'assets/images/payment-methods/bancontact.svg?asset';
-import EpsAsset from 'assets/images/payment-methods/eps.svg?asset';
-import GiropayAsset from 'assets/images/payment-methods/giropay.svg?asset';
-import SofortAsset from 'assets/images/payment-methods/sofort.svg?asset';
-import SepaAsset from 'assets/images/payment-methods/sepa-debit.svg?asset';
-import P24Asset from 'assets/images/payment-methods/p24.svg?asset';
-import IdealAsset from 'assets/images/payment-methods/ideal.svg?asset';
-import BankDebitAsset from 'assets/images/payment-methods/bank-debit.svg?asset';
-import AffirmAsset from 'assets/images/payment-methods/affirm-badge.svg?asset';
-import AfterpayAsset from 'assets/images/payment-methods/afterpay-logo.svg?asset';
-import ClearpayAsset from 'assets/images/payment-methods/clearpay.svg?asset';
 import JCBAsset from 'assets/images/payment-methods/jcb.svg?asset';
-import KlarnaAsset from 'assets/images/payment-methods/klarna.svg?asset';
-import GrabPayAsset from 'assets/images/payment-methods/grabpay.svg?asset';
 import VisaAsset from 'assets/images/cards/visa.svg?asset';
 import MasterCardAsset from 'assets/images/cards/mastercard.svg?asset';
-import MultibancoAsset from 'assets/images/payment-methods/multibanco.svg?asset';
 import AmexAsset from 'assets/images/cards/amex.svg?asset';
 import WooAsset from 'assets/images/payment-methods/woo.svg?asset';
 import WooAssetShort from 'assets/images/payment-methods/woo-short.svg?asset';
@@ -35,8 +21,6 @@ import DiscoverAsset from 'assets/images/cards/discover.svg?asset';
 import CBAsset from 'assets/images/cards/cb.svg?asset';
 import UnionPayAsset from 'assets/images/cards/unionpay.svg?asset';
 import LinkAsset from 'assets/images/payment-methods/link.svg?asset';
-import CreditCardAsset from 'assets/images/payment-methods/cc.svg?asset';
-import WeChatPayAsset from 'assets/images/payment-methods/wechat-pay.svg?asset';
 import './style.scss';
 
 const iconComponent = (
@@ -56,18 +40,6 @@ const iconComponent = (
 	/>
 );
 
-export const AffirmIcon = iconComponent(
-	AffirmAsset,
-	__( 'Affirm', 'woocommerce-payments' )
-);
-export const AfterpayIcon = iconComponent(
-	AfterpayAsset,
-	__( 'Afterpay', 'woocommerce-payments' )
-);
-export const ClearpayIcon = iconComponent(
-	ClearpayAsset,
-	__( 'Clearpay', 'woocommerce-payments' )
-);
 export const AmericanExpressIcon = iconComponent(
 	AmexAsset,
 	__( 'American Express', 'woocommerce-payments' )
@@ -75,19 +47,6 @@ export const AmericanExpressIcon = iconComponent(
 export const ApplePayIcon = iconComponent(
 	ApplePayAsset,
 	__( 'Apple Pay', 'woocommerce-payments' )
-);
-export const BancontactIcon = iconComponent(
-	BancontactAsset,
-	__( 'Bancontact', 'woocommerce-payments' )
-);
-export const BankDebitIcon = iconComponent(
-	BankDebitAsset,
-	__( 'BECS Direct Debit', 'woocommerce-payments' )
-);
-export const CreditCardIcon = iconComponent(
-	CreditCardAsset,
-	__( 'Credit card / Debit card', 'woocommerce-payments' ),
-	false
 );
 export const CBIcon = iconComponent(
 	CBAsset,
@@ -101,29 +60,13 @@ export const DiscoverIcon = iconComponent(
 	DiscoverAsset,
 	__( 'Discover', 'woocommerce-payments' )
 );
-export const EpsIcon = iconComponent(
-	EpsAsset,
-	__( 'BECS Direct Debit', 'woocommerce-payments' )
-);
-export const GiropayIcon = iconComponent(
-	GiropayAsset,
-	__( 'Giropay', 'woocommerce-payments' )
-);
 export const GooglePayIcon = iconComponent(
 	GooglePayAsset,
 	__( 'Google Pay', 'woocommerce-payments' )
 );
-export const IdealIcon = iconComponent(
-	IdealAsset,
-	__( 'iDEAL', 'woocommerce-payments' )
-);
 export const JCBIcon = iconComponent(
 	JCBAsset,
 	__( 'JCB', 'woocommerce-payments' )
-);
-export const KlarnaIcon = iconComponent(
-	KlarnaAsset,
-	__( 'Klarna', 'woocommerce-payments' )
 );
 export const LinkIcon = iconComponent(
 	LinkAsset,
@@ -133,22 +76,6 @@ export const MastercardIcon = iconComponent(
 	MasterCardAsset,
 	__( 'Mastercard', 'woocommerce-payments' )
 );
-export const MultibancoIcon = iconComponent(
-	MultibancoAsset,
-	__( 'Multibanco', 'woocommerce-payments' )
-);
-export const P24Icon = iconComponent(
-	P24Asset,
-	__( 'Przelewy24 (P24)', 'woocommerce-payments' )
-);
-export const SepaIcon = iconComponent(
-	SepaAsset,
-	__( 'SEPA Direct Debit', 'woocommerce-payments' )
-);
-export const SofortIcon = iconComponent(
-	SofortAsset,
-	__( 'Sofort', 'woocommerce-payments' )
-);
 export const UnionPayIcon = iconComponent(
 	UnionPayAsset,
 	__( 'UnionPay', 'woocommerce-payments' )
@@ -156,14 +83,6 @@ export const UnionPayIcon = iconComponent(
 export const VisaIcon = iconComponent(
 	VisaAsset,
 	__( 'Visa', 'woocommerce-payments' )
-);
-export const GrabPayIcon = iconComponent(
-	GrabPayAsset,
-	__( 'GrabPay', 'woocommerce-payments' )
-);
-export const WeChatPayIcon = iconComponent(
-	WeChatPayAsset,
-	__( 'WeChat Pay', 'woocommerce-payments' )
 );
 export const WooIcon = iconComponent(
 	WooAsset,

--- a/client/payment-methods-map.tsx
+++ b/client/payment-methods-map.tsx
@@ -9,321 +9,55 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 
-import {
-	AffirmIcon,
-	AfterpayIcon,
-	ClearpayIcon,
-	BancontactIcon,
-	BankDebitIcon,
-	CreditCardIcon,
-	EpsIcon,
-	GiropayIcon,
-	IdealIcon,
-	JCBIcon,
-	KlarnaIcon,
-	P24Icon,
-	SepaIcon,
-	SofortIcon,
-	MultibancoIcon,
-	GrabPayIcon,
-	WeChatPayIcon,
-} from 'wcpay/payment-methods-icons';
-
-const accountCountry = window.wcpaySettings?.accountStatus?.country || 'US';
+import { JCBIcon } from 'wcpay/payment-methods-icons';
 
 import type { PaymentMethodMapEntry } from './types/payment-methods';
 
-// Get any payment method definitions from the client.
-const PaymentMethodDefinitions =
-	typeof wooPaymentsPaymentMethodDefinitions !== 'undefined'
-		? wooPaymentsPaymentMethodDefinitions
-		: {};
+if ( typeof wooPaymentsPaymentMethodDefinitions === 'undefined' ) {
+	throw new Error( 'wooPaymentsPaymentMethodDefinitions is undefined' );
+}
 
-const convertedPaymentMethodDefinitions = Object.fromEntries<
+const PaymentMethodInformationObject: Record<
+	string,
 	PaymentMethodMapEntry
->(
-	Object.entries( PaymentMethodDefinitions ).map( ( [ key, value ] ) => [
-		key,
-		{
-			id: value.id,
-			label: value.title,
-			description: value.description,
-			icon: ( { className } ) => (
+> = Object.keys( wooPaymentsPaymentMethodDefinitions ).reduce(
+	( acc: Record< string, PaymentMethodMapEntry >, key: string ) => {
+		acc[ key ] = {
+			...wooPaymentsPaymentMethodDefinitions[ key ],
+			icon: ( { className }: { className?: string } ) => (
 				<img
-					src={ value.settings_icon_url }
-					alt={ value.title }
+					src={
+						wooPaymentsPaymentMethodDefinitions[ key ]
+							.settings_icon_url
+					}
+					alt={ wooPaymentsPaymentMethodDefinitions[ key ].label }
 					className={ classNames(
 						'payment-method__icon',
+						key === 'card' ? 'no-border' : '',
 						className
 					) }
 				/>
 			),
-			currencies: value.currencies,
-			stripe_key: value.stripe_key,
-			allows_manual_capture: value.allows_manual_capture,
-			allows_pay_later: value.allows_pay_later,
-			accepts_only_domestic_payment: value.accepts_only_domestic_payment,
+		};
+		return acc;
+	},
+	{
+		jcb: {
+			id: 'jcb',
+			label: __( 'JCB', 'woocommerce-payments' ),
+			description: __(
+				'Let your customers pay with JCB, the only international payment brand based in Japan.',
+				'woocommerce-payments'
+			),
+			icon: JCBIcon,
+			currencies: [ 'JPY' ],
+			stripe_key: 'jcb_payments',
+			allows_manual_capture: false,
+			allows_pay_later: false,
+			accepts_only_domestic_payment: false,
+			settings_icon_url: '',
 		},
-	] )
+	}
 );
-
-/**
- * FLAG: PAYMENT_METHODS_LIST
- *
- * As we convert payment methods to use definitions, we'll remove them from this object.
- */
-const PaymentMethodInformationObject: Record<
-	string,
-	PaymentMethodMapEntry
-> = {
-	card: {
-		id: 'card',
-		label: __( 'Credit / Debit Cards', 'woocommerce-payments' ),
-		description: __(
-			'Let your customers pay with major credit and debit cards without leaving your store.',
-			'woocommerce-payments'
-		),
-		icon: CreditCardIcon,
-		currencies: [],
-		stripe_key: 'card_payments',
-		allows_manual_capture: true,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	au_becs_debit: {
-		id: 'au_becs_debit',
-		label: __( 'BECS Direct Debit', 'woocommerce-payments' ),
-		description: __(
-			'Bulk Electronic Clearing System — Accept secure bank transfer from Australia.',
-			'woocommerce-payments'
-		),
-		icon: BankDebitIcon,
-		currencies: [ 'AUD' ],
-		stripe_key: 'au_becs_debit_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	bancontact: {
-		id: 'bancontact',
-		label: __( 'Bancontact', 'woocommerce-payments' ),
-		description: __(
-			'Bancontact is a bank redirect payment method offered by more than 80% of online businesses in Belgium.',
-			'woocommerce-payments'
-		),
-		icon: BancontactIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'bancontact_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	eps: {
-		id: 'eps',
-		label: __( 'EPS', 'woocommerce-payments' ),
-		description: __(
-			'Accept your payment with EPS — a common payment method in Austria.',
-			'woocommerce-payments'
-		),
-		icon: EpsIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'eps_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	giropay: {
-		id: 'giropay',
-		label: __( 'giropay', 'woocommerce-payments' ),
-		description: __(
-			'Expand your business with giropay — Germany’s second most popular payment system.',
-			'woocommerce-payments'
-		),
-		icon: GiropayIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'giropay_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	ideal: {
-		id: 'ideal',
-		label: __( 'iDEAL', 'woocommerce-payments' ),
-		description: __(
-			'Expand your business with iDEAL — Netherlands’s most popular payment method.',
-			'woocommerce-payments'
-		),
-		icon: IdealIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'ideal_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	p24: {
-		id: 'p24',
-		label: __( 'Przelewy24 (P24)', 'woocommerce-payments' ),
-		description: __(
-			'Accept payments with Przelewy24 (P24), the most popular payment method in Poland.',
-			'woocommerce-payments'
-		),
-		icon: P24Icon,
-		currencies: [ 'EUR', 'PLN' ],
-		stripe_key: 'p24_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	sepa_debit: {
-		id: 'sepa_debit',
-		label: __( 'SEPA Direct Debit', 'woocommerce-payments' ),
-		description: __(
-			'Reach 500 million customers and over 20 million businesses across the European Union.',
-			'woocommerce-payments'
-		),
-		icon: SepaIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'sepa_debit_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	sofort: {
-		id: 'sofort',
-		label: __( 'Sofort', 'woocommerce-payments' ),
-		description: __(
-			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
-			'woocommerce-payments'
-		),
-		icon: SofortIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'sofort_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	multibanco: {
-		id: 'multibanco',
-		label: __( 'Multibanco', 'woocommerce-payments' ),
-		description: __(
-			'A voucher based payment method for your customers in Portugal.',
-			'woocommerce-payments'
-		),
-		icon: MultibancoIcon,
-		currencies: [ 'EUR' ],
-		stripe_key: 'multibanco_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	affirm: {
-		id: 'affirm',
-		label: __( 'Affirm', 'woocommerce-payments' ),
-		description: __(
-			'Allow customers to pay over time with Affirm.',
-			'woocommerce-payments'
-		),
-		icon: AffirmIcon,
-		currencies: [ 'USD', 'CAD' ],
-		stripe_key: 'affirm_payments',
-		allows_manual_capture: false,
-		allows_pay_later: true,
-		accepts_only_domestic_payment: true,
-	},
-	afterpay_clearpay: {
-		id: 'afterpay_clearpay',
-		label:
-			'GB' === accountCountry
-				? __( 'Clearpay', 'woocommerce-payments' )
-				: __( 'Afterpay', 'woocommerce-payments' ),
-		description:
-			'GB' === accountCountry
-				? __(
-						'Allow customers to pay over time with Clearpay.',
-						'woocommerce-payments'
-				  )
-				: __(
-						'Allow customers to pay over time with Afterpay.',
-						'woocommerce-payments'
-				  ),
-		icon: 'GB' === accountCountry ? ClearpayIcon : AfterpayIcon,
-		currencies: [ 'USD', 'AUD', 'CAD', 'NZD', 'GBP' ],
-		stripe_key: 'afterpay_clearpay_payments',
-		allows_manual_capture: false,
-		allows_pay_later: true,
-		accepts_only_domestic_payment: true,
-	},
-	jcb: {
-		id: 'jcb',
-		label: __( 'JCB', 'woocommerce-payments' ),
-		description: __(
-			'Let your customers pay with JCB, the only international payment brand based in Japan.',
-			'woocommerce-payments'
-		),
-		icon: JCBIcon,
-		currencies: [ 'JPY' ],
-		stripe_key: 'jcb_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	klarna: {
-		id: 'klarna',
-		label: __( 'Klarna', 'woocommerce-payments' ),
-		description: __(
-			'Allow customers to pay over time or pay now with Klarna.',
-			'woocommerce-payments'
-		),
-		icon: KlarnaIcon,
-		currencies: [ 'EUR', 'GBP', 'USD', 'DKK', 'NOK', 'SEK' ],
-		stripe_key: 'klarna_payments',
-		allows_manual_capture: false,
-		allows_pay_later: true,
-		accepts_only_domestic_payment: true,
-	},
-	grabpay: {
-		id: 'grabpay',
-		label: __( 'GrabPay', 'woocommerce-payments' ),
-		description: __(
-			'A popular digital wallet for cashless payments in Singapore.',
-			'woocommerce-payments'
-		),
-		icon: GrabPayIcon,
-		currencies: [ 'SGD' ],
-		stripe_key: 'grabpay_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	wechat_pay: {
-		id: 'wechat_pay',
-		label: __( 'WeChat Pay', 'woocommerce-payments' ),
-		description: __(
-			'A digital wallet popular with customers from China.',
-			'woocommerce-payments'
-		),
-		icon: WeChatPayIcon,
-		currencies: [
-			'USD',
-			'CNY',
-			'AUD',
-			'CAD',
-			'EUR',
-			'GBP',
-			'HKD',
-			'JPY',
-			'SGD',
-			'DKK',
-			'NOK',
-			'SEK',
-			'CHF',
-		],
-		stripe_key: 'wechat_pay_payments',
-		allows_manual_capture: false,
-		allows_pay_later: false,
-		accepts_only_domestic_payment: false,
-	},
-	...convertedPaymentMethodDefinitions,
-};
 
 export default PaymentMethodInformationObject;

--- a/client/settings/payment-methods-list/__tests__/__snapshots__/activation-modal.test.js.snap
+++ b/client/settings/payment-methods-list/__tests__/__snapshots__/activation-modal.test.js.snap
@@ -84,9 +84,9 @@ exports[`Activation Modal matches the snapshot 1`] = `
             class="payment-confirm-illustration__illustrations"
           >
             <img
-              alt="Credit card / Debit card"
+              alt="Credit / Debit Cards"
               class="payment-method__icon no-border payment-confirm-illustration__payment-icon"
-              src="assets/images/payment-methods/cc.svg"
+              src="assets/images/icon-card.svg"
             />
             <svg
               class="gridicon gridicons-help payment-confirm-illustration__payment-question-mark-icon"

--- a/client/settings/payment-methods-list/__tests__/__snapshots__/delete-modal.test.js.snap
+++ b/client/settings/payment-methods-list/__tests__/__snapshots__/delete-modal.test.js.snap
@@ -84,9 +84,9 @@ exports[`Activation Modal matches the snapshot 1`] = `
             class="payment-delete-illustration__illustrations"
           >
             <img
-              alt="Credit card / Debit card"
+              alt="Credit / Debit Cards"
               class="payment-method__icon no-border payment-delete-illustration__payment-icon"
-              src="assets/images/payment-methods/cc.svg"
+              src="assets/images/icon-card.svg"
             />
             <svg
               class="gridicon gridicons-cross-circle payment-delete-illustration__payment-cross-icon"

--- a/client/types/payment-methods.d.ts
+++ b/client/types/payment-methods.d.ts
@@ -6,14 +6,18 @@
  * Internal dependencies
  */
 
-export interface PaymentMethodMapEntry {
+export interface PaymentMethodServerDefinition {
 	id: string;
 	label: string;
 	description: string;
-	icon: ReactImgFuncComponent;
+	settings_icon_url: string;
 	currencies: string[];
 	stripe_key: string;
 	allows_manual_capture: boolean;
 	allows_pay_later: boolean;
 	accepts_only_domestic_payment: boolean;
+}
+
+export interface PaymentMethodMapEntry extends PaymentMethodServerDefinition {
+	icon: ReactImgFuncComponent;
 }

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -365,12 +365,12 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
           <img
             alt="Giropay"
             class="payment-method__icon"
-            src="assets/images/payment-methods/giropay.svg"
+            src="assets/images/icon-giropay.svg"
           />
           <span
             class="woocommerce-payments__payment-method-icon__label"
           >
-            giropay
+            Giropay
           </span>
         </span>
       </li>
@@ -381,7 +381,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
           <img
             alt="Sofort"
             class="payment-method__icon"
-            src="assets/images/payment-methods/sofort.svg"
+            src="assets/images/icon-sofort.svg"
           />
           <span
             class="woocommerce-payments__payment-method-icon__label"
@@ -397,7 +397,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
           <img
             alt="SEPA Direct Debit"
             class="payment-method__icon"
-            src="assets/images/payment-methods/sepa-debit.svg"
+            src="assets/images/icon-sepa_debit.svg"
           />
           <span
             class="woocommerce-payments__payment-method-icon__label"

--- a/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
@@ -57,11 +57,23 @@ class AlipayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Get the customer-facing description of the payment method
+	 * Get the title of the payment method for the settings page.
+	 *
+	 * @param string|null $account_country Optional. The merchant's account country.
 	 *
 	 * @return string
 	 */
-	public static function get_description(): string {
+	public static function get_settings_label( ?string $account_country = null ): string {
+		return self::get_title( $account_country );
+	}
+
+	/**
+	 * Get the customer-facing description of the payment method
+	 *
+	 * @param string|null $account_country Optional. The merchant's account country.
+	 * @return string
+	 */
+	public static function get_description( ?string $account_country = null ): string {
 		return __( 'Alipay is a popular wallet in China, operated by Ant Financial Services Group, a financial services provider affiliated with Alibaba.', 'woocommerce-payments' );
 	}
 
@@ -232,10 +244,12 @@ class AlipayDefinition implements PaymentMethodDefinitionInterface {
 	/**
 	 * Get the URL for the payment method's settings icon
 	 *
+	 * @param string|null $account_country Optional. The merchant's account country.
+	 *
 	 * @return string
 	 */
-	public static function get_settings_icon_url(): string {
-		return self::get_icon_url();
+	public static function get_settings_icon_url( ?string $account_country = null ): string {
+		return self::get_icon_url( $account_country );
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
+++ b/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
@@ -42,11 +42,20 @@ interface PaymentMethodDefinitionInterface {
 	public static function get_title( ?string $account_country = null ): string;
 
 	/**
-	 * Get the customer-facing description of the payment method
+	 * Get the title of the payment method for the settings page.
 	 *
+	 * @param string|null $account_country Optional. The merchant's account country.
 	 * @return string
 	 */
-	public static function get_description(): string;
+	public static function get_settings_label( ?string $account_country = null ): string;
+
+	/**
+	 * Get the customer-facing description of the payment method
+	 *
+	 * @param string|null $account_country Optional. The merchant's account country.
+	 * @return string
+	 */
+	public static function get_description( ?string $account_country = null ): string;
 
 	/**
 	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
@@ -120,9 +129,10 @@ interface PaymentMethodDefinitionInterface {
 	 * Get the URL for the payment method's settings icon
 	 * This icon is used in the payment method settings page.
 	 *
+	 * @param string|null $account_country Optional. The merchant's account country.
 	 * @return string
 	 */
-	public static function get_settings_icon_url(): string;
+	public static function get_settings_icon_url( ?string $account_country = null ): string;
 
 	/**
 	 * Get the testing instructions for the payment method

--- a/includes/payment-methods/class-affirm-payment-method.php
+++ b/includes/payment-methods/class-affirm-payment-method.php
@@ -58,4 +58,28 @@ class Affirm_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Allow customers to pay over time with Affirm.',
+			'woocommerce-payments'
+		);
+	}
+
+	/**
+	 * Returns payment method settings icon.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_icon_url( ?string $account_country = null ) {
+		return plugins_url( 'assets/images/payment-methods/affirm-badge.svg', WCPAY_PLUGIN_FILE );
+	}
 }

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -76,4 +76,39 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		if ( Country_Code::UNITED_KINGDOM === $account_country ) {
+			return __(
+				'Allow customers to pay over time with Clearpay.',
+				'woocommerce-payments'
+			);
+		}
+
+		return __(
+			'Allow customers to pay over time with Afterpay.',
+			'woocommerce-payments'
+		);
+	}
+
+	/**
+	 * Returns payment method settings icon.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_icon_url( ?string $account_country = null ) {
+		if ( Country_Code::UNITED_KINGDOM === $account_country ) {
+			return plugins_url( 'assets/images/payment-methods/clearpay.svg', WCPAY_PLUGIN_FILE );
+		}
+
+		return plugins_url( 'assets/images/payment-methods/afterpay-logo.svg', WCPAY_PLUGIN_FILE );
+	}
 }

--- a/includes/payment-methods/class-bancontact-payment-method.php
+++ b/includes/payment-methods/class-bancontact-payment-method.php
@@ -42,4 +42,18 @@ class Bancontact_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Bancontact is a bank redirect payment method offered by more than 80% of online businesses in Belgium.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-becs-payment-method.php
+++ b/includes/payment-methods/class-becs-payment-method.php
@@ -42,4 +42,18 @@ class Becs_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return __( '<strong>Test mode:</strong> use the test account number <number>000123456</number>. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a>here</a>.', 'woocommerce-payments' );
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Bulk Electronic Clearing System — Accept secure bank transfer from Australia.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-cc-payment-method.php
+++ b/includes/payment-methods/class-cc-payment-method.php
@@ -79,4 +79,47 @@ class CC_Payment_Method extends UPE_Payment_Method {
 			$test_card_number
 		);
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Let your customers pay with major credit and debit cards without leaving your store.',
+			'woocommerce-payments'
+		);
+	}
+
+	/**
+	 * Returns payment method settings label.
+	 *
+	 * @param string $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_label( string $account_country ) {
+		return __( 'Credit / Debit Cards', 'woocommerce-payments' );
+	}
+
+	/**
+	 * Returns payment method settings icon.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_icon_url( ?string $account_country = null ) {
+		return plugins_url( 'assets/images/payment-methods/cc.svg', WCPAY_PLUGIN_FILE );
+	}
+
+	/**
+	 * Returns boolean dependent on whether payment method allows manual capture.
+	 *
+	 * @return bool
+	 */
+	public function allows_manual_capture() {
+		return true;
+	}
 }

--- a/includes/payment-methods/class-eps-payment-method.php
+++ b/includes/payment-methods/class-eps-payment-method.php
@@ -42,4 +42,18 @@ class Eps_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Accept your payment with EPS — a common payment method in Austria.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-giropay-payment-method.php
+++ b/includes/payment-methods/class-giropay-payment-method.php
@@ -42,4 +42,18 @@ class Giropay_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Expand your business with giropay — Germany’s second most popular payment system.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-grabpay-payment-method.php
+++ b/includes/payment-methods/class-grabpay-payment-method.php
@@ -57,4 +57,18 @@ class Grabpay_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'A popular digital wallet for cashless payments in Singapore.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-ideal-payment-method.php
+++ b/includes/payment-methods/class-ideal-payment-method.php
@@ -42,4 +42,18 @@ class Ideal_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Expand your business with iDEAL — Netherlands’s most popular payment method.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -87,4 +87,28 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Allow customers to pay over time or pay now with Klarna.',
+			'woocommerce-payments'
+		);
+	}
+
+	/**
+	 * Returns payment method settings icon.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_icon_url( ?string $account_country = null ) {
+		return plugins_url( 'assets/images/payment-methods/klarna.svg', WCPAY_PLUGIN_FILE );
+	}
 }

--- a/includes/payment-methods/class-link-payment-method.php
+++ b/includes/payment-methods/class-link-payment-method.php
@@ -51,4 +51,16 @@ class Link_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		// Description is hardcoded in the react component.
+		return '';
+	}
 }

--- a/includes/payment-methods/class-multibanco-payment-method.php
+++ b/includes/payment-methods/class-multibanco-payment-method.php
@@ -55,4 +55,28 @@ class Multibanco_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'A voucher based payment method for your customers in Portugal.',
+			'woocommerce-payments'
+		);
+	}
+
+	/**
+	 * Returns payment method settings icon.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_icon_url( ?string $account_country = null ) {
+		return plugins_url( 'assets/images/payment-methods/multibanco.svg', WCPAY_PLUGIN_FILE );
+	}
 }

--- a/includes/payment-methods/class-p24-payment-method.php
+++ b/includes/payment-methods/class-p24-payment-method.php
@@ -42,4 +42,18 @@ class P24_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Accept payments with Przelewy24 (P24), the most popular payment method in Poland.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-sepa-payment-method.php
+++ b/includes/payment-methods/class-sepa-payment-method.php
@@ -46,4 +46,18 @@ class Sepa_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return __( '<strong>Test mode:</strong> use the test account number <number>AT611904300234573201</number>. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a>here</a>.', 'woocommerce-payments' );
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Reach 500 million customers and over 20 million businesses across the European Union.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-sofort-payment-method.php
+++ b/includes/payment-methods/class-sofort-payment-method.php
@@ -43,4 +43,18 @@ class Sofort_Payment_Method extends UPE_Payment_Method {
 	public function get_testing_instructions( string $account_country ) {
 		return '';
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -124,7 +124,7 @@ class UPE_Payment_Method {
 
 		if ( null !== $this->definition ) {
 			// Cache values that don't require context.
-			$this->stripe_id                    = $this->definition::get_stripe_id();
+			$this->stripe_id                    = $this->definition::get_id();
 			$this->is_reusable                  = $this->definition::is_reusable();
 			$this->currencies                   = $this->definition::get_supported_currencies();
 			$this->accept_only_domestic_payment = $this->definition::accepts_only_domestic_payments();
@@ -365,6 +365,91 @@ class UPE_Payment_Method {
 		$account_country = isset( $account['country'] ) ? strtoupper( $account['country'] ) : '';
 
 		return $this->has_domestic_transactions_restrictions() ? [ $account_country ] : $this->countries;
+	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		if ( null !== $this->definition ) {
+			return $this->definition::get_description( $account_country );
+		}
+		return '';
+	}
+
+	/**
+	 * Returns payment method settings label.
+	 *
+	 * @param string $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_label( string $account_country ) {
+		if ( null !== $this->definition ) {
+			return $this->definition::get_settings_label( $account_country );
+		}
+		return $this->get_title( $account_country );
+	}
+
+	/**
+	 * Returns payment method settings icon.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 * @return string
+	 */
+	public function get_settings_icon_url( ?string $account_country = null ) {
+		if ( null !== $this->definition ) {
+			return $this->definition::get_settings_icon_url( $account_country );
+		}
+		return $this->get_icon( $account_country );
+	}
+
+	/**
+	 * Returns boolean dependent on whether payment method allows manual capture.
+	 *
+	 * @return bool
+	 */
+	public function allows_manual_capture() {
+		if ( null !== $this->definition ) {
+			return $this->definition::allows_manual_capture();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the Stripe key for the payment method.
+	 *
+	 * @return string
+	 */
+	public function get_stripe_key() {
+		if ( null !== $this->definition ) {
+			return $this->definition::get_stripe_id();
+		}
+		return \WC_Payments::get_gateway()->get_payment_method_capability_key_map()[ $this->stripe_id ];
+	}
+
+	/**
+	 * Returns payment method settings definition.
+	 *
+	 * @param string $account_country Country of merchants account.
+	 * @return array
+	 */
+	public function get_payment_method_information_object( string $account_country ) {
+		return [
+			'id'                            => $this->stripe_id,
+			'label'                         => $this->get_settings_label( $account_country ),
+			'description'                   => $this->get_description( $account_country ),
+			'settings_icon_url'             => $this->get_settings_icon_url( $account_country ),
+			'currencies'                    => $this->get_currencies(),
+			'stripe_key'                    => $this->get_stripe_key(),
+			'allows_manual_capture'         => $this->allows_manual_capture(),
+			'allows_pay_later'              => $this->is_bnpl(),
+			'accepts_only_domestic_payment' => $this->has_domestic_transactions_restrictions(),
+		];
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -440,7 +440,7 @@ class UPE_Payment_Method {
 	 */
 	public function get_payment_method_information_object( string $account_country ) {
 		return [
-			'id'                            => $this->stripe_id,
+			'id'                            => $this->get_id(),
 			'label'                         => $this->get_settings_label( $account_country ),
 			'description'                   => $this->get_description( $account_country ),
 			'settings_icon_url'             => $this->get_settings_icon_url( $account_country ),

--- a/includes/payment-methods/class-wechatpay-payment-method.php
+++ b/includes/payment-methods/class-wechatpay-payment-method.php
@@ -151,4 +151,18 @@ class Wechatpay_Payment_Method extends UPE_Payment_Method {
 				return [ 'UNSUPPORTED' ];
 		}
 	}
+
+	/**
+	 * Returns payment method description for the settings page.
+	 *
+	 * @param string|null $account_country Country of merchants account.
+	 *
+	 * @return string
+	 */
+	public function get_description( ?string $account_country = null ) {
+		return __(
+			'A digital wallet popular with customers from China.',
+			'woocommerce-payments'
+		);
+	}
 }

--- a/tests/js/jest-test-file-setup.js
+++ b/tests/js/jest-test-file-setup.js
@@ -133,3 +133,56 @@ jest.mock( 'tracks', () => ( {
 	isEnabled: jest.fn(),
 	events: {},
 } ) );
+
+function buildMockDefinition( id, label, currencies = [], overrides = {} ) {
+	return {
+		id,
+		label,
+		description: `Mock ${ label } Description`,
+		settings_icon_url: `assets/images/icon-${ id }.svg`,
+		currencies,
+		stripe_key: `${ id }_payments`,
+		allows_manual_capture: false,
+		allows_pay_later: false,
+		accepts_only_domestic_payment: false,
+		...overrides,
+	};
+}
+
+// This doesn't include all the payment methods, only the ones relevant for tests.
+global.wooPaymentsPaymentMethodDefinitions = {
+	card: buildMockDefinition( 'card', 'Credit / Debit Cards', [], {
+		allows_manual_capture: true,
+	} ),
+	bancontact: buildMockDefinition( 'bancontact', 'Bancontact', [ 'EUR' ] ),
+	ideal: buildMockDefinition( 'ideal', 'iDEAL', [ 'EUR' ] ),
+	eps: buildMockDefinition( 'eps', 'EPS', [ 'EUR' ] ),
+	giropay: buildMockDefinition( 'giropay', 'Giropay', [ 'EUR' ] ),
+	sofort: buildMockDefinition( 'sofort', 'Sofort', [ 'EUR' ] ),
+	sepa_debit: buildMockDefinition( 'sepa_debit', 'SEPA Direct Debit', [
+		'EUR',
+	] ),
+	p24: buildMockDefinition( 'p24', 'Przelewy24 (P24)', [ 'EUR', 'PLN' ] ),
+	au_becs_debit: buildMockDefinition( 'au_becs_debit', 'BECS Direct Debit', [
+		'AUD',
+	] ),
+	affirm: buildMockDefinition( 'affirm', 'Affirm', [ 'USD', 'CAD' ], {
+		allows_pay_later: true,
+		accepts_only_domestic_payment: true,
+	} ),
+	afterpay_clearpay: buildMockDefinition(
+		'afterpay_clearpay',
+		'Afterpay',
+		[ 'USD', 'AUD', 'CAD', 'NZD', 'GBP' ],
+		{ allows_pay_later: true, accepts_only_domestic_payment: true }
+	),
+	klarna: buildMockDefinition(
+		'klarna',
+		'Klarna',
+		[ 'EUR', 'GBP', 'USD', 'DKK', 'NOK', 'SEK' ],
+		{
+			allows_pay_later: true,
+			accepts_only_domestic_payment: true,
+		}
+	),
+};

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
@@ -34,7 +34,11 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return 'Second Mock Method';
 	}
 
-	public static function get_description(): string {
+	public static function get_settings_label( ?string $account_country = null ): string {
+		return 'Second Mock Method';
+	}
+
+	public static function get_description( ?string $account_country = null ): string {
 		return 'Second mock payment method for testing';
 	}
 
@@ -74,7 +78,7 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return 'https://example.com/dark-icon.png';
 	}
 
-	public static function get_settings_icon_url(): string {
+	public static function get_settings_icon_url( ?string $account_country = null ): string {
 		return 'https://example.com/settings-icon.png';
 	}
 

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
@@ -34,7 +34,11 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return 'Mock Method';
 	}
 
-	public static function get_description(): string {
+	public static function get_settings_label( ?string $account_country = null ): string {
+		return 'Mock Method';
+	}
+
+	public static function get_description( ?string $account_country = null ): string {
 		return 'Mock payment method for testing';
 	}
 
@@ -74,7 +78,7 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return 'https://example.com/dark-icon.png';
 	}
 
-	public static function get_settings_icon_url(): string {
+	public static function get_settings_icon_url( ?string $account_country = null ): string {
 		return 'https://example.com/settings-icon.png';
 	}
 


### PR DESCRIPTION
Pre-requisite for #10515

#### Changes proposed in this Pull Request

Move all the definitions from `client/payment-methods-map.tsx` to the backend using the data from the Definitions and UPE payment method classes.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a US account. Make sure multi-currency is enabled and both USD and EUR are enabled.

* Make sure that the settings are properly rendered, modified, and changes are saved.
![image](https://github.com/user-attachments/assets/b0341954-0d7c-4630-a074-166246769de1)

* Disable multi-currency and verify that LPMs show warnings regarding the required currencies.
![image](https://github.com/user-attachments/assets/74cadfc6-28d0-4f7b-8d30-093ed310d2dc)

* Re-enable multi-currency, go to the multi-currency settings and try to remove the EUR currency. A message should display the affected payment methods.
![image](https://github.com/user-attachments/assets/1e7fcd83-d90e-4cbd-b2b1-74d617cb665a)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
