### PR TITLE
Set the onboarding test mode while creating test drive account with API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,31 @@
 *** WooPayments Changelog ***
 
+= 9.3.0 - 2025-04-30 =
+* Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
+* Add - Transaction Fees breakdown component in the Payment details.
+* Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
+* Fix - fix: Multibanco payment instructions font size adjustment on some block-based themes (e.g.: Twenty-Twenty-Four, Twenty-Twenty-Three)
+* Fix - Fix a bug when the notice after downloading CSV that was mispositioned.
+* Fix - Fixed inconsistent spacing between "Add to Cart" button and express checkout buttons on product pages.
+* Fix - Fixes a styling issue when the payment method has a tooltip next to it, it was shifting the logo to the right.
+* Fix - Fix for validation issue with POST params in some cases generating account session.
+* Fix - Improve styling of the Embedded components to be closer to WPDS.
+* Fix - Improve subscriptions code compatibility to avoid causing fatal errors.
+* Fix - Remove the referrer check to update the fraud protection settings
+* Update - Add dedicated onboarding REST API endpoint for resetting onboarding, when possible.
+* Update - Advanced fraud protection settings redesign.
+* Update - chore: removed notices about the JCB capability request. JCB will be automatically requested for every new and existing merchant, regardless of the merchant country.
+* Update - Include a failure message in the order notes when Stripe Billing subscription renewal has failed.
+* Update - On the payment settings page, change the "Credit/Debit Cards" icon to a more generic icon and add a static list of card brands below the "Credit/Debit Cards" element.
+* Update - Remove progressive onboarding eligibility check during embedded KYC session creation
+* Update - Simplified refund handling with clear errors and standard reasons to aid resolution.
+* Update - Updated the Stripe locales list.
+* Update - Update log file format for better compatibility with the WooCommerce log viewer.
+* Dev - Add Cursor config folder to .gitignore
+* Dev - Bump WC tested up to version to 9.8.1
+* Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
+* Dev - Replace WCPay in messages with WooPayments
+
 = 9.2.1 - 2025-04-23 =
 * Update - Update account session creation route definition to use POST rather than GET.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooPayments Changelog ***
 
-= 9.3.0 - 2025-04-30 =
+= 9.3.0 - 2025-05-05 =
 * Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
 * Add - Transaction Fees breakdown component in the Payment details.
 * Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
@@ -23,6 +23,7 @@
 * Update - Update log file format for better compatibility with the WooCommerce log viewer.
 * Dev - Add Cursor config folder to .gitignore
 * Dev - Bump WC tested up to version to 9.8.1
+* Dev - Bump WC tested up to version to 9.8.2
 * Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
 * Dev - Replace WCPay in messages with WooPayments
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooPayments Changelog ***
 
-= 9.3.0 - 2025-05-05 =
+= 9.3.0 - 2025-04-30 =
+
 * Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
 * Add - Transaction Fees breakdown component in the Payment details.
 * Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
@@ -23,7 +24,6 @@
 * Update - Update log file format for better compatibility with the WooCommerce log viewer.
 * Dev - Add Cursor config folder to .gitignore
 * Dev - Bump WC tested up to version to 9.8.1
-* Dev - Bump WC tested up to version to 9.8.2
 * Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
 * Dev - Replace WCPay in messages with WooPayments
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 *** WooPayments Changelog ***
 
 = 9.3.0 - 2025-04-30 =
-
 * Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
 * Add - Transaction Fees breakdown component in the Payment details.
 * Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
@@ -24,6 +23,7 @@
 * Update - Update log file format for better compatibility with the WooCommerce log viewer.
 * Dev - Add Cursor config folder to .gitignore
 * Dev - Bump WC tested up to version to 9.8.1
+* Dev - Bump WC tested up to version to 9.8.2
 * Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
 * Dev - Replace WCPay in messages with WooPayments
 

--- a/changelog/add-1342-transaction-breakdown-block
+++ b/changelog/add-1342-transaction-breakdown-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Transaction Fees breakdown component in the Payment details.

