### PR TITLE
fix: ECE HK Test address override

### DIFF
--- a/changelog/fix-hk-address-override
+++ b/changelog/fix-hk-address-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+fix: Google Pay/Apple Pay HK test address override.

--- a/client/tokenized-express-checkout/index.js
+++ b/client/tokenized-express-checkout/index.js
@@ -238,6 +238,7 @@ jQuery( ( $ ) => {
 			} );
 
 			eceButton.on( 'click', function ( event ) {
+				addToCartErrorMessage = '';
 				// If login is required for checkout, display redirect confirmation dialog.
 				if ( getExpressCheckoutData( 'login_confirmation' ) ) {
 					displayLoginConfirmation( event.expressPaymentType );
@@ -272,6 +273,11 @@ jQuery( ( $ ) => {
 						}
 						return;
 					}
+
+					// on product pages, we need to interact with an anonymous cart to check out the product,
+					// so that we don't affect the products in the main cart.
+					// On cart, checkout, place order pages we instead use the cart itself.
+					getCartApiHandler().useSeparateCart();
 
 					// Add products to the cart if everything is right.
 					// we are storing the promise to ensure that the "add to cart" call is completed,
@@ -438,13 +444,6 @@ jQuery( ( $ ) => {
 			// once (and if) cart data has been fetched, we can safely clear product data from the backend.
 			if ( cachedCartData ) {
 				wcpayExpressCheckoutParams.product = undefined;
-			}
-
-			if ( getExpressCheckoutData( 'button_context' ) === 'product' ) {
-				// on product pages, we need to interact with an anonymous cart to check out the product,
-				// so that we don't affect the products in the main cart.
-				// On cart, checkout, place order pages we instead use the cart itself.
-				getCartApiHandler().useSeparateCart();
 			}
 
 			const total = getTotalAmount();

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -516,20 +516,24 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 		}
 
 		if ( isset( $request['shipping_address'] ) ) {
-			$request['shipping_address'] = $this->transform_ece_address_state_data( $request['shipping_address'] );
+			$shipping_address = $request['shipping_address'];
+			$shipping_address = $this->transform_ece_address_state_data( $shipping_address );
 			// on the "update customer" route, Google Pay/Apple Pay might provide redacted postcode data.
 			// we need to modify the zip code to ensure that shipping zone identification still works.
 			if ( $is_update_customer_route ) {
-				$request['shipping_address'] = $this->transform_ece_address_postcode_data( $request['shipping_address'] );
+				$shipping_address = $this->transform_ece_address_postcode_data( $shipping_address );
 			}
+			$request['shipping_address'] = $shipping_address;
 		}
 		if ( isset( $request['billing_address'] ) ) {
-			$request['billing_address'] = $this->transform_ece_address_state_data( $request['billing_address'] );
+			$billing_address = $request['billing_address'];
+			$billing_address = $this->transform_ece_address_state_data( $billing_address );
 			// on the "update customer" route, Google Pay/Apple Pay might provide redacted postcode data.
 			// we need to modify the zip code to ensure that shipping zone identification still works.
 			if ( $is_update_customer_route ) {
-				$request['billing_address'] = $this->transform_ece_address_postcode_data( $request['billing_address'] );
+				$billing_address = $this->transform_ece_address_postcode_data( $billing_address );
 			}
+			$request['billing_address'] = $billing_address;
 		}
 
 		return $response;
@@ -560,9 +564,9 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 	}
 
 	/**
-	 * Transform a GooglePay/ApplePay state address data fields into values that are valid for WooCommerce.
+	 * Transform a Google Pay/Apple Pay state address data fields into values that are valid for WooCommerce.
 	 *
-	 * @param array $address The address to normalize from the GooglePay/ApplePay request.
+	 * @param array $address The address to normalize from the Google Pay/Apple Pay request.
 	 *
 	 * @return array
 	 */
@@ -582,9 +586,9 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 	}
 
 	/**
-	 * Transform a GooglePay/ApplePay postcode address data fields into values that are valid for WooCommerce.
+	 * Transform a Google Pay/Apple Pay postcode address data fields into values that are valid for WooCommerce.
 	 *
-	 * @param array $address The address to normalize from the GooglePay/ApplePay request.
+	 * @param array $address The address to normalize from the Google Pay/Apple Pay request.
 	 *
 	 * @return array
 	 */

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -508,28 +508,27 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 		}
 
 		// This route is used to get shipping rates.
-		// GooglePay/ApplePay might provide us with "trimmed" zip codes.
+		// Google Pay/Apple Pay might provide us with "trimmed" zip codes.
 		// If that's the case, let's temporarily allow to skip the zip code validation, in order to get some shipping rates.
 		$is_update_customer_route = $request->get_route() === '/wc/store/v1/cart/update-customer';
 		if ( $is_update_customer_route ) {
 			add_filter( 'woocommerce_validate_postcode', [ $this, 'maybe_skip_postcode_validation' ], 10, 3 );
 		}
 
-		$request_data = $request->get_json_params();
-		if ( isset( $request_data['shipping_address'] ) ) {
-			$request->set_param( 'shipping_address', $this->transform_ece_address_state_data( $request_data['shipping_address'] ) );
-			// on the "update customer" route, GooglePay/Apple pay might provide redacted postcode data.
+		if ( isset( $request['shipping_address'] ) ) {
+			$request['shipping_address'] = $this->transform_ece_address_state_data( $request['shipping_address'] );
+			// on the "update customer" route, Google Pay/Apple Pay might provide redacted postcode data.
 			// we need to modify the zip code to ensure that shipping zone identification still works.
 			if ( $is_update_customer_route ) {
-				$request->set_param( 'shipping_address', $this->transform_ece_address_postcode_data( $request_data['shipping_address'] ) );
+				$request['shipping_address'] = $this->transform_ece_address_postcode_data( $request['shipping_address'] );
 			}
 		}
-		if ( isset( $request_data['billing_address'] ) ) {
-			$request->set_param( 'billing_address', $this->transform_ece_address_state_data( $request_data['billing_address'] ) );
-			// on the "update customer" route, GooglePay/Apple pay might provide redacted postcode data.
+		if ( isset( $request['billing_address'] ) ) {
+			$request['billing_address'] = $this->transform_ece_address_state_data( $request['billing_address'] );
+			// on the "update customer" route, Google Pay/Apple Pay might provide redacted postcode data.
 			// we need to modify the zip code to ensure that shipping zone identification still works.
 			if ( $is_update_customer_route ) {
-				$request->set_param( 'billing_address', $this->transform_ece_address_postcode_data( $request_data['billing_address'] ) );
+				$request['billing_address'] = $this->transform_ece_address_postcode_data( $request['billing_address'] );
 			}
 		}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -515,7 +515,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 			add_filter( 'woocommerce_validate_postcode', [ $this, 'maybe_skip_postcode_validation' ], 10, 3 );
 		}
 
-		if ( isset( $request['shipping_address'] ) ) {
+		if ( isset( $request['shipping_address'] ) && is_array( $request['shipping_address'] ) ) {
 			$shipping_address = $request['shipping_address'];
 			$shipping_address = $this->transform_ece_address_state_data( $shipping_address );
 			// on the "update customer" route, Google Pay/Apple Pay might provide redacted postcode data.
@@ -523,9 +523,9 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 			if ( $is_update_customer_route ) {
 				$shipping_address = $this->transform_ece_address_postcode_data( $shipping_address );
 			}
-			$request['shipping_address'] = $shipping_address;
+			$request->set_param( 'shipping_address', $shipping_address );
 		}
-		if ( isset( $request['billing_address'] ) ) {
+		if ( isset( $request['billing_address'] ) && is_array( $request['billing_address'] ) ) {
 			$billing_address = $request['billing_address'];
 			$billing_address = $this->transform_ece_address_state_data( $billing_address );
 			// on the "update customer" route, Google Pay/Apple Pay might provide redacted postcode data.
@@ -533,7 +533,7 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 			if ( $is_update_customer_route ) {
 				$billing_address = $this->transform_ece_address_postcode_data( $billing_address );
 			}
-			$request['billing_address'] = $billing_address;
+			$request->set_param( 'billing_address', $billing_address );
 		}
 
 		return $response;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that for some reason the override on the `$request['shipping_address']`/`$request['billing_address']` wasn't working anymore for the test HK address.

I think the issue happened on `update-customer` because in the previous implementation, the code applied the state transformation and then immediately applied the postcode transformation directly on the original shipping address, which resulted in the state changes being overwritten.


Before:
![2025-04-01 18 43 32](https://github.com/user-attachments/assets/93a94a32-0a0a-4dcc-95a3-f437bb75278f)

After:
![2025-04-01 18 42 58](https://github.com/user-attachments/assets/09b27c7a-6e0b-4355-9124-e3600ce09ee8)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a merchant, ensure you have Google Pay/Apple Pay enabled on your site
- As a customer, navigate to the product page of a physical product (or add physical products to the cart)
- Click on the **Google Pay** button on your site (Apple Pay won't provide the test addresses)
- From the shipping address list, click on the HK or JP address
- Notice how there shouldn't be a notice saying that the shipping address was invalid
- Place the order
- The order should go through
<img width="1384" alt="Screenshot 2025-04-01 at 7 07 54 PM" src="https://github.com/user-attachments/assets/1535af3b-412f-44c4-93e0-b3596459d3dc" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
