### PR TITLE
chore: remove unrequested JCB notice

### DIFF
--- a/changelog/chore-disable-jcb-request
+++ b/changelog/chore-disable-jcb-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+chore: disable request of JCB capability

--- a/client/settings/payment-methods-list/capability-request/capability-request-map.ts
+++ b/client/settings/payment-methods-list/capability-request/capability-request-map.ts
@@ -10,15 +10,6 @@ const CapabilityRequestList: Array< CapabilityRequestMap > = [
 		label: __( 'JCB', 'woocommerce-payments' ),
 		country: 'JP',
 		states: {
-			unrequested: {
-				status: 'info',
-				content: __(
-					'Enable JCB for your customers, the only international payment brand based in Japan.',
-					'woocommerce-payments'
-				),
-				actions: 'request',
-				actionsLabel: __( 'Enable JCB', 'woocommerce-payments' ),
-			},
 			pending_verification: {
 				status: 'warning',
 				content: __(

--- a/client/settings/payment-methods-list/capability-request/test/index.test.js
+++ b/client/settings/payment-methods-list/capability-request/test/index.test.js
@@ -83,6 +83,14 @@ describe( 'CapabilityRequestNotice', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
+	it( 'should not render the UNREQUESTED notice for JCB, if it is not part of the list', () => {
+		const { container } = render(
+			<CapabilityNotice id="jcb" label="JCB" country="JP" states={ {} } />
+		);
+
+		expect( container ).toBeEmpty();
+	} );
+
 	it( 'should render content and button - Render CapabilityNotice', () => {
 		render(
 			<CapabilityNotice


### PR DESCRIPTION
Fixes #10312
Fixes WOOPMNT-4749

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new JN site (without this branch's code)
<img width="477" alt="Screenshot 2025-04-04 at 6 03 48 PM" src="https://github.com/user-attachments/assets/0eaa1881-a3c9-4906-9c95-b52c4ba5c4c5" />

- In the WooCommerce settings, ensure your store's country is "Japan"
<img width="709" alt="Screenshot 2025-04-04 at 6 31 33 PM" src="https://github.com/user-attachments/assets/6c3de560-0d0c-4ba6-9641-2eb513b6eabf" />

- Click on the "Payments (1)" on the sidebar
- Connect your Jetpack account
- Onboard with a _new_ Stripe account 
  - Ensure you make it based in JP, Individual (so it's easier to go through the testing)
<img width="752" alt="Screenshot 2025-04-04 at 6 34 52 PM" src="https://github.com/user-attachments/assets/04bf13b3-d2f1-4b2e-9a61-1ebcd026b5e1" />

  - Use the test phone number, verification code, etc
<img width="420" alt="Screenshot 2025-04-04 at 6 35 57 PM" src="https://github.com/user-attachments/assets/93bf11ef-1ce3-4c91-84b5-eb659122615e" />

  - Enter whatever you want in the personal information (A8C email, `240-0024` for zip code, random product description, use the test account for the payouts, test document to verify the identity)
<img width="669" alt="Screenshot 2025-04-04 at 6 38 00 PM" src="https://github.com/user-attachments/assets/feb6e857-e8ee-4ea8-8775-a30dc97fd51a" />
<img width="674" alt="Screenshot 2025-04-04 at 6 39 31 PM" src="https://github.com/user-attachments/assets/6254ceb9-7436-445b-bc22-2cf1ec421404" />

- Back on the site, go to Payments > Settings (or WooCommerce > Payments > WooPayments)
- There should be a notice below the payment methods:
<img width="1080" alt="Screenshot 2025-04-04 at 6 40 21 PM" src="https://github.com/user-attachments/assets/733e65c1-b0db-41e1-ae56-12af167dccb8" />

- Use the [Jetpack beta tester](https://jetpack.com/download-jetpack-beta/) to install a build of this branch `chore/disable-jcb-request` on the site 
<img width="756" alt="Screenshot 2025-04-04 at 6 42 59 PM" src="https://github.com/user-attachments/assets/d4c46490-0f8e-44f6-8f63-7fbdb500b471" />

- Go back to Payments > Settings
- The notice should be gone (and the settings will look different - but that's expected as part of the next release)
<img width="1256" alt="Screenshot 2025-04-04 at 6 43 23 PM" src="https://github.com/user-attachments/assets/4527f835-4e04-43f4-b17e-109e240bff1b" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
