### PR TITLE
Fix background color for the Payments settings page

### DIFF
--- a/changelog/fix-fix-settings-background-color
+++ b/changelog/fix-fix-settings-background-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Set background color to white for the Payments settings page

--- a/client/settings/settings-manager/style.scss
+++ b/client/settings/settings-manager/style.scss
@@ -5,7 +5,8 @@ body {
 			background: #fff;
 			.settings-content,
 			#wpbody-content,
-			#wpcontent {
+			#wpcontent,
+			#mainform {
 				background: #fff;
 			}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
We need to make sure the payments settings page background color is white. 
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
- onboard a new account
- go to Payments settings page ( `admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments` )
- check if the background color is white.
<img width="1747" alt="Screenshot 2025-04-02 at 13 11 47" src="https://github.com/user-attachments/assets/32080e13-1b51-456b-97c0-60d632f5bb98" />

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
