### PR TITLE
Set the onboarding test mode while creating test drive account with API

### DIFF
--- a/changelog/fix-WOOPMNT-4941-set-onboarding-test-mode-api
+++ b/changelog/fix-WOOPMNT-4941-set-onboarding-test-mode-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set the onboarding test mode while creating test drive account with API

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -629,6 +629,9 @@ class WC_Payments_Onboarding_Service {
 
 		$current_user = get_userdata( get_current_user_id() );
 
+		// Make sure the onboarding test mode DB flag is set.
+		self::set_test_mode( true );
+
 		$site_data    = [
 			'site_username' => wp_get_current_user()->user_login,
 			'site_locale'   => get_locale(),


### PR DESCRIPTION
Fixes WOOPMNT-4941

#### Changes proposed in this Pull Request
This PR properly sets the onboarding test mode flag while creating a test drive account from `payments/onboarding/test_drive_account/init` API endpoint.

#### Testing instructions
- Create a new JN site with `add/onboarding-modal` branch. Use this [link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=add/onboarding-modal).
- Make sure you do not have WooPayments Dev Tools plugin activated.
- Navigate to Jetpack > Beta Tester and click Manage on WooCommerce Payments plugin.
- Search for `fix/test-drive-onboarding-endpoint` branch in Search for Feature Branch field and activate it.
- Verify the Feature branch under WooCommerce plugin is `Feature Branch: add/onboarding-modal`.
- Navigate to WooCommerce > Home and skip the wizard. Select US as a country.
- Navigate to WooCommerce > Settings > Advanced > Features and verify the `Enable the new payments settings experience` is enabled.
- Go to WooCommerce > Settings > Payments and click Complete setup next to the WooPayments plugin.
- Select any Payment Methods and click Continue.
- On the next step proceed with the Jetpack connection.
- Once the Jetpack connection is established the Onboarding modal should be opened automatically at the Test Account creation step.
- Wait and ensure the test account is created successfully.
- 
-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
