### PR TITLE
Update to use POST rather than GET for embedded account creation

### DIFF
--- a/changelog/update-route-definition
+++ b/changelog/update-route-definition
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update route definition to use POST rather than GET.

--- a/changelog/update-route-definition
+++ b/changelog/update-route-definition
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update route definition to use POST rather than GET.
+Update account session creation route definition to use POST rather than GET.

--- a/client/embedded-components/hooks.tsx
+++ b/client/embedded-components/hooks.tsx
@@ -34,11 +34,12 @@ export const createKycAccountSession = async (
 ): Promise< AccountSession > => {
 	const urlParams = new URLSearchParams( window.location.search );
 	return await apiFetch< AccountSession >( {
-		path: addQueryArgs( `${ NAMESPACE }/onboarding/kyc/session`, {
+		path: `${ NAMESPACE }/onboarding/kyc/session`,
+		method: 'POST',
+		data: {
 			self_assessment: fromDotNotation( data ),
 			capabilities: urlParams.get( 'capabilities' ) || '',
 			progressive: isPoEligible,
-		} ),
-		method: 'GET',
+		},
 	} );
 };

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -52,8 +52,8 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 			$this->namespace,
 			'/' . $this->rest_base . '/kyc/session',
 			[
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'get_embedded_kyc_session' ],
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_embedded_kyc_session' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
 					'progressive'     => [
@@ -226,9 +226,9 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response Response object containing the account session, or an error if session creation failed.
 	 */
-	public function get_embedded_kyc_session( WP_REST_Request $request ) {
+	public function create_embedded_kyc_session( WP_REST_Request $request ) {
 		$self_assessment_data = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
 		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && filter_var( $request->get_param( 'progressive' ), FILTER_VALIDATE_BOOLEAN );
 

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -141,7 +141,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
-	public function test_get_embedded_kyc_session() {
+	public function test_create_embedded_kyc_session() {
 		$kyc_session = [
 			'clientSecret'   => 'accs_secret__XXX',
 			'expiresAt'      => time() + 120,
@@ -158,15 +158,15 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 				$kyc_session
 			);
 
-		$request = new WP_REST_Request( 'GET' );
-		$request->set_query_params(
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
 			[
 				'progressive'         => true,
 				'create_live_account' => true,
 			]
 		);
 
-		$response = $this->controller->get_embedded_kyc_session( $request );
+		$response = $this->controller->create_embedded_kyc_session( $request );
 		$this->assertSame( 200, $response->status );
 		$this->assertSame(
 			array_merge(


### PR DESCRIPTION
Fixes [WOOPMNT-4929](https://linear.app/a8c/issue/WOOPMNT-4929/requests-to-the-account-session-endpoint-failing-on-some-hosts)
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new Jurassic Ninja using this branch.
* Initiate an onboarding by going to `Payments` and clicking `Connect your store`
* When you get to the MOX, get past the first step, and get to the embedded onboarding. Check the network tab for a request to the `/session` endpoint. Verify that the request is a `POST`, and that it is successful.
* Verify that the embedded component loads as expected.

<img width="1512" alt="Screenshot 2025-04-16 at 11 59 35" src="https://github.com/user-attachments/assets/f8dfab69-bef6-4995-a648-a67ae054b36a" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
