### PR TITLE
Hotfix/account session updates

### DIFF
--- a/changelog/dev-fix-account-session
+++ b/changelog/dev-fix-account-session
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix for validation issue with POST params in some cases generating account session.

--- a/changelog/dev-fix-account-session
+++ b/changelog/dev-fix-account-session
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix for validation issue with POST params in some cases generating account session.

--- a/changelog/update-route-definition
+++ b/changelog/update-route-definition
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update account session creation route definition to use POST rather than GET.

--- a/client/embedded-components/hooks.tsx
+++ b/client/embedded-components/hooks.tsx
@@ -33,13 +33,21 @@ export const createKycAccountSession = async (
 	isPoEligible: boolean
 ): Promise< AccountSession > => {
 	const urlParams = new URLSearchParams( window.location.search );
+	const selfAssessmentData = fromDotNotation( data );
+
+	const requestData: Record< string, unknown > = {
+		capabilities: urlParams.get( 'capabilities' ) || '',
+		progressive: isPoEligible,
+	};
+
+	// Only pass the self assessment data if at least one field is set.
+	if ( Object.keys( selfAssessmentData ).length > 0 ) {
+		requestData.self_assessment = selfAssessmentData;
+	}
+
 	return await apiFetch< AccountSession >( {
 		path: `${ NAMESPACE }/onboarding/kyc/session`,
 		method: 'POST',
-		data: {
-			self_assessment: fromDotNotation( data ),
-			capabilities: urlParams.get( 'capabilities' ) || '',
-			progressive: isPoEligible,
-		},
+		data: requestData,
 	} );
 };

--- a/client/embedded-components/hooks.tsx
+++ b/client/embedded-components/hooks.tsx
@@ -33,21 +33,14 @@ export const createKycAccountSession = async (
 	isPoEligible: boolean
 ): Promise< AccountSession > => {
 	const urlParams = new URLSearchParams( window.location.search );
-	const selfAssessmentData = fromDotNotation( data );
-
-	const requestData: Record< string, unknown > = {
-		capabilities: urlParams.get( 'capabilities' ) || '',
-		progressive: isPoEligible,
-	};
-
-	// Only pass the self assessment data if at least one field is set.
-	if ( Object.keys( selfAssessmentData ).length > 0 ) {
-		requestData.self_assessment = selfAssessmentData;
-	}
 
 	return await apiFetch< AccountSession >( {
 		path: `${ NAMESPACE }/onboarding/kyc/session`,
 		method: 'POST',
-		data: requestData,
+		data: {
+			self_assessment: fromDotNotation( data ),
+			capabilities: urlParams.get( 'capabilities' ) || '',
+			progressive: isPoEligible,
+		},
 	} );
 };

--- a/client/embedded-components/hooks.tsx
+++ b/client/embedded-components/hooks.tsx
@@ -34,11 +34,12 @@ export const createKycAccountSession = async (
 ): Promise< AccountSession > => {
 	const urlParams = new URLSearchParams( window.location.search );
 	return await apiFetch< AccountSession >( {
-		path: addQueryArgs( `${ NAMESPACE }/onboarding/kyc/session`, {
+		path: `${ NAMESPACE }/onboarding/kyc/session`,
+		method: 'POST',
+		data: {
 			self_assessment: fromDotNotation( data ),
 			capabilities: urlParams.get( 'capabilities' ) || '',
 			progressive: isPoEligible,
-		} ),
-		method: 'GET',
+		},
 	} );
 };

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -71,32 +71,26 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 							'country'           => [
 								'type'        => 'string',
 								'description' => 'The country code where the company is legally registered.',
-								'required'    => true,
 							],
 							'business_type'     => [
 								'type'        => 'string',
 								'description' => 'The company incorporation type.',
-								'required'    => true,
 							],
 							'mcc'               => [
 								'type'        => 'string',
 								'description' => 'The merchant category code. This can either be a true MCC or an MCCs tree item id from the onboarding form.',
-								'required'    => true,
 							],
 							'annual_revenue'    => [
 								'type'        => 'string',
 								'description' => 'The estimated annual revenue bucket id.',
-								'required'    => true,
 							],
 							'go_live_timeframe' => [
 								'type'        => 'string',
 								'description' => 'The timeframe bucket for the estimated first live transaction.',
-								'required'    => true,
 							],
 							'site'              => [
 								'type'        => 'string',
 								'description' => 'The URL of the site.',
-								'required'    => true,
 							],
 						],
 					],

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -52,8 +52,8 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 			$this->namespace,
 			'/' . $this->rest_base . '/kyc/session',
 			[
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'get_embedded_kyc_session' ],
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_embedded_kyc_session' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
 					'progressive'     => [
@@ -226,9 +226,9 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response Response object containing the account session, or an error if session creation failed.
 	 */
-	public function get_embedded_kyc_session( WP_REST_Request $request ) {
+	public function create_embedded_kyc_session( WP_REST_Request $request ) {
 		$self_assessment_data = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
 		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && filter_var( $request->get_param( 'progressive' ), FILTER_VALIDATE_BOOLEAN );
 

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -141,7 +141,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
-	public function test_get_embedded_kyc_session() {
+	public function test_create_embedded_kyc_session() {
 		$kyc_session = [
 			'clientSecret'   => 'accs_secret__XXX',
 			'expiresAt'      => time() + 120,
@@ -158,15 +158,15 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 				$kyc_session
 			);
 
-		$request = new WP_REST_Request( 'GET' );
-		$request->set_query_params(
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
 			[
 				'progressive'         => true,
 				'create_live_account' => true,
 			]
 		);
 
-		$response = $this->controller->get_embedded_kyc_session( $request );
+		$response = $this->controller->create_embedded_kyc_session( $request );
 		$this->assertSame( 200, $response->status );
 		$this->assertSame(
 			array_merge(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Hotfix containing the following PRs:
#10704 
#10698 

This hotfix contains updates to the account session logic in order to prevent hosts blocking it. This was happening because it was a `GET` request with an extremely long query string, which we think triggered some security protection on hosts. It has been updated to correctly use a `POST` request, as well as a fix to only post self assessment data if it is present.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Please follow the instructions in #10698 and #10704 in order to test this PR. You can use a JN site using the prompt [here](https://github.com/Automattic/woocommerce-payments/pull/10713#issuecomment-2820897771).

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
