### PR TITLE
Advanced fraud protection settings redesign

### DIFF
--- a/changelog/update-woopmnt-4905-fraud-settings-redesign
+++ b/changelog/update-woopmnt-4905-fraud-settings-redesign
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Advanced fraud protection settings redesign.

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -251,6 +251,7 @@ declare global {
 			userLocale: string;
 		};
 		siteTitle: string;
+		wcVersion: string;
 	};
 
 	const wcpayPluginSettings: {

--- a/client/index.js
+++ b/client/index.js
@@ -268,7 +268,7 @@ addFilter(
 				container: FraudProtectionAdvancedSettingsPage,
 				path: '/payments/fraud-protection',
 				wpOpenMenu: menuID,
-				breadcrumbs: [ 'WooPayments' ],
+				breadcrumbs: [ rootLink, 'Settings' ], // to align with the WooPayments settings pages.
 				capability: 'manage_woocommerce',
 			} );
 		}

--- a/client/settings/fraud-protection/advanced-settings/cards/address-mismatch.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/address-mismatch.tsx
@@ -14,17 +14,17 @@ import FraudProtectionRuleToggle from '../rule-toggle';
 const AddressMismatchRuleCard: React.FC = () => (
 	<FraudProtectionRuleCard
 		title={ __( 'Address Mismatch', 'woocommerce-payments' ) }
-		description={ __(
-			'This filter screens for differences between the shipping information and the ' +
-				'billing information (country).',
-			'woocommerce-payments'
-		) }
 		id="address-mismatch-card"
 	>
 		<FraudProtectionRuleToggle
 			setting={ 'address_mismatch' }
 			label={ __(
-				'Block transactions for mismatched addresses',
+				'Enable Address Mismatch filter',
+				'woocommerce-payments'
+			) }
+			description={ __(
+				'This filter screens for differences between the shipping information and the ' +
+					'billing information (country). When enabled the payment will be blocked.',
 				'woocommerce-payments'
 			) }
 		/>

--- a/client/settings/fraud-protection/advanced-settings/cards/avs-mismatch.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/avs-mismatch.tsx
@@ -15,17 +15,17 @@ const AVSMismatchRuleCard: React.FC = () => {
 	return (
 		<FraudProtectionRuleCard
 			title={ __( 'AVS Mismatch', 'woocommerce-payments' ) }
-			description={ __(
-				'This filter compares the street number and the post code submitted by the customer against the data on ' +
-					'file with the card issuer.',
-				'woocommerce-payments'
-			) }
 			id="avs-mismatch-card"
 		>
 			<FraudProtectionRuleToggle
 				setting="avs_verification"
 				label={ __(
-					'Block transactions for mismatched AVS',
+					'Enable AVS Mismatch filter',
+					'woocommerce-payments'
+				) }
+				description={ __(
+					'This filter compares the street number and the post code submitted by the customer against the data on ' +
+						'file with the card issuer. When enabled the payment will be blocked.',
 					'woocommerce-payments'
 				) }
 			/>

--- a/client/settings/fraud-protection/advanced-settings/cards/cvc-verification.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/cvc-verification.tsx
@@ -20,19 +20,8 @@ const CVCVerificationRuleCard: React.FC = () => {
 	return (
 		<FraudProtectionRuleCard
 			title={ __( 'CVC Verification', 'woocommerce-payments' ) }
-			description={ __(
-				'This filter checks the security code submitted by the customer against the data on file with the card issuer.',
-				'woocommerce-payments'
-			) }
 			id="cvc-verification-card"
 		>
-			<FraudProtectionRuleDescription>
-				{ __(
-					'Because the card security code appears only on the card and not on receipts or statements, the card security code ' +
-						'provides some assurance that the physical card is in the possession of the buyer.',
-					'woocommerce-payments'
-				) }
-			</FraudProtectionRuleDescription>
 			<FraudProtectionRuleCardNotice type="warning">
 				{ declineOnCVCFailure
 					? interpolateComponents( {
@@ -57,6 +46,13 @@ const CVCVerificationRuleCard: React.FC = () => {
 							'woocommerce-payments'
 					  ) }
 			</FraudProtectionRuleCardNotice>
+			<FraudProtectionRuleDescription>
+				{ __(
+					'Because the card security code appears only on the card and not on receipts or statements, the card security code ' +
+						'provides some assurance that the physical card is in the possession of the buyer.',
+					'woocommerce-payments'
+				) }
+			</FraudProtectionRuleDescription>
 		</FraudProtectionRuleCard>
 	);
 };

--- a/client/settings/fraud-protection/advanced-settings/cards/international-ip-address.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/international-ip-address.tsx
@@ -23,31 +23,6 @@ const InternationalIPAddressRuleCard: React.FC = () => {
 	return (
 		<FraudProtectionRuleCard
 			title={ __( 'International IP Address', 'woocommerce-payments' ) }
-			description={ interpolateComponents( {
-				mixedString: __(
-					'This filter screens for {{ipAddressLink}}IP addresses{{/ipAddressLink}} outside of your ' +
-						'{{supportedCountriesLink}}supported countries{{/supportedCountriesLink}}.',
-					'woocommerce-payments'
-				),
-				components: {
-					ipAddressLink: (
-						<Link
-							target="_blank"
-							type="external"
-							href="https://simple.wikipedia.org/wiki/IP_address"
-						/>
-					),
-					supportedCountriesLink: (
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						<a
-							href={ getAdminUrl( {
-								page: 'wc-settings',
-								tab: 'general',
-							} ) }
-						/>
-					),
-				},
-			} ) }
 			id="international-ip-address-card"
 		>
 			{ supportsAllCountries && (
@@ -62,9 +37,34 @@ const InternationalIPAddressRuleCard: React.FC = () => {
 				<FraudProtectionRuleToggle
 					setting={ 'international_ip_address' }
 					label={ __(
-						'Block transactions for international IP addresses',
+						'Enable International IP Address filter',
 						'woocommerce-payments'
 					) }
+					description={ interpolateComponents( {
+						mixedString: __(
+							'This filter screens for {{ipAddressLink}}IP addresses{{/ipAddressLink}} outside of your ' +
+								'{{supportedCountriesLink}}supported countries{{/supportedCountriesLink}}. When enabled the payment will be blocked.',
+							'woocommerce-payments'
+						),
+						components: {
+							ipAddressLink: (
+								<Link
+									target="_blank"
+									type="external"
+									href="https://simple.wikipedia.org/wiki/IP_address"
+								/>
+							),
+							supportedCountriesLink: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a
+									href={ getAdminUrl( {
+										page: 'wc-settings',
+										tab: 'general',
+									} ) }
+								/>
+							),
+						},
+					} ) }
 				></FraudProtectionRuleToggle>
 			) }
 			<FraudProtectionRuleDescription>

--- a/client/settings/fraud-protection/advanced-settings/cards/ip-address-mismatch.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/ip-address-mismatch.tsx
@@ -16,30 +16,30 @@ import FraudProtectionRuleToggle from '../rule-toggle';
 const IPAddressMismatchRuleCard: React.FC = () => (
 	<FraudProtectionRuleCard
 		title={ __( 'IP Address Mismatch', 'woocommerce-payments' ) }
-		description={ interpolateComponents( {
-			mixedString: __(
-				"This filter screens for customer's {{ipAddressLink}}IP address{{/ipAddressLink}} to see if it is in a different " +
-					'country than indicated in their billing address.',
-				'woocommerce-payments'
-			),
-			components: {
-				ipAddressLink: (
-					<Link
-						target="_blank"
-						type="external"
-						href="https://simple.wikipedia.org/wiki/IP_address"
-					/>
-				),
-			},
-		} ) }
 		id="ip-address-mismatch"
 	>
 		<FraudProtectionRuleToggle
 			setting={ 'ip_address_mismatch' }
 			label={ __(
-				"Screen transactions where the IP country and billing country don't match",
+				'Enable IP Address Mismatch filter',
 				'woocommerce-payments'
 			) }
+			description={ interpolateComponents( {
+				mixedString: __(
+					"This filter screens for customer's {{ipAddressLink}}IP address{{/ipAddressLink}} to see if it is in a different " +
+						'country than indicated in their billing address. When enabled the payment will be blocked.',
+					'woocommerce-payments'
+				),
+				components: {
+					ipAddressLink: (
+						<Link
+							target="_blank"
+							type="external"
+							href="https://simple.wikipedia.org/wiki/IP_address"
+						/>
+					),
+				},
+			} ) }
 		></FraudProtectionRuleToggle>
 		<FraudProtectionRuleDescription>
 			{ __(

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
@@ -117,7 +117,7 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 				</div>
 			</div>
 			{ isItemRangeEmpty && (
-				<div>
+				<div className="fraud-protection-rule-toggle-children-notice">
 					<br />
 					<FraudProtectionRuleCardNotice type={ 'warning' }>
 						{ __(
@@ -128,7 +128,7 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 				</div>
 			) }
 			{ isMinGreaterThanMax ? (
-				<div>
+				<div className="fraud-protection-rule-toggle-children-notice">
 					<br />
 					<FraudProtectionRuleCardNotice type={ 'error' }>
 						{ __(

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
@@ -144,16 +144,17 @@ const OrderItemsThresholdCustomForm: React.FC< OrderItemsThresholdCustomFormProp
 const OrderItemsThresholdRuleCard: React.FC = () => (
 	<FraudProtectionRuleCard
 		title={ __( 'Order Items Threshold', 'woocommerce-payments' ) }
-		description={ __(
-			'This filter compares the amount of items in an order to the minimum and maximum counts that you specify.',
-			'woocommerce-payments'
-		) }
 		id="order-items-threshold-card"
 	>
 		<FraudProtectionRuleToggle
 			setting={ 'order_items_threshold' }
 			label={ __(
-				'Block transactions for abnormal item counts',
+				'Enable Order Items Threshold filter',
+				'woocommerce-payments'
+			) }
+			description={ __(
+				'This filter compares the amount of items in an order to the minimum and maximum counts that you specify. ' +
+					'When enabled the payment will be blocked.',
 				'woocommerce-payments'
 			) }
 		>

--- a/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
@@ -154,16 +154,17 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 const PurchasePriceThresholdRuleCard: React.FC = () => (
 	<FraudProtectionRuleCard
 		title={ __( 'Purchase Price Threshold', 'woocommerce-payments' ) }
-		description={ __(
-			'This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.',
-			'woocommerce-payments'
-		) }
 		id="purchase-price-threshold-card"
 	>
 		<FraudProtectionRuleToggle
 			setting={ 'purchase_price_threshold' }
 			label={ __(
-				'Block transactions for abnormal purchase prices',
+				'Enable Purchase Price Threshold filter',
+				'woocommerce-payments'
+			) }
+			description={ __(
+				'This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. ' +
+					'When enabled the payment will be blocked.',
 				'woocommerce-payments'
 			) }
 		>

--- a/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.tsx
@@ -126,7 +126,7 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 				</div>
 			</div>
 			{ areInputsEmpty && (
-				<div>
+				<div className="fraud-protection-rule-toggle-children-notice">
 					<br />
 					<FraudProtectionRuleCardNotice type={ 'warning' }>
 						{ __(
@@ -137,7 +137,7 @@ const PurchasePriceThresholdCustomForm: React.FC< PurchasePriceThresholdCustomFo
 				</div>
 			) }
 			{ isMinGreaterThanMax ? (
-				<div>
+				<div className="fraud-protection-rule-toggle-children-notice">
 					<br />
 					<FraudProtectionRuleCardNotice type={ 'error' }>
 						{ __(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/address-mismatch.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/address-mismatch.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Address mismatch card renders correctly 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -22,25 +22,10 @@ exports[`Address mismatch card renders correctly 1`] = `
           >
             Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for differences between the shipping information and the billing information (country).
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -51,7 +36,6 @@ exports[`Address mismatch card renders correctly 1`] = `
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-0__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-0"
                   type="checkbox"
@@ -67,15 +51,14 @@ exports[`Address mismatch card renders correctly 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-0"
               >
-                Block transactions for mismatched addresses
+                Enable Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-0__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -118,7 +101,7 @@ exports[`Address mismatch card renders correctly when enabled 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -128,25 +111,10 @@ exports[`Address mismatch card renders correctly when enabled 1`] = `
           >
             Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for differences between the shipping information and the billing information (country).
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -157,7 +125,6 @@ exports[`Address mismatch card renders correctly when enabled 1`] = `
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-1__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
@@ -174,15 +141,14 @@ exports[`Address mismatch card renders correctly when enabled 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-1"
               >
-                Block transactions for mismatched addresses
+                Enable Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-1__help"
-            >
-              The payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
           </div>
           <div />
         </div>
@@ -226,7 +192,7 @@ exports[`Address mismatch card renders correctly when enabled and checked 1`] = 
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -236,25 +202,10 @@ exports[`Address mismatch card renders correctly when enabled and checked 1`] = 
           >
             Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for differences between the shipping information and the billing information (country).
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -265,7 +216,6 @@ exports[`Address mismatch card renders correctly when enabled and checked 1`] = 
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-2__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
@@ -282,15 +232,14 @@ exports[`Address mismatch card renders correctly when enabled and checked 1`] = 
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-2"
               >
-                Block transactions for mismatched addresses
+                Enable Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-2__help"
-            >
-              The payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
           </div>
           <div />
         </div>
@@ -334,7 +283,7 @@ exports[`Address mismatch card renders like disabled when checked, but not enabl
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -344,25 +293,10 @@ exports[`Address mismatch card renders like disabled when checked, but not enabl
           >
             Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for differences between the shipping information and the billing information (country).
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -373,7 +307,6 @@ exports[`Address mismatch card renders like disabled when checked, but not enabl
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-3__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-3"
                   type="checkbox"
@@ -389,15 +322,14 @@ exports[`Address mismatch card renders like disabled when checked, but not enabl
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-3"
               >
-                Block transactions for mismatched addresses
+                Enable Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-3__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
           </div>
         </div>
         <div

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/avs-mismatch.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/avs-mismatch.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`AVS mismatch card renders correctly when AVS check is disabled 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -22,25 +22,10 @@ exports[`AVS mismatch card renders correctly when AVS check is disabled 1`] = `
           >
             AVS Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -51,7 +36,6 @@ exports[`AVS mismatch card renders correctly when AVS check is disabled 1`] = `
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-1__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
                   type="checkbox"
@@ -67,15 +51,14 @@ exports[`AVS mismatch card renders correctly when AVS check is disabled 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-1"
               >
-                Block transactions for mismatched AVS
+                Enable AVS Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-1__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -118,7 +101,7 @@ exports[`AVS mismatch card renders correctly when AVS check is enabled 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -128,25 +111,10 @@ exports[`AVS mismatch card renders correctly when AVS check is enabled 1`] = `
           >
             AVS Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -157,7 +125,6 @@ exports[`AVS mismatch card renders correctly when AVS check is enabled 1`] = `
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-0__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-0"
                   type="checkbox"
@@ -173,15 +140,14 @@ exports[`AVS mismatch card renders correctly when AVS check is enabled 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-0"
               >
-                Block transactions for mismatched AVS
+                Enable AVS Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-0__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
           </div>
         </div>
         <div

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/cvc-verification.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/cvc-verification.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`CVC verification card renders correctly when CVC check is disabled 1`] 
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -21,28 +21,6 @@ exports[`CVC verification card renders correctly when CVC check is disabled 1`] 
             class="fraud-protection-rule-card-header"
           >
             CVC Verification
-          </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter checks the security code submitted by the customer against the data on file with the card issuer.
-          </p>
-        </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
-        <div
-          class="fraud-protection-rule-description"
-        >
-          <strong>
-            How does this filter protect me?
-          </strong>
-          <p>
-            Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
           </p>
         </div>
         <div
@@ -88,6 +66,16 @@ exports[`CVC verification card renders correctly when CVC check is disabled 1`] 
             />
           </div>
         </div>
+        <div
+          class="fraud-protection-rule-description"
+        >
+          <strong>
+            How does this filter protect me?
+          </strong>
+          <p>
+            Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+          </p>
+        </div>
       </div>
     </div>
     <div
@@ -118,7 +106,7 @@ exports[`CVC verification card renders correctly when CVC check is enabled 1`] =
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -127,28 +115,6 @@ exports[`CVC verification card renders correctly when CVC check is enabled 1`] =
             class="fraud-protection-rule-card-header"
           >
             CVC Verification
-          </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter checks the security code submitted by the customer against the data on file with the card issuer.
-          </p>
-        </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
-        <div
-          class="fraud-protection-rule-description"
-        >
-          <strong>
-            How does this filter protect me?
-          </strong>
-          <p>
-            Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
           </p>
         </div>
         <div
@@ -200,6 +166,16 @@ exports[`CVC verification card renders correctly when CVC check is enabled 1`] =
               class="components-notice__actions"
             />
           </div>
+        </div>
+        <div
+          class="fraud-protection-rule-description"
+        >
+          <strong>
+            How does this filter protect me?
+          </strong>
+          <p>
+            Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+          </p>
         </div>
       </div>
     </div>

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/international-ip-address.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/international-ip-address.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`International IP address card renders correctly when enabled 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -22,39 +22,10 @@ exports[`International IP address card renders correctly when enabled 1`] = `
           >
             International IP Address
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP addresses
-            </a>
-             outside of your 
-            <a
-              href="admin.php?page=wc-settings&tab=general"
-            >
-              supported countries
-            </a>
-            .
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -65,7 +36,6 @@ exports[`International IP address card renders correctly when enabled 1`] = `
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-2__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
@@ -82,15 +52,28 @@ exports[`International IP address card renders correctly when enabled 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-2"
               >
-                Block transactions for international IP addresses
+                Enable International IP Address filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-2__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              The payment will be blocked.
-            </p>
+              IP addresses
+            </a>
+             outside of your 
+            <a
+              href="admin.php?page=wc-settings&tab=general"
+            >
+              supported countries
+            </a>
+            . When enabled the payment will be blocked.
           </div>
           <div />
         </div>
@@ -179,7 +162,7 @@ exports[`International IP address card renders correctly when enabled and checke
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -189,39 +172,10 @@ exports[`International IP address card renders correctly when enabled and checke
           >
             International IP Address
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP addresses
-            </a>
-             outside of your 
-            <a
-              href="admin.php?page=wc-settings&tab=general"
-            >
-              supported countries
-            </a>
-            .
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -232,7 +186,6 @@ exports[`International IP address card renders correctly when enabled and checke
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-3__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-3"
@@ -249,15 +202,28 @@ exports[`International IP address card renders correctly when enabled and checke
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-3"
               >
-                Block transactions for international IP addresses
+                Enable International IP Address filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-3__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              The payment will be blocked.
-            </p>
+              IP addresses
+            </a>
+             outside of your 
+            <a
+              href="admin.php?page=wc-settings&tab=general"
+            >
+              supported countries
+            </a>
+            . When enabled the payment will be blocked.
           </div>
           <div />
         </div>
@@ -346,7 +312,7 @@ exports[`International IP address card renders correctly when woocommerce_allowe
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -356,33 +322,7 @@ exports[`International IP address card renders correctly when woocommerce_allowe
           >
             International IP Address
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP addresses
-            </a>
-             outside of your 
-            <a
-              href="admin.php?page=wc-settings&tab=general"
-            >
-              supported countries
-            </a>
-            .
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
         >
@@ -466,7 +406,7 @@ exports[`International IP address card renders correctly when woocommerce_allowe
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -476,39 +416,10 @@ exports[`International IP address card renders correctly when woocommerce_allowe
           >
             International IP Address
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP addresses
-            </a>
-             outside of your 
-            <a
-              href="admin.php?page=wc-settings&tab=general"
-            >
-              supported countries
-            </a>
-            .
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -519,7 +430,6 @@ exports[`International IP address card renders correctly when woocommerce_allowe
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-1__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
                   type="checkbox"
@@ -535,15 +445,28 @@ exports[`International IP address card renders correctly when woocommerce_allowe
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-1"
               >
-                Block transactions for international IP addresses
+                Enable International IP Address filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-1__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              When enabled, the payment will be blocked.
-            </p>
+              IP addresses
+            </a>
+             outside of your 
+            <a
+              href="admin.php?page=wc-settings&tab=general"
+            >
+              supported countries
+            </a>
+            . When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -631,7 +554,7 @@ exports[`International IP address card renders correctly when woocommerce_allowe
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -641,39 +564,10 @@ exports[`International IP address card renders correctly when woocommerce_allowe
           >
             International IP Address
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP addresses
-            </a>
-             outside of your 
-            <a
-              href="admin.php?page=wc-settings&tab=general"
-            >
-              supported countries
-            </a>
-            .
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -684,7 +578,6 @@ exports[`International IP address card renders correctly when woocommerce_allowe
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-0__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-0"
                   type="checkbox"
@@ -700,15 +593,28 @@ exports[`International IP address card renders correctly when woocommerce_allowe
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-0"
               >
-                Block transactions for international IP addresses
+                Enable International IP Address filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-0__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              When enabled, the payment will be blocked.
-            </p>
+              IP addresses
+            </a>
+             outside of your 
+            <a
+              href="admin.php?page=wc-settings&tab=general"
+            >
+              supported countries
+            </a>
+            . When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -796,7 +702,7 @@ exports[`International IP address card renders like disabled when checked, but n
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -806,39 +712,10 @@ exports[`International IP address card renders like disabled when checked, but n
           >
             International IP Address
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP addresses
-            </a>
-             outside of your 
-            <a
-              href="admin.php?page=wc-settings&tab=general"
-            >
-              supported countries
-            </a>
-            .
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -849,7 +726,6 @@ exports[`International IP address card renders like disabled when checked, but n
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-4__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-4"
                   type="checkbox"
@@ -865,15 +741,28 @@ exports[`International IP address card renders like disabled when checked, but n
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-4"
               >
-                Block transactions for international IP addresses
+                Enable International IP Address filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-4__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              When enabled, the payment will be blocked.
-            </p>
+              IP addresses
+            </a>
+             outside of your 
+            <a
+              href="admin.php?page=wc-settings&tab=general"
+            >
+              supported countries
+            </a>
+            . When enabled the payment will be blocked.
           </div>
         </div>
         <div

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/ip-address-mismatch.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/ip-address-mismatch.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`International billing address card renders correctly 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -22,33 +22,10 @@ exports[`International billing address card renders correctly 1`] = `
           >
             IP Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for customer's 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP address
-            </a>
-             to see if it is in a different country than indicated in their billing address.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -59,7 +36,6 @@ exports[`International billing address card renders correctly 1`] = `
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-0__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-0"
                   type="checkbox"
@@ -75,15 +51,22 @@ exports[`International billing address card renders correctly 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-0"
               >
-                Screen transactions where the IP country and billing country don't match
+                Enable IP Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-0__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for customer's 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              When enabled, the payment will be blocked.
-            </p>
+              IP address
+            </a>
+             to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -126,7 +109,7 @@ exports[`International billing address card renders correctly when enabled 1`] =
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -136,33 +119,10 @@ exports[`International billing address card renders correctly when enabled 1`] =
           >
             IP Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for customer's 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP address
-            </a>
-             to see if it is in a different country than indicated in their billing address.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -173,7 +133,6 @@ exports[`International billing address card renders correctly when enabled 1`] =
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-1__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
@@ -190,15 +149,22 @@ exports[`International billing address card renders correctly when enabled 1`] =
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-1"
               >
-                Screen transactions where the IP country and billing country don't match
+                Enable IP Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-1__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for customer's 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              The payment will be blocked.
-            </p>
+              IP address
+            </a>
+             to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
           </div>
           <div />
         </div>
@@ -242,7 +208,7 @@ exports[`International billing address card renders correctly when enabled and c
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -252,33 +218,10 @@ exports[`International billing address card renders correctly when enabled and c
           >
             IP Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for customer's 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP address
-            </a>
-             to see if it is in a different country than indicated in their billing address.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -289,7 +232,6 @@ exports[`International billing address card renders correctly when enabled and c
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-2__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
@@ -306,15 +248,22 @@ exports[`International billing address card renders correctly when enabled and c
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-2"
               >
-                Screen transactions where the IP country and billing country don't match
+                Enable IP Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-2__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for customer's 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              The payment will be blocked.
-            </p>
+              IP address
+            </a>
+             to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
           </div>
           <div />
         </div>
@@ -358,7 +307,7 @@ exports[`International billing address card renders like disabled when checked, 
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -368,33 +317,10 @@ exports[`International billing address card renders like disabled when checked, 
           >
             IP Address Mismatch
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter screens for customer's 
-            <a
-              data-link-type="external"
-              href="https://simple.wikipedia.org/wiki/IP_address"
-              target="_blank"
-            >
-              IP address
-            </a>
-             to see if it is in a different country than indicated in their billing address.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -405,7 +331,6 @@ exports[`International billing address card renders like disabled when checked, 
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-3__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-3"
                   type="checkbox"
@@ -421,15 +346,22 @@ exports[`International billing address card renders like disabled when checked, 
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-3"
               >
-                Screen transactions where the IP country and billing country don't match
+                Enable IP Address Mismatch filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-3__help"
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter screens for customer's 
+            <a
+              data-link-type="external"
+              href="https://simple.wikipedia.org/wiki/IP_address"
+              target="_blank"
             >
-              When enabled, the payment will be blocked.
-            </p>
+              IP address
+            </a>
+             to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
           </div>
         </div>
         <div

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/order-items-threshold.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/order-items-threshold.test.tsx.snap
@@ -227,7 +227,9 @@ exports[`Order items threshold card renders correctly when enabled 1`] = `
                   </div>
                 </div>
               </div>
-              <div>
+              <div
+                class="fraud-protection-rule-toggle-children-notice"
+              >
                 <br />
                 <div
                   class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
@@ -442,7 +444,9 @@ exports[`Order items threshold card renders correctly when enabled and checked 1
                   </div>
                 </div>
               </div>
-              <div>
+              <div
+                class="fraud-protection-rule-toggle-children-notice"
+              >
                 <br />
                 <div
                   class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/order-items-threshold.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/order-items-threshold.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Order items threshold card renders correctly 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -22,25 +22,10 @@ exports[`Order items threshold card renders correctly 1`] = `
           >
             Order Items Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -51,7 +36,6 @@ exports[`Order items threshold card renders correctly 1`] = `
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-0__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-0"
                   type="checkbox"
@@ -67,15 +51,14 @@ exports[`Order items threshold card renders correctly 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-0"
               >
-                Block transactions for abnormal item counts
+                Enable Order Items Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-0__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -118,7 +101,7 @@ exports[`Order items threshold card renders correctly when enabled 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -128,25 +111,10 @@ exports[`Order items threshold card renders correctly when enabled 1`] = `
           >
             Order Items Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -157,7 +125,6 @@ exports[`Order items threshold card renders correctly when enabled 1`] = `
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-1__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
@@ -174,15 +141,14 @@ exports[`Order items threshold card renders correctly when enabled 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-1"
               >
-                Block transactions for abnormal item counts
+                Enable Order Items Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-1__help"
-            >
-              The payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
           </div>
           <div>
             <div
@@ -350,7 +316,7 @@ exports[`Order items threshold card renders correctly when enabled and checked 1
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -360,25 +326,10 @@ exports[`Order items threshold card renders correctly when enabled and checked 1
           >
             Order Items Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -389,7 +340,6 @@ exports[`Order items threshold card renders correctly when enabled and checked 1
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-2__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
@@ -406,15 +356,14 @@ exports[`Order items threshold card renders correctly when enabled and checked 1
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-2"
               >
-                Block transactions for abnormal item counts
+                Enable Order Items Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-2__help"
-            >
-              The payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
           </div>
           <div>
             <div
@@ -582,7 +531,7 @@ exports[`Order items threshold card renders like disabled when checked, but not 
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -592,25 +541,10 @@ exports[`Order items threshold card renders like disabled when checked, but not 
           >
             Order Items Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -621,7 +555,6 @@ exports[`Order items threshold card renders like disabled when checked, but not 
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-3__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-3"
                   type="checkbox"
@@ -637,15 +570,14 @@ exports[`Order items threshold card renders like disabled when checked, but not 
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-3"
               >
-                Block transactions for abnormal item counts
+                Enable Order Items Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-3__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
           </div>
         </div>
         <div

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/purchase-price-threshold.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/purchase-price-threshold.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Purchase price threshold card renders correctly 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -22,25 +22,10 @@ exports[`Purchase price threshold card renders correctly 1`] = `
           >
             Purchase Price Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -51,7 +36,6 @@ exports[`Purchase price threshold card renders correctly 1`] = `
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-0__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-0"
                   type="checkbox"
@@ -67,15 +51,14 @@ exports[`Purchase price threshold card renders correctly 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-0"
               >
-                Block transactions for abnormal purchase prices
+                Enable Purchase Price Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-0__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
           </div>
         </div>
         <div
@@ -118,7 +101,7 @@ exports[`Purchase price threshold card renders correctly when enabled 1`] = `
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -128,25 +111,10 @@ exports[`Purchase price threshold card renders correctly when enabled 1`] = `
           >
             Purchase Price Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -157,7 +125,6 @@ exports[`Purchase price threshold card renders correctly when enabled 1`] = `
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-1__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-1"
@@ -174,15 +141,14 @@ exports[`Purchase price threshold card renders correctly when enabled 1`] = `
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-1"
               >
-                Block transactions for abnormal purchase prices
+                Enable Purchase Price Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-1__help"
-            >
-              The payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
           </div>
           <div>
             <div
@@ -352,7 +318,7 @@ exports[`Purchase price threshold card renders correctly when enabled and checke
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -362,25 +328,10 @@ exports[`Purchase price threshold card renders correctly when enabled and checke
           >
             Purchase Price Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -391,7 +342,6 @@ exports[`Purchase price threshold card renders correctly when enabled and checke
                 class="components-form-toggle is-checked"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-2__help"
                   checked=""
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-2"
@@ -408,15 +358,14 @@ exports[`Purchase price threshold card renders correctly when enabled and checke
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-2"
               >
-                Block transactions for abnormal purchase prices
+                Enable Purchase Price Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-2__help"
-            >
-              The payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
           </div>
           <div>
             <div
@@ -586,7 +535,7 @@ exports[`Purchase price threshold card renders like disabled when checked, but n
       class="css-mgwsf4-View-Content em57xhy0"
     >
       <div
-        class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
         data-wp-c16t="true"
         data-wp-component="CardBody"
       >
@@ -596,25 +545,10 @@ exports[`Purchase price threshold card renders like disabled when checked, but n
           >
             Purchase Price Threshold
           </p>
-          <p
-            class="fraud-protection-rule-card-description"
-          >
-            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-          </p>
         </div>
-      </div>
-      <hr />
-      <div
-        class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-        data-wp-c16t="true"
-        data-wp-component="CardBody"
-      >
         <div
           class="fraud-protection-rule-toggle"
         >
-          <strong>
-            Enable filtering
-          </strong>
           <div
             class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
           >
@@ -625,7 +559,6 @@ exports[`Purchase price threshold card renders like disabled when checked, but n
                 class="components-form-toggle"
               >
                 <input
-                  aria-describedby="inspector-toggle-control-3__help"
                   class="components-form-toggle__input"
                   id="inspector-toggle-control-3"
                   type="checkbox"
@@ -641,15 +574,14 @@ exports[`Purchase price threshold card renders like disabled when checked, but n
                 class="components-toggle-control__label"
                 for="inspector-toggle-control-3"
               >
-                Block transactions for abnormal purchase prices
+                Enable Purchase Price Threshold filter
               </label>
             </div>
-            <p
-              class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-              id="inspector-toggle-control-3__help"
-            >
-              When enabled, the payment will be blocked.
-            </p>
+          </div>
+          <div
+            class="fraud-protection-rule-toggle-description"
+          >
+            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
           </div>
         </div>
         <div

--- a/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/purchase-price-threshold.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/__snapshots__/purchase-price-threshold.test.tsx.snap
@@ -229,7 +229,9 @@ exports[`Purchase price threshold card renders correctly when enabled 1`] = `
                   </div>
                 </div>
               </div>
-              <div>
+              <div
+                class="fraud-protection-rule-toggle-children-notice"
+              >
                 <br />
                 <div
                   class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
@@ -446,7 +448,9 @@ exports[`Purchase price threshold card renders correctly when enabled and checke
                   </div>
                 </div>
               </div>
-              <div>
+              <div
+                class="fraud-protection-rule-toggle-children-notice"
+              >
                 <br />
                 <div
                   class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -201,20 +201,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			}
 
 			updateProtectionLevel( ProtectionLevel.BASIC );
-			dispatch( 'core/notices' ).createErrorNotice(
-				__(
-					'Current protection level is set to "basic". At least one risk filter needs to be enabled for advanced protection.',
-					'woocommerce-payments'
-				)
-			);
 		} else if ( ProtectionLevel.ADVANCED !== currentProtectionLevel ) {
 			updateProtectionLevel( ProtectionLevel.ADVANCED );
-			dispatch( 'core/notices' ).createSuccessNotice(
-				__(
-					'Current protection level is set to "advanced".',
-					'woocommerce-payments'
-				)
-			);
 		}
 
 		const settings = writeRuleset( protectionSettingsUI );
@@ -231,6 +219,8 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 		updateAdvancedFraudProtectionSettings( settings );
 
 		saveSettings();
+
+		setIsDirty( false );
 
 		recordEvent( 'wcpay_fraud_protection_advanced_settings_saved', {
 			settings: JSON.stringify( settings ),
@@ -332,7 +322,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				! isDirty
 			}
 		>
-			{ __( 'Save Changes', 'woocommerce-payments' ) }
+			{ __( 'Save changes', 'woocommerce-payments' ) }
 		</Button>
 	);
 

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -75,50 +75,57 @@ const AdvancedFraudSettingsDescription = () => (
 	</>
 );
 
-const showNewBackLink = isVersionGreater(
-	window.wcSettings.wcVersion,
-	'9.9.0'
-);
+interface BreadcrumbProps {
+	showNewBackLink: boolean;
+}
 
 // Temporary solution until we have wider header redesign.
-const Breadcrumb = () => (
-	<>
-		{ showNewBackLink && (
-			<h2 className="fraud-protection-header-breadcrumb">
-				<small>
-					<Link
-						type="wp-admin"
-						href={ getAdminUrl( {
-							page: 'wc-settings',
-							tab: 'checkout',
-							section: 'woocommerce_payments',
-						} ) }
-					>
-						<span className="dashicons dashicons-arrow-left-alt2"></span>
-					</Link>
-				</small>
-				{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
-			</h2>
-		) }
-		{ ! showNewBackLink && (
-			<h2 className="fraud-protection-header-breadcrumb-old">
-				{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
-				<small>
-					<Link
-						type="wp-admin"
-						href={ getAdminUrl( {
-							page: 'wc-settings',
-							tab: 'checkout',
-							section: 'woocommerce_payments',
-						} ) }
-					>
-						&#x2934;&#xfe0e;
-					</Link>
-				</small>
-			</h2>
-		) }
-	</>
-);
+const Breadcrumb = ( props: BreadcrumbProps ): JSX.Element => {
+	return (
+		<>
+			{ props.showNewBackLink && (
+				<h2 className="fraud-protection-header-breadcrumb">
+					<small>
+						<Link
+							type="wp-admin"
+							href={ getAdminUrl( {
+								page: 'wc-settings',
+								tab: 'checkout',
+								section: 'woocommerce_payments',
+							} ) }
+						>
+							<span className="dashicons dashicons-arrow-left-alt2"></span>
+						</Link>
+					</small>
+					{ __(
+						'Advanced fraud protection',
+						'woocommerce-payments'
+					) }
+				</h2>
+			) }
+			{ ! props.showNewBackLink && (
+				<h2 className="fraud-protection-header-breadcrumb-old">
+					{ __(
+						'Advanced fraud protection',
+						'woocommerce-payments'
+					) }
+					<small>
+						<Link
+							type="wp-admin"
+							href={ getAdminUrl( {
+								page: 'wc-settings',
+								tab: 'checkout',
+								section: 'woocommerce_payments',
+							} ) }
+						>
+							&#x2934;&#xfe0e;
+						</Link>
+					</small>
+				</h2>
+			) }
+		</>
+	);
+};
 
 const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 	const [ isDirty, setIsDirty ] = useState( false );
@@ -329,6 +336,11 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 		</Button>
 	);
 
+	const showNewBackLink = isVersionGreater(
+		window.wcSettings.wcVersion,
+		'9.9.0'
+	);
+
 	return (
 		<FraudPreventionSettingsContext.Provider
 			value={ {
@@ -337,7 +349,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				setIsDirty,
 			} }
 		>
-			<Breadcrumb />
+			<Breadcrumb showNewBackLink={ showNewBackLink } />
 			<SettingsLayout>
 				<SettingsSection
 					description={ AdvancedFraudSettingsDescription }

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -18,7 +18,7 @@ import {
 	useSettings,
 } from '../../../data';
 import ErrorBoundary from '../../../components/error-boundary';
-import { getAdminUrl } from '../../../utils';
+import { getAdminUrl, isVersionGreater } from '../../../utils';
 import SettingsLayout from 'wcpay/settings/settings-layout';
 import AVSMismatchRuleCard from './cards/avs-mismatch';
 import CVCVerificationRuleCard from './cards/cvc-verification';
@@ -75,24 +75,48 @@ const AdvancedFraudSettingsDescription = () => (
 	</>
 );
 
+const showNewBackLink = isVersionGreater(
+	window.wcSettings.wcVersion,
+	'9.9.0'
+);
+
 // Temporary solution until we have wider header redesign.
 const Breadcrumb = () => (
 	<>
-		<h2 className="fraud-protection-header-breadcrumb">
-			<small>
-				<Link
-					type="wp-admin"
-					href={ getAdminUrl( {
-						page: 'wc-settings',
-						tab: 'checkout',
-						section: 'woocommerce_payments',
-					} ) }
-				>
-					<span className="dashicons dashicons-arrow-left-alt2"></span>
-				</Link>
-			</small>
-			{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
-		</h2>
+		{ showNewBackLink && (
+			<h2 className="fraud-protection-header-breadcrumb">
+				<small>
+					<Link
+						type="wp-admin"
+						href={ getAdminUrl( {
+							page: 'wc-settings',
+							tab: 'checkout',
+							section: 'woocommerce_payments',
+						} ) }
+					>
+						<span className="dashicons dashicons-arrow-left-alt2"></span>
+					</Link>
+				</small>
+				{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
+			</h2>
+		) }
+		{ ! showNewBackLink && (
+			<h2 className="fraud-protection-header-breadcrumb-old">
+				{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
+				<small>
+					<Link
+						type="wp-admin"
+						href={ getAdminUrl( {
+							page: 'wc-settings',
+							tab: 'checkout',
+							section: 'woocommerce_payments',
+						} ) }
+					>
+						&#x2934;&#xfe0e;
+					</Link>
+				</small>
+			</h2>
+		) }
 	</>
 );
 

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -18,7 +18,7 @@ import {
 	useSettings,
 } from '../../../data';
 import ErrorBoundary from '../../../components/error-boundary';
-import { getAdminUrl, isVersionGreater } from '../../../utils';
+import { getAdminUrl, isVersionGreaterOrEqual } from '../../../utils';
 import SettingsLayout from 'wcpay/settings/settings-layout';
 import AVSMismatchRuleCard from './cards/avs-mismatch';
 import CVCVerificationRuleCard from './cards/cvc-verification';
@@ -336,7 +336,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 		</Button>
 	);
 
-	const showNewBackLink = isVersionGreater(
+	const showNewBackLink = isVersionGreaterOrEqual(
 		window.wcSettings.wcVersion,
 		'9.9.0'
 	);

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import React, {
-	useEffect,
-	useLayoutEffect,
-	useState,
-	useRef,
-	EffectCallback,
-} from 'react';
-import ReactDOM from 'react-dom';
+import React, { useEffect, useState, useRef, EffectCallback } from 'react';
 import { isMatchWith } from 'lodash';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
@@ -51,6 +44,7 @@ import {
 	SettingsHook,
 } from '../interfaces';
 import useConfirmNavigation from 'wcpay/utils/use-confirm-navigation';
+import SettingsSection from 'wcpay/settings/settings-section';
 
 const observerEventMapping: Record< string, string > = {
 	'avs-mismatch-card':
@@ -69,37 +63,38 @@ const observerEventMapping: Record< string, string > = {
 		'wcpay_fraud_protection_advanced_settings_card_items_threshold_viewed',
 };
 
-const Breadcrumb = () => (
+const AdvancedFraudSettingsDescription = () => (
 	<>
-		<h2 className="fraud-protection-header-breadcrumb">
-			<Link
-				type="wp-admin"
-				href={ getAdminUrl( {
-					page: 'wc-settings',
-					tab: 'checkout',
-					section: 'woocommerce_payments',
-				} ) }
-			>
-				{ 'WooPayments' }
-			</Link>
-			&nbsp;&gt;&nbsp;
-			{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
-		</h2>
-		<p className="fraud-protection-advanced-settings-notice">
+		<h2>{ __( 'Filter configuration', 'woocommerce-payments' ) }</h2>
+		<p>
 			{ __(
-				'At least one risk filter needs to be enabled for advanced protection.',
+				'Set up advanced fraud filters. Enable at least one filter to activate advanced protection.',
 				'woocommerce-payments'
 			) }
 		</p>
 	</>
 );
 
-const SaveFraudProtectionSettingsButton: React.FC = ( { children } ) => {
-	const headerElement = document.querySelector(
-		'.woocommerce-layout__header-wrapper'
-	);
-	return headerElement && ReactDOM.createPortal( children, headerElement );
-};
+// Temporary solution until we have wider header redesign.
+const Breadcrumb = () => (
+	<>
+		<h2 className="fraud-protection-header-breadcrumb">
+			<small>
+				<Link
+					type="wp-admin"
+					href={ getAdminUrl( {
+						page: 'wc-settings',
+						tab: 'checkout',
+						section: 'woocommerce_payments',
+					} ) }
+				>
+					<span className="dashicons dashicons-arrow-left-alt2"></span>
+				</Link>
+			</small>
+			{ __( 'Advanced fraud protection', 'woocommerce-payments' ) }
+		</h2>
+	</>
+);
 
 const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 	const [ isDirty, setIsDirty ] = useState( false );
@@ -128,17 +123,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			readRuleset( advancedFraudProtectionSettings )
 		);
 	}, [ advancedFraudProtectionSettings ] );
-
-	useLayoutEffect( () => {
-		const saveButton = document.querySelector(
-			'.fraud-protection-header-save-button'
-		);
-		if ( saveButton ) {
-			document
-				.querySelector( '.woocommerce-layout__header-heading' )
-				?.after( saveButton );
-		}
-	} );
 
 	const validateSettings = (
 		fraudProtectionSettings: ProtectionSettingsUI
@@ -221,18 +205,6 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 			settings: JSON.stringify( settings ),
 		} );
 	};
-
-	// Hack to make "Payments > Settings" the active selected menu item.
-	useEffect( () => {
-		const wcSettingsMenuItem = document.querySelector(
-			'#toplevel_page_wc-admin-path--payments-overview a[href$="section=woocommerce_payments"]'
-		);
-		if ( wcSettingsMenuItem ) {
-			wcSettingsMenuItem.setAttribute( 'aria-current', 'page' );
-			wcSettingsMenuItem.classList.add( 'current' );
-			wcSettingsMenuItem.parentElement?.classList.add( 'current' );
-		}
-	}, [ isLoading ] );
 
 	// Intersection observer callback for tracking card viewed events.
 	const observerCallback = ( entries: IntersectionObserverEntry[] ) => {
@@ -341,10 +313,13 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 				setIsDirty,
 			} }
 		>
+			<Breadcrumb />
 			<SettingsLayout>
-				<ErrorBoundary>
-					<div className="fraud-protection-advanced-settings-layout">
-						<Breadcrumb />
+				<SettingsSection
+					description={ AdvancedFraudSettingsDescription }
+					id="advanced-fraud"
+				>
+					<ErrorBoundary>
 						{ validationError && (
 							<div className="fraud-protection-advanced-settings-error-notice">
 								<Notice
@@ -399,31 +374,11 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 						</LoadableBlock>
 
 						<footer className="fraud-protection-advanced-settings__footer">
-							<Button
-								href={ getAdminUrl( {
-									page: 'wc-settings',
-									tab: 'checkout',
-									section: 'woocommerce_payments',
-								} ) }
-								variant="secondary"
-								disabled={ isSaving || isLoading }
-							>
-								{ __(
-									'Back to Payments Settings',
-									'woocommerce-payments'
-								) }
-							</Button>
-
 							{ renderSaveButton() }
 						</footer>
-					</div>
-				</ErrorBoundary>
+					</ErrorBoundary>
+				</SettingsSection>
 			</SettingsLayout>
-			<SaveFraudProtectionSettingsButton>
-				<div className="fraud-protection-header-save-button">
-					{ renderSaveButton() }
-				</div>
-			</SaveFraudProtectionSettingsButton>
 		</FraudPreventionSettingsContext.Provider>
 	);
 };

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -328,7 +328,7 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 
 	const showNewBackLink = isVersionGreaterOrEqual(
 		window.wcSettings.wcVersion,
-		'9.9.0'
+		'9.8.3'
 	);
 
 	return (

--- a/client/settings/fraud-protection/advanced-settings/rule-card.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-card.tsx
@@ -12,30 +12,24 @@ import CardBody from '../../card-body';
 
 interface FraudProtectionRuleCardProps {
 	title: string;
-	description: React.ReactNode;
 	id: string;
 }
 
 const FraudProtectionRuleCard: React.FC< FraudProtectionRuleCardProps > = ( {
 	title,
-	description,
 	children,
 	id,
 } ) => {
 	return (
 		<Card id={ id } className="fraud-protection-rule-card">
-			<CardBody className="fraud-protection-rule-card-header-container">
+			<CardBody>
 				<div>
 					<p className="fraud-protection-rule-card-header">
 						{ title }
 					</p>
-					<p className="fraud-protection-rule-card-description">
-						{ description }
-					</p>
 				</div>
+				{ children }
 			</CardBody>
-			<hr></hr>
-			<CardBody>{ children }</CardBody>
 		</Card>
 	);
 };

--- a/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
@@ -15,6 +15,7 @@ import { FraudPreventionSettings } from '../interfaces';
 interface FraudProtectionRuleToggleProps {
 	setting: string;
 	label: string;
+	description: React.ReactNode;
 }
 
 export const filterActions = {
@@ -33,23 +34,6 @@ const radioOptions = [
 	},
 ];
 
-const helpTextMapping = {
-	unchecked: __( 'When enabled, the payment will be blocked.' ),
-	[ filterActions.REVIEW ]: __(
-		'The payment method will not be charged until you review and approve the transaction.'
-	),
-	[ filterActions.BLOCK ]: __( 'The payment will be blocked.' ),
-};
-
-export const getHelpText = (
-	toggleState: boolean,
-	filterAction: string
-): string => {
-	if ( ! toggleState ) return helpTextMapping.unchecked;
-
-	return helpTextMapping[ filterAction ];
-};
-
 const getFilterAction = (
 	settingUI: FraudPreventionSettings,
 	isFRTReviewFeatureActive: boolean
@@ -62,6 +46,7 @@ const getFilterAction = (
 const FraudProtectionRuleToggle: React.FC< FraudProtectionRuleToggleProps > = ( {
 	setting,
 	label,
+	description,
 	children,
 } ) => {
 	const {
@@ -101,17 +86,17 @@ const FraudProtectionRuleToggle: React.FC< FraudProtectionRuleToggleProps > = ( 
 	// Render view.
 	return (
 		<div className="fraud-protection-rule-toggle">
-			<strong>
-				{ __( 'Enable filtering', 'woocommerce-payments' ) }
-			</strong>
 			<ToggleControl
 				label={ label }
 				key={ setting }
-				help={ getHelpText( settingUI?.enabled, filterAction ) }
 				checked={ settingUI?.enabled }
 				className="fraud-protection-rule-toggle-toggle"
 				onChange={ handleEnableToggleChange }
 			/>
+
+			<div className="fraud-protection-rule-toggle-description">
+				{ description }
+			</div>
 
 			{ settingUI?.enabled && (
 				<div>

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -645,7 +645,9 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                               </div>
                             </div>
                           </div>
-                          <div>
+                          <div
+                            class="fraud-protection-rule-toggle-children-notice"
+                          >
                             <br />
                             <div
                               class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-error components-notice is-error"
@@ -906,7 +908,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                   class="components-button is-primary"
                   type="button"
                 >
-                  Save Changes
+                  Save changes
                 </button>
               </footer>
             </div>
@@ -1531,7 +1533,9 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                             </div>
                           </div>
                         </div>
-                        <div>
+                        <div
+                          class="fraud-protection-rule-toggle-children-notice"
+                        >
                           <br />
                           <div
                             class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-error components-notice is-error"
@@ -1792,7 +1796,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="components-button is-primary"
                 type="button"
               >
-                Save Changes
+                Save changes
               </button>
             </footer>
           </div>
@@ -2616,7 +2620,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                   disabled=""
                   type="button"
                 >
-                  Save Changes
+                  Save changes
                 </button>
               </footer>
             </div>
@@ -3358,7 +3362,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 disabled=""
                 type="button"
               >
-                Save Changes
+                Save changes
               </button>
             </footer>
           </div>
@@ -4158,7 +4162,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                 disabled=""
                 type="button"
               >
-                Save Changes
+                Save changes
               </button>
             </footer>
           </div>
@@ -4875,7 +4879,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               disabled=""
               type="button"
             >
-              Save Changes
+              Save changes
             </button>
           </footer>
         </div>
@@ -5760,9 +5764,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
               >
                 <button
                   class="components-button is-primary"
+                  disabled=""
                   type="button"
                 >
-                  Save Changes
+                  Save changes
                 </button>
               </footer>
             </div>
@@ -6566,9 +6571,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
             >
               <button
                 class="components-button is-primary"
+                disabled=""
                 type="button"
               >
-                Save Changes
+                Save changes
               </button>
             </footer>
           </div>

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -18,9 +18,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
       class="a11y-speak-region"
       id="a11y-speak-assertive"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
-    >
-      Settings were not saved. Maximum purchase price must be greater than the minimum purchase price.
-    </div>
+    />
     <div
       aria-atomic="true"
       aria-live="polite"
@@ -28,7 +26,9 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
       class="a11y-speak-region"
       id="a11y-speak-polite"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
-    />
+    >
+              Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
+    </div>
     <div>
       <div>
         <div
@@ -37,40 +37,930 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
           <div
             class="woocommerce-layout__header-heading"
           />
-          <div
-            class="fraud-protection-header-save-button"
-          >
-            <button
-              class="components-button is-primary"
-              type="button"
-            >
-              Save Changes
-            </button>
-          </div>
         </div>
+        <h2
+          class="fraud-protection-header-breadcrumb"
+        >
+          <small>
+            <a
+              data-link-type="wp-admin"
+              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+            >
+              <span
+                class="dashicons dashicons-arrow-left-alt2"
+              />
+            </a>
+          </small>
+          Advanced fraud protection
+        </h2>
         <div
           class="wcpay-settings-layout"
         >
           <div
-            class="fraud-protection-advanced-settings-layout"
+            class="settings-section"
+            id="advanced-fraud"
           >
-            <h2
-              class="fraud-protection-header-breadcrumb"
+            <div
+              class="settings-section__details"
             >
-              <a
-                data-link-type="wp-admin"
-                href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+              <h2>
+                Filter configuration
+              </h2>
+              <p>
+                Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+              </p>
+            </div>
+            <div
+              class="settings-section__controls"
+            >
+              <div
+                class="fraud-protection-advanced-settings-error-notice"
               >
-                WooPayments
-              </a>
-               &gt; 
-              Advanced fraud protection
+                <div
+                  class="components-notice is-error is-dismissible"
+                >
+                  <div
+                    class="components-notice__content"
+                  >
+                    Settings were not saved. Maximum purchase price must be greater than the minimum purchase price.
+                    <div
+                      class="components-notice__actions"
+                    />
+                  </div>
+                  <button
+                    aria-label="Dismiss this notice"
+                    class="components-button components-notice__dismiss has-icon"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="avs-mismatch-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        AVS Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-12"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-12"
+                          >
+                            Enable AVS Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="international-ip-address-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        International IP Address
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-13"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-13"
+                          >
+                            Enable International IP Address filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for 
+                        <a
+                          data-link-type="external"
+                          href="https://simple.wikipedia.org/wiki/IP_address"
+                          target="_blank"
+                        >
+                          IP addresses
+                        </a>
+                         outside of your 
+                        <a
+                          href="admin.php?page=wc-settings&tab=general"
+                        >
+                          supported countries
+                        </a>
+                        . When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
+                    >
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              focusable="false"
+                              height="24"
+                              size="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            Orders from outside of the following countries will be blocked by the filter: 
+                            <strong>
+                              Canada, United States
+                            </strong>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="ip-address-mismatch"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        IP Address Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-14"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-14"
+                          >
+                            Enable IP Address Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for customer's 
+                        <a
+                          data-link-type="external"
+                          href="https://simple.wikipedia.org/wiki/IP_address"
+                          target="_blank"
+                        >
+                          IP address
+                        </a>
+                         to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="address-mismatch-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Address Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-15"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-15"
+                          >
+                            Enable Address Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="purchase-price-threshold-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Purchase Price Threshold
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle is-checked"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-16"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-16"
+                          >
+                            Enable Purchase Price Threshold filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                      </div>
+                      <div>
+                        <div
+                          class="fraud-protection-rule-toggle-children-container"
+                        >
+                          <strong>
+                            Limits
+                          </strong>
+                          <div
+                            class="fraud-protection-rule-toggle-children-horizontal-form"
+                          >
+                            <div
+                              class="fraud-protection-rule-toggle-children-vertical-form"
+                            >
+                              <label
+                                for="fraud-protection-purchase-price-minimum"
+                              >
+                                Minimum purchase price
+                              </label>
+                              <div
+                                class="components-base-control components-amount-input__container"
+                              >
+                                <div
+                                  class="components-base-control__field components-amount-input__input_container"
+                                >
+                                  <span
+                                    class="components-amount-input__prefix"
+                                  >
+                                    $
+                                  </span>
+                                  <input
+                                    class="components-text-control__input components-amount-input__input"
+                                    data-testid="amount-input"
+                                    id="fraud-protection-purchase-price-minimum"
+                                    placeholder="0.00"
+                                    value="10"
+                                  />
+                                </div>
+                                <span
+                                  class="components-amount-input__help_text"
+                                >
+                                  Leave blank for no limit
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              class="fraud-protection-rule-toggle-children-vertical-form"
+                            >
+                              <label
+                                for="fraud-protection-purchase-price-maximum"
+                              >
+                                Maximum purchase price
+                              </label>
+                              <div
+                                class="components-base-control components-amount-input__container"
+                              >
+                                <div
+                                  class="components-base-control__field components-amount-input__input_container"
+                                >
+                                  <span
+                                    class="components-amount-input__prefix"
+                                  >
+                                    $
+                                  </span>
+                                  <input
+                                    class="components-text-control__input components-amount-input__input"
+                                    data-testid="amount-input"
+                                    id="fraud-protection-purchase-price-maximum"
+                                    placeholder="0.00"
+                                    value="1"
+                                  />
+                                </div>
+                                <span
+                                  class="components-amount-input__help_text"
+                                >
+                                  Leave blank for no limit
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                          <div>
+                            <br />
+                            <div
+                              class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-error components-notice is-error"
+                            >
+                              <div
+                                class="components-notice__content"
+                              >
+                                <div
+                                  class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                                  data-wp-c16t="true"
+                                  data-wp-component="Flex"
+                                >
+                                  <div
+                                    class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                                    data-wp-c16t="true"
+                                    data-wp-component="FlexItem"
+                                  >
+                                    <svg
+                                      class="gridicon gridicons-notice-outline"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      width="24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <g>
+                                        <path
+                                          d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </div>
+                                  <div
+                                    class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                                    data-wp-c16t="true"
+                                    data-wp-component="FlexItem"
+                                  >
+                                    Maximum purchase price must be greater than the minimum purchase price.
+                                  </div>
+                                </div>
+                                <div
+                                  class="components-notice__actions"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="order-items-threshold-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Order Items Threshold
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-17"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-17"
+                          >
+                            Enable Order Items Threshold filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="cvc-verification-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        CVC Verification
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
+                    >
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              class="gridicon gridicons-notice-outline"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <g>
+                                <path
+                                  d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                            <a
+                              data-link-type="external"
+                              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                              target="_blank"
+                            >
+                              Learn more
+                            </a>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <footer
+                class="fraud-protection-advanced-settings__footer"
+              >
+                <button
+                  class="components-button is-primary"
+                  type="button"
+                >
+                  Save Changes
+                </button>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        class="woocommerce-layout__header-wrapper"
+      >
+        <div
+          class="woocommerce-layout__header-heading"
+        />
+      </div>
+      <h2
+        class="fraud-protection-header-breadcrumb"
+      >
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            <span
+              class="dashicons dashicons-arrow-left-alt2"
+            />
+          </a>
+        </small>
+        Advanced fraud protection
+      </h2>
+      <div
+        class="wcpay-settings-layout"
+      >
+        <div
+          class="settings-section"
+          id="advanced-fraud"
+        >
+          <div
+            class="settings-section__details"
+          >
+            <h2>
+              Filter configuration
             </h2>
-            <p
-              class="fraud-protection-advanced-settings-notice"
-            >
-              At least one risk filter needs to be enabled for advanced protection.
+            <p>
+              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
             </p>
+          </div>
+          <div
+            class="settings-section__controls"
+          >
             <div
               class="fraud-protection-advanced-settings-error-notice"
             >
@@ -115,7 +1005,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -125,25 +1015,10 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                     >
                       AVS Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -154,7 +1029,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-12__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-12"
                             type="checkbox"
@@ -170,15 +1044,14 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-12"
                         >
-                          Block transactions for mismatched AVS
+                          Enable AVS Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-12__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -216,7 +1089,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -226,39 +1099,10 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                     >
                       International IP Address
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for 
-                      <a
-                        data-link-type="external"
-                        href="https://simple.wikipedia.org/wiki/IP_address"
-                        target="_blank"
-                      >
-                        IP addresses
-                      </a>
-                       outside of your 
-                      <a
-                        href="admin.php?page=wc-settings&tab=general"
-                      >
-                        supported countries
-                      </a>
-                      .
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -269,7 +1113,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-13__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-13"
                             type="checkbox"
@@ -285,15 +1128,28 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-13"
                         >
-                          Block transactions for international IP addresses
+                          Enable International IP Address filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-13__help"
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
                       >
-                        When enabled, the payment will be blocked.
-                      </p>
+                        IP addresses
+                      </a>
+                       outside of your 
+                      <a
+                        href="admin.php?page=wc-settings&tab=general"
+                      >
+                        supported countries
+                      </a>
+                      . When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -376,7 +1232,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -386,33 +1242,10 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                     >
                       IP Address Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for customer's 
-                      <a
-                        data-link-type="external"
-                        href="https://simple.wikipedia.org/wiki/IP_address"
-                        target="_blank"
-                      >
-                        IP address
-                      </a>
-                       to see if it is in a different country than indicated in their billing address.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -423,7 +1256,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-14__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-14"
                             type="checkbox"
@@ -439,15 +1271,22 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-14"
                         >
-                          Screen transactions where the IP country and billing country don't match
+                          Enable IP Address Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-14__help"
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for customer's 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
                       >
-                        When enabled, the payment will be blocked.
-                      </p>
+                        IP address
+                      </a>
+                       to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -485,7 +1324,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -495,25 +1334,10 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                     >
                       Address Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for differences between the shipping information and the billing information (country).
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -524,7 +1348,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-15__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-15"
                             type="checkbox"
@@ -540,15 +1363,14 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-15"
                         >
-                          Block transactions for mismatched addresses
+                          Enable Address Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-15__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -586,7 +1408,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -596,25 +1418,10 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                     >
                       Purchase Price Threshold
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -625,7 +1432,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-form-toggle is-checked"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-16__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-16"
                             type="checkbox"
@@ -641,15 +1447,14 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-16"
                         >
-                          Block transactions for abnormal purchase prices
+                          Enable Purchase Price Threshold filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-16__help"
-                      >
-                        The payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
                     </div>
                     <div>
                       <div
@@ -814,7 +1619,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -824,25 +1629,10 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                     >
                       Order Items Threshold
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -853,7 +1643,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-17__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-17"
                             type="checkbox"
@@ -869,15 +1658,14 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-17"
                         >
-                          Block transactions for abnormal item counts
+                          Enable Order Items Threshold filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-17__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -915,7 +1703,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -924,28 +1712,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                       class="fraud-protection-rule-card-header"
                     >
                       CVC Verification
-                    </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                    </p>
-                  </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
                     </p>
                   </div>
                   <div
@@ -998,6 +1764,16 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                       />
                     </div>
                   </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                    </p>
+                  </div>
                 </div>
               </div>
               <div
@@ -1016,12 +1792,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
             <footer
               class="fraud-protection-advanced-settings__footer"
             >
-              <a
-                class="components-button is-secondary"
-                href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-              >
-                Back to Payments Settings
-              </a>
               <button
                 class="components-button is-primary"
                 type="button"
@@ -1030,1010 +1800,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
               </button>
             </footer>
           </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div>
-      <div
-        class="woocommerce-layout__header-wrapper"
-      >
-        <div
-          class="woocommerce-layout__header-heading"
-        />
-        <div
-          class="fraud-protection-header-save-button"
-        >
-          <button
-            class="components-button is-primary"
-            type="button"
-          >
-            Save Changes
-          </button>
-        </div>
-      </div>
-      <div
-        class="wcpay-settings-layout"
-      >
-        <div
-          class="fraud-protection-advanced-settings-layout"
-        >
-          <h2
-            class="fraud-protection-header-breadcrumb"
-          >
-            <a
-              data-link-type="wp-admin"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              WooPayments
-            </a>
-             &gt; 
-            Advanced fraud protection
-          </h2>
-          <p
-            class="fraud-protection-advanced-settings-notice"
-          >
-            At least one risk filter needs to be enabled for advanced protection.
-          </p>
-          <div
-            class="fraud-protection-advanced-settings-error-notice"
-          >
-            <div
-              class="components-notice is-error is-dismissible"
-            >
-              <div
-                class="components-notice__content"
-              >
-                Settings were not saved. Maximum purchase price must be greater than the minimum purchase price.
-                <div
-                  class="components-notice__actions"
-                />
-              </div>
-              <button
-                aria-label="Dismiss this notice"
-                class="components-button components-notice__dismiss has-icon"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  focusable="false"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="avs-mismatch-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    AVS Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-12__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-12"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-12"
-                      >
-                        Block transactions for mismatched AVS
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-12__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="international-ip-address-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    International IP Address
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP addresses
-                    </a>
-                     outside of your 
-                    <a
-                      href="admin.php?page=wc-settings&tab=general"
-                    >
-                      supported countries
-                    </a>
-                    .
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-13__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-13"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-13"
-                      >
-                        Block transactions for international IP addresses
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-13__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
-                >
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          size="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                        >
-                          <path
-                            d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        Orders from outside of the following countries will be blocked by the filter: 
-                        <strong>
-                          Canada, United States
-                        </strong>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="ip-address-mismatch"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    IP Address Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for customer's 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP address
-                    </a>
-                     to see if it is in a different country than indicated in their billing address.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-14__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-14"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-14"
-                      >
-                        Screen transactions where the IP country and billing country don't match
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-14__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="address-mismatch-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Address Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for differences between the shipping information and the billing information (country).
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-15__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-15"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-15"
-                      >
-                        Block transactions for mismatched addresses
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-15__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="purchase-price-threshold-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Purchase Price Threshold
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle is-checked"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-16__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-16"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-16"
-                      >
-                        Block transactions for abnormal purchase prices
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-16__help"
-                    >
-                      The payment will be blocked.
-                    </p>
-                  </div>
-                  <div>
-                    <div
-                      class="fraud-protection-rule-toggle-children-container"
-                    >
-                      <strong>
-                        Limits
-                      </strong>
-                      <div
-                        class="fraud-protection-rule-toggle-children-horizontal-form"
-                      >
-                        <div
-                          class="fraud-protection-rule-toggle-children-vertical-form"
-                        >
-                          <label
-                            for="fraud-protection-purchase-price-minimum"
-                          >
-                            Minimum purchase price
-                          </label>
-                          <div
-                            class="components-base-control components-amount-input__container"
-                          >
-                            <div
-                              class="components-base-control__field components-amount-input__input_container"
-                            >
-                              <span
-                                class="components-amount-input__prefix"
-                              >
-                                $
-                              </span>
-                              <input
-                                class="components-text-control__input components-amount-input__input"
-                                data-testid="amount-input"
-                                id="fraud-protection-purchase-price-minimum"
-                                placeholder="0.00"
-                                value="10"
-                              />
-                            </div>
-                            <span
-                              class="components-amount-input__help_text"
-                            >
-                              Leave blank for no limit
-                            </span>
-                          </div>
-                        </div>
-                        <div
-                          class="fraud-protection-rule-toggle-children-vertical-form"
-                        >
-                          <label
-                            for="fraud-protection-purchase-price-maximum"
-                          >
-                            Maximum purchase price
-                          </label>
-                          <div
-                            class="components-base-control components-amount-input__container"
-                          >
-                            <div
-                              class="components-base-control__field components-amount-input__input_container"
-                            >
-                              <span
-                                class="components-amount-input__prefix"
-                              >
-                                $
-                              </span>
-                              <input
-                                class="components-text-control__input components-amount-input__input"
-                                data-testid="amount-input"
-                                id="fraud-protection-purchase-price-maximum"
-                                placeholder="0.00"
-                                value="1"
-                              />
-                            </div>
-                            <span
-                              class="components-amount-input__help_text"
-                            >
-                              Leave blank for no limit
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <div>
-                        <br />
-                        <div
-                          class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-error components-notice is-error"
-                        >
-                          <div
-                            class="components-notice__content"
-                          >
-                            <div
-                              class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                              data-wp-c16t="true"
-                              data-wp-component="Flex"
-                            >
-                              <div
-                                class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                                data-wp-c16t="true"
-                                data-wp-component="FlexItem"
-                              >
-                                <svg
-                                  class="gridicon gridicons-notice-outline"
-                                  height="24"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <g>
-                                    <path
-                                      d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                                    />
-                                  </g>
-                                </svg>
-                              </div>
-                              <div
-                                class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                                data-wp-c16t="true"
-                                data-wp-component="FlexItem"
-                              >
-                                Maximum purchase price must be greater than the minimum purchase price.
-                              </div>
-                            </div>
-                            <div
-                              class="components-notice__actions"
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="order-items-threshold-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Order Items Threshold
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-17__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-17"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-17"
-                      >
-                        Block transactions for abnormal item counts
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-17__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="cvc-verification-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    CVC Verification
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
-                >
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          class="gridicon gridicons-notice-outline"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g>
-                            <path
-                              d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                            />
-                          </g>
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                        <a
-                          data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                          target="_blank"
-                        >
-                          Learn more
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <footer
-            class="fraud-protection-advanced-settings__footer"
-          >
-            <a
-              class="components-button is-secondary"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              Back to Payments Settings
-            </a>
-            <button
-              class="components-button is-primary"
-              type="button"
-            >
-              Save Changes
-            </button>
-          </footer>
         </div>
       </div>
     </div>
@@ -2129,41 +1895,786 @@ exports[`Advanced fraud protection settings renders an error message when settin
           <div
             class="woocommerce-layout__header-heading"
           />
-          <div
-            class="fraud-protection-header-save-button"
-          >
-            <button
-              class="components-button is-primary"
-              disabled=""
-              type="button"
-            >
-              Save Changes
-            </button>
-          </div>
         </div>
+        <h2
+          class="fraud-protection-header-breadcrumb"
+        >
+          <small>
+            <a
+              data-link-type="wp-admin"
+              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+            >
+              <span
+                class="dashicons dashicons-arrow-left-alt2"
+              />
+            </a>
+          </small>
+          Advanced fraud protection
+        </h2>
         <div
           class="wcpay-settings-layout"
         >
           <div
-            class="fraud-protection-advanced-settings-layout"
+            class="settings-section"
+            id="advanced-fraud"
           >
-            <h2
-              class="fraud-protection-header-breadcrumb"
+            <div
+              class="settings-section__details"
             >
-              <a
-                data-link-type="wp-admin"
-                href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+              <h2>
+                Filter configuration
+              </h2>
+              <p>
+                Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+              </p>
+            </div>
+            <div
+              class="settings-section__controls"
+            >
+              <div
+                class="fraud-protection-advanced-settings-error-notice"
               >
-                WooPayments
-              </a>
-               &gt; 
-              Advanced fraud protection
+                <div
+                  class="components-notice is-error"
+                >
+                  <div
+                    class="components-notice__content"
+                  >
+                    There was an error retrieving your fraud protection settings. Please refresh the page to try again.
+                    <div
+                      class="components-notice__actions"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="avs-mismatch-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        AVS Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-6"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-6"
+                          >
+                            Enable AVS Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="international-ip-address-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        International IP Address
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-7"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-7"
+                          >
+                            Enable International IP Address filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for 
+                        <a
+                          data-link-type="external"
+                          href="https://simple.wikipedia.org/wiki/IP_address"
+                          target="_blank"
+                        >
+                          IP addresses
+                        </a>
+                         outside of your 
+                        <a
+                          href="admin.php?page=wc-settings&tab=general"
+                        >
+                          supported countries
+                        </a>
+                        . When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
+                    >
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              focusable="false"
+                              height="24"
+                              size="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            Orders from outside of the following countries will be blocked by the filter: 
+                            <strong>
+                              Canada, United States
+                            </strong>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="ip-address-mismatch"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        IP Address Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-8"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-8"
+                          >
+                            Enable IP Address Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for customer's 
+                        <a
+                          data-link-type="external"
+                          href="https://simple.wikipedia.org/wiki/IP_address"
+                          target="_blank"
+                        >
+                          IP address
+                        </a>
+                         to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="address-mismatch-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Address Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-9"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-9"
+                          >
+                            Enable Address Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="purchase-price-threshold-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Purchase Price Threshold
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-10"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-10"
+                          >
+                            Enable Purchase Price Threshold filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="order-items-threshold-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Order Items Threshold
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-11"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-11"
+                          >
+                            Enable Order Items Threshold filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="cvc-verification-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        CVC Verification
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
+                    >
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              class="gridicon gridicons-notice-outline"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <g>
+                                <path
+                                  d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                            <a
+                              data-link-type="external"
+                              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                              target="_blank"
+                            >
+                              Learn more
+                            </a>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <footer
+                class="fraud-protection-advanced-settings__footer"
+              >
+                <button
+                  class="components-button is-primary"
+                  disabled=""
+                  type="button"
+                >
+                  Save Changes
+                </button>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        class="woocommerce-layout__header-wrapper"
+      >
+        <div
+          class="woocommerce-layout__header-heading"
+        />
+      </div>
+      <h2
+        class="fraud-protection-header-breadcrumb"
+      >
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            <span
+              class="dashicons dashicons-arrow-left-alt2"
+            />
+          </a>
+        </small>
+        Advanced fraud protection
+      </h2>
+      <div
+        class="wcpay-settings-layout"
+      >
+        <div
+          class="settings-section"
+          id="advanced-fraud"
+        >
+          <div
+            class="settings-section__details"
+          >
+            <h2>
+              Filter configuration
             </h2>
-            <p
-              class="fraud-protection-advanced-settings-notice"
-            >
-              At least one risk filter needs to be enabled for advanced protection.
+            <p>
+              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
             </p>
+          </div>
+          <div
+            class="settings-section__controls"
+          >
             <div
               class="fraud-protection-advanced-settings-error-notice"
             >
@@ -2190,7 +2701,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2200,25 +2711,10 @@ exports[`Advanced fraud protection settings renders an error message when settin
                     >
                       AVS Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -2229,7 +2725,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-6__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-6"
                             type="checkbox"
@@ -2245,15 +2740,14 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-6"
                         >
-                          Block transactions for mismatched AVS
+                          Enable AVS Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-6__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -2291,7 +2785,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2301,39 +2795,10 @@ exports[`Advanced fraud protection settings renders an error message when settin
                     >
                       International IP Address
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for 
-                      <a
-                        data-link-type="external"
-                        href="https://simple.wikipedia.org/wiki/IP_address"
-                        target="_blank"
-                      >
-                        IP addresses
-                      </a>
-                       outside of your 
-                      <a
-                        href="admin.php?page=wc-settings&tab=general"
-                      >
-                        supported countries
-                      </a>
-                      .
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -2344,7 +2809,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-7__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-7"
                             type="checkbox"
@@ -2360,15 +2824,28 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-7"
                         >
-                          Block transactions for international IP addresses
+                          Enable International IP Address filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-7__help"
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
                       >
-                        When enabled, the payment will be blocked.
-                      </p>
+                        IP addresses
+                      </a>
+                       outside of your 
+                      <a
+                        href="admin.php?page=wc-settings&tab=general"
+                      >
+                        supported countries
+                      </a>
+                      . When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -2451,7 +2928,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2461,33 +2938,10 @@ exports[`Advanced fraud protection settings renders an error message when settin
                     >
                       IP Address Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for customer's 
-                      <a
-                        data-link-type="external"
-                        href="https://simple.wikipedia.org/wiki/IP_address"
-                        target="_blank"
-                      >
-                        IP address
-                      </a>
-                       to see if it is in a different country than indicated in their billing address.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -2498,7 +2952,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-8__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-8"
                             type="checkbox"
@@ -2514,15 +2967,22 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-8"
                         >
-                          Screen transactions where the IP country and billing country don't match
+                          Enable IP Address Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-8__help"
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for customer's 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
                       >
-                        When enabled, the payment will be blocked.
-                      </p>
+                        IP address
+                      </a>
+                       to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -2560,7 +3020,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2570,25 +3030,10 @@ exports[`Advanced fraud protection settings renders an error message when settin
                     >
                       Address Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for differences between the shipping information and the billing information (country).
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -2599,7 +3044,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-9__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-9"
                             type="checkbox"
@@ -2615,15 +3059,14 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-9"
                         >
-                          Block transactions for mismatched addresses
+                          Enable Address Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-9__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -2661,7 +3104,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2671,25 +3114,10 @@ exports[`Advanced fraud protection settings renders an error message when settin
                     >
                       Purchase Price Threshold
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -2700,7 +3128,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-10__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-10"
                             type="checkbox"
@@ -2716,15 +3143,14 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-10"
                         >
-                          Block transactions for abnormal purchase prices
+                          Enable Purchase Price Threshold filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-10__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -2762,7 +3188,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2772,25 +3198,10 @@ exports[`Advanced fraud protection settings renders an error message when settin
                     >
                       Order Items Threshold
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -2801,7 +3212,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-11__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-11"
                             type="checkbox"
@@ -2817,15 +3227,14 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-11"
                         >
-                          Block transactions for abnormal item counts
+                          Enable Order Items Threshold filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-11__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -2863,7 +3272,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -2872,28 +3281,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
                       class="fraud-protection-rule-card-header"
                     >
                       CVC Verification
-                    </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                    </p>
-                  </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
                     </p>
                   </div>
                   <div
@@ -2946,6 +3333,16 @@ exports[`Advanced fraud protection settings renders an error message when settin
                       />
                     </div>
                   </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                    </p>
+                  </div>
                 </div>
               </div>
               <div
@@ -2964,12 +3361,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
             <footer
               class="fraud-protection-advanced-settings__footer"
             >
-              <a
-                class="components-button is-secondary"
-                href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-              >
-                Back to Payments Settings
-              </a>
               <button
                 class="components-button is-primary"
                 disabled=""
@@ -2979,867 +3370,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
               </button>
             </footer>
           </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div>
-      <div
-        class="woocommerce-layout__header-wrapper"
-      >
-        <div
-          class="woocommerce-layout__header-heading"
-        />
-        <div
-          class="fraud-protection-header-save-button"
-        >
-          <button
-            class="components-button is-primary"
-            disabled=""
-            type="button"
-          >
-            Save Changes
-          </button>
-        </div>
-      </div>
-      <div
-        class="wcpay-settings-layout"
-      >
-        <div
-          class="fraud-protection-advanced-settings-layout"
-        >
-          <h2
-            class="fraud-protection-header-breadcrumb"
-          >
-            <a
-              data-link-type="wp-admin"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              WooPayments
-            </a>
-             &gt; 
-            Advanced fraud protection
-          </h2>
-          <p
-            class="fraud-protection-advanced-settings-notice"
-          >
-            At least one risk filter needs to be enabled for advanced protection.
-          </p>
-          <div
-            class="fraud-protection-advanced-settings-error-notice"
-          >
-            <div
-              class="components-notice is-error"
-            >
-              <div
-                class="components-notice__content"
-              >
-                There was an error retrieving your fraud protection settings. Please refresh the page to try again.
-                <div
-                  class="components-notice__actions"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="avs-mismatch-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    AVS Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-6__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-6"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-6"
-                      >
-                        Block transactions for mismatched AVS
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-6__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="international-ip-address-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    International IP Address
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP addresses
-                    </a>
-                     outside of your 
-                    <a
-                      href="admin.php?page=wc-settings&tab=general"
-                    >
-                      supported countries
-                    </a>
-                    .
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-7__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-7"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-7"
-                      >
-                        Block transactions for international IP addresses
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-7__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
-                >
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          size="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                        >
-                          <path
-                            d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        Orders from outside of the following countries will be blocked by the filter: 
-                        <strong>
-                          Canada, United States
-                        </strong>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="ip-address-mismatch"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    IP Address Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for customer's 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP address
-                    </a>
-                     to see if it is in a different country than indicated in their billing address.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-8__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-8"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-8"
-                      >
-                        Screen transactions where the IP country and billing country don't match
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-8__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="address-mismatch-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Address Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for differences between the shipping information and the billing information (country).
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-9__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-9"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-9"
-                      >
-                        Block transactions for mismatched addresses
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-9__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="purchase-price-threshold-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Purchase Price Threshold
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-10__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-10"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-10"
-                      >
-                        Block transactions for abnormal purchase prices
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-10__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="order-items-threshold-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Order Items Threshold
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-11__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-11"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-11"
-                      >
-                        Block transactions for abnormal item counts
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-11__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="cvc-verification-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    CVC Verification
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
-                >
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          class="gridicon gridicons-notice-outline"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g>
-                            <path
-                              d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                            />
-                          </g>
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                        <a
-                          data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                          target="_blank"
-                        >
-                          Learn more
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <footer
-            class="fraud-protection-advanced-settings__footer"
-          >
-            <a
-              class="components-button is-secondary"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              Back to Payments Settings
-            </a>
-            <button
-              class="components-button is-primary"
-              disabled=""
-              type="button"
-            >
-              Save Changes
-            </button>
-          </footer>
         </div>
       </div>
     </div>
@@ -3928,29 +3458,760 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               Orders from outside of the following countries will be blocked by the filter:  Canada, United States   
     </div>
     <div>
+      <h2
+        class="fraud-protection-header-breadcrumb"
+      >
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            <span
+              class="dashicons dashicons-arrow-left-alt2"
+            />
+          </a>
+        </small>
+        Advanced fraud protection
+      </h2>
       <div
         class="wcpay-settings-layout"
       >
         <div
-          class="fraud-protection-advanced-settings-layout"
+          class="settings-section"
+          id="advanced-fraud"
         >
-          <h2
-            class="fraud-protection-header-breadcrumb"
+          <div
+            class="settings-section__details"
           >
-            <a
-              data-link-type="wp-admin"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+            <h2>
+              Filter configuration
+            </h2>
+            <p>
+              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+            </p>
+          </div>
+          <div
+            class="settings-section__controls"
+          >
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="avs-mismatch-card"
             >
-              WooPayments
-            </a>
-             &gt; 
-            Advanced fraud protection
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      AVS Mismatch
+                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle"
+                  >
+                    <div
+                      class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                    >
+                      <div
+                        class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                      >
+                        <span
+                          class="components-form-toggle"
+                        >
+                          <input
+                            class="components-form-toggle__input"
+                            id="inspector-toggle-control-0"
+                            type="checkbox"
+                          />
+                          <span
+                            class="components-form-toggle__track"
+                          />
+                          <span
+                            class="components-form-toggle__thumb"
+                          />
+                        </span>
+                        <label
+                          class="components-toggle-control__label"
+                          for="inspector-toggle-control-0"
+                        >
+                          Enable AVS Mismatch filter
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="international-ip-address-card"
+            >
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      International IP Address
+                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle"
+                  >
+                    <div
+                      class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                    >
+                      <div
+                        class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                      >
+                        <span
+                          class="components-form-toggle"
+                        >
+                          <input
+                            class="components-form-toggle__input"
+                            id="inspector-toggle-control-1"
+                            type="checkbox"
+                          />
+                          <span
+                            class="components-form-toggle__track"
+                          />
+                          <span
+                            class="components-form-toggle__thumb"
+                          />
+                        </span>
+                        <label
+                          class="components-toggle-control__label"
+                          for="inspector-toggle-control-1"
+                        >
+                          Enable International IP Address filter
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
+                      >
+                        IP addresses
+                      </a>
+                       outside of your 
+                      <a
+                        href="admin.php?page=wc-settings&tab=general"
+                      >
+                        supported countries
+                      </a>
+                      . When enabled the payment will be blocked.
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                    </p>
+                  </div>
+                  <div
+                    class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
+                  >
+                    <div
+                      class="components-notice__content"
+                    >
+                      <div
+                        class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                        data-wp-c16t="true"
+                        data-wp-component="Flex"
+                      >
+                        <div
+                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            height="24"
+                            size="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                          >
+                            <path
+                              d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
+                        >
+                          Orders from outside of the following countries will be blocked by the filter: 
+                          <strong>
+                            Canada, United States
+                          </strong>
+                        </div>
+                      </div>
+                      <div
+                        class="components-notice__actions"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="ip-address-mismatch"
+            >
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      IP Address Mismatch
+                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle"
+                  >
+                    <div
+                      class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                    >
+                      <div
+                        class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                      >
+                        <span
+                          class="components-form-toggle"
+                        >
+                          <input
+                            class="components-form-toggle__input"
+                            id="inspector-toggle-control-2"
+                            type="checkbox"
+                          />
+                          <span
+                            class="components-form-toggle__track"
+                          />
+                          <span
+                            class="components-form-toggle__thumb"
+                          />
+                        </span>
+                        <label
+                          class="components-toggle-control__label"
+                          for="inspector-toggle-control-2"
+                        >
+                          Enable IP Address Mismatch filter
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for customer's 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
+                      >
+                        IP address
+                      </a>
+                       to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="address-mismatch-card"
+            >
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      Address Mismatch
+                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle"
+                  >
+                    <div
+                      class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                    >
+                      <div
+                        class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                      >
+                        <span
+                          class="components-form-toggle"
+                        >
+                          <input
+                            class="components-form-toggle__input"
+                            id="inspector-toggle-control-3"
+                            type="checkbox"
+                          />
+                          <span
+                            class="components-form-toggle__track"
+                          />
+                          <span
+                            class="components-form-toggle__thumb"
+                          />
+                        </span>
+                        <label
+                          class="components-toggle-control__label"
+                          for="inspector-toggle-control-3"
+                        >
+                          Enable Address Mismatch filter
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="purchase-price-threshold-card"
+            >
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      Purchase Price Threshold
+                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle"
+                  >
+                    <div
+                      class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                    >
+                      <div
+                        class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                      >
+                        <span
+                          class="components-form-toggle"
+                        >
+                          <input
+                            class="components-form-toggle__input"
+                            id="inspector-toggle-control-4"
+                            type="checkbox"
+                          />
+                          <span
+                            class="components-form-toggle__track"
+                          />
+                          <span
+                            class="components-form-toggle__thumb"
+                          />
+                        </span>
+                        <label
+                          class="components-toggle-control__label"
+                          for="inspector-toggle-control-4"
+                        >
+                          Enable Purchase Price Threshold filter
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="order-items-threshold-card"
+            >
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      Order Items Threshold
+                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle"
+                  >
+                    <div
+                      class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                    >
+                      <div
+                        class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                      >
+                        <span
+                          class="components-form-toggle"
+                        >
+                          <input
+                            class="components-form-toggle__input"
+                            id="inspector-toggle-control-5"
+                            type="checkbox"
+                          />
+                          <span
+                            class="components-form-toggle__track"
+                          />
+                          <span
+                            class="components-form-toggle__thumb"
+                          />
+                        </span>
+                        <label
+                          class="components-toggle-control__label"
+                          for="inspector-toggle-control-5"
+                        >
+                          Enable Order Items Threshold filter
+                        </label>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <div
+              class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+              id="cvc-verification-card"
+            >
+              <div
+                class="css-mgwsf4-View-Content em57xhy0"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <p
+                      class="fraud-protection-rule-card-header"
+                    >
+                      CVC Verification
+                    </p>
+                  </div>
+                  <div
+                    class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
+                  >
+                    <div
+                      class="components-notice__content"
+                    >
+                      <div
+                        class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                        data-wp-c16t="true"
+                        data-wp-component="Flex"
+                      >
+                        <div
+                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
+                        >
+                          <svg
+                            class="gridicon gridicons-notice-outline"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <g>
+                              <path
+                                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                        <div
+                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
+                        >
+                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                          <a
+                            data-link-type="external"
+                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                            target="_blank"
+                          >
+                            Learn more
+                          </a>
+                        </div>
+                      </div>
+                      <div
+                        class="components-notice__actions"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+            <footer
+              class="fraud-protection-advanced-settings__footer"
+            >
+              <button
+                class="components-button is-primary"
+                disabled=""
+                type="button"
+              >
+                Save Changes
+              </button>
+            </footer>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <h2
+      class="fraud-protection-header-breadcrumb"
+    >
+      <small>
+        <a
+          data-link-type="wp-admin"
+          href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+        >
+          <span
+            class="dashicons dashicons-arrow-left-alt2"
+          />
+        </a>
+      </small>
+      Advanced fraud protection
+    </h2>
+    <div
+      class="wcpay-settings-layout"
+    >
+      <div
+        class="settings-section"
+        id="advanced-fraud"
+      >
+        <div
+          class="settings-section__details"
+        >
+          <h2>
+            Filter configuration
           </h2>
-          <p
-            class="fraud-protection-advanced-settings-notice"
-          >
-            At least one risk filter needs to be enabled for advanced protection.
+          <p>
+            Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
           </p>
+        </div>
+        <div
+          class="settings-section__controls"
+        >
           <div
             class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
             data-wp-c16t="true"
@@ -3961,7 +4222,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -3971,25 +4232,10 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                   >
                     AVS Mismatch
                   </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                  </p>
                 </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
                 <div
                   class="fraud-protection-rule-toggle"
                 >
-                  <strong>
-                    Enable filtering
-                  </strong>
                   <div
                     class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                   >
@@ -4000,7 +4246,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-form-toggle"
                       >
                         <input
-                          aria-describedby="inspector-toggle-control-0__help"
                           class="components-form-toggle__input"
                           id="inspector-toggle-control-0"
                           type="checkbox"
@@ -4016,15 +4261,14 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-toggle-control__label"
                         for="inspector-toggle-control-0"
                       >
-                        Block transactions for mismatched AVS
+                        Enable AVS Mismatch filter
                       </label>
                     </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-0__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle-description"
+                  >
+                    This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
                   </div>
                 </div>
                 <div
@@ -4062,7 +4306,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -4072,39 +4316,10 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                   >
                     International IP Address
                   </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP addresses
-                    </a>
-                     outside of your 
-                    <a
-                      href="admin.php?page=wc-settings&tab=general"
-                    >
-                      supported countries
-                    </a>
-                    .
-                  </p>
                 </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
                 <div
                   class="fraud-protection-rule-toggle"
                 >
-                  <strong>
-                    Enable filtering
-                  </strong>
                   <div
                     class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                   >
@@ -4115,7 +4330,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-form-toggle"
                       >
                         <input
-                          aria-describedby="inspector-toggle-control-1__help"
                           class="components-form-toggle__input"
                           id="inspector-toggle-control-1"
                           type="checkbox"
@@ -4131,15 +4345,28 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-toggle-control__label"
                         for="inspector-toggle-control-1"
                       >
-                        Block transactions for international IP addresses
+                        Enable International IP Address filter
                       </label>
                     </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-1__help"
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle-description"
+                  >
+                    This filter screens for 
+                    <a
+                      data-link-type="external"
+                      href="https://simple.wikipedia.org/wiki/IP_address"
+                      target="_blank"
                     >
-                      When enabled, the payment will be blocked.
-                    </p>
+                      IP addresses
+                    </a>
+                     outside of your 
+                    <a
+                      href="admin.php?page=wc-settings&tab=general"
+                    >
+                      supported countries
+                    </a>
+                    . When enabled the payment will be blocked.
                   </div>
                 </div>
                 <div
@@ -4222,7 +4449,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -4232,33 +4459,10 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                   >
                     IP Address Mismatch
                   </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for customer's 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP address
-                    </a>
-                     to see if it is in a different country than indicated in their billing address.
-                  </p>
                 </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
                 <div
                   class="fraud-protection-rule-toggle"
                 >
-                  <strong>
-                    Enable filtering
-                  </strong>
                   <div
                     class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                   >
@@ -4269,7 +4473,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-form-toggle"
                       >
                         <input
-                          aria-describedby="inspector-toggle-control-2__help"
                           class="components-form-toggle__input"
                           id="inspector-toggle-control-2"
                           type="checkbox"
@@ -4285,15 +4488,22 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-toggle-control__label"
                         for="inspector-toggle-control-2"
                       >
-                        Screen transactions where the IP country and billing country don't match
+                        Enable IP Address Mismatch filter
                       </label>
                     </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-2__help"
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle-description"
+                  >
+                    This filter screens for customer's 
+                    <a
+                      data-link-type="external"
+                      href="https://simple.wikipedia.org/wiki/IP_address"
+                      target="_blank"
                     >
-                      When enabled, the payment will be blocked.
-                    </p>
+                      IP address
+                    </a>
+                     to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
                   </div>
                 </div>
                 <div
@@ -4331,7 +4541,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -4341,25 +4551,10 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                   >
                     Address Mismatch
                   </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for differences between the shipping information and the billing information (country).
-                  </p>
                 </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
                 <div
                   class="fraud-protection-rule-toggle"
                 >
-                  <strong>
-                    Enable filtering
-                  </strong>
                   <div
                     class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                   >
@@ -4370,7 +4565,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-form-toggle"
                       >
                         <input
-                          aria-describedby="inspector-toggle-control-3__help"
                           class="components-form-toggle__input"
                           id="inspector-toggle-control-3"
                           type="checkbox"
@@ -4386,15 +4580,14 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-toggle-control__label"
                         for="inspector-toggle-control-3"
                       >
-                        Block transactions for mismatched addresses
+                        Enable Address Mismatch filter
                       </label>
                     </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-3__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle-description"
+                  >
+                    This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
                   </div>
                 </div>
                 <div
@@ -4432,7 +4625,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -4442,25 +4635,10 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                   >
                     Purchase Price Threshold
                   </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                  </p>
                 </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
                 <div
                   class="fraud-protection-rule-toggle"
                 >
-                  <strong>
-                    Enable filtering
-                  </strong>
                   <div
                     class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                   >
@@ -4471,7 +4649,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-form-toggle"
                       >
                         <input
-                          aria-describedby="inspector-toggle-control-4__help"
                           class="components-form-toggle__input"
                           id="inspector-toggle-control-4"
                           type="checkbox"
@@ -4487,15 +4664,14 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-toggle-control__label"
                         for="inspector-toggle-control-4"
                       >
-                        Block transactions for abnormal purchase prices
+                        Enable Purchase Price Threshold filter
                       </label>
                     </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-4__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle-description"
+                  >
+                    This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
                   </div>
                 </div>
                 <div
@@ -4533,7 +4709,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -4543,25 +4719,10 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                   >
                     Order Items Threshold
                   </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                  </p>
                 </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
                 <div
                   class="fraud-protection-rule-toggle"
                 >
-                  <strong>
-                    Enable filtering
-                  </strong>
                   <div
                     class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                   >
@@ -4572,7 +4733,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-form-toggle"
                       >
                         <input
-                          aria-describedby="inspector-toggle-control-5__help"
                           class="components-form-toggle__input"
                           id="inspector-toggle-control-5"
                           type="checkbox"
@@ -4588,15 +4748,14 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         class="components-toggle-control__label"
                         for="inspector-toggle-control-5"
                       >
-                        Block transactions for abnormal item counts
+                        Enable Order Items Threshold filter
                       </label>
                     </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-5__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
+                  </div>
+                  <div
+                    class="fraud-protection-rule-toggle-description"
+                  >
+                    This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
                   </div>
                 </div>
                 <div
@@ -4634,7 +4793,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
               class="css-mgwsf4-View-Content em57xhy0"
             >
               <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                 data-wp-c16t="true"
                 data-wp-component="CardBody"
               >
@@ -4643,28 +4802,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                     class="fraud-protection-rule-card-header"
                   >
                     CVC Verification
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
                   </p>
                 </div>
                 <div
@@ -4717,6 +4854,16 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                     />
                   </div>
                 </div>
+                <div
+                  class="fraud-protection-rule-description"
+                >
+                  <strong>
+                    How does this filter protect me?
+                  </strong>
+                  <p>
+                    Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                  </p>
+                </div>
               </div>
             </div>
             <div
@@ -4735,12 +4882,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
           <footer
             class="fraud-protection-advanced-settings__footer"
           >
-            <a
-              class="components-button is-secondary"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              Back to Payments Settings
-            </a>
             <button
               class="components-button is-primary"
               disabled=""
@@ -4750,831 +4891,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
             </button>
           </footer>
         </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div
-      class="wcpay-settings-layout"
-    >
-      <div
-        class="fraud-protection-advanced-settings-layout"
-      >
-        <h2
-          class="fraud-protection-header-breadcrumb"
-        >
-          <a
-            data-link-type="wp-admin"
-            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-          >
-            WooPayments
-          </a>
-           &gt; 
-          Advanced fraud protection
-        </h2>
-        <p
-          class="fraud-protection-advanced-settings-notice"
-        >
-          At least one risk filter needs to be enabled for advanced protection.
-        </p>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="avs-mismatch-card"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  AVS Mismatch
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-toggle"
-              >
-                <strong>
-                  Enable filtering
-                </strong>
-                <div
-                  class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                >
-                  <div
-                    class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                  >
-                    <span
-                      class="components-form-toggle"
-                    >
-                      <input
-                        aria-describedby="inspector-toggle-control-0__help"
-                        class="components-form-toggle__input"
-                        id="inspector-toggle-control-0"
-                        type="checkbox"
-                      />
-                      <span
-                        class="components-form-toggle__track"
-                      />
-                      <span
-                        class="components-form-toggle__thumb"
-                      />
-                    </span>
-                    <label
-                      class="components-toggle-control__label"
-                      for="inspector-toggle-control-0"
-                    >
-                      Block transactions for mismatched AVS
-                    </label>
-                  </div>
-                  <p
-                    class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                    id="inspector-toggle-control-0__help"
-                  >
-                    When enabled, the payment will be blocked.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="international-ip-address-card"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  International IP Address
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter screens for 
-                  <a
-                    data-link-type="external"
-                    href="https://simple.wikipedia.org/wiki/IP_address"
-                    target="_blank"
-                  >
-                    IP addresses
-                  </a>
-                   outside of your 
-                  <a
-                    href="admin.php?page=wc-settings&tab=general"
-                  >
-                    supported countries
-                  </a>
-                  .
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-toggle"
-              >
-                <strong>
-                  Enable filtering
-                </strong>
-                <div
-                  class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                >
-                  <div
-                    class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                  >
-                    <span
-                      class="components-form-toggle"
-                    >
-                      <input
-                        aria-describedby="inspector-toggle-control-1__help"
-                        class="components-form-toggle__input"
-                        id="inspector-toggle-control-1"
-                        type="checkbox"
-                      />
-                      <span
-                        class="components-form-toggle__track"
-                      />
-                      <span
-                        class="components-form-toggle__thumb"
-                      />
-                    </span>
-                    <label
-                      class="components-toggle-control__label"
-                      for="inspector-toggle-control-1"
-                    >
-                      Block transactions for international IP addresses
-                    </label>
-                  </div>
-                  <p
-                    class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                    id="inspector-toggle-control-1__help"
-                  >
-                    When enabled, the payment will be blocked.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                </p>
-              </div>
-              <div
-                class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
-              >
-                <div
-                  class="components-notice__content"
-                >
-                  <div
-                    class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                    data-wp-c16t="true"
-                    data-wp-component="Flex"
-                  >
-                    <div
-                      class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="FlexItem"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        focusable="false"
-                        height="24"
-                        size="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                      >
-                        <path
-                          d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="FlexItem"
-                    >
-                      Orders from outside of the following countries will be blocked by the filter: 
-                      <strong>
-                        Canada, United States
-                      </strong>
-                    </div>
-                  </div>
-                  <div
-                    class="components-notice__actions"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="ip-address-mismatch"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  IP Address Mismatch
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter screens for customer's 
-                  <a
-                    data-link-type="external"
-                    href="https://simple.wikipedia.org/wiki/IP_address"
-                    target="_blank"
-                  >
-                    IP address
-                  </a>
-                   to see if it is in a different country than indicated in their billing address.
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-toggle"
-              >
-                <strong>
-                  Enable filtering
-                </strong>
-                <div
-                  class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                >
-                  <div
-                    class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                  >
-                    <span
-                      class="components-form-toggle"
-                    >
-                      <input
-                        aria-describedby="inspector-toggle-control-2__help"
-                        class="components-form-toggle__input"
-                        id="inspector-toggle-control-2"
-                        type="checkbox"
-                      />
-                      <span
-                        class="components-form-toggle__track"
-                      />
-                      <span
-                        class="components-form-toggle__thumb"
-                      />
-                    </span>
-                    <label
-                      class="components-toggle-control__label"
-                      for="inspector-toggle-control-2"
-                    >
-                      Screen transactions where the IP country and billing country don't match
-                    </label>
-                  </div>
-                  <p
-                    class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                    id="inspector-toggle-control-2__help"
-                  >
-                    When enabled, the payment will be blocked.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="address-mismatch-card"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  Address Mismatch
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter screens for differences between the shipping information and the billing information (country).
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-toggle"
-              >
-                <strong>
-                  Enable filtering
-                </strong>
-                <div
-                  class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                >
-                  <div
-                    class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                  >
-                    <span
-                      class="components-form-toggle"
-                    >
-                      <input
-                        aria-describedby="inspector-toggle-control-3__help"
-                        class="components-form-toggle__input"
-                        id="inspector-toggle-control-3"
-                        type="checkbox"
-                      />
-                      <span
-                        class="components-form-toggle__track"
-                      />
-                      <span
-                        class="components-form-toggle__thumb"
-                      />
-                    </span>
-                    <label
-                      class="components-toggle-control__label"
-                      for="inspector-toggle-control-3"
-                    >
-                      Block transactions for mismatched addresses
-                    </label>
-                  </div>
-                  <p
-                    class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                    id="inspector-toggle-control-3__help"
-                  >
-                    When enabled, the payment will be blocked.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="purchase-price-threshold-card"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  Purchase Price Threshold
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-toggle"
-              >
-                <strong>
-                  Enable filtering
-                </strong>
-                <div
-                  class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                >
-                  <div
-                    class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                  >
-                    <span
-                      class="components-form-toggle"
-                    >
-                      <input
-                        aria-describedby="inspector-toggle-control-4__help"
-                        class="components-form-toggle__input"
-                        id="inspector-toggle-control-4"
-                        type="checkbox"
-                      />
-                      <span
-                        class="components-form-toggle__track"
-                      />
-                      <span
-                        class="components-form-toggle__thumb"
-                      />
-                    </span>
-                    <label
-                      class="components-toggle-control__label"
-                      for="inspector-toggle-control-4"
-                    >
-                      Block transactions for abnormal purchase prices
-                    </label>
-                  </div>
-                  <p
-                    class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                    id="inspector-toggle-control-4__help"
-                  >
-                    When enabled, the payment will be blocked.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="order-items-threshold-card"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  Order Items Threshold
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-toggle"
-              >
-                <strong>
-                  Enable filtering
-                </strong>
-                <div
-                  class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                >
-                  <div
-                    class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                  >
-                    <span
-                      class="components-form-toggle"
-                    >
-                      <input
-                        aria-describedby="inspector-toggle-control-5__help"
-                        class="components-form-toggle__input"
-                        id="inspector-toggle-control-5"
-                        type="checkbox"
-                      />
-                      <span
-                        class="components-form-toggle__track"
-                      />
-                      <span
-                        class="components-form-toggle__thumb"
-                      />
-                    </span>
-                    <label
-                      class="components-toggle-control__label"
-                      for="inspector-toggle-control-5"
-                    >
-                      Block transactions for abnormal item counts
-                    </label>
-                  </div>
-                  <p
-                    class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                    id="inspector-toggle-control-5__help"
-                  >
-                    When enabled, the payment will be blocked.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <div
-          class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="Card"
-          id="cvc-verification-card"
-        >
-          <div
-            class="css-mgwsf4-View-Content em57xhy0"
-          >
-            <div
-              class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div>
-                <p
-                  class="fraud-protection-rule-card-header"
-                >
-                  CVC Verification
-                </p>
-                <p
-                  class="fraud-protection-rule-card-description"
-                >
-                  This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                </p>
-              </div>
-            </div>
-            <hr />
-            <div
-              class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="CardBody"
-            >
-              <div
-                class="fraud-protection-rule-description"
-              >
-                <strong>
-                  How does this filter protect me?
-                </strong>
-                <p>
-                  Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                </p>
-              </div>
-              <div
-                class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
-              >
-                <div
-                  class="components-notice__content"
-                >
-                  <div
-                    class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                    data-wp-c16t="true"
-                    data-wp-component="Flex"
-                  >
-                    <div
-                      class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="FlexItem"
-                    >
-                      <svg
-                        class="gridicon gridicons-notice-outline"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g>
-                          <path
-                            d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                    <div
-                      class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="FlexItem"
-                    >
-                      For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                      <a
-                        data-link-type="external"
-                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                        target="_blank"
-                      >
-                        Learn more
-                      </a>
-                    </div>
-                  </div>
-                  <div
-                    class="components-notice__actions"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-          <div
-            aria-hidden="true"
-            class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Elevation"
-          />
-        </div>
-        <footer
-          class="fraud-protection-advanced-settings__footer"
-        >
-          <a
-            class="components-button is-secondary"
-            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-          >
-            Back to Payments Settings
-          </a>
-          <button
-            class="components-button is-primary"
-            disabled=""
-            type="button"
-          >
-            Save Changes
-          </button>
-        </footer>
       </div>
     </div>
   </div>,
@@ -5669,40 +4985,850 @@ exports[`Advanced fraud protection settings saves settings when there are no val
           <div
             class="woocommerce-layout__header-heading"
           />
-          <div
-            class="fraud-protection-header-save-button"
-          >
-            <button
-              class="components-button is-primary"
-              type="button"
-            >
-              Save Changes
-            </button>
-          </div>
         </div>
+        <h2
+          class="fraud-protection-header-breadcrumb"
+        >
+          <small>
+            <a
+              data-link-type="wp-admin"
+              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+            >
+              <span
+                class="dashicons dashicons-arrow-left-alt2"
+              />
+            </a>
+          </small>
+          Advanced fraud protection
+        </h2>
         <div
           class="wcpay-settings-layout"
         >
           <div
-            class="fraud-protection-advanced-settings-layout"
+            class="settings-section"
+            id="advanced-fraud"
           >
-            <h2
-              class="fraud-protection-header-breadcrumb"
+            <div
+              class="settings-section__details"
             >
-              <a
-                data-link-type="wp-admin"
-                href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+              <h2>
+                Filter configuration
+              </h2>
+              <p>
+                Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+              </p>
+            </div>
+            <div
+              class="settings-section__controls"
+            >
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="avs-mismatch-card"
               >
-                WooPayments
-              </a>
-               &gt; 
-              Advanced fraud protection
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        AVS Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-18"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-18"
+                          >
+                            Enable AVS Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="international-ip-address-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        International IP Address
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-19"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-19"
+                          >
+                            Enable International IP Address filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for 
+                        <a
+                          data-link-type="external"
+                          href="https://simple.wikipedia.org/wiki/IP_address"
+                          target="_blank"
+                        >
+                          IP addresses
+                        </a>
+                         outside of your 
+                        <a
+                          href="admin.php?page=wc-settings&tab=general"
+                        >
+                          supported countries
+                        </a>
+                        . When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
+                    >
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              focusable="false"
+                              height="24"
+                              size="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            Orders from outside of the following countries will be blocked by the filter: 
+                            <strong>
+                              Canada, United States
+                            </strong>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="ip-address-mismatch"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        IP Address Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-20"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-20"
+                          >
+                            Enable IP Address Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for customer's 
+                        <a
+                          data-link-type="external"
+                          href="https://simple.wikipedia.org/wiki/IP_address"
+                          target="_blank"
+                        >
+                          IP address
+                        </a>
+                         to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="address-mismatch-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Address Mismatch
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-21"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-21"
+                          >
+                            Enable Address Mismatch filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="purchase-price-threshold-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Purchase Price Threshold
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle is-checked"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-22"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-22"
+                          >
+                            Enable Purchase Price Threshold filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                      </div>
+                      <div>
+                        <div
+                          class="fraud-protection-rule-toggle-children-container"
+                        >
+                          <strong>
+                            Limits
+                          </strong>
+                          <div
+                            class="fraud-protection-rule-toggle-children-horizontal-form"
+                          >
+                            <div
+                              class="fraud-protection-rule-toggle-children-vertical-form"
+                            >
+                              <label
+                                for="fraud-protection-purchase-price-minimum"
+                              >
+                                Minimum purchase price
+                              </label>
+                              <div
+                                class="components-base-control components-amount-input__container"
+                              >
+                                <div
+                                  class="components-base-control__field components-amount-input__input_container"
+                                >
+                                  <span
+                                    class="components-amount-input__prefix"
+                                  >
+                                    $
+                                  </span>
+                                  <input
+                                    class="components-text-control__input components-amount-input__input"
+                                    data-testid="amount-input"
+                                    id="fraud-protection-purchase-price-minimum"
+                                    placeholder="0.00"
+                                    value="1"
+                                  />
+                                </div>
+                                <span
+                                  class="components-amount-input__help_text"
+                                >
+                                  Leave blank for no limit
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              class="fraud-protection-rule-toggle-children-vertical-form"
+                            >
+                              <label
+                                for="fraud-protection-purchase-price-maximum"
+                              >
+                                Maximum purchase price
+                              </label>
+                              <div
+                                class="components-base-control components-amount-input__container"
+                              >
+                                <div
+                                  class="components-base-control__field components-amount-input__input_container"
+                                >
+                                  <span
+                                    class="components-amount-input__prefix"
+                                  >
+                                    $
+                                  </span>
+                                  <input
+                                    class="components-text-control__input components-amount-input__input"
+                                    data-testid="amount-input"
+                                    id="fraud-protection-purchase-price-maximum"
+                                    placeholder="0.00"
+                                    value="10"
+                                  />
+                                </div>
+                                <span
+                                  class="components-amount-input__help_text"
+                                >
+                                  Leave blank for no limit
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="order-items-threshold-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        Order Items Threshold
+                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
+                      >
+                        <div
+                          class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
+                        >
+                          <span
+                            class="components-form-toggle"
+                          >
+                            <input
+                              class="components-form-toggle__input"
+                              id="inspector-toggle-control-23"
+                              type="checkbox"
+                            />
+                            <span
+                              class="components-form-toggle__track"
+                            />
+                            <span
+                              class="components-form-toggle__thumb"
+                            />
+                          </span>
+                          <label
+                            class="components-toggle-control__label"
+                            for="inspector-toggle-control-23"
+                          >
+                            Enable Order Items Threshold filter
+                          </label>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-description"
+                      >
+                        This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="cvc-verification-card"
+              >
+                <div
+                  class="css-mgwsf4-View-Content em57xhy0"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <div>
+                      <p
+                        class="fraud-protection-rule-card-header"
+                      >
+                        CVC Verification
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
+                    >
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              class="gridicon gridicons-notice-outline"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <g>
+                                <path
+                                  d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                            <a
+                              data-link-type="external"
+                              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                              target="_blank"
+                            >
+                              Learn more
+                            </a>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <footer
+                class="fraud-protection-advanced-settings__footer"
+              >
+                <button
+                  class="components-button is-primary"
+                  type="button"
+                >
+                  Save Changes
+                </button>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        class="woocommerce-layout__header-wrapper"
+      >
+        <div
+          class="woocommerce-layout__header-heading"
+        />
+      </div>
+      <h2
+        class="fraud-protection-header-breadcrumb"
+      >
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            <span
+              class="dashicons dashicons-arrow-left-alt2"
+            />
+          </a>
+        </small>
+        Advanced fraud protection
+      </h2>
+      <div
+        class="wcpay-settings-layout"
+      >
+        <div
+          class="settings-section"
+          id="advanced-fraud"
+        >
+          <div
+            class="settings-section__details"
+          >
+            <h2>
+              Filter configuration
             </h2>
-            <p
-              class="fraud-protection-advanced-settings-notice"
-            >
-              At least one risk filter needs to be enabled for advanced protection.
+            <p>
+              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
             </p>
+          </div>
+          <div
+            class="settings-section__controls"
+          >
             <div
               class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
               data-wp-c16t="true"
@@ -5713,7 +5839,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -5723,25 +5849,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                     >
                       AVS Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -5752,7 +5863,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-18__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-18"
                             type="checkbox"
@@ -5768,15 +5878,14 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-18"
                         >
-                          Block transactions for mismatched AVS
+                          Enable AVS Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-18__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -5814,7 +5923,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -5824,39 +5933,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                     >
                       International IP Address
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for 
-                      <a
-                        data-link-type="external"
-                        href="https://simple.wikipedia.org/wiki/IP_address"
-                        target="_blank"
-                      >
-                        IP addresses
-                      </a>
-                       outside of your 
-                      <a
-                        href="admin.php?page=wc-settings&tab=general"
-                      >
-                        supported countries
-                      </a>
-                      .
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -5867,7 +5947,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-19__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-19"
                             type="checkbox"
@@ -5883,15 +5962,28 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-19"
                         >
-                          Block transactions for international IP addresses
+                          Enable International IP Address filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-19__help"
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
                       >
-                        When enabled, the payment will be blocked.
-                      </p>
+                        IP addresses
+                      </a>
+                       outside of your 
+                      <a
+                        href="admin.php?page=wc-settings&tab=general"
+                      >
+                        supported countries
+                      </a>
+                      . When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -5974,7 +6066,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -5984,33 +6076,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                     >
                       IP Address Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for customer's 
-                      <a
-                        data-link-type="external"
-                        href="https://simple.wikipedia.org/wiki/IP_address"
-                        target="_blank"
-                      >
-                        IP address
-                      </a>
-                       to see if it is in a different country than indicated in their billing address.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -6021,7 +6090,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-20__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-20"
                             type="checkbox"
@@ -6037,15 +6105,22 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-20"
                         >
-                          Screen transactions where the IP country and billing country don't match
+                          Enable IP Address Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-20__help"
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for customer's 
+                      <a
+                        data-link-type="external"
+                        href="https://simple.wikipedia.org/wiki/IP_address"
+                        target="_blank"
                       >
-                        When enabled, the payment will be blocked.
-                      </p>
+                        IP address
+                      </a>
+                       to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -6083,7 +6158,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -6093,25 +6168,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                     >
                       Address Mismatch
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter screens for differences between the shipping information and the billing information (country).
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -6122,7 +6182,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-21__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-21"
                             type="checkbox"
@@ -6138,15 +6197,14 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-21"
                         >
-                          Block transactions for mismatched addresses
+                          Enable Address Mismatch filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-21__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -6184,7 +6242,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -6194,25 +6252,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                     >
                       Purchase Price Threshold
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -6223,7 +6266,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-form-toggle is-checked"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-22__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-22"
                             type="checkbox"
@@ -6239,15 +6281,14 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-22"
                         >
-                          Block transactions for abnormal purchase prices
+                          Enable Purchase Price Threshold filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-22__help"
-                      >
-                        The payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
                     </div>
                     <div>
                       <div
@@ -6366,7 +6407,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -6376,25 +6417,10 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                     >
                       Order Items Threshold
                     </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                    </p>
                   </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
                   <div
                     class="fraud-protection-rule-toggle"
                   >
-                    <strong>
-                      Enable filtering
-                    </strong>
                     <div
                       class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
                     >
@@ -6405,7 +6431,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-form-toggle"
                         >
                           <input
-                            aria-describedby="inspector-toggle-control-23__help"
                             class="components-form-toggle__input"
                             id="inspector-toggle-control-23"
                             type="checkbox"
@@ -6421,15 +6446,14 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           class="components-toggle-control__label"
                           for="inspector-toggle-control-23"
                         >
-                          Block transactions for abnormal item counts
+                          Enable Order Items Threshold filter
                         </label>
                       </div>
-                      <p
-                        class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                        id="inspector-toggle-control-23__help"
-                      >
-                        When enabled, the payment will be blocked.
-                      </p>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-toggle-description"
+                    >
+                      This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
                     </div>
                   </div>
                   <div
@@ -6467,7 +6491,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 class="css-mgwsf4-View-Content em57xhy0"
               >
                 <div
-                  class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
                   data-wp-c16t="true"
                   data-wp-component="CardBody"
                 >
@@ -6476,28 +6500,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                       class="fraud-protection-rule-card-header"
                     >
                       CVC Verification
-                    </p>
-                    <p
-                      class="fraud-protection-rule-card-description"
-                    >
-                      This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                    </p>
-                  </div>
-                </div>
-                <hr />
-                <div
-                  class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
                     </p>
                   </div>
                   <div
@@ -6550,6 +6552,16 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                       />
                     </div>
                   </div>
+                  <div
+                    class="fraud-protection-rule-description"
+                  >
+                    <strong>
+                      How does this filter protect me?
+                    </strong>
+                    <p>
+                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                    </p>
+                  </div>
                 </div>
               </div>
               <div
@@ -6568,12 +6580,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
             <footer
               class="fraud-protection-advanced-settings__footer"
             >
-              <a
-                class="components-button is-secondary"
-                href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-              >
-                Back to Payments Settings
-              </a>
               <button
                 class="components-button is-primary"
                 type="button"
@@ -6582,930 +6588,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
               </button>
             </footer>
           </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div>
-      <div
-        class="woocommerce-layout__header-wrapper"
-      >
-        <div
-          class="woocommerce-layout__header-heading"
-        />
-        <div
-          class="fraud-protection-header-save-button"
-        >
-          <button
-            class="components-button is-primary"
-            type="button"
-          >
-            Save Changes
-          </button>
-        </div>
-      </div>
-      <div
-        class="wcpay-settings-layout"
-      >
-        <div
-          class="fraud-protection-advanced-settings-layout"
-        >
-          <h2
-            class="fraud-protection-header-breadcrumb"
-          >
-            <a
-              data-link-type="wp-admin"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              WooPayments
-            </a>
-             &gt; 
-            Advanced fraud protection
-          </h2>
-          <p
-            class="fraud-protection-advanced-settings-notice"
-          >
-            At least one risk filter needs to be enabled for advanced protection.
-          </p>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="avs-mismatch-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    AVS Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-18__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-18"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-18"
-                      >
-                        Block transactions for mismatched AVS
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-18__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="international-ip-address-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    International IP Address
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP addresses
-                    </a>
-                     outside of your 
-                    <a
-                      href="admin.php?page=wc-settings&tab=general"
-                    >
-                      supported countries
-                    </a>
-                    .
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-19__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-19"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-19"
-                      >
-                        Block transactions for international IP addresses
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-19__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-info-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-info components-notice is-info"
-                >
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          size="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                        >
-                          <path
-                            d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        Orders from outside of the following countries will be blocked by the filter: 
-                        <strong>
-                          Canada, United States
-                        </strong>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="ip-address-mismatch"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    IP Address Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for customer's 
-                    <a
-                      data-link-type="external"
-                      href="https://simple.wikipedia.org/wiki/IP_address"
-                      target="_blank"
-                    >
-                      IP address
-                    </a>
-                     to see if it is in a different country than indicated in their billing address.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-20__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-20"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-20"
-                      >
-                        Screen transactions where the IP country and billing country don't match
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-20__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="address-mismatch-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Address Mismatch
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter screens for differences between the shipping information and the billing information (country).
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-21__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-21"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-21"
-                      >
-                        Block transactions for mismatched addresses
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-21__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="purchase-price-threshold-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Purchase Price Threshold
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle is-checked"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-22__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-22"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-22"
-                      >
-                        Block transactions for abnormal purchase prices
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-22__help"
-                    >
-                      The payment will be blocked.
-                    </p>
-                  </div>
-                  <div>
-                    <div
-                      class="fraud-protection-rule-toggle-children-container"
-                    >
-                      <strong>
-                        Limits
-                      </strong>
-                      <div
-                        class="fraud-protection-rule-toggle-children-horizontal-form"
-                      >
-                        <div
-                          class="fraud-protection-rule-toggle-children-vertical-form"
-                        >
-                          <label
-                            for="fraud-protection-purchase-price-minimum"
-                          >
-                            Minimum purchase price
-                          </label>
-                          <div
-                            class="components-base-control components-amount-input__container"
-                          >
-                            <div
-                              class="components-base-control__field components-amount-input__input_container"
-                            >
-                              <span
-                                class="components-amount-input__prefix"
-                              >
-                                $
-                              </span>
-                              <input
-                                class="components-text-control__input components-amount-input__input"
-                                data-testid="amount-input"
-                                id="fraud-protection-purchase-price-minimum"
-                                placeholder="0.00"
-                                value="1"
-                              />
-                            </div>
-                            <span
-                              class="components-amount-input__help_text"
-                            >
-                              Leave blank for no limit
-                            </span>
-                          </div>
-                        </div>
-                        <div
-                          class="fraud-protection-rule-toggle-children-vertical-form"
-                        >
-                          <label
-                            for="fraud-protection-purchase-price-maximum"
-                          >
-                            Maximum purchase price
-                          </label>
-                          <div
-                            class="components-base-control components-amount-input__container"
-                          >
-                            <div
-                              class="components-base-control__field components-amount-input__input_container"
-                            >
-                              <span
-                                class="components-amount-input__prefix"
-                              >
-                                $
-                              </span>
-                              <input
-                                class="components-text-control__input components-amount-input__input"
-                                data-testid="amount-input"
-                                id="fraud-protection-purchase-price-maximum"
-                                placeholder="0.00"
-                                value="10"
-                              />
-                            </div>
-                            <span
-                              class="components-amount-input__help_text"
-                            >
-                              Leave blank for no limit
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="order-items-threshold-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    Order Items Threshold
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter compares the amount of items in an order to the minimum and maximum counts that you specify.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <strong>
-                    Enable filtering
-                  </strong>
-                  <div
-                    class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
-                  >
-                    <div
-                      class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
-                    >
-                      <span
-                        class="components-form-toggle"
-                      >
-                        <input
-                          aria-describedby="inspector-toggle-control-23__help"
-                          class="components-form-toggle__input"
-                          id="inspector-toggle-control-23"
-                          type="checkbox"
-                        />
-                        <span
-                          class="components-form-toggle__track"
-                        />
-                        <span
-                          class="components-form-toggle__thumb"
-                        />
-                      </span>
-                      <label
-                        class="components-toggle-control__label"
-                        for="inspector-toggle-control-23"
-                      >
-                        Block transactions for abnormal item counts
-                      </label>
-                    </div>
-                    <p
-                      class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-                      id="inspector-toggle-control-23__help"
-                    >
-                      When enabled, the payment will be blocked.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card css-nsno0f-View-Surface-getBorders-primary-Card-rounded em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="cvc-verification-card"
-          >
-            <div
-              class="css-mgwsf4-View-Content em57xhy0"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <p
-                    class="fraud-protection-rule-card-header"
-                  >
-                    CVC Verification
-                  </p>
-                  <p
-                    class="fraud-protection-rule-card-description"
-                  >
-                    This filter checks the security code submitted by the customer against the data on file with the card issuer.
-                  </p>
-                </div>
-              </div>
-              <hr />
-              <div
-                class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-warning-notice fraud-protection-rule-card-notice fraud-protection-rule-card-notice-warning components-notice is-warning"
-                >
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex css-bmzg3m-View-Flex-sx-Base-sx-Items-ItemsRow em57xhy0"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          class="gridicon gridicons-notice-outline"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g>
-                            <path
-                              d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                            />
-                          </g>
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content css-mw3lhz-View-Item-sx-Base em57xhy0"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                        <a
-                          data-link-type="external"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                          target="_blank"
-                        >
-                          Learn more
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation css-91yjwm-View-Elevation-sx-Base-elevationClassName em57xhy0"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <footer
-            class="fraud-protection-advanced-settings__footer"
-          >
-            <a
-              class="components-button is-secondary"
-              href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-            >
-              Back to Payments Settings
-            </a>
-            <button
-              class="components-button is-primary"
-              type="button"
-            >
-              Save Changes
-            </button>
-          </footer>
         </div>
       </div>
     </div>

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.tsx.snap
@@ -39,19 +39,17 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
           />
         </div>
         <h2
-          class="fraud-protection-header-breadcrumb"
+          class="fraud-protection-header-breadcrumb-old"
         >
+          Advanced fraud protection
           <small>
             <a
               data-link-type="wp-admin"
               href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
             >
-              <span
-                class="dashicons dashicons-arrow-left-alt2"
-              />
+              ⤴︎
             </a>
           </small>
-          Advanced fraud protection
         </h2>
         <div
           class="wcpay-settings-layout"
@@ -927,19 +925,17 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
         />
       </div>
       <h2
-        class="fraud-protection-header-breadcrumb"
+        class="fraud-protection-header-breadcrumb-old"
       >
+        Advanced fraud protection
         <small>
           <a
             data-link-type="wp-admin"
             href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
           >
-            <span
-              class="dashicons dashicons-arrow-left-alt2"
-            />
+            ⤴︎
           </a>
         </small>
-        Advanced fraud protection
       </h2>
       <div
         class="wcpay-settings-layout"
@@ -1897,19 +1893,17 @@ exports[`Advanced fraud protection settings renders an error message when settin
           />
         </div>
         <h2
-          class="fraud-protection-header-breadcrumb"
+          class="fraud-protection-header-breadcrumb-old"
         >
+          Advanced fraud protection
           <small>
             <a
               data-link-type="wp-admin"
               href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
             >
-              <span
-                class="dashicons dashicons-arrow-left-alt2"
-              />
+              ⤴︎
             </a>
           </small>
-          Advanced fraud protection
         </h2>
         <div
           class="wcpay-settings-layout"
@@ -2641,19 +2635,17 @@ exports[`Advanced fraud protection settings renders an error message when settin
         />
       </div>
       <h2
-        class="fraud-protection-header-breadcrumb"
+        class="fraud-protection-header-breadcrumb-old"
       >
+        Advanced fraud protection
         <small>
           <a
             data-link-type="wp-admin"
             href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
           >
-            <span
-              class="dashicons dashicons-arrow-left-alt2"
-            />
+            ⤴︎
           </a>
         </small>
-        Advanced fraud protection
       </h2>
       <div
         class="wcpay-settings-layout"
@@ -3459,19 +3451,17 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
     </div>
     <div>
       <h2
-        class="fraud-protection-header-breadcrumb"
+        class="fraud-protection-header-breadcrumb-old"
       >
+        Advanced fraud protection
         <small>
           <a
             data-link-type="wp-admin"
             href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
           >
-            <span
-              class="dashicons dashicons-arrow-left-alt2"
-            />
+            ⤴︎
           </a>
         </small>
-        Advanced fraud protection
       </h2>
       <div
         class="wcpay-settings-layout"
@@ -4178,19 +4168,17 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
   </body>,
   "container": <div>
     <h2
-      class="fraud-protection-header-breadcrumb"
+      class="fraud-protection-header-breadcrumb-old"
     >
+      Advanced fraud protection
       <small>
         <a
           data-link-type="wp-admin"
           href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
         >
-          <span
-            class="dashicons dashicons-arrow-left-alt2"
-          />
+          ⤴︎
         </a>
       </small>
-      Advanced fraud protection
     </h2>
     <div
       class="wcpay-settings-layout"
@@ -4987,19 +4975,17 @@ exports[`Advanced fraud protection settings saves settings when there are no val
           />
         </div>
         <h2
-          class="fraud-protection-header-breadcrumb"
+          class="fraud-protection-header-breadcrumb-old"
         >
+          Advanced fraud protection
           <small>
             <a
               data-link-type="wp-admin"
               href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
             >
-              <span
-                class="dashicons dashicons-arrow-left-alt2"
-              />
+              ⤴︎
             </a>
           </small>
-          Advanced fraud protection
         </h2>
         <div
           class="wcpay-settings-layout"
@@ -5795,19 +5781,17 @@ exports[`Advanced fraud protection settings saves settings when there are no val
         />
       </div>
       <h2
-        class="fraud-protection-header-breadcrumb"
+        class="fraud-protection-header-breadcrumb-old"
       >
+        Advanced fraud protection
         <small>
           <a
             data-link-type="wp-admin"
             href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
           >
-            <span
-              class="dashicons dashicons-arrow-left-alt2"
-            />
+            ⤴︎
           </a>
         </small>
-        Advanced fraud protection
       </h2>
       <div
         class="wcpay-settings-layout"

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/rule-card.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/rule-card.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Fraud protection rule card tests renders correctly 1`] = `
           class="css-mgwsf4-View-Content em57xhy0"
         >
           <div
-            class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+            class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
             data-wp-c16t="true"
             data-wp-component="CardBody"
           >
@@ -49,19 +49,7 @@ exports[`Fraud protection rule card tests renders correctly 1`] = `
               >
                 test title
               </p>
-              <p
-                class="fraud-protection-rule-card-description"
-              >
-                test description
-              </p>
             </div>
-          </div>
-          <hr />
-          <div
-            class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-            data-wp-c16t="true"
-            data-wp-component="CardBody"
-          >
             test content
           </div>
         </div>
@@ -91,7 +79,7 @@ exports[`Fraud protection rule card tests renders correctly 1`] = `
         class="css-mgwsf4-View-Content em57xhy0"
       >
         <div
-          class="components-card__body components-card-body wcpay-card-body fraud-protection-rule-card-header-container css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
+          class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
           data-wp-c16t="true"
           data-wp-component="CardBody"
         >
@@ -101,19 +89,7 @@ exports[`Fraud protection rule card tests renders correctly 1`] = `
             >
               test title
             </p>
-            <p
-              class="fraud-protection-rule-card-description"
-            >
-              test description
-            </p>
           </div>
-        </div>
-        <hr />
-        <div
-          class="components-card__body components-card-body wcpay-card-body css-1nwhnu3-View-Body-borderRadius-medium em57xhy0"
-          data-wp-c16t="true"
-          data-wp-component="CardBody"
-        >
           test content
         </div>
       </div>

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/rule-toggle.test.tsx.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/rule-toggle.test.tsx.snap
@@ -32,9 +32,6 @@ exports[`Fraud protection rule toggle tests renders correctly when disabled 1`] 
       <div
         class="fraud-protection-rule-toggle"
       >
-        <strong>
-          Enable filtering
-        </strong>
         <div
           class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
         >
@@ -45,7 +42,6 @@ exports[`Fraud protection rule toggle tests renders correctly when disabled 1`] 
               class="components-form-toggle"
             >
               <input
-                aria-describedby="inspector-toggle-control-0__help"
                 class="components-form-toggle__input"
                 id="inspector-toggle-control-0"
                 type="checkbox"
@@ -64,12 +60,11 @@ exports[`Fraud protection rule toggle tests renders correctly when disabled 1`] 
               Test rule toggle
             </label>
           </div>
-          <p
-            class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-            id="inspector-toggle-control-0__help"
-          >
-            When enabled, the payment will be blocked.
-          </p>
+        </div>
+        <div
+          class="fraud-protection-rule-toggle-description"
+        >
+          Test rule toggle description
         </div>
       </div>
     </div>
@@ -78,9 +73,6 @@ exports[`Fraud protection rule toggle tests renders correctly when disabled 1`] 
     <div
       class="fraud-protection-rule-toggle"
     >
-      <strong>
-        Enable filtering
-      </strong>
       <div
         class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
       >
@@ -91,7 +83,6 @@ exports[`Fraud protection rule toggle tests renders correctly when disabled 1`] 
             class="components-form-toggle"
           >
             <input
-              aria-describedby="inspector-toggle-control-0__help"
               class="components-form-toggle__input"
               id="inspector-toggle-control-0"
               type="checkbox"
@@ -110,12 +101,11 @@ exports[`Fraud protection rule toggle tests renders correctly when disabled 1`] 
             Test rule toggle
           </label>
         </div>
-        <p
-          class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-          id="inspector-toggle-control-0__help"
-        >
-          When enabled, the payment will be blocked.
-        </p>
+      </div>
+      <div
+        class="fraud-protection-rule-toggle-description"
+      >
+        Test rule toggle description
       </div>
     </div>
   </div>,
@@ -205,9 +195,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
       <div
         class="fraud-protection-rule-toggle"
       >
-        <strong>
-          Enable filtering
-        </strong>
         <div
           class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
         >
@@ -218,7 +205,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
               class="components-form-toggle is-checked"
             >
               <input
-                aria-describedby="inspector-toggle-control-1__help"
                 checked=""
                 class="components-form-toggle__input"
                 id="inspector-toggle-control-1"
@@ -238,12 +224,11 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
               Test rule toggle
             </label>
           </div>
-          <p
-            class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-            id="inspector-toggle-control-1__help"
-          >
-            The payment will be blocked.
-          </p>
+        </div>
+        <div
+          class="fraud-protection-rule-toggle-description"
+        >
+          Test rule toggle description
         </div>
         <div>
           test content
@@ -255,9 +240,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
     <div
       class="fraud-protection-rule-toggle"
     >
-      <strong>
-        Enable filtering
-      </strong>
       <div
         class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
       >
@@ -268,7 +250,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
             class="components-form-toggle is-checked"
           >
             <input
-              aria-describedby="inspector-toggle-control-1__help"
               checked=""
               class="components-form-toggle__input"
               id="inspector-toggle-control-1"
@@ -288,12 +269,11 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled 1`] =
             Test rule toggle
           </label>
         </div>
-        <p
-          class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-          id="inspector-toggle-control-1__help"
-        >
-          The payment will be blocked.
-        </p>
+      </div>
+      <div
+        class="fraud-protection-rule-toggle-description"
+      >
+        Test rule toggle description
       </div>
       <div>
         test content
@@ -386,9 +366,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
       <div
         class="fraud-protection-rule-toggle"
       >
-        <strong>
-          Enable filtering
-        </strong>
         <div
           class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
         >
@@ -399,7 +376,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
               class="components-form-toggle is-checked"
             >
               <input
-                aria-describedby="inspector-toggle-control-2__help"
                 checked=""
                 class="components-form-toggle__input"
                 id="inspector-toggle-control-2"
@@ -419,12 +395,11 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
               Test rule toggle
             </label>
           </div>
-          <p
-            class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-            id="inspector-toggle-control-2__help"
-          >
-            The payment will be blocked.
-          </p>
+        </div>
+        <div
+          class="fraud-protection-rule-toggle-description"
+        >
+          Test rule toggle description
         </div>
         <div>
           test content
@@ -436,9 +411,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
     <div
       class="fraud-protection-rule-toggle"
     >
-      <strong>
-        Enable filtering
-      </strong>
       <div
         class="components-base-control components-toggle-control fraud-protection-rule-toggle-toggle css-wdf2ti-Wrapper ej5x27r4"
       >
@@ -449,7 +421,6 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
             class="components-form-toggle is-checked"
           >
             <input
-              aria-describedby="inspector-toggle-control-2__help"
               checked=""
               class="components-form-toggle__input"
               id="inspector-toggle-control-2"
@@ -469,12 +440,11 @@ exports[`Fraud protection rule toggle tests renders correctly when enabled and b
             Test rule toggle
           </label>
         </div>
-        <p
-          class="components-base-control__help css-v0euhr-StyledHelp-deprecatedMarginHelp ej5x27r1"
-          id="inspector-toggle-control-2__help"
-        >
-          The payment will be blocked.
-        </p>
+      </div>
+      <div
+        class="fraud-protection-rule-toggle-description"
+      >
+        Test rule toggle description
       </div>
       <div>
         test content

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -211,13 +211,9 @@ describe( 'Advanced fraud protection settings', () => {
 			/There was an error retrieving your fraud protection settings/i
 		);
 
-		const [
-			firstSaveButton,
-			secondSaveButton,
-		] = await container.findAllByText( 'Save Changes' );
+		const saveButton = await container.findByText( 'Save Changes' );
 
-		expect( firstSaveButton ).toBeDisabled();
-		expect( secondSaveButton ).toBeDisabled();
+		expect( saveButton ).toBeDisabled();
 	} );
 	test( "doesn't save when there's a validation error", async () => {
 		defaultSettings.push( {
@@ -260,7 +256,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 
 		const avsThresholdToggle = await container.findByLabelText(
-			'Block transactions for mismatched AVS'
+			'Enable AVS Mismatch filter'
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
@@ -313,7 +309,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 
 		const avsThresholdToggle = await container.findByLabelText(
-			'Block transactions for mismatched AVS'
+			'Enable AVS Mismatch filter'
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
@@ -380,7 +376,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 
 		const avsThresholdToggle = await container.findByLabelText(
-			'Block transactions for mismatched AVS'
+			'Enable AVS Mismatch filter'
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
@@ -451,7 +447,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 
 		const avsThresholdToggle = await container.findByLabelText(
-			'Block transactions for mismatched AVS'
+			'Enable AVS Mismatch filter'
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
@@ -504,7 +500,7 @@ describe( 'Advanced fraud protection settings', () => {
 			</div>
 		);
 		const avsThresholdToggle = await container.findByLabelText(
-			'Block transactions for mismatched AVS'
+			'Enable AVS Mismatch filter'
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -55,6 +55,7 @@ declare const global: {
 		countries: {
 			[ key: string ]: string;
 		};
+		wcVersion: string;
 	};
 	wcpaySettings: {
 		storeCurrency: string;
@@ -126,6 +127,7 @@ describe( 'Advanced fraud protection settings', () => {
 				CA: 'Canada',
 				US: 'United States',
 			},
+			wcVersion: '9.8.1',
 		};
 
 		global.wcpaySettings = {

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.tsx
@@ -213,7 +213,7 @@ describe( 'Advanced fraud protection settings', () => {
 			/There was an error retrieving your fraud protection settings/i
 		);
 
-		const saveButton = await container.findByText( 'Save Changes' );
+		const saveButton = await container.findByText( 'Save changes' );
 
 		expect( saveButton ).toBeDisabled();
 	} );
@@ -262,7 +262,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
-		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
+		const [ saveButton ] = await container.findAllByText( 'Save changes' );
 		saveButton.click();
 		expect( mockUseSettings().saveSettings.mock.calls.length ).toBe( 0 );
 		expect( container ).toMatchSnapshot();
@@ -315,7 +315,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
-		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
+		const [ saveButton ] = await container.findAllByText( 'Save changes' );
 		saveButton.click();
 		await waitFor( () => {
 			expect( mockUseSettings().saveSettings.mock.calls.length ).toBe(
@@ -382,7 +382,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
-		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
+		const [ saveButton ] = await container.findAllByText( 'Save changes' );
 		saveButton.click();
 		await waitFor( () => {
 			expect( mockUseSettings().saveSettings.mock.calls.length ).toBe(
@@ -453,7 +453,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
-		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
+		const [ saveButton ] = await container.findAllByText( 'Save changes' );
 		saveButton.click();
 		await waitFor( () => {
 			expect( mockUseSettings().saveSettings.mock.calls.length ).toBe(
@@ -506,7 +506,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 		avsThresholdToggle.click();
 		avsThresholdToggle.click();
-		const [ saveButton ] = await container.findAllByText( 'Save Changes' );
+		const [ saveButton ] = await container.findAllByText( 'Save changes' );
 
 		saveButton.click();
 		await waitFor( () => {

--- a/client/settings/fraud-protection/advanced-settings/test/rule-card.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-card.test.tsx
@@ -10,11 +10,7 @@ import FraudProtectionRuleCard from '../rule-card';
 describe( 'Fraud protection rule card tests', () => {
 	test( 'renders correctly', () => {
 		const container = render(
-			<FraudProtectionRuleCard
-				title="test title"
-				description="test description"
-				id="test-id"
-			>
+			<FraudProtectionRuleCard title="test title" id="test-id">
 				test content
 			</FraudProtectionRuleCard>
 		);

--- a/client/settings/fraud-protection/advanced-settings/test/rule-card.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-card.test.tsx
@@ -16,9 +16,6 @@ describe( 'Fraud protection rule card tests', () => {
 		);
 		expect( container ).toMatchSnapshot();
 		expect( container.queryByText( 'test title' ) ).toBeInTheDocument();
-		expect(
-			container.queryByText( 'test description' )
-		).toBeInTheDocument();
 		expect( container.queryByText( 'test content' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -63,6 +63,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 				<FraudProtectionRuleToggle
 					setting={ 'test_rule' }
 					label={ 'Test rule toggle' }
+					description={ 'Test rule toggle description' }
 				>
 					test content
 				</FraudProtectionRuleToggle>
@@ -91,6 +92,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 				<FraudProtectionRuleToggle
 					setting={ 'test_rule' }
 					label={ 'Test rule toggle' }
+					description={ 'Test rule toggle description' }
 				>
 					test content
 				</FraudProtectionRuleToggle>
@@ -114,6 +116,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 				<FraudProtectionRuleToggle
 					setting={ 'test_rule' }
 					label={ 'Test rule toggle' }
+					description={ 'Test rule toggle description' }
 				>
 					test content
 				</FraudProtectionRuleToggle>
@@ -137,6 +140,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 				<FraudProtectionRuleToggle
 					setting={ 'test_rule' }
 					label={ 'Test rule toggle' }
+					description={ 'Test rule toggle description' }
 				>
 					test content
 				</FraudProtectionRuleToggle>

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.tsx
@@ -74,11 +74,6 @@ describe( 'Fraud protection rule toggle tests', () => {
 			container.getByLabelText( 'Test rule toggle' )
 		).not.toBeChecked();
 		expect(
-			container.queryByText(
-				'When enabled, the payment will be blocked.'
-			)
-		).toBeInTheDocument();
-		expect(
 			container.queryByText( 'Test rule toggle' )
 		).toBeInTheDocument();
 		expect(
@@ -100,9 +95,6 @@ describe( 'Fraud protection rule toggle tests', () => {
 		);
 		expect( container ).toMatchSnapshot();
 		expect(
-			container.queryByText( 'The payment will be blocked.' )
-		).toBeInTheDocument();
-		expect(
 			container.queryByText( 'Test rule toggle' )
 		).toBeInTheDocument();
 		expect( container.getByLabelText( 'Test rule toggle' ) ).toBeChecked();
@@ -123,9 +115,6 @@ describe( 'Fraud protection rule toggle tests', () => {
 			</FraudPreventionSettingsContext.Provider>
 		);
 		expect( container ).toMatchSnapshot();
-		expect(
-			container.queryByText( 'The payment will be blocked.' )
-		).toBeInTheDocument();
 		expect(
 			container.queryByText( 'Test rule toggle' )
 		).toBeInTheDocument();

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -3,8 +3,13 @@ body {
 	&.woocommerce-admin-page__payments_fraud-protection {
 		background: #fff;
 		.wcpay-settings-layout {
-			margin: 24px 0 0;
+			margin: 40px 0 0;
 			max-width: 1184px;
+		}
+		@media screen and ( max-width: 782px ) {
+			.woocommerce-layout .woocommerce-layout__main {
+				padding-top: 0; // reduce the padding in mobile view (it's too big)
+			}
 		}
 		.woocommerce-layout__header {
 			&-heading {
@@ -18,6 +23,11 @@ body {
 		}
 		#woocommerce-activity-panel {
 			display: none;
+		}
+		.settings-section__details {
+			h2 {
+				margin-top: 0; // align section header and details by reducing h2 margin
+			}
 		}
 	}
 }
@@ -202,7 +212,7 @@ body {
 
 		strong,
 		&-toggle > div {
-			margin: 0 0 12px;
+			margin: 0 0 8px;
 		}
 
 		&-block {
@@ -223,7 +233,7 @@ body {
 
 		&-children {
 			&-container {
-				margin-bottom: 24px;
+				margin: 24px 0;
 
 				.components-base-control__help {
 					margin-bottom: 0;
@@ -240,6 +250,9 @@ body {
 				flex: 1;
 				flex-direction: column;
 				gap: $gap-smaller;
+			}
+			&-notice {
+				margin-top: -24px; // to override default notice margin
 			}
 		}
 	}

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -67,7 +67,11 @@ body {
 	}
 	// Have this until further redesign of the breadcrumbs.
 	&-header-breadcrumb {
-		margin: 0;
+		&-old {
+			small {
+				margin-left: 0.5em;
+			}
+		}
 		small {
 			margin-right: 0.5em;
 		}

--- a/client/settings/fraud-protection/style.scss
+++ b/client/settings/fraud-protection/style.scss
@@ -1,3 +1,27 @@
+// Override body and header for Advanced fraud settings page to be consistent with other settings pages.
+body {
+	&.woocommerce-admin-page__payments_fraud-protection {
+		background: #fff;
+		.wcpay-settings-layout {
+			margin: 24px 0 0;
+			max-width: 1184px;
+		}
+		.woocommerce-layout__header {
+			&-heading {
+				font-size: 16px;
+				padding: 0 0 0 30px;
+			}
+			border-bottom: 1px solid #ddd;
+		}
+		.woocommerce-layout__primary {
+			margin: 24px 0 128px 30px;
+		}
+		#woocommerce-activity-panel {
+			display: none;
+		}
+	}
+}
+
 .fraud-protection {
 	&-advanced-settings {
 		&-layout {
@@ -41,18 +65,19 @@
 			}
 		}
 	}
+	// Have this until further redesign of the breadcrumbs.
 	&-header-breadcrumb {
-		margin-top: 0;
-		margin-bottom: 8px;
-		@media screen and ( min-width: 961px ) {
-			margin-top: -16px;
+		margin: 0;
+		small {
+			margin-right: 0.5em;
 		}
-		@media screen and ( max-width: 782px ) {
-			margin-top: -36px;
+		a {
+			color: #1d2327;
+			text-decoration: none;
 		}
-	}
-	&-header-save-button {
-		margin-right: 8px;
+		a:hover {
+			color: var( --wp-admin-theme-color, #3858e9 );
+		}
 	}
 
 	&-radio-wrapper {
@@ -140,7 +165,7 @@
 	}
 
 	&-rule-toggle {
-		margin-bottom: 24px;
+		margin-bottom: 24px !important; // override due to very high logic applied for .wcpay-card-body > *
 		strong {
 			font-size: 13px;
 			font-weight: 600;
@@ -148,10 +173,12 @@
 			color: #1e1e1e;
 			display: block;
 		}
-
+		&-description {
+			padding-left: 40px;
+			font-size: 12px;
+			color: #757575;
+		}
 		&-toggle {
-			margin-bottom: 24px;
-
 			label {
 				padding-left: 8px;
 				line-height: 21px;
@@ -214,27 +241,16 @@
 	}
 
 	&-rule-card {
+		margin-bottom: 24px;
 		&-header-container {
 			padding: 16px 24px;
 		}
 		&-header {
-			margin: 0 0 4px 0;
-			font-size: 20px;
-			line-height: 28px;
-			font-weight: 400;
-			color: #1e1e1e;
-		}
-		&-description {
-			margin: 0;
+			margin: 0 0 24px 0;
 			font-size: 14px;
-			line-height: 18px;
-			font-weight: 400;
-			color: #757575;
-		}
-		hr {
-			margin: 0;
-			border-bottom: 1px solid #e0e0e0;
-			border-top: 0;
+			line-height: 20px;
+			font-weight: 600;
+			color: #1e1e1e;
 		}
 	}
 

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -247,3 +247,21 @@ export const objectRemoveEmptyProperties = ( obj ) => {
 		.filter( ( k ) => obj[ k ] !== null && obj[ k ] !== undefined )
 		.reduce( ( a, k ) => ( { ...a, [ k ]: obj[ k ] } ), {} );
 };
+
+/**
+ * Checks if the passed version is greater than base.
+ *
+ * @param {string} version Version that is compared.
+ * @param {string} base Version to compare with.
+ * @return {boolean} Whether version is greater than base.
+ */
+export const isVersionGreater = ( version, base ) => {
+	const parse = ( v ) => v.split( '.' ).map( Number );
+	const [ v1, v2, v3 ] = parse( version );
+	const [ b1, b2, b3 ] = parse( base );
+	return (
+		v1 > b1 ||
+		( v1 === b1 && v2 > b2 ) ||
+		( v1 === b1 && v2 === b2 && v3 >= b3 )
+	);
+};

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -249,16 +249,18 @@ export const objectRemoveEmptyProperties = ( obj ) => {
 };
 
 /**
- * Checks if the passed version is greater than base.
+ * Checks if the passed version is greater than or equal to the base version.
+ *
+ * Supports semantic version strings like "1.2.3-beta" by ignoring pre-release tags.
  *
  * @param {string} version Version that is compared.
  * @param {string} base Version to compare with.
- * @return {boolean} Whether version is greater than base.
+ * @return {boolean} Whether version is greater than or equal to base.
  */
-export const isVersionGreater = ( version, base ) => {
-	const parse = ( v ) => v.split( '.' ).map( Number );
-	const [ v1, v2, v3 ] = parse( version );
-	const [ b1, b2, b3 ] = parse( base );
+export const isVersionGreaterOrEqual = ( version, base ) => {
+	const parse = ( v ) => v.split( '-' )[ 0 ].split( '.' ).map( Number );
+	const [ v1 = 0, v2 = 0, v3 = 0 ] = parse( version );
+	const [ b1 = 0, b2 = 0, b3 = 0 ] = parse( base );
 	return (
 		v1 > b1 ||
 		( v1 === b1 && v2 > b2 ) ||

--- a/client/utils/test/index.js
+++ b/client/utils/test/index.js
@@ -3,7 +3,11 @@
 /**
  * Internal dependencies
  */
-import { getDocumentUrl, getPaymentMethodSettingsUrl } from '../index';
+import {
+	getDocumentUrl,
+	getPaymentMethodSettingsUrl,
+	isVersionGreaterOrEqual,
+} from '../index';
 
 describe( 'Utilities', () => {
 	test( 'payment method settings link matches expected', () => {
@@ -16,5 +20,32 @@ describe( 'Utilities', () => {
 		expect( getDocumentUrl( 'documentID' ) ).toEqual(
 			'https://site.com/wp-json/wc/v3/payments/documents/documentID?_wpnonce=random_wp_rest_nonce'
 		);
+	} );
+} );
+
+describe( 'isVersionGreaterOrEqual', () => {
+	it( 'treats pre-release as equal to same numeric version', () => {
+		expect( isVersionGreaterOrEqual( '9.4.5-beta', '9.4.5' ) ).toBe( true );
+		expect( isVersionGreaterOrEqual( '9.4.5', '9.4.5-beta' ) ).toBe( true );
+	} );
+
+	it( 'returns true when version is greater in major/minor/patch', () => {
+		expect( isVersionGreaterOrEqual( '10.0.0', '9.9.9' ) ).toBe( true );
+		expect( isVersionGreaterOrEqual( '9.5.0', '9.4.9' ) ).toBe( true );
+		expect( isVersionGreaterOrEqual( '9.4.6', '9.4.5' ) ).toBe( true );
+	} );
+
+	it( 'returns true when versions are equal', () => {
+		expect( isVersionGreaterOrEqual( '9.4.5', '9.4.5' ) ).toBe( true );
+	} );
+
+	it( 'returns false when version is smaller', () => {
+		expect( isVersionGreaterOrEqual( '9.4.4', '9.4.5' ) ).toBe( false );
+		expect( isVersionGreaterOrEqual( '9.3.9', '9.4.0' ) ).toBe( false );
+	} );
+
+	it( 'handles versions with missing patch/minor', () => {
+		expect( isVersionGreaterOrEqual( '9.4', '9.4.0' ) ).toBe( true );
+		expect( isVersionGreaterOrEqual( '9', '9.0.0' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes WOOPMNT-4905

#### Changes proposed in this Pull Request

- Redesign of the Advanced fraud protection settings page according to the designs in Figma.
- Make page consistent with other settings pages

| Before  | After |
| ------------- | ------------- | 
| ![image](https://github.com/user-attachments/assets/19702d95-48fe-4441-a46c-e9b5d75083ac) | ![image](https://github.com/user-attachments/assets/6c3253d6-5336-426b-9a29-04430fe61d24) |

#### Testing instructions

* Check out this branch locally / 🚀 [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=update/woopmnt-4905-fraud-settings-redesign) 🚀
* Onboard test drive account from the connect page (just to create account quickly)
![image](https://github.com/user-attachments/assets/7b9ec2c2-fcdf-464f-a91a-d43a0f49621c)
* After it is created, go into WooPayments Settings -> Fraud Protection and enable Advanced and Click Configure
![image](https://github.com/user-attachments/assets/575a6775-85e7-4e23-aa49-be5162aed09b)
* Check that page design is updated. Check that back button works.
![image](https://github.com/user-attachments/assets/26bf13f4-6464-49cc-a0a3-7ae482d1d0e4)
* Smoke test saving advanced checks, that it still works.
* bonus for devs: Install WooCommerce 9.9.0 and check that back button has updated design.
![image](https://github.com/user-attachments/assets/6c3253d6-5336-426b-9a29-04430fe61d24) 
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
