### PR TITLE
Update messages to replace WCPay occurrences with WooPayments

### DIFF
--- a/changelog/dev-update-messages-to-replace-wcpay-to-woopayments
+++ b/changelog/dev-update-messages-to-replace-wcpay-to-woopayments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Replace WCPay in messages with WooPayments

--- a/client/payment-details/payment-method/multibanco/index.tsx
+++ b/client/payment-details/payment-method/multibanco/index.tsx
@@ -10,7 +10,6 @@ import React from 'react';
  * Internal dependencies.
  */
 import Detail from '../detail';
-import { PaymentMethodDetails } from 'wcpay/payment-details/types';
 import { Charge } from 'wcpay/types/charges';
 
 /**

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -446,7 +446,7 @@ class WC_Payments_Invoice_Service {
 			$wcpay_item_id = $this->get_wcpay_item_id( $item );
 
 			if ( ! isset( $wcpay_items[ $wcpay_item_id ] ) ) {
-				$message = __( 'The WCPay invoice items do not match WC subscription items.', 'woocommerce-payments' );
+				$message = __( 'The WooPayments invoice items do not match WC subscription items.', 'woocommerce-payments' );
 				Logger::error( $message );
 				throw new Rest_Request_Exception( $message );
 			}

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -287,7 +287,7 @@ class WC_Payments_Product_Service {
 		} catch ( \Exception $e ) {
 			Logger::log(
 				sprintf(
-					'Error validating WCPay product: product_id=%d, wcpay_product_id=%s, account_id=%s, error=%s',
+					'Error validating WooPayments product: product_id=%d, wcpay_product_id=%s, account_id=%s, error=%s',
 					$product->get_id(),
 					$wcpay_product_id,
 					$current_account_id,

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -398,7 +398,7 @@ class WC_Payments_Subscription_Service {
 		$wcpay_customer_id      = $this->customer_service->get_customer_id_for_order( $subscription );
 
 		if ( ! $wcpay_customer_id ) {
-			Logger::error( 'There was a problem creating the WCPay subscription. WCPay customer ID missing.' );
+			Logger::error( 'There was a problem creating the WooPayments subscription. WooPayments customer ID missing.' );
 			throw new Exception( $checkout_error_message );
 		}
 
@@ -421,7 +421,7 @@ class WC_Payments_Subscription_Service {
 				$this->invoice_service->set_subscription_invoice_id( $subscription, $response['latest_invoice'] );
 			}
 		} catch ( \Exception $e ) {
-			Logger::log( sprintf( 'There was a problem creating the WCPay subscription. %s', $e->getMessage() ) );
+			Logger::log( sprintf( 'There was a problem creating the WooPayments subscription. %s', $e->getMessage() ) );
 
 			if ( $e instanceof Amount_Too_Small_Exception ) {
 				throw new Exception(
@@ -490,7 +490,7 @@ class WC_Payments_Subscription_Service {
 		try {
 			$this->payments_api_client->cancel_subscription( $wcpay_subscription_id );
 		} catch ( API_Exception $e ) {
-			Logger::log( sprintf( 'There was a problem canceling the subscription on WCPay server: %s.', $e->getMessage() ) );
+			Logger::log( sprintf( 'There was a problem canceling the subscription on WooPayments server: %s.', $e->getMessage() ) );
 		}
 	}
 
@@ -512,7 +512,7 @@ class WC_Payments_Subscription_Service {
 		$this->suspend_subscription( $subscription );
 
 		// Add an order note as a visible record of suspend.
-		$subscription->add_order_note( __( 'Suspended WCPay Subscription because subscription status changed to on-hold.', 'woocommerce-payments' ) );
+		$subscription->add_order_note( __( 'Suspended WooPayments Subscription because subscription status changed to on-hold.', 'woocommerce-payments' ) );
 
 		// Log that the subscription was suspended.
 		// Include a brief stack trace to help determine where status change originated.
@@ -521,7 +521,7 @@ class WC_Payments_Subscription_Service {
 		$trace = $e->getTraceAsString();
 		Logger::log(
 			sprintf(
-				'Suspended WCPay Subscription because subscription status changed to on-hold. WC ID: %d; WCPay ID: %s; stack: %s',
+				'Suspended WooPayments Subscription because subscription status changed to on-hold. WC ID: %d; WooPayments ID: %s; stack: %s',
 				$subscription->get_id(),
 				self::get_wcpay_subscription_id( $subscription ),
 				$trace
@@ -541,7 +541,7 @@ class WC_Payments_Subscription_Service {
 		if ( ! static::is_wcpay_subscription( $subscription ) ) {
 			Logger::log(
 				sprintf(
-					'Aborting WC_Payments_Subscription_Service::suspend_subscription; subscription is a tokenised (non WCPay) subscription. WC ID: %d.',
+					'Aborting WC_Payments_Subscription_Service::suspend_subscription; subscription is a tokenised (non WooPayments) subscription. WC ID: %d.',
 					$subscription->get_id()
 				)
 			);
@@ -553,7 +553,7 @@ class WC_Payments_Subscription_Service {
 
 	/**
 	 * Reactivates the WCPay subscription when the WC subscription is activated.
-	 * This is done by making a request to server to unset the "cancellation at end of period" value for the WCPay subscription.
+	 * This is done by making a request to server to unset the "cancellation at end of period" value for the WooPayments subscription.
 	 *
 	 * @param WC_Subscription $subscription The WC subscription that was activated.
 	 *
@@ -570,7 +570,7 @@ class WC_Payments_Subscription_Service {
 	}
 
 	/**
-	 * Marks the WCPay subscription as pending-cancel by setting the "cancellation at end of period" on the WCPay subscription.
+	 * Marks the WCPay subscription as pending-cancel by setting the "cancellation at end of period" on the WooPayments subscription.
 	 *
 	 * @param WC_Subscription $subscription The subscription that was set as pending cancel.
 	 *
@@ -605,7 +605,7 @@ class WC_Payments_Subscription_Service {
 				try {
 					$this->update_subscription( $subscription, [ 'default_payment_method' => $wcpay_payment_method_id ] );
 				} catch ( API_Exception $e ) {
-					Logger::error( sprintf( 'There was a problem updating the WCPay subscription\'s default payment method on server: %s.', $e->getMessage() ) );
+					Logger::error( sprintf( 'There was a problem updating the WooPayments subscription\'s default payment method on server: %s.', $e->getMessage() ) );
 					return;
 				}
 			}
@@ -733,7 +733,7 @@ class WC_Payments_Subscription_Service {
 	}
 
 	/**
-	 * Updates a subscription's next payment date to match the WCPay subscription's payment date.
+	 * Updates a subscription's next payment date to match the WooPayments subscription's payment date.
 	 *
 	 * @param array           $wcpay_subscription The WCPay Subscription data.
 	 * @param WC_Subscription $subscription       The WC Subscription object.
@@ -741,7 +741,7 @@ class WC_Payments_Subscription_Service {
 	 * @return void
 	 */
 	public function update_dates_to_match_wcpay_subscription( array $wcpay_subscription, WC_Subscription $subscription ) {
-		// Temporarily allow date changes when we're updating dates to match the dates on the WCPay subscription.
+		// Temporarily allow date changes when we're updating dates to match the dates on the WooPayments subscription.
 		$this->set_feature_support_exception( $subscription, 'subscription_date_changes' );
 
 		$next_payment_date = gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] );
