### PR TITLE
fix: notice after download CVS misplaced

### DIFF
--- a/changelog/fix-notice-after-downloading-csv-looks-weird-on-mobile
+++ b/changelog/fix-notice-after-downloading-csv-looks-weird-on-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug when the notice after downloading CSV that was mispositioned.

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -154,3 +154,14 @@ $gap-small: 12px;
 		}
 	}
 }
+
+.components-snackbar-list {
+	@include breakpoint( '<660px' ) {
+		position: absolute;
+		left: $gap;
+		right: $gap;
+		bottom: 100%;
+		margin-bottom: $gap-small;
+		width: auto;
+	}
+}


### PR DESCRIPTION
Fixes WOOPMNT-4820

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Notice after downloading CSV that was mispositioned, this PR fixes it.

Before:

https://github.com/user-attachments/assets/eab2a9bd-020c-4cfd-b98c-70a10631aa13

After:

https://github.com/user-attachments/assets/76b95133-eaa3-454b-b523-e04c9b804728

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On mobile hit `/wp-admin/admin.php?page=wc-admin&path=/payments/transactions`
* Then click on the button to download the transactions
* The notice should be centered and the text aligned

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