--- a/changelog/add-cursor-config-folder-to-gitignore
+++ b/changelog/add-cursor-config-folder-to-gitignore
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add Cursor config folder to .gitignore

--- a/changelog/chore-e2e-users-config
+++ b/changelog/chore-e2e-users-config
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: chore: consolidate e2e test users config.
-
-

--- a/changelog/chore-remove-codeowners-file
+++ b/changelog/chore-remove-codeowners-file
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: chore: remove codeowners file
-
-

--- a/changelog/chore-remove-jcb-capability-notices
+++ b/changelog/chore-remove-jcb-capability-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-chore: removed notices about the JCB capability request. JCB will be automatically requested for every new and existing merchant, regardless of the merchant country.

--- a/changelog/dev-bump-wc-version-9-8-1
+++ b/changelog/dev-bump-wc-version-9-8-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump WC tested up to version to 9.8.1

--- a/changelog/dev-bump-wc-version-9-8-2
+++ b/changelog/dev-bump-wc-version-9-8-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump WC tested up to version to 9.8.2

--- a/changelog/dev-bump-wc-version-9-8-2
+++ b/changelog/dev-bump-wc-version-9-8-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 9.8.2

--- a/changelog/dev-fix-account-session
+++ b/changelog/dev-fix-account-session
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix for validation issue with POST params in some cases generating account session.

--- a/changelog/dev-update-messages-to-replace-wcpay-to-woopayments
+++ b/changelog/dev-update-messages-to-replace-wcpay-to-woopayments
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Replace WCPay in messages with WooPayments

--- a/changelog/fix-10673-fraud-protection-settings-referer-check
+++ b/changelog/fix-10673-fraud-protection-settings-referer-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove the referrer check to update the fraud protection settings

--- a/changelog/fix-e2e-blocks-billing-address-form
+++ b/changelog/fix-e2e-blocks-billing-address-form
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: e2e tests on Atomic
-
-

--- a/changelog/fix-ece-on-free-coupon
+++ b/changelog/fix-ece-on-free-coupon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0

--- a/changelog/fix-multibanco-order-received-page-font-size-on-block-theme
+++ b/changelog/fix-multibanco-order-received-page-font-size-on-block-theme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix: Multibanco payment instructions font size adjustment on some block-based themes (e.g.: Twenty-Twenty-Four, Twenty-Twenty-Three)

--- a/changelog/fix-notice-after-downloading-csv-looks-weird-on-mobile
+++ b/changelog/fix-notice-after-downloading-csv-looks-weird-on-mobile
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix a bug when the notice after downloading CSV that was mispositioned.

--- a/changelog/fix-payment-method-with-a-tooltip-has-right-shifted
+++ b/changelog/fix-payment-method-with-a-tooltip-has-right-shifted
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes a styling issue when the payment method has a tooltip next to it, it was shifting the logo to the right.

--- a/changelog/fix-woopmnt-4909-tweak-embedded-components-style
+++ b/changelog/fix-woopmnt-4909-tweak-embedded-components-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Improve styling of the Embedded components to be closer to WPDS.

--- a/changelog/update-WOOPLUG-3802-receive-country-code-for-test-drive-account
+++ b/changelog/update-WOOPLUG-3802-receive-country-code-for-test-drive-account
@@ -1,5 +1,0 @@
-Significance: patch
-Type: update
-Comment: Update the test-drive init API endpoint to accept and use a country code.
-
-

--- a/changelog/update-WOOPMNT-4933-stripe-locales
+++ b/changelog/update-WOOPMNT-4933-stripe-locales
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Updated the Stripe locales list.

--- a/changelog/update-disable-test-mode-account-api
+++ b/changelog/update-disable-test-mode-account-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.

--- a/changelog/update-onboarding-apis-for-account
+++ b/changelog/update-onboarding-apis-for-account
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Add dedicated onboarding REST API endpoint for resetting onboarding, when possible.