@@ -750,7 +750,7 @@ class WC_Payments_Subscription_Service {
 		$next_payment_time_difference = absint( $wcpay_subscription['current_period_end'] - $subscription->get_time( 'next_payment' ) );
 
 		if ( $next_payment_time_difference > 0 && $next_payment_time_difference >= 12 * HOUR_IN_SECONDS ) {
-			$subscription->add_order_note( __( 'The subscription\'s next payment date has been updated to match WCPay server.', 'woocommerce-payments' ) );
+			$subscription->add_order_note( __( 'The subscription\'s next payment date has been updated to match WooPayments server.', 'woocommerce-payments' ) );
 		}
 
 		// Remove the 'subscription_date_changes' exception.
@@ -967,7 +967,7 @@ class WC_Payments_Subscription_Service {
 		try {
 			$response = $this->payments_api_client->update_subscription( $wcpay_subscription_id, $data );
 		} catch ( API_Exception $e ) {
-			Logger::log( sprintf( 'There was a problem updating the WCPay subscription on server: %s', $e->getMessage() ) );
+			Logger::log( sprintf( 'There was a problem updating the WooPayments subscription on server: %s', $e->getMessage() ) );
 		}
 
 		return $response;
@@ -1020,7 +1020,7 @@ class WC_Payments_Subscription_Service {
 				Logger::log(
 					sprintf(
 						// Translators: %s Stripe subscription item ID.
-						__( 'Unable to set subscription item ID meta for WCPay subscription item %s.', 'woocommerce-payments' ),
+						__( 'Unable to set subscription item ID meta for WooPayments subscription item %s.', 'woocommerce-payments' ),
 						$wcpay_subscription_item_id
 					)
 				);

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -88,10 +88,10 @@ class WC_Payments_Subscriptions_Event_Handler {
 				$this->subscription_service->cancel_subscription( $subscription );
 			} else {
 				$this->subscription_service->suspend_subscription( $subscription );
-				$subscription->add_order_note( __( 'Suspended WCPay Subscription in invoice.upcoming webhook handler because subscription next_payment date is 0.', 'woocommerce-payments' ) );
+				$subscription->add_order_note( __( 'Suspended WooPayments Subscription in invoice.upcoming webhook handler because subscription next_payment date is 0.', 'woocommerce-payments' ) );
 				Logger::log(
 					sprintf(
-						'Suspended WCPay Subscription in invoice.upcoming webhook handler because subscription next_payment date is 0. WC ID: %d; WCPay ID: %s.',
+						'Suspended WooPayments Subscription in invoice.upcoming webhook handler because subscription next_payment date is 0. WC ID: %d; WooPayments ID: %s.',
 						$subscription->get_id(),
 						$wcpay_subscription_id
 					)
@@ -269,8 +269,8 @@ class WC_Payments_Subscriptions_Event_Handler {
 				sprintf(
 					// Translators: %1$d Number of failed renewal attempts. %2$s contains failure message, %3$s contains error code.
 					_n(
-						'WCPay subscription renewal attempt %1$d failed with the following message "%2$s" and failure code <code>%3$s</code>',
-						'WCPay subscription renewal attempt %1$d failed with the following message "%2$s" and failure code <code>%3$s</code>',
+						'WooPayments subscription renewal attempt %1$d failed with the following message "%2$s" and failure code <code>%3$s</code>',
+						'WooPayments subscription renewal attempt %1$d failed with the following message "%2$s" and failure code <code>%3$s</code>',
 						$attempts,
 						'woocommerce-payments'
 					),
@@ -292,7 +292,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 			);
 		} else {
 			// Translators: %d Number of failed renewal attempts.
-			$subscription->add_order_note( sprintf( _n( 'WCPay subscription renewal attempt %d failed.', 'WCPay subscription renewal attempt %d failed.', $attempts, 'woocommerce-payments' ), $attempts ) );
+			$subscription->add_order_note( sprintf( _n( 'WooPayments subscription renewal attempt %d failed.', 'WooPayments subscription renewal attempt %d failed.', $attempts, 'woocommerce-payments' ), $attempts ) );
 		}
 
 		if ( self::MAX_RETRIES > $attempts ) {

--- a/includes/woopay/class-woopay-order-status-sync.php
+++ b/includes/woopay/class-woopay-order-status-sync.php
@@ -62,7 +62,7 @@ class WooPay_Order_Status_Sync {
 	 * @return string
 	 */
 	private static function get_webhook_name() {
-		return __( 'WCPay woopay order status sync', 'woocommerce-payments' );
+		return __( 'WooPayments woopay order status sync', 'woocommerce-payments' );
 	}
 
 	/**


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Update plugin messages to replace obsolete `WCPay` with `WooPayments`

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
