### PR TITLE
Workaround: Hide the transaction breakdown

### DIFF
--- a/changelog/workaround-disable-transaction-breakdown
+++ b/changelog/workaround-disable-transaction-breakdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disabled the Transactions Breakdown section to avoid misleading data in certain scenarios.

--- a/client/payment-details/transaction-breakdown/index.tsx
+++ b/client/payment-details/transaction-breakdown/index.tsx
@@ -30,6 +30,13 @@ interface PaymentTransactionBreakdownProps {
 	paymentIntentId: string;
 }
 
+/**
+ * Temporary flag to disable transaction breakdown.
+ *
+ * Switch to `false` while testing.
+ */
+const disableTransactionBreakdown = true;
+
 const PaymentTransactionBreakdown: React.FC< PaymentTransactionBreakdownProps > = ( {
 	paymentIntentId,
 } ) => {
@@ -46,6 +53,10 @@ const PaymentTransactionBreakdown: React.FC< PaymentTransactionBreakdownProps > 
 	);
 
 	const transactionAmounts = useTransactionAmounts( captureEvent );
+
+	if ( disableTransactionBreakdown ) {
+		return null;
+	}
 
 	if (
 		! captureEvent?.transaction_details ||

--- a/client/payment-details/transaction-breakdown/tests/index.test.tsx
+++ b/client/payment-details/transaction-breakdown/tests/index.test.tsx
@@ -35,7 +35,7 @@ declare const global: {
 	};
 };
 
-describe( 'PaymentTransactionBreakdown', () => {
+describe.skip( 'PaymentTransactionBreakdown', () => {
 	beforeEach( () => {
 		( useTimeline as jest.Mock ).mockReset();
 		( useTransactionAmounts as jest.Mock ).mockReset();


### PR DESCRIPTION
See p1745900434361019-slack-C01BPL3ALGP

#### Changes proposed in this Pull Request

Hide the transaction breakdown block, until we can be sure that it is fully functional.

#### Testing instructions

Just make sure that the Transaction Breakdown block is not visible.