### PR TITLE
Update to check for at least one field of the self assessment data being set

### DIFF
--- a/changelog/dev-fix-account-session
+++ b/changelog/dev-fix-account-session
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix for validation issue with POST params in some cases generating account session.

--- a/client/embedded-components/hooks.tsx
+++ b/client/embedded-components/hooks.tsx
@@ -33,13 +33,21 @@ export const createKycAccountSession = async (
 	isPoEligible: boolean
 ): Promise< AccountSession > => {
 	const urlParams = new URLSearchParams( window.location.search );
+	const selfAssessmentData = fromDotNotation( data );
+
+	const requestData: Record< string, unknown > = {
+		capabilities: urlParams.get( 'capabilities' ) || '',
+		progressive: isPoEligible,
+	};
+
+	// Only pass the self assessment data if at least one field is set.
+	if ( Object.keys( selfAssessmentData ).length > 0 ) {
+		requestData.self_assessment = selfAssessmentData;
+	}
+
 	return await apiFetch< AccountSession >( {
 		path: `${ NAMESPACE }/onboarding/kyc/session`,
 		method: 'POST',
-		data: {
-			self_assessment: fromDotNotation( data ),
-			capabilities: urlParams.get( 'capabilities' ) || '',
-			progressive: isPoEligible,
-		},
+		data: requestData,
 	} );
 };


### PR DESCRIPTION
Fixes regression caused by #10698 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

In #10698 we made improvements to the embedded onboarding logic. However, it caused a regression when returning to an onboarding halfway through. This is because the self assessment data was being passed into the request as an empty object, whereas our route definition expects certain parameters when it is passed.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new JN site from this branch. (with WCPay dev tools)
* If using a newer version of WooCommerce Core, **disable** the new payment settings experience via the settings.
* Start an onboarding by going to `Payments`.
* Get past the first step of the onboarding to get to the Stripe embedded component. Start the onboarding and get past a couple of steps (for example, select your country and get to the personal details/bank details step).
* Close the onboarding via the X in the top right corner.  You will get redirected back to the payments page. Click the `Finish...` button to go back to the embedded onboarding.
* The embedded onboarding should load, and you should land on the step you left earlier.
* Complete the onboarding and verify that the account is onboarded successfully.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