--- a/changelog/update-payment-intents-controller-class
+++ b/changelog/update-payment-intents-controller-class
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.

--- a/changelog/update-route-definition
+++ b/changelog/update-route-definition
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update account session creation route definition to use POST rather than GET.

--- a/changelog/update-settings-page-show-individual-card-brands
+++ b/changelog/update-settings-page-show-individual-card-brands
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-On the payment settings page, change the "Credit/Debit Cards" icon to a more generic icon and add a static list of card brands below the "Credit/Debit Cards" element.

--- a/changelog/update-woopmnt-4905-fraud-settings-redesign
+++ b/changelog/update-woopmnt-4905-fraud-settings-redesign
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Advanced fraud protection settings redesign.

--- a/changelog/update-woopmt-4706-remove-po-eligible-api-request
+++ b/changelog/update-woopmt-4706-remove-po-eligible-api-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove progressive onboarding eligibility check during embedded KYC session creation

--- a/changelog/woopmnt-4601-stipe-billing-when-a-renewal-invoice-fails-fetch-the-reason
+++ b/changelog/woopmnt-4601-stipe-billing-when-a-renewal-invoice-fails-fetch-the-reason
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Include a failure message in the order notes when Stripe Billing subscription renewal has failed.

--- a/changelog/woopmnt-4892-handle-more-refund-failure-reason-codes-in-refund-notes
+++ b/changelog/woopmnt-4892-handle-more-refund-failure-reason-codes-in-refund-notes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Simplified refund handling with clear errors and standard reasons to aid resolution.

--- a/changelog/woopmnt-4899-update-logging-format-to-be-more-compatible-with-woo-core
+++ b/changelog/woopmnt-4899-update-logging-format-to-be-more-compatible-with-woo-core
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update log file format for better compatibility with the WooCommerce log viewer.

--- a/changelog/woopmnt-4914-fatal-errors-with-is_duplicate_site-and
+++ b/changelog/woopmnt-4914-fatal-errors-with-is_duplicate_site-and
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Improve subscriptions code compatibility to avoid causing fatal errors.

