### PR TITLE
Remove the referrer check to update the fraud protection settings

### DIFF
--- a/changelog/fix-10673-fraud-protection-settings-referer-check
+++ b/changelog/fix-10673-fraud-protection-settings-referer-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove the referrer check to update the fraud protection settings


### PR DESCRIPTION
Fixes #10673

#### Changes proposed in this Pull Request

This PR removes the referrer check which was added to understand if the request was coming from the Advanced Fraud Protection settings page, or the WooPayments settings page (only protection level change), to keep the advanced settings intact if someone wants to change the protection level to Basic, but wants to keep the advanced settings to be able to switch back.

But that was only applying for some while, as the fraud ruleset is being updated from the server when the user requests the fraud protection settings from the backend once one day is passed (transient is being saved for one day, and being refreshed from the server when requested while it is expired):

https://github.com/Automattic/woocommerce-payments/blob/a023444db64682d57741f6afca449fcd20bc999e/includes/class-wc-payment-gateway-wcpay.php#L3052-L3054

So, this feels like redundant and needs to be removed. When the user switches to basic settings, losing all advanced settings should be expected, and when switching back to the advanced settings, it must be entered again.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Switch to basic settings
* Find the transient that contains the fraud protection settings (`_transient_wcpay_fraud_protection_settings`) in `wp_options` table, and check if it contains `a:0:{}` (empty array)
* Go to advanced settings, enable one filter. Save.
* Check the transient if it contains something different than the empty array.
* Go to settings page, change something unrelated, save the settings. 
* Check the transient if it still contains the fraud protection settings.
* Delete the transient. Go to settings page. 
* Check if the transient came back and contains the same data. 
* Do the deletion for the basic settings, and test if it gets restored after deletion and going to settings page.

> [!Note]
> If you don't refresh the page after switching to the basic protection level, you can switch back to the advanced level and keep all the data, because the JS object on the settings page still holds the advanced configuration. But if you refresh the page after switching to basic protection, it'll get lost. I don't know if we should keep it as a feature, or erase the advanced data on the JS object too on save. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
