### PR TITLE
fix: style issue when payment methods with a tooltip right shifted

### DIFF
--- a/changelog/fix-payment-method-with-a-tooltip-has-right-shifted
+++ b/changelog/fix-payment-method-with-a-tooltip-has-right-shifted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a styling issue when the payment method has a tooltip next to it, it was shifting the logo to the right.

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -91,7 +91,7 @@ const LoadableCheckboxControl = ( {
 			needsAttention ? (
 				<div
 					className="loadable-checkbox__icon"
-					style={ { marginRight: '16px' } }
+					style={ { marginRight: '8px' } }
 				>
 					<HoverTooltip
 						content={ setupTooltip }


### PR DESCRIPTION
Fixes WOOPRD-159

#### Changes proposed in this Pull Request

Very minor fix, when the payment method has a tooltip next to it, it was shifting the logo to the right.

Before:
![image](https://github.com/user-attachments/assets/255e8a50-3b0e-4606-901f-5a623273b1f3)

Now
![image](https://github.com/user-attachments/assets/c7b1918e-85b6-443c-86eb-aca7cb59196b)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments` and ensure all payment methods are aligned.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
