### PR TITLE
fix: ECE display on pay-for-order pages

### DIFF
--- a/changelog/fix-ece-not-displayed-on-pay-for-order
+++ b/changelog/fix-ece-not-displayed-on-pay-for-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: Google Pay/Apple Pay display on pay-for-order pages.

--- a/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--order-pay-page.test.js
+++ b/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--order-pay-page.test.js
@@ -1,0 +1,320 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import $ from 'jquery';
+import { recordUserEvent } from 'tracks';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( 'tracks', () => ( {
+	recordUserEvent: jest.fn(),
+} ) );
+jest.mock( 'lodash', () => ( {
+	debounce: jest.fn( ( callback ) => callback ),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn( () => Promise.resolve() ),
+} ) );
+
+describe( 'Tokenized Express Checkout Element - Pay-for-order page logic', () => {
+	let stripeElementMock, stripeInstance;
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockImplementation( async () =>
+			Promise.resolve( {
+				id: 999,
+				status: 'pending',
+				items: [
+					{
+						key: 'wc_order_fAk3nUmB3R',
+						id: 1,
+						quantity: 2,
+						name: 'Cap',
+						sku: 'woo-cap',
+						prices: {
+							price: '1500',
+							regular_price: '1700',
+							sale_price: '1500',
+							price_range: null,
+							currency_code: 'EUR',
+							currency_symbol: '\u20ac',
+							currency_minor_unit: 2,
+							currency_decimal_separator: ',',
+							currency_thousand_separator: '.',
+							currency_prefix: '\u20ac',
+							currency_suffix: '',
+							raw_prices: {
+								precision: 6,
+								price: '15000000',
+								regular_price: '17000000',
+								sale_price: '15000000',
+							},
+						},
+						totals: {
+							line_subtotal: '3200',
+							line_subtotal_tax: '160',
+							line_total: '3200',
+							line_total_tax: '160',
+							currency_code: 'EUR',
+							currency_symbol: '\u20ac',
+							currency_minor_unit: 2,
+							currency_decimal_separator: ',',
+							currency_thousand_separator: '.',
+							currency_prefix: '\u20ac',
+							currency_suffix: '',
+						},
+					},
+					{
+						key: 'wc_order_fAk3nUmB3R',
+						id: 2,
+						quantity: 1,
+						name: 'T-Shirt',
+						sku: 'woo-tshirt',
+						prices: {
+							price: '1700',
+							regular_price: '1700',
+							sale_price: '1700',
+							price_range: null,
+							currency_code: 'EUR',
+							currency_symbol: '\u20ac',
+							currency_minor_unit: 2,
+							currency_decimal_separator: ',',
+							currency_thousand_separator: '.',
+							currency_prefix: '\u20ac',
+							currency_suffix: '',
+							raw_prices: {
+								precision: 6,
+								price: '17000000',
+								regular_price: '17000000',
+								sale_price: '17000000',
+							},
+						},
+						totals: {
+							line_subtotal: '1800',
+							line_subtotal_tax: '90',
+							line_total: '1800',
+							line_total_tax: '90',
+							currency_code: 'EUR',
+							currency_symbol: '\u20ac',
+							currency_minor_unit: 2,
+							currency_decimal_separator: ',',
+							currency_thousand_separator: '.',
+							currency_prefix: '\u20ac',
+							currency_suffix: '',
+						},
+						catalog_visibility: 'visible',
+					},
+				],
+				coupons: [],
+				fees: [
+					{
+						key: 3,
+						name: '$10.00 fee',
+						totals: {
+							total: '1000',
+							total_tax: '50',
+							currency_code: 'EUR',
+							currency_symbol: '\u20ac',
+							currency_minor_unit: 2,
+							currency_decimal_separator: ',',
+							currency_thousand_separator: '.',
+							currency_prefix: '\u20ac',
+							currency_suffix: '',
+						},
+					},
+				],
+				totals: {
+					subtotal: '5000',
+					total_discount: '0',
+					total_shipping: '200',
+					total_fees: '1000',
+					total_tax: '310',
+					total_refund: '0',
+					total_price: '6510',
+					total_items: '5000',
+					total_items_tax: '300',
+					total_fees_tax: '50',
+					total_discount_tax: '0',
+					total_shipping_tax: '10',
+					tax_lines: [
+						{
+							name: 'Global Tax rate',
+							price: '300',
+							rate: '5',
+						},
+					],
+					currency_code: 'EUR',
+					currency_symbol: '\u20ac',
+					currency_minor_unit: 2,
+					currency_decimal_separator: ',',
+					currency_thousand_separator: '.',
+					currency_prefix: '\u20ac',
+					currency_suffix: '',
+				},
+				shipping_address: {
+					first_name: 'Fake',
+					last_name: 'User',
+					company: '',
+					address_1: '',
+					address_2: '',
+					city: 'Bruges',
+					state: '',
+					postcode: '8000',
+					country: 'BE',
+					phone: '',
+				},
+				billing_address: {
+					first_name: 'Fake',
+					last_name: 'User',
+					company: '',
+					address_1: '',
+					address_2: '',
+					city: 'Bruges',
+					state: '',
+					postcode: '8000',
+					country: 'BE',
+					email: 'cheese@toast.com',
+					phone: '',
+				},
+				needs_payment: true,
+				needs_shipping: true,
+				errors: [],
+			} )
+		);
+		// ensuring jQuery is available globally.
+		global.$ = global.jQuery = $;
+		// ensuring that `callback` is immediately invoked on document.ready.
+		$.fn.ready = ( callback ) => callback( $ );
+		global.jQuery.blockUI = () => null;
+		global.jQuery.unblockUI = () => null;
+
+		global.wcpayConfig = {
+			order_id: 999,
+			key: 'wc_order_fAk3nUmB3R',
+			billing_email: 'cheese@toast.com',
+		};
+		global.wcpayExpressCheckoutParams = {};
+		global.wcpayExpressCheckoutParams.nonce = {
+			store_api_nonce: 'store_api_nonce',
+		};
+		global.wcpayExpressCheckoutParams.stripe = {
+			accountId: 'acc_id',
+			locale: 'it',
+			publishableKey: 'stripe_public_key',
+		};
+		global.wcpayExpressCheckoutParams.checkout = {
+			currency_decimals: 2,
+			allowed_shipping_countries: [ 'US' ],
+		};
+		global.wcpayExpressCheckoutParams.store_name = 'My fancy store';
+		global.wcpayExpressCheckoutParams.button_context = 'pay_for_order';
+
+		// just mocking some server-side-provided DOM elements.
+		render(
+			<div>
+				<div className="woocommerce-notices-wrapper" />
+				<div id="wcpay-express-checkout-wrapper">
+					<div
+						id="wcpay-express-checkout-element"
+						data-testid="wcpay-express-checkout-element"
+						style={ { display: 'none' } }
+					/>
+				</div>
+			</div>
+		);
+
+		const stripeElementRegisteredEventCallbacks = {};
+		stripeElementMock = {
+			submit: jest.fn(),
+			mount: jest.fn(),
+			unmount: jest.fn(),
+			__getRegisteredEvent: ( eventName ) =>
+				stripeElementRegisteredEventCallbacks[ eventName ],
+			on: jest.fn( ( event, callback ) => {
+				stripeElementRegisteredEventCallbacks[ event ] = callback;
+			} ),
+		};
+		global.Stripe = jest.fn( () => {
+			stripeInstance = {
+				elements: jest.fn( () => ( {
+					create: jest.fn( () => stripeElementMock ),
+				} ) ),
+			};
+
+			return stripeInstance;
+		} );
+	} );
+
+	afterEach( () => {
+		delete global.Stripe;
+	} );
+
+	it( 'should not initialize Stripe if there is no publishable key', async () => {
+		global.wcpayExpressCheckoutParams.stripe.publishableKey = '';
+
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		expect( global.Stripe ).not.toHaveBeenCalled();
+		expect( recordUserEvent ).not.toHaveBeenCalled();
+		expect(
+			screen.getByTestId( 'wcpay-express-checkout-element' )
+		).not.toBeVisible();
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should track the initialization', async () => {
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		// waiting for the API call to be completed.
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalled() );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'GET',
+				path:
+					'/wc/store/v1/order/999?key=wc_order_fAk3nUmB3R&billing_email=cheese%40toast.com',
+			} )
+		);
+
+		expect( global.Stripe ).toHaveBeenCalled();
+		expect( stripeInstance.elements ).toHaveBeenCalledWith( {
+			mode: 'payment',
+			amount: 6510,
+			currency: 'eur',
+			paymentMethodCreation: 'manual',
+			appearance: expect.anything(),
+			locale: 'it',
+		} );
+
+		// triggering the `ready` event on the ECE button, to test its callback.
+		stripeElementMock.__getRegisteredEvent( 'ready' )( {
+			availablePaymentMethods: {
+				link: false,
+				applePay: true,
+				googlePay: true,
+				paypal: false,
+				amazonPay: false,
+			},
+		} );
+
+		expect( recordUserEvent ).toHaveBeenNthCalledWith(
+			1,
+			'applepay_button_load',
+			expect.objectContaining( { source: 'pay_for_order' } )
+		);
+		expect( recordUserEvent ).toHaveBeenNthCalledWith(
+			2,
+			'gpay_button_load',
+			expect.objectContaining( { source: 'pay_for_order' } )
+		);
+		expect(
+			screen.getByTestId( 'wcpay-express-checkout-element' )
+		).toBeVisible();
+	} );
+} );

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -34,7 +34,7 @@ import {
 } from './event-handlers';
 import ExpressCheckoutOrderApi from './order-api';
 import ExpressCheckoutCartApi from './cart-api';
