### PR TITLE
fix: tokenized ECE to honor woocommerce_tax_display_cart

### DIFF
--- a/changelog/fix-tokenized-ece-to-honor-tax-display
+++ b/changelog/fix-tokenized-ece-to-honor-tax-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+update: ensure Google Pay/Apple Pay honor 'Display prices during cart and checkout' setting

--- a/client/settings/settings-layout/style.scss
+++ b/client/settings/settings-layout/style.scss
@@ -12,7 +12,7 @@
 body {
 	&.woocommerce-payments-checkout-section {
 		.wcpay-settings-layout {
-			margin: 0;
+			margin: 24px 0 0;
 			max-width: 1184px;
 		}
 	}

--- a/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js
+++ b/client/tokenized-express-checkout/__tests__/tokenized-express-checkout--product-page.test.js
@@ -460,8 +460,8 @@ describe( 'Tokenized Express Checkout Element - Product page logic', () => {
 			expect.objectContaining( {
 				lineItems: [
 					{ amount: 2399, name: 'Beanie' },
-					{ amount: 198, name: 'Tax' },
 					{ amount: 1100, name: 'Shipping' },
+					{ amount: 198, name: 'Tax' },
 				],
 				shippingAddressRequired: true,
 				shippingRates: [

--- a/client/tokenized-express-checkout/event-handlers.js
+++ b/client/tokenized-express-checkout/event-handlers.js
@@ -37,6 +37,7 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 	lastSelectedAddress = event.address;
 
 	try {
+		console.log( '### entering' );
 		// Please note that the `event.address` might not contain all the fields.
 		// Some fields might not be present (like `line_1` or `line_2`) due to semi-anonymized data.
 		const cartData = await cartApi.updateCustomer( {
@@ -46,11 +47,14 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 			),
 		} );
 
+		console.log( cartData );
+
 		const shippingRates = transformCartDataForShippingRates( cartData );
 
 		// when no shipping options are returned, the API still returns a 200 status code.
 		// We need to ensure that shipping options are present - otherwise the ECE dialog won't update correctly.
 		if ( shippingRates.length === 0 ) {
+			console.log( '### no rates' );
 			event.reject();
 
 			return;
@@ -69,6 +73,7 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 			lineItems: transformCartDataForDisplayItems( cartData ),
 		} );
 	} catch ( error ) {
+		console.log( '### err', error );
 		event.reject();
 	}
 };

--- a/client/tokenized-express-checkout/event-handlers.js
+++ b/client/tokenized-express-checkout/event-handlers.js
@@ -37,7 +37,6 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 	lastSelectedAddress = event.address;
 
 	try {
-		console.log( '### entering' );
 		// Please note that the `event.address` might not contain all the fields.
 		// Some fields might not be present (like `line_1` or `line_2`) due to semi-anonymized data.
 		const cartData = await cartApi.updateCustomer( {
@@ -47,14 +46,11 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 			),
 		} );
 
-		console.log( cartData );
-
 		const shippingRates = transformCartDataForShippingRates( cartData );
 
 		// when no shipping options are returned, the API still returns a 200 status code.
 		// We need to ensure that shipping options are present - otherwise the ECE dialog won't update correctly.
 		if ( shippingRates.length === 0 ) {
-			console.log( '### no rates' );
 			event.reject();
 
 			return;
@@ -73,7 +69,6 @@ export const shippingAddressChangeHandler = async ( event, elements ) => {
 			lineItems: transformCartDataForDisplayItems( cartData ),
 		} );
 	} catch ( error ) {
-		console.log( '### err', error );
 		event.reject();
 	}
 };

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -250,6 +250,7 @@ class WC_Payments_Express_Checkout_Button_Handler {
 				// Defaults to 'required' to match how core initializes this option.
 				'needs_payer_phone'          => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
 				'allowed_shipping_countries' => array_keys( WC()->countries->get_shipping_countries() ?? [] ),
+				'display_prices_with_tax'    => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
 			],
 			'button'             => $this->get_button_settings(),
 			'login_confirmation' => $this->get_login_confirmation_settings(),


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/10623
Fixes WOOPMNT-4883

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Ensuring that the Tokenized ECE will start honoring the "Display prices during cart and checkout" setting.

The effect is as follows:

<details><summary>1️⃣  When "Display prices during cart and checkout" is set as "Excluding tax" (default)</summary>
<p>

<img width="670" alt="Screenshot 2025-04-01 at 10 38 31 AM" src="https://github.com/user-attachments/assets/acd2c778-11c8-495a-a424-9d5f64276b8c" />
<img width="1365" alt="Screenshot 2025-04-01 at 11 37 07 AM" src="https://github.com/user-attachments/assets/0f37ee6e-3bec-486d-bdf4-3b8b04074e01" />
<img width="571" alt="Screenshot 2025-04-01 at 11 37 02 AM" src="https://github.com/user-attachments/assets/58fb559b-deba-4508-9b0e-3ae8d75d0565" />

Also notice that the individual shipping options in the payment sheet are displayed without tax:
<img width="591" alt="Screenshot 2025-04-01 at 10 38 00 AM" src="https://github.com/user-attachments/assets/f88a7567-8f35-470e-a31c-66151d3005c4" />

</p>
</details> 

<details><summary>2️⃣   When "Display prices during cart and checkout" is set as "Including tax"</summary>
<p>

<img width="693" alt="Screenshot 2025-04-01 at 10 35 11 AM" src="https://github.com/user-attachments/assets/7b63c571-9e03-418a-9b88-fd08a756b7b8" />

Notice that the shipping rates shows the price in its selection, and the tax line item is not displayed in the payment sheet summary
<img width="1391" alt="Screenshot 2025-04-01 at 11 36 13 AM" src="https://github.com/user-attachments/assets/d641a3a6-d39b-4d04-b6fc-87223c429dab" />
<img width="573" alt="Screenshot 2025-04-01 at 11 36 22 AM" src="https://github.com/user-attachments/assets/3464bb18-7ba5-4f71-8e0e-2da1237cfaf6" />

Also notice that the individual shipping options in the payment sheet are displayed with tax:
<img width="590" alt="Screenshot 2025-04-01 at 10 34 39 AM" src="https://github.com/user-attachments/assets/c3c3a71a-67a9-4a9d-bb81-f5efdb8c73c0" />

</p>
</details> 



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> I'd suggest testing with some products added to the cart, so that you can just change the setting 

**Baseline**
- As a merchant, ensure you have Google Pay/Apple Pay enabled
- As a merchant, ensure you have a coupon like `10off`, which sets 10% off (just to test it in the line items)
- As a customer, add some products to the cart
- Navigate to either the block-based or shortcode-based cart page (the implementation will be identical)
- Apply the `10off` coupon

1️⃣ Test 1: "Display prices during cart and checkout" is set as "Excluding tax"
- As a merchant, navigate to WooCommerce > Settings > Tax
- Set the "Display prices during cart and checkout" to "Excluding tax" (which should be the default behavior on your store)
- As a customer, refresh the cart page from the previous step
- Click on the Google Pay/Apple Pay button
- The payment sheet should appear
- Unless there are discrepancies with the totals, you should be able to inspect the line items, the Tax line item should appear
- Dismiss the payment sheet
- Apply the `10off` coupon
- Click on the Google Pay/Apple Pay button
- The payment sheet should appear
- Unless there are discrepancies with the totals, you should be able to inspect the line items, the "Tax" and "Discount" line items should appear

2️⃣  Test 2: "Display prices during cart and checkout" is set as "Including tax"
- As a merchant, navigate to WooCommerce > Settings > Tax
- Set the "Display prices during cart and checkout" to "Including tax"
- As a customer, refresh the cart page from the previous step
- Click on the Google Pay/Apple Pay button
- The payment sheet should appear
- Unless there are discrepancies with the totals, you should be able to inspect the line items, the Tax line item should not be preset
- Dismiss the payment sheet
- Apply the `10off` coupon
- Click on the Google Pay/Apple Pay button
- The payment sheet should appear
- Unless there are discrepancies with the totals, you should be able to inspect the line items, the "Tax" line item should not be present, and the "Discount" line item be present, including the tax amount

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
