### PR TITLE
chore: consolidate e2e test users config

### DIFF
--- a/changelog/chore-e2e-users-config
+++ b/changelog/chore-e2e-users-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: consolidate e2e test users config.
+
+

--- a/tests/e2e/config/default.ts
+++ b/tests/e2e/config/default.ts
@@ -1,29 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { users } from './users.json';
+
 export const config = {
-	users: {
-		admin: {
-			username: 'admin',
-			password: 'password',
-			email: 'e2e-wcpay-admin@woocommerce.com',
-		},
-		customer: {
-			username: 'customer',
-			password: 'password',
-			email: 'e2e-wcpay-customer@woocommerce.com',
-		},
-		'subscriptions-customer': {
-			username: 'subscriptions-customer',
-			password: 'password',
-			email: 'e2e-wcpay-customer@woocommerce.com',
-		},
-		guest: {
-			email: 'e2e-wcpay-guest@woocommerce.com',
-		},
-		editor: {
-			username: 'editor',
-			password: 'password',
-			email: 'e2e-wcpay-editor@woocommerce.com',
-		},
-	},
+	users,
 	products: {
 		cap: {
 			name: 'Cap',

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -193,6 +193,10 @@ if [[ "$DEBUG" != true ]]; then
 	cli wp config set WP_DEBUG_LOG true --raw
 fi
 
+# Ensuring that the jetpack "account protection" feature is disabled,
+# since the passwords for the locally run e2e tests can be allowed to be weak.
+cli wp config set DISABLE_JETPACK_ACCOUNT_PROTECTION true --raw
+
 echo "Updating permalink structure"
 cli wp rewrite structure '/%postname%/'
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

It seems that there used to be a `tests/e2e/config/default.json`, but it got converted to a TS file at some point.
But, at the same time, the `users.json` was created (with the same contents as `default.json`/`default.ts`) so that its contents could be parsed with the `jq` utility in the e2e setup files.

Ensuring that the `users.json` becomes the "source of truth".

Also, disabling the jetpack auth check on the e2e tests setup - the users are just created locally, and it's fine if they have a "weak" password.
If we add a "stronger" randomly generated password, said password could also be scanned (since this is a public repo). And we'd have an endless loop of updating passwords in our local e2e tests.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
