### PR TITLE
fix(gh-10673): fraud protection adv settings not saving with referrer blocked

### DIFF
--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -187,8 +187,18 @@ export function* saveSettings() {
 		} );
 
 		yield updateSettingsValues( {
-			payment_method_statuses: response.data.payment_method_statuses,
-		} );
+			...response.data,
+        }  );
+
+		// Errors for Fraud advanced switched back to basic protection level when not configured.
+		if( response.data.current_protection_level === 'basic' && settings.current_protection_level === 'advanced' ) {
+			dispatch( 'core/notices' ).createErrorNotice(
+				__(
+					'Current protection level is set to "basic". At least one risk filter needs to be enabled for advanced protection.',
+					'woocommerce-payments'
+				)
+			);
+		}
 
 		yield dispatch( 'core/notices' ).createSuccessNotice(
 			__( 'Settings saved.', 'woocommerce-payments' )
@@ -252,6 +262,7 @@ export function updateProtectionLevel( level ) {
 export function updateAdvancedFraudProtectionSettings( settings ) {
 	return updateSettingsValues( {
 		advanced_fraud_protection_settings: settings,
+		is_advanced_fraud_protection_enabled: settings.length > 0,
 	} );
 }
 

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -964,7 +964,13 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 			return;
 		}
 
-		$protection_level = $request->get_param( 'current_protection_level' );
+		$is_advanced_fraud_protection_enabled = $request->get_param( 'is_advanced_fraud_protection_enabled' );
+		$protection_level = $is_advanced_fraud_protection_enabled ? 'advanced' : $request->get_param( 'current_protection_level' );
+
+		// Prevents enabling from payment settings page, forcing activation of a fraud protection setting first.
+		if($protection_level === 'advanced' && !$request->get_param( 'is_advanced_fraud_protection_enabled' )) {
+			$protection_level = 'basic';
+		}
 
 		// Check validity of the protection level.
 		if ( ! in_array( $protection_level, [ 'basic', 'standard', 'high', 'advanced' ], true ) ) {
@@ -983,15 +989,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				$ruleset_config = Fraud_Risk_Tools::get_high_protection_settings();
 				break;
 			case 'advanced':
-				$referer                   = $request->get_header( 'referer' );
-				$is_advanced_settings_page = 0 < strpos( $referer, 'fraud-protection' );
-				if ( ! $is_advanced_settings_page ) {
-					// When the button is clicked from the Payments > Settings page, the advanced fraud protection settings shouldn't change.
-					$ruleset_config = get_transient( 'wcpay_fraud_protection_settings' ) ?? [];
-				} else {
-					// When the button is clicked from the Advanced fraud protection settings page, it should change.
-					$ruleset_config = $request->get_param( 'advanced_fraud_protection_settings' );
-				}
+				$ruleset_config = $request->get_param( 'advanced_fraud_protection_settings' ) ?? [];
 				break;
 		}
 


### PR DESCRIPTION
Fixes gh-10673

#### Changes proposed in this Pull Request

Payment settings advanced fraud page fails to save when referrer header disabled.

This change is needed to make sure the advanced fraud settings page can save correctly. Moving the detection of the saving of advanced settings to rely on an injected from front end parameter allows the saving without relying on an optional http header.

Functionally this appears to replace the functionality and hopefully improves the condition of switching from advanced to basic for the user messaging.


Screen recording of the new implementation: https://github.com/user-attachments/assets/a45585e9-1889-49d4-b3fb-6dc4fa7f62ed

Screen recording of the old implementation: https://github.com/user-attachments/assets/9ba110fe-f155-49ee-8388-3faf265e2c66


#### Testing instructions

Testing either develop or this PR with referrer disabled:

1. Create a new file `docker/wordpress_xdebug/config/disable-referrer.conf`
```
<IfModule mod_headers.c>
Header always set Referrer-Policy "no-referrer"
</IfModule>
```
2. Alter the docker file `docker/wordpress_xdebug/Dockerfile`, add to the end:
```
COPY docker/wordpress_xdebug/config/disable-referrer.conf /etc/apache2/conf-available/disable-referrer.conf
RUN a2enmod headers \
  && a2enconf disable-referrer.conf \
  && apache2ctl configtest
```
4. As we are using PHP-FPM, the above works, however with the development environment using Apache and PHP Module, the following also needs disabling:
```php 
<?php
remove_action( 'admin_init', 'wp_admin_headers' );
```
5. Rebuild container image `docker compose build`
6. Run and test `docker compose up -d`


Go to the Payments -> Settings -> Change Fraud to Advanced -> Configure/Edit -> Activate options and Save

Check for persisted values in the database: 
```sql
select * from wp_options wo where wo.option_name IN ('current_protection_level', '_transient_wcpay_fraud_protection_settings');
```

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