-import { getUPEConfig } from 'wcpay/utils/checkout';
+import { getConfig } from 'wcpay/utils/checkout';
 import expressCheckoutButtonUi from './button-ui';
 import {
 	transformCartDataForDisplayItems,
@@ -151,9 +151,9 @@ jQuery( ( $ ) => {
 	if ( getExpressCheckoutData( 'button_context' ) === 'pay_for_order' ) {
 		setCartApiHandler(
 			new ExpressCheckoutOrderApi( {
-				orderId: getUPEConfig( 'order_id' ),
-				key: getUPEConfig( 'key' ),
-				billingEmail: getUPEConfig( 'billing_email' ),
+				orderId: getConfig( 'order_id' ),
+				key: getConfig( 'key' ),
+				billingEmail: getConfig( 'billing_email' ),
 			} )
 		);
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I'm not sure why or how it started - but I noticed that the ECE wasn't displaying on the pay-for-order pages anymore.
It looks like it was reading the variables from `getUPEConfig` - changing to `getConfig` (which has a fallback on `getUPEConfig`) fixes things 🤷 

Before:
<img width="1053" alt="Screenshot 2025-04-01 at 11 00 44 AM" src="https://github.com/user-attachments/assets/06cedd05-d995-4c29-a039-cbebf592a191" />


After:
<img width="1069" alt="Screenshot 2025-04-01 at 11 00 20 AM" src="https://github.com/user-attachments/assets/4239d4c2-5cfb-4390-a5dc-09929ca0419a" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a merchant, ensure you have Google Pay/Apple Pay enabled on your site
- As a merchant, create a manual order in the back-end, ensure you filled in the "billing address" details (including the email)
- Save the order
- Click on the "Customer payment page" link
- The page should show Google Pay/Apple Pay payments

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
