### PR TITLE
fix: fatal error w/ Klarna, EU country, and non-EU currency

### DIFF
--- a/changelog/fix-klarna-with-eu-country-and-non-eu-currency
+++ b/changelog/fix-klarna-with-eu-country-and-non-eu-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: fatal error when Klarna is enabled on an EU account and a non-EU currency is configured on the store.

--- a/includes/payment-methods/class-klarna-payment-method.php
+++ b/includes/payment-methods/class-klarna-payment-method.php
@@ -70,6 +70,11 @@ class Klarna_Payment_Method extends UPE_Payment_Method {
 		if ( in_array( $account_country, $eea_countries, true ) ) {
 			$store_currency = strtoupper( get_woocommerce_currency() );
 
+			// if the store is set to an EU country, but the currency used is not set as a valid EU currency, I guess Klarna shouldn't be eligible.
+			if ( ! isset( $this->limits_per_currency[ $store_currency ] ) ) {
+				return [ 'NONE_SUPPORTED' ];
+			}
+
 			$countries_that_support_store_currency = array_keys( $this->limits_per_currency[ $store_currency ] );
 
 			return array_values( array_intersect( $eea_countries, $countries_that_support_store_currency ) );

--- a/tests/unit/payment-methods/test-class-upe-payment-method.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-method.php
@@ -83,6 +83,7 @@ class UPE_Payment_Method_Test extends WCPAY_UnitTestCase {
 			Link_Payment_Method::class,
 			Affirm_Payment_Method::class,
 			Afterpay_Payment_Method::class,
+			Klarna_Payment_Method::class,
 		];
 
 		foreach ( $payment_method_classes as $payment_method_class ) {
@@ -121,6 +122,52 @@ class UPE_Payment_Method_Test extends WCPAY_UnitTestCase {
 		}
 
 		$this->assertEquals( $expected_result, $payment_method->get_countries() );
+	}
+
+	public function test_klarna_get_countries_with_eu_country_and_eu_currency() {
+		WC_Helper_Site_Currency::$mock_site_currency = 'EUR';
+		$payment_method                              = $this->mock_payment_methods['klarna'];
+
+		$this->mock_wcpay_account->method( 'get_cached_account_data' )->willReturn(
+			[
+				'country' => 'DE',
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'AT',
+				'BE',
+				'FI',
+				'FR',
+				'DE',
+				'IE',
+				'IT',
+				'NL',
+				'ES',
+			],
+			$payment_method->get_countries()
+		);
+		WC_Helper_Site_Currency::$mock_site_currency = '';
+	}
+
+	public function test_klarna_get_countries_with_eu_country_and_non_eu_currency() {
+		WC_Helper_Site_Currency::$mock_site_currency = 'AUD';
+		$payment_method                              = $this->mock_payment_methods['klarna'];
+
+		$this->mock_wcpay_account->method( 'get_cached_account_data' )->willReturn(
+			[
+				'country' => 'IT',
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'NONE_SUPPORTED',
+			],
+			$payment_method->get_countries()
+		);
+		WC_Helper_Site_Currency::$mock_site_currency = '';
 	}
 
 	public function provider_test_get_countries() {


### PR DESCRIPTION
Fixes WOOPMNT-4903

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I checked for other scenarios where we might be incorrectly accessing `$this->limits_per_currency`. The rest seems fine.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure your account is a EU account (e.g.: `DE`)
  - If not, onboard with a EU account
  - Or, if you want to quickly test this, override the `country` before the cached account data is returned here: https://github.com/Automattic/woocommerce-payments/blob/e244672e43029f06c3262fb6f40016403a272077/includes/class-wc-payments-account.php#L2337-L2337 
- In your WooCommerce Settings, change the store currency to `AUD` (for example)
- Fatal error should no longer occur

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
