### PR TITLE
Remove level3 retry logic and legacy request_with_level3_data method

### DIFF
--- a/changelog/woopmnt-4896-cleanup-remove-level3-retries
+++ b/changelog/woopmnt-4896-cleanup-remove-level3-retries
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Remove level3 retry logic
+Remove level3 retry logic and legacy request_with_level3_data method

--- a/changelog/woopmnt-4896-cleanup-remove-level3-retries
+++ b/changelog/woopmnt-4896-cleanup-remove-level3-retries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove level3 retry logic

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2327,44 +2327,6 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	}
 
 	/**
-	 * Handles issues with level3 data and retries requests when necessary.
-	 *
-	 * @param array  $params           - Request parameters to send as either JSON or GET string. Defaults to test_mode=1 if either in dev or test mode, 0 otherwise.
-	 * @param string $api              - The API endpoint to call.
-	 * @param string $method           - The HTTP method to make the request with.
-	 * @param bool   $is_site_specific - If true, the site ID will be included in the request url.
-	 *
-	 * @return array
-	 * @throws API_Exception - If the account ID hasn't been set.
-	 */
-	private function request_with_level3_data( $params, $api, $method, $is_site_specific = true ) {
-		// If level3 data is not present for some reason, simply proceed normally.
-		if ( empty( $params['level3'] ) || ! is_array( $params['level3'] ) ) {
-			return $this->request( $params, $api, $method, $is_site_specific );
-		}
-
-		// If level3 data doesn't contain any items, add a zero priced fee to meet Stripe's requirement.
-		if ( ! isset( $params['level3']['line_items'] ) || ! is_array( $params['level3']['line_items'] ) || 0 === count( $params['level3']['line_items'] ) ) {
-			$params['level3']['line_items'] = [
-				[
-					'discount_amount'     => 0,
-					'product_code'        => 'empty-order',
-					'product_description' => 'The order is empty',
-					'quantity'            => 1,
-					'tax_amount'          => 0,
-					'unit_cost'           => 0,
-				],
-			];
-		}
-
-		/**
-		 * In case of invalid request errors, level3 data is now removed,
-		 * and the request is retried within `request()` instead of here.
-		 */
-		return $this->request( $params, $api, $method, $is_site_specific );
-	}
-
-	/**
 	 * From a given response extract the body.
 	 *
 	 * @param array $response That was given to us by http_client remote_request.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2295,25 +2295,6 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 				$this->check_response_for_errors( $response );
 			} catch ( Connection_Exception $e ) {
 				$last_exception = $e;
-			} catch ( API_Exception $e ) {
-				if ( isset( $params['level3'] ) && 'invalid_request_error' === $e->get_error_code() ) {
-					// phpcs:disable WordPress.PHP.DevelopmentFunctions
-
-					// Log the issue so we could debug it.
-					Logger::error(
-						'Level3 data error: ' . PHP_EOL
-						. print_r( $e->getMessage(), true ) . PHP_EOL
-						. print_r( 'Level 3 data sent: ', true ) . PHP_EOL
-						. print_r( $params['level3'], true )
-					);
-
-					// phpcs:enable WordPress.PHP.DevelopmentFunctions
-
-					// Retry without level3 data.
-					unset( $params['level3'] );
-					return $this->request( $params, $api, $method, $is_site_specific, $use_user_token, $raw_response );
-				}
-				throw $e;
 			}
 
 			if ( $response_code || time() >= $stop_trying_at || $retries_limit === $retries ) {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -103,7 +103,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WCPAY_UnitTestCase {
 		// Note that we cannot use createStub here since it's not defined in PHPUnit 6.5.
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'create_and_confirm_intention', 'get_payment_method', 'request_with_level3_data', 'is_server_connected' ] )
+			->setMethods( [ 'create_and_confirm_intention', 'get_payment_method', 'is_server_connected' ] )
 			->getMock();
 
 		// Arrange: Mock WC_Payments_Account instance to use later.

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -437,42 +437,6 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	}
 
 
-	/**
-	 * @dataProvider data_request_with_level3_data
-	 */
-	public function test_request_with_level3_data( $input_args, $expected_level3_args ) {
-		$this->mock_http_client
-			->expects( $this->once() )
-			->method( 'remote_request' )
-			->with(
-				$this->anything(),
-				$this->callback(
-					function ( $request_args_json ) use ( $expected_level3_args ) {
-						$request_args = json_decode( $request_args_json, true );
-
-						$this->assertSame( $expected_level3_args, $request_args['level3'] );
-
-						return true;
-					}
-				)
-			)
-			->willReturn(
-				[
-					'body'     => wp_json_encode( [ 'result' => 'success' ] ),
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
-					],
-				]
-			);
-
-		PHPUnit_Utils::call_method(
-			$this->payments_api_client,
-			'request_with_level3_data',
-			[ $input_args, 'intentions', 'POST' ]
-		);
-	}
-
 	public function test_create_terminal_location_validation_array() {
 		$this->expectException( API_Exception::class );
 		$this->expectExceptionMessageMatches( '~address.*required~i' );
@@ -567,70 +531,6 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 			$this->payments_api_client->delete_terminal_location( 'tml_XXXXXXX' ),
 			$delete_location_response
 		);
-	}
-
-	/**
-	 * Data provider for test_request_with_level3_data
-	 */
-	public function data_request_with_level3_data() {
-		return [
-			'australian_merchant'               => [
-				[
-					'level3' => [],
-				],
-				[],
-			],
-			'american_merchant_no_line_items'   => [
-				[
-					'level3' => [
-						'merchant_reference' => 'abc123',
-					],
-				],
-				[
-					'merchant_reference' => 'abc123',
-					'line_items'         => [
-						[
-							'discount_amount'     => 0,
-							'product_code'        => 'empty-order',
-							'product_description' => 'The order is empty',
-							'quantity'            => 1,
-							'tax_amount'          => 0,
-							'unit_cost'           => 0,
-						],
-					],
-				],
-			],
-			'american_merchant_with_line_items' => [
-				[
-					'level3' => [
-						'merchant_reference' => 'abc123',
-						'line_items'         => [
-							[
-								'discount_amount'     => 0,
-								'product_code'        => 'free-hug',
-								'product_description' => 'Free hug',
-								'quantity'            => 1,
-								'tax_amount'          => 0,
-								'unit_cost'           => 0,
-							],
-						],
-					],
-				],
-				[
-					'merchant_reference' => 'abc123',
-					'line_items'         => [
-						[
-							'discount_amount'     => 0,
-							'product_code'        => 'free-hug',
-							'product_description' => 'Free hug',
-							'quantity'            => 1,
-							'tax_amount'          => 0,
-							'unit_cost'           => 0,
-						],
-					],
-				],
-			],
-		];
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOPMNT-4896

#### Changes proposed in this Pull Request

The level3 retry logic was previously used to handle cases where level3 data caused invalid_request_error responses. This functionality is now handled server-side, making the client-side retry logic unnecessary.

Alongside this change, we are also removing the legacy request_with_level3_data method.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The level3 retry logic lives on the server now, you can do a sanity check that the payment succeeds when there's a data mismatch:
* Modify the unit cost in this [line](https://github.com/Automattic/woocommerce-payments/blob/0d5d493344c59ede904847c0dd92a0f7aad16388/src/Internal/Service/Level3Service.php#L170) i.e. add 100 to force a level3 data mismatch
* Add a product to the cart and checkout
* Check that the payment succeeds

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