--- a/changelog/woopmnt-4919-express-checkout-container-spacing
+++ b/changelog/woopmnt-4919-express-checkout-container-spacing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed inconsistent spacing between "Add to Cart" button and express checkout buttons on product pages.

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -629,6 +629,9 @@ class WC_Payments_Onboarding_Service {
 
 		$current_user = get_userdata( get_current_user_id() );
 
+		// Make sure the onboarding test mode DB flag is set.
+		self::set_test_mode( true );
+
 		$site_data    = [
 			'site_username' => wp_get_current_user()->user_login,
 			'site_locale'   => get_locale(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-payments",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-payments",
-      "version": "9.2.1",
+      "version": "9.3.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 7.3
-Stable tag: 9.2.1
+Stable tag: 9.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,6 +86,32 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 4. Manage Disputes
 
 == Changelog ==
+
+= 9.3.0 - 2025-04-30 =
+* Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
+* Add - Transaction Fees breakdown component in the Payment details.
+* Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
+* Fix - fix: Multibanco payment instructions font size adjustment on some block-based themes (e.g.: Twenty-Twenty-Four, Twenty-Twenty-Three)
+* Fix - Fix a bug when the notice after downloading CSV that was mispositioned.
+* Fix - Fixed inconsistent spacing between "Add to Cart" button and express checkout buttons on product pages.
+* Fix - Fixes a styling issue when the payment method has a tooltip next to it, it was shifting the logo to the right.
+* Fix - Fix for validation issue with POST params in some cases generating account session.
+* Fix - Improve styling of the Embedded components to be closer to WPDS.
+* Fix - Improve subscriptions code compatibility to avoid causing fatal errors.
+* Fix - Remove the referrer check to update the fraud protection settings
+* Update - Add dedicated onboarding REST API endpoint for resetting onboarding, when possible.
+* Update - Advanced fraud protection settings redesign.
+* Update - chore: removed notices about the JCB capability request. JCB will be automatically requested for every new and existing merchant, regardless of the merchant country.
+* Update - Include a failure message in the order notes when Stripe Billing subscription renewal has failed.
+* Update - On the payment settings page, change the "Credit/Debit Cards" icon to a more generic icon and add a static list of card brands below the "Credit/Debit Cards" element.
+* Update - Remove progressive onboarding eligibility check during embedded KYC session creation
+* Update - Simplified refund handling with clear errors and standard reasons to aid resolution.
+* Update - Updated the Stripe locales list.
+* Update - Update log file format for better compatibility with the WooCommerce log viewer.
+* Dev - Add Cursor config folder to .gitignore
+* Dev - Bump WC tested up to version to 9.8.1
+* Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
+* Dev - Replace WCPay in messages with WooPayments
 
 = 9.2.1 - 2025-04-23 =
 * Update - Update account session creation route definition to use POST rather than GET.

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 
 == Changelog ==
 
-= 9.3.0 - 2025-04-30 =
+= 9.3.0 - 2025-05-05 =
 * Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
 * Add - Transaction Fees breakdown component in the Payment details.
 * Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
@@ -110,6 +110,7 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 * Update - Update log file format for better compatibility with the WooCommerce log viewer.
 * Dev - Add Cursor config folder to .gitignore
 * Dev - Bump WC tested up to version to 9.8.1
+* Dev - Bump WC tested up to version to 9.8.2
 * Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
 * Dev - Replace WCPay in messages with WooPayments
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 
 == Changelog ==
 
-= 9.3.0 - 2025-05-05 =
+= 9.3.0 - 2025-04-30 =
 * Add - Add dedicated onboarding REST API endpoint for disabling test drive account, when possible.
 * Add - Transaction Fees breakdown component in the Payment details.
 * Fix - fix: ensuring that Google Pay/Apple Pay buttons hide on shortcode cart & checkout when totals go to 0
@@ -110,7 +110,6 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 * Update - Update log file format for better compatibility with the WooCommerce log viewer.
 * Dev - Add Cursor config folder to .gitignore
 * Dev - Bump WC tested up to version to 9.8.1
-* Dev - Bump WC tested up to version to 9.8.2
 * Dev - Merged WC_REST_Payments_Payment_Intents_Create_Controller back into WC_REST_Payments_Payment_Intents_Controller after confirming that the issue that caused the split was solved.
 * Dev - Replace WCPay in messages with WooPayments
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 9.8.1
+ * WC tested up to: 9.8.2
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 9.3.0

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 9.8.1
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 9.2.1
+ * Version: 9.3.0
  * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
Fixes WOOPMNT-4941

#### Changes proposed in this Pull Request
This PR properly sets the onboarding test mode flag while creating a test drive account from `payments/onboarding/test_drive_account/init` API endpoint.

#### Testing instructions
- Create a new JN site with `add/onboarding-modal` branch. Use this [link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=add/onboarding-modal).
- Make sure you do not have WooPayments Dev Tools plugin activated.
- Navigate to Jetpack > Beta Tester and click Manage on WooCommerce Payments plugin.
- Search for `fix/test-drive-onboarding-endpoint` branch in Search for Feature Branch field and activate it.
- Verify the Feature branch under WooCommerce plugin is `Feature Branch: add/onboarding-modal`.
- Navigate to WooCommerce > Home and skip the wizard. Select US as a country.
- Navigate to WooCommerce > Settings > Advanced > Features and verify the `Enable the new payments settings experience` is enabled.
- Go to WooCommerce > Settings > Payments and click Complete setup next to the WooPayments plugin.
- Select any Payment Methods and click Continue.
- On the next step proceed with the Jetpack connection.
- Once the Jetpack connection is established the Onboarding modal should be opened automatically at the Test Account creation step.
- Wait and ensure the test account is created successfully.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
