### PR TITLE
Fix express checkout container spacing on product pages

### DIFF
--- a/changelog/woopmnt-4919-express-checkout-container-spacing
+++ b/changelog/woopmnt-4919-express-checkout-container-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed inconsistent spacing between "Add to Cart" button and express checkout buttons on product pages.

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -40,6 +40,12 @@
 		margin-top: 1em;
 		margin-bottom: 1em;
 	}
+
+	// Add spacing for shortcode cart
+	.wc-proceed-to-checkout & {
+		margin-top: 1em;
+		margin-bottom: 1em;
+	}
 }
 
 // This fixes width calculation issues inside the iframe for blocks and shortcode pages.

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -34,8 +34,9 @@
 		}
 	}
 
-	// Add specific spacing for product pages
-	.single-product & {
+	// Add specific spacing for product pages in both traditional and block-based layouts
+	.woocommerce .type-product &,
+	.wp-block-add-to-cart-form & {
 		margin-top: 1em;
 		margin-bottom: 1em;
 	}

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -34,14 +34,9 @@
 		}
 	}
 
-	// Add specific spacing for product pages in both traditional and block-based layouts
+	// Add spacing for product pages and shortcode cart
 	.woocommerce .type-product &,
-	.wp-block-add-to-cart-form & {
-		margin-top: 1em;
-		margin-bottom: 1em;
-	}
-
-	// Add spacing for shortcode cart
+	.wp-block-add-to-cart-form &,
 	.wc-proceed-to-checkout & {
 		margin-top: 1em;
 		margin-bottom: 1em;

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -33,6 +33,12 @@
 			margin-top: 4px;
 		}
 	}
+
+	// Add specific spacing for product pages
+	.single-product & {
+		margin-top: 1em;
+		margin-bottom: 1em;
+	}
 }
 
 // This fixes width calculation issues inside the iframe for blocks and shortcode pages.


### PR DESCRIPTION
Fixes WOOPMNT-4919

The express checkout container was rendering too close to the "Add to Cart" button on product pages and shorcode-based cart in certain themes (Twenty-Twenty-Three, Twenty-Twenty-Two, Tsubaki). This was causing a poor user experience and inconsistent layout.

#### Changes proposed in this Pull Request

- Added margin-top: 1em and margin-bottom: 1em to the express checkout wrapper on product pages
- The CSS rules target both traditional and block-based product layouts using the following selectors:
  - `.woocommerce .type-product .wcpay-express-checkout-wrapper`
  - `.wp-block-add-to-cart-form .wcpay-express-checkout-wrapper`
  - `.wc-proceed-to-checkout .wcpay-express-checkout-wrapper`
- This ensures proper spacing between the "Add to Cart" button and the express checkout buttons

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Screenshots

| Theme | Before | After |
|--------|--------|--------|
| Twenty-Twenty-Two | <img width="1063" alt="Screenshot 2025-04-22 at 18 12 56" src="https://github.com/user-attachments/assets/90646a04-1dd9-40c0-9709-7f0bae6f066e" />|<img width="1107" alt="Screenshot 2025-04-22 at 18 13 24" src="https://github.com/user-attachments/assets/4cad187d-d763-4b21-8c5b-1a95867bb783" />|
| Twenty-Twenty-Three |<img width="1087" alt="Screenshot 2025-04-22 at 18 16 17" src="https://github.com/user-attachments/assets/58e67aff-f4cf-4701-973e-6d0b20888f92" />|<img width="1096" alt="Screenshot 2025-04-22 at 18 17 33" src="https://github.com/user-attachments/assets/6eb6621e-48d1-4e0c-a5c5-12007a770eec" />| 



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is what I checked:

- [x] Tested on Twenty-Twenty-Five theme
- [x] Tested on Twenty-Twenty-Four theme
- [x] Tested on Twenty-Twenty-Three theme
- [x] Tested on Twenty-Twenty-Two theme
- [x] Tested on Tsubaki theme
- [x] Tested on Storefront
- [x] Verified spacing is consistent with other WooCommerce pages

1. Ensure you have Google Pay/Apple Pay enabled in the WooPayments settings
2. Ensure you have Google Pay/Apple Pay enabled on product pages
3. Ensure you're using one of these themes (there could be more): Twenty-Twenty-Three, Twenty-Twenty-Two, Tsubaki
4. Navigate to the product page of a simple product
5. The express checkout buttons are not rendered without any space after the Add to Cart button 







-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
