### PR TITLE
fix: multibanco order received page font sizes tweak

### DIFF
--- a/assets/css/success.css
+++ b/assets/css/success.css
@@ -25,7 +25,7 @@
 	--woopayments-multibanco-bg-color: rgba( 109, 109, 109, 0.06 );
 	--woopayments-multibanco-border-color: rgba( 109, 109, 109, 0.16 );
 	--woopayments-multibanco-card-bg-color: rgb( 255, 255, 255 );
-
+	font-size: initial;
 	display: flex;
 	justify-content: center;
 	margin: 2em 0;

--- a/assets/css/success.rtl.css
+++ b/assets/css/success.rtl.css
@@ -25,7 +25,7 @@
 	--woopayments-multibanco-bg-color: rgba( 109, 109, 109, 0.06 );
 	--woopayments-multibanco-border-color: rgba( 109, 109, 109, 0.16 );
 	--woopayments-multibanco-card-bg-color: rgb( 255, 255, 255 );
-
+	font-size: initial;
 	display: flex;
 	justify-content: center;
 	margin: 2em 0;

--- a/changelog/fix-multibanco-order-received-page-font-size-on-block-theme
+++ b/changelog/fix-multibanco-order-received-page-font-size-on-block-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: Multibanco payment instructions font size adjustment on some block-based themes (e.g.: Twenty-Twenty-Four, Twenty-Twenty-Three)


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Initially reported here: p1744202031618089/1744189506.770009-slack-CGGCLBN58

The Multibanco payment instructions font sizes need some adjustments on TT4, TT3 themes (and possibly other block-based themes).
We inject the Multibanco payment instructions as part of the `woocommerce_before_thankyou` action, which is called for both block-based and non-block-based themes.
The problem arises in some block-based themes.
The blocking wrapping the `woocommerce_before_thankyou` action has a `has-large-font-size` class name wrapping it, which is used to render titles.
But since our Multibanco component is wrapped by a block with that `has-large-font-size` class name, also its contents inherit similar font sizes as titles.

I tweaked the contents by using the `font-size: initial`, so that the font size on the wrapping element is ignored, and the font size is reset to `medium`.
Each element within the Multibanco payment instruction has its own font-size, so this should be fine.

I considered using a different hook, but I didn't find a decent candidate.
I considered using JS to extract/inject the component somewhere else outside of the container with `has-large-font-size`, but that seemed brittle and inefficient.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have a US-based Stripe account
- Ensure you have the latest server changes pulled
- Ensure you have EUR as the currency set during checkout (you can change the default currency in WooCommerce > Settings > Currency options, if you'd like)
- Ensure you have "Multibanco" selected in the WooPayments settings
- As a customer, add a product to the cart
- Navigate to the checkout page
- Enter [a Portuguese address](https://www.fakeaddressgenerator.com/World/Portugal_address_generator)
- Select Multibanco as a payment method
- Place the order

Now:
- Stay on the "Order received" page
- As a customer, on a new tab, navigate to My account > Orders, view the details of the orders you just placed
- Keep the two tabs open

Now, as a merchant:
- On a new tab, navigate to Appearance > Themes
- Select a different theme
- Check the "Order received" page and the order details page from earlier
- Keep changing themes: Storefront, TT3, TT5, Divi, etc.
- The goals is to ensure that the Multibanco payment instructions don't differ too much between themes. Variations on button styles, border colors, width are ok. The main purpose is to ensure the whole container doesn't look blown out of proportions

Before on TT3:
<img width="1376" alt="Screenshot 2025-04-09 at 5 18 08 PM" src="https://github.com/user-attachments/assets/9da3d6fa-99ed-462e-b294-5c6e332a240f" />


After on TT3:
<img width="1361" alt="Screenshot 2025-04-09 at 5 17 41 PM" src="https://github.com/user-attachments/assets/3a141532-7b72-4bd6-a205-3f228e8196df" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.