### PR TITLE
Add a lock to Refund webhooks

### DIFF
--- a/changelog/add-prevent-duplicated-refunds
+++ b/changelog/add-prevent-duplicated-refunds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Prevent external refund webhooks to duplicate refunds

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -917,7 +917,7 @@ class WC_Payments_Webhook_Processing_Service {
 	 *
 	 * @return bool    A flag that indicates whether the order is already locked.
 	 */
-	private function is_order_locked_for_refund( WC_Order $order ): bool {
+	final public function is_order_locked_for_refund( WC_Order $order ): bool {
 		$order_id       = $order->get_id();
 		$transient_name = 'wcpay_processing_refund_' . $order_id;
 		$processing     = get_transient( $transient_name );
@@ -933,7 +933,7 @@ class WC_Payments_Webhook_Processing_Service {
 	 *
 	 * @return void
 	 */
-	private function lock_order_refund( WC_Order $order ): void {
+	final public function lock_order_refund( WC_Order $order ): void {
 		$order_id       = $order->get_id();
 		$transient_name = 'wcpay_processing_refund_' . $order_id;
 

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -864,9 +864,22 @@ class WC_Payments_Webhook_Processing_Service {
 			);
 		}
 
-		$wc_refund = $this->order_service->create_refund_for_order( $order, $refunded_amount, $refund_reason, ( ! $is_partial_refund ? $order->get_items() : [] ) );
-		// Process the refund in the order service.
-		$this->order_service->add_note_and_metadata_for_created_refund( $order, $wc_refund, $refund_id, $refund_balance_transaction_id, Refund_Status::PENDING === $refund['status'] );
+		if ( $this->is_order_locked_for_refund( $order ) ) {
+			// This order is already being refunded.
+			return;
+		}
+
+		$this->lock_order_refund( $order );
+
+		try {
+			$wc_refund = $this->order_service->create_refund_for_order( $order, $refunded_amount, $refund_reason, ( ! $is_partial_refund ? $order->get_items() : [] ) );
+			// Process the refund in the order service.
+			$this->order_service->add_note_and_metadata_for_created_refund( $order, $wc_refund, $refund_id, $refund_balance_transaction_id, Refund_Status::PENDING === $refund['status'] );
+			$this->unlock_order_refund( $order );
+		} catch ( Exception $e ) {
+			$this->unlock_order_refund( $order );
+			throw $e;
+		}
 	}
 
 	/**
@@ -895,5 +908,47 @@ class WC_Payments_Webhook_Processing_Service {
 				WC_Payments_Subscriptions::get_event_handler()->handle_invoice_payment_failed( $event_body );
 				break;
 		}
+	}
+
+	/**
+	 * Check if order is locked for refund processing
+	 *
+	 * @param WC_Order $order  The order that is being paid.
+	 *
+	 * @return bool    A flag that indicates whether the order is already locked.
+	 */
+	private function is_order_locked_for_refund( WC_Order $order ): bool {
+		$order_id       = $order->get_id();
+		$transient_name = 'wcpay_processing_refund_' . $order_id;
+		$processing     = get_transient( $transient_name );
+
+		// Block the process if the order is already being refunded.
+		return '-1' === $processing;
+	}
+
+	/**
+	 * Lock an order for refund processing for 30 seconds.
+	 *
+	 * @param WC_Order $order     The order that is being paid.
+	 *
+	 * @return void
+	 */
+	private function lock_order_refund( WC_Order $order ): void {
+		$order_id       = $order->get_id();
+		$transient_name = 'wcpay_processing_refund_' . $order_id;
+
+		set_transient( $transient_name, '-1', 0.5 * MINUTE_IN_SECONDS );
+	}
+
+	/**
+	 * Unlocks an order for processing refunds.
+	 *
+	 * @param WC_Order $order The order that is being unlocked.
+	 *
+	 * @return void
+	 */
+	private function unlock_order_refund( WC_Order $order ): void {
+		$order_id = $order->get_id();
+		delete_transient( 'wcpay_processing_refund_' . $order_id );
 	}
 }

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1636,6 +1636,60 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$this->webhook_processing_service->process( $this->event_body );
 	}
 
+	final public function test_process_full_refund_succeeded_should_leave_order_unlocked(): void {
+		$this->test_process_full_refund_succeeded();
+		$this->assertFalse( $this->webhook_processing_service->is_order_locked_for_refund( $this->mock_order ) );
+	}
+
+	final public function test_process_full_refund_succeeded_should_not_process_if_order_is_locked(): void {
+		$this->assertFalse( $this->webhook_processing_service->is_order_locked_for_refund( $this->mock_order ) );
+		$this->webhook_processing_service->lock_order_refund( $this->mock_order );
+		$this->assertTrue( $this->webhook_processing_service->is_order_locked_for_refund( $this->mock_order ) );
+
+		$this->event_body['type']           = 'charge.refunded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'test_charge_id',
+			'refunds'  => [
+				'data' => [
+					[
+						'id'                  => 'test_refund_id',
+						'status'              => Refund_Status::SUCCEEDED,
+						'amount'              => 1800,
+						'currency'            => 'usd',
+						'reason'              => 'requested_by_customer',
+						'balance_transaction' => 'txn_123',
+					],
+				],
+			],
+			'status'   => 'succeeded',
+			'amount'   => 1800,
+			'currency' => 'usd',
+		];
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'get_total' )
+			->willReturn( 18 );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
+		$this->order_service
+			->expects( $this->never() )
+			->method( 'get_wcpay_refund_id_for_order' );
+
+		// This should not be called as the refund is locked.
+		$this->order_service
+			->expects( $this->never() )
+			->method( 'create_refund_for_order' );
+
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
 	public function test_process_partial_refund_succeeded(): void {
 		$this->event_body['type']           = 'charge.refunded';
 		$this->event_body['livemode']       = true;


### PR DESCRIPTION


Fixes [MSTOR-14: Duplicate Tumblr Blaze Refunds with WooPayments](https://linear.app/a8c/issue/MSTOR-14/duplicate-tumblr-blaze-refunds-with-woopayments)

#### Changes proposed in this Pull Request

- Add a lock to external refunds from webhook to prevent duplicated refunds
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests are covering this
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
