### PR TITLE
fix: manual capture tooltip in setup wizard

### DIFF
--- a/changelog/fix-manual-capture-tooltip-in-wizard
+++ b/changelog/fix-manual-capture-tooltip-in-wizard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: "Manual Capture" tooltip on setup wizard

--- a/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
@@ -8,7 +8,7 @@ import React, {
 	useMemo,
 	useState,
 } from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Card,
@@ -29,6 +29,7 @@ import {
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,
 	useGetPaymentMethodStatuses,
+	useManualCapture,
 	useSettings,
 } from '../../data';
 import PaymentMethodCheckboxes from '../../components/payment-methods-checkboxes';
@@ -214,15 +215,31 @@ const AddPaymentMethodsTask = () => {
 		}
 	};
 
+	const [ isManualCaptureEnabled ] = useManualCapture();
+
 	const prepareUpePaymentMethods = ( upeMethodIds ) => {
 		return upeMethodIds.map( ( key ) => {
-			const { label, currencies } = paymentMethodsMap[ key ];
+			const {
+				label,
+				currencies,
+				allows_manual_capture: isAllowingManualCapture,
+			} = paymentMethodsMap[ key ];
 
 			if ( availablePaymentMethods.includes( key ) ) {
 				let isSetupRequired = false;
 				let setupTooltip = '';
 
-				if (
+				if ( isManualCaptureEnabled && ! isAllowingManualCapture ) {
+					isSetupRequired = true;
+					setupTooltip = sprintf(
+						/* translators: %s: a payment method name. */
+						__(
+							'%s is not available to your customers when the "manual capture" setting is enabled.',
+							'woocommerce-payments'
+						),
+						label
+					);
+				} else if (
 					! wcpaySettings.isMultiCurrencyEnabled &&
 					key !== PAYMENT_METHOD_IDS.CARD
 				) {

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -24,7 +24,7 @@ const LoadableCheckboxControl = ( {
 	hideLabel = false,
 	isAllowingManualCapture = false,
 	isSetupRequired = false,
-	setupTooltip = '',
+	setupTooltip,
 	delayMsOnCheck = 0,
 	delayMsOnUncheck = 0,
 	needsAttention = false,

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -96,10 +96,10 @@
 			content: '';
 			position: absolute;
 			// adds some spacing for the borders, so that they're not part of the opacity
-			top: 1px;
-			bottom: 1px;
+			top: 0;
+			bottom: 0;
 			// ensures that the info icon isn't part of the opacity
-			left: 55px;
+			left: 30px;
 			right: 0;
 			background: #fff;
 			opacity: 0.5;

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.tsx
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.tsx
@@ -147,9 +147,7 @@ const PaymentMethodCheckbox: React.FC< PaymentMethodCheckboxProps > = ( {
 								'woocommerce-payments'
 							) }
 						>
-							<Pill
-								className={ 'payment-status-pending-approval' }
-							>
+							<Pill className="payment-status-pending-approval">
 								{ __(
 									'Pending approval',
 									'woocommerce-payments'
@@ -169,11 +167,7 @@ const PaymentMethodCheckbox: React.FC< PaymentMethodCheckboxProps > = ( {
 								wcpaySettings?.accountEmail ?? ''
 							) }
 						>
-							<Pill
-								className={
-									'payment-status-pending-verification'
-								}
-							>
+							<Pill className="payment-status-pending-verification">
 								{ __(
 									'Pending activation',
 									'woocommerce-payments'
@@ -192,7 +186,7 @@ const PaymentMethodCheckbox: React.FC< PaymentMethodCheckboxProps > = ( {
 						</PaymentMethodDisabledTooltip>
 					) }
 				</div>
-				<div className={ 'payment-method-checkbox__pills-right' }>
+				<div className="payment-method-checkbox__pills-right">
 					<HoverTooltip
 						content={ formatMethodFeesTooltip(
 							accountFees[ name ]

--- a/client/components/tooltip/tooltip-base.tsx
+++ b/client/components/tooltip/tooltip-base.tsx
@@ -163,7 +163,7 @@ const TooltipPortal: React.FC< TooltipPortalProps > = memo(
 export type TooltipBaseProps = {
 	className?: string;
 	children?: React.ReactNode;
-	content: React.ReactNode;
+	content: React.ReactNode | Element;
 	parentElement?: HTMLElement;
 	hideDelayMs?: number;
 	isVisible?: boolean;

--- a/client/settings/payment-methods-list/index.js
+++ b/client/settings/payment-methods-list/index.js
@@ -21,7 +21,6 @@ import methodsConfiguration from '../../payment-methods-map';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
 import ConfirmPaymentMethodActivationModal from './activation-modal';
 import ConfirmPaymentMethodDeleteModal from './delete-modal';
-import { getMissingCurrenciesTooltipMessage } from 'multi-currency/interface/functions';
 
 const PaymentMethodsList = ( { methodIds } ) => {
 	const [ enabledMethodIds ] = useEnabledPaymentMethodIds();
@@ -110,23 +109,7 @@ const PaymentMethodsList = ( { methodIds } ) => {
 						icon: Icon,
 						description,
 						allows_manual_capture: isAllowingManualCapture,
-						setup_required: isSetupRequired,
-						setup_tooltip: setupTooltip,
-						currencies,
 					} ) => {
-						if (
-							! wcpaySettings.isMultiCurrencyEnabled &&
-							id !== PAYMENT_METHOD_IDS.CARD
-						) {
-							const currency = wcpaySettings.storeCurrency;
-							if ( currencies.indexOf( currency ) < 0 ) {
-								isSetupRequired = true;
-								setupTooltip = getMissingCurrenciesTooltipMessage(
-									label,
-									currencies
-								);
-							}
-						}
 						return (
 							<PaymentMethod
 								id={ id }
@@ -146,8 +129,6 @@ const PaymentMethodsList = ( { methodIds } ) => {
 								}
 								Icon={ Icon }
 								status={ getStatusAndRequirements( id ).status }
-								isSetupRequired={ isSetupRequired }
-								setupTooltip={ setupTooltip }
 								isAllowingManualCapture={
 									isAllowingManualCapture
 								}

--- a/client/settings/payment-methods-list/payment-method.scss
+++ b/client/settings/payment-methods-list/payment-method.scss
@@ -166,10 +166,6 @@
 		}
 	}
 
-	&.has-icon-border &__icon {
-		box-shadow: 0 0 0 1px #ddd;
-	}
-
 	&.overlay {
 		position: relative;
 
@@ -177,10 +173,10 @@
 			content: '';
 			position: absolute;
 			// adds some spacing for the borders, so that they're not part of the opacity
-			top: 1px;
-			bottom: 1px;
+			top: 0;
+			bottom: 0;
 			// ensures that the info icon isn't part of the opacity
-			left: 55px;
+			left: 30px;
 			right: 0;
 			background: #fff;
 			opacity: 0.5;

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -167,7 +167,6 @@ const PaymentMethod = ( {
 		needsMoreInformation ||
 		isPoInProgress ||
 		upeCapabilityStatuses.REJECTED === status;
-	const shouldDisplayNotice = id === 'sofort';
 	const {
 		duplicates,
 		dismissedDuplicateNotices,
@@ -285,14 +284,12 @@ const PaymentMethod = ( {
 	};
 
 	return (
-		<li
-			className={ classNames(
-				'payment-method__list-item',
-				{ 'has-icon-border': id !== 'card', overlay: needsOverlay },
-				className
-			) }
-		>
-			<div className="payment-method">
+		<li className={ classNames( 'payment-method__list-item', className ) }>
+			<div
+				className={ classNames( 'payment-method', {
+					overlay: needsOverlay,
+				} ) }
+			>
 				<div className="payment-method__checkbox">
 					<LoadableCheckboxControl
 						label={ label }
@@ -302,7 +299,7 @@ const PaymentMethod = ( {
 						hideLabel
 						isAllowingManualCapture={ isAllowingManualCapture }
 						isSetupRequired={ isSetupRequired }
-						setupTooltip={ getTooltipContent( id ) as any }
+						setupTooltip={ getTooltipContent( id ) }
 						needsAttention={ needsAttention }
 					/>
 				</div>
@@ -375,7 +372,7 @@ const PaymentMethod = ( {
 					</div>
 				</div>
 			</div>
-			{ shouldDisplayNotice && (
+			{ id === 'sofort' && (
 				<InlineNotice
 					status="warning"
 					icon={ true }


### PR DESCRIPTION
Fixes #10347

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
<img width="817" alt="Screenshot 2025-04-29 at 10 39 10 AM" src="https://github.com/user-attachments/assets/54b874ca-507b-4890-aa0b-020c4ef31fcb" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable "Manual capture"
- Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fadditional-payment-methods`
- Hover over the tooltip icon
- Message should appear

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
