### PR TITLE
Bump WC tested up to version to 9.8.1

### DIFF
--- a/changelog/dev-bump-wc-version-9-8-1
+++ b/changelog/dev-bump-wc-version-9-8-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 9.8.1

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 9.7.1
+ * WC tested up to: 9.8.1
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 9.2.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR bumps `WC tested up to` to `9.81` which is the [latest stable release of WooCommerce](https://github.com/woocommerce/woocommerce/releases/latest) at the time of this PR. 

WooCommerce 9.9.0 is scheduled for release on June 2, 2025 according to the WooCommerce Release plan (sidebar) 7bje6-p2.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
