### PR TITLE
Improve styling of the Embedded components to be consistent and closer to WPDS

### DIFF
--- a/changelog/fix-woopmnt-4909-tweak-embedded-components-style
+++ b/changelog/fix-woopmnt-4909-tweak-embedded-components-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve styling of the Embedded components to be closer to WPDS.

--- a/client/embedded-components/appearance.ts
+++ b/client/embedded-components/appearance.ts
@@ -50,13 +50,16 @@ export default {
 		headingLgFontWeight: '400',
 		headingMdFontSize: '20px',
 		headingMdFontWeight: '400',
-		headingSmFontSize: '16px',
+		headingSmFontSize: '13px',
 		headingSmFontWeight: '600',
 		headingXsFontSize: '12px',
 		headingXsFontWeight: '600',
 		bodyMdFontWeight: '400',
 		bodyMdFontSize: '16px',
-		bodySmFontSize: '14px',
+		bodySmFontSize: '13px',
 		bodySmFontWeight: '400',
+		labelSmFontSize: '12px', // badge font size to match WPDS
+		labelSmFontWeight: '200', // badges font weight to match WPDS
+		labelMdFontSize: '13px',
 	},
 };


### PR DESCRIPTION
Fixes WOOPMNT-4909

#### Changes proposed in this Pull Request

* Improved styling of Embedded KYC and Notifications banner component

| Before | After |
|-----|-----|
| ![image](https://github.com/user-attachments/assets/783b6ea4-ce90-47f2-a5fd-de93e494f077) | ![image](https://github.com/user-attachments/assets/52ddbbdf-635d-4a2f-bc32-7454c5ad46f3) |
| ![image](https://github.com/user-attachments/assets/1bd05ad0-b1a8-4d03-8e47-1cc1daa426af) | ![image](https://github.com/user-attachments/assets/5d5e7e93-c6ed-4f51-97ea-df2788c74a49) |
| ![image](https://github.com/user-attachments/assets/857fd559-b567-4af8-8504-8f8c45007625) | ![image](https://github.com/user-attachments/assets/f3c685ab-b0c9-4622-bd3f-31ee0d4d82dd) |
| ![image](https://github.com/user-attachments/assets/15918f86-c338-47d1-809d-2763c37b5ef7) |  ![image](https://github.com/user-attachments/assets/304a3184-949c-45e6-b1c6-3e8132d47603) |
| ![image](https://github.com/user-attachments/assets/699f06ef-605f-4183-9664-9575b5e2b2d8) | ![image](https://github.com/user-attachments/assets/934d8092-3d75-44c7-a6e0-1cf267179850) |

#### Testing instructions

* 🚀 [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=fix/woopmnt-4909-tweak-embedded-components-style) 🚀
* Kick off new account onboarding
* During the Stripe embedded KYC, provide `1111` as last 4 SSN and `11111111111` as SSN.
* Observe the font size and weight of the embedded KYC component, notifications banner component as described in the screenshots above.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
