### PR TITLE
Standardize and expand onboarding init locking

### DIFF
--- a/changelog/update-onboarding-init-locking
+++ b/changelog/update-onboarding-init-locking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: We standardize and enforce stricter onboarding initialization locking.
+
+

--- a/changelog/update-onboarding-init-locking
+++ b/changelog/update-onboarding-init-locking
@@ -1,5 +1,5 @@
 Significance: patch
 Type: update
-Comment: We standardize and enforce stricter onboarding initialization locking.
+Comment: Standardize and enforce stricter onboarding initialization locking.
 
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -27,7 +27,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	// ACCOUNT_OPTION is only used in the supporting dev tools plugin, it can be removed once everyone has upgraded.
 	const ACCOUNT_OPTION                                        = 'wcpay_account_data';
 	const ONBOARDING_DISABLED_TRANSIENT                         = 'wcpay_on_boarding_disabled';
-	const ONBOARDING_STARTED_TRANSIENT                          = 'wcpay_on_boarding_started';
 	const ONBOARDING_STATE_TRANSIENT                            = 'wcpay_stripe_onboarding_state';
 	const WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT                   = 'woopay_enabled_by_default';
 	const ONBOARDING_TEST_DRIVE_SETTINGS_FOR_LIVE_ACCOUNT       = 'test_drive_account_settings_for_live_account';
@@ -1628,7 +1627,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			// the merchant will get redirected to the Payments > Overview page.
 			try {
 				// Prevent duplicate requests to start the onboarding flow.
-				if ( get_transient( self::ONBOARDING_STARTED_TRANSIENT ) ) {
+				if ( $this->onboarding_service->is_onboarding_init_in_progress() ) {
 					Logger::warning( 'Duplicate onboarding attempt detected.' );
 					$this->redirect_service->redirect_to_connect_page(
 						__( 'There was a duplicate attempt to initiate account setup. Please wait a few seconds and try again.', 'woocommerce-payments' )
@@ -1696,11 +1695,8 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					return;
 				}
 
-				// Set a quickly expiring transient to avoid duplicate requests.
-				// The duration should be sufficient for our platform to respond.
-				// There is no danger in having this transient expire too late
-				// because we delete it after we initiate the onboarding.
-				set_transient( self::ONBOARDING_STARTED_TRANSIENT, true, MINUTE_IN_SECONDS );
+				// Mark the onboarding initialization as in progress.
+				$this->onboarding_service->set_onboarding_init_in_progress();
 
 				$redirect_to = $this->init_stripe_onboarding(
 					$create_test_drive_account ? 'test_drive' : ( $should_onboard_in_test_mode ? 'test' : 'live' ),
@@ -1714,7 +1710,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					]
 				);
 
-				delete_transient( self::ONBOARDING_STARTED_TRANSIENT );
+				$this->onboarding_service->clear_onboarding_init_in_progress();
 
 				// Always clear the account cache after a Stripe onboarding init attempt.
 				// This allows the merchant to use connect links to refresh its account cache, in case something is wrong.
@@ -1733,7 +1729,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					$this->redirect_service->redirect_to( $redirect_to );
 				}
 			} catch ( API_Exception $e ) {
-				delete_transient( self::ONBOARDING_STARTED_TRANSIENT );
+				$this->onboarding_service->clear_onboarding_init_in_progress();
 
 				// Always clear the account cache in case of errors.
 				$this->clear_cache();

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -659,8 +659,18 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * @return bool Whether the account was created.
 	 * @throws API_Exception When the API request fails.
+	 * @throws Exception When an onboarding initialization is already in progress.
 	 */
 	public function init_test_drive_account( string $country, array $capabilities = [] ): bool {
+		if ( ! $this->payments_api_client->is_server_connected() ) {
+			throw new Exception( __( 'Your store is not connected to WordPress.com. Please connect it first.', 'woocommerce-payments' ) );
+		}
+
+		if ( $this->is_onboarding_init_in_progress() ) {
+			// We can't allow multiple onboarding initializations to happen at the same time.
+			throw new Exception( __( 'Onboarding initialization is already in progress. Please wait for it to finish.', 'woocommerce-payments' ) );
+		}
+
 		// Since there should be no Stripe KYC needed, make sure we start with a clean state.
 		delete_transient( WC_Payments_Account::ONBOARDING_STATE_TRANSIENT );
 		delete_option( WC_Payments_Account::EMBEDDED_KYC_IN_PROGRESS_OPTION );

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -762,7 +762,7 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function reset_onboarding( array $context ): bool {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			return false;
+			throw new Exception( __( 'Your store is not connected to WordPress.com. Please connect it first.', 'woocommerce-payments' ) );
 		}
 
 		// Delete the currently connected Stripe account, in the onboarding mode we are currently in.
@@ -808,7 +808,7 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function disable_test_drive_account( array $context ): bool {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			return false;
+			throw new Exception( __( 'Your store is not connected to WordPress.com. Please connect it first.', 'woocommerce-payments' ) );
 		}
 
 		// If the test mode onboarding is not enabled, we don't need to do anything.

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -23,6 +23,7 @@ class WC_Payments_Onboarding_Service {
 	const TEST_MODE_OPTION                           = 'wcpay_onboarding_test_mode';
 	const ONBOARDING_ELIGIBILITY_MODAL_OPTION        = 'wcpay_onboarding_eligibility_modal_dismissed';
 	const ONBOARDING_CONNECTION_SUCCESS_MODAL_OPTION = 'wcpay_connection_success_modal_dismissed';
+	const ONBOARDING_INIT_IN_PROGRESS_TRANSIENT      = 'wcpay_onboarding_init_in_progress';
 
 	// Onboarding flow sources.
 	// We use these to identify the originating place for the current onboarding flow.
@@ -438,6 +439,37 @@ class WC_Payments_Onboarding_Service {
 	}
 
 	/**
+	 * Check whether an onboarding initialization is in progress.
+	 *
+	 * This only relates to the initial account creation, not the full KYC flow.
+	 *
+	 * @return bool Whether an onboarding flow is in progress.
+	 */
+	public function is_onboarding_init_in_progress(): bool {
+		return filter_var( get_transient( self::ONBOARDING_INIT_IN_PROGRESS_TRANSIENT ), FILTER_VALIDATE_BOOLEAN );
+	}
+
+	/**
+	 * Mark the onboarding initialization as in progress.
+	 *
+	 * This only relates to the initial account creation, not the full KYC flow.
+	 *
+	 * @return void
+	 */
+	public function set_onboarding_init_in_progress(): void {
+		set_transient( self::ONBOARDING_INIT_IN_PROGRESS_TRANSIENT, 'yes', 3 * MINUTE_IN_SECONDS );
+	}
+
+	/**
+	 * Clear the onboarding initialization in progress transient.
+	 *
+	 * @return void
+	 */
+	public function clear_onboarding_init_in_progress(): void {
+		delete_transient( self::ONBOARDING_INIT_IN_PROGRESS_TRANSIENT );
+	}
+
+	/**
 	 * Check whether the business types fetched from the cache are valid.
 	 *
 	 * @param array|bool|string $business_types The business types returned from the cache.
@@ -621,11 +653,7 @@ class WC_Payments_Onboarding_Service {
 		delete_transient( WC_Payments_Account::ONBOARDING_STATE_TRANSIENT );
 		delete_option( WC_Payments_Account::EMBEDDED_KYC_IN_PROGRESS_OPTION );
 
-		// Set a quickly expiring transient to avoid duplicate requests.
-		// The duration should be sufficient for our platform to respond.
-		// There is no danger in having this transient expire too late
-		// because we delete it after we initiate the onboarding.
-		set_transient( WC_Payments_Account::ONBOARDING_STARTED_TRANSIENT, true, MINUTE_IN_SECONDS );
+		$this->set_onboarding_init_in_progress();
 
 		$current_user = get_userdata( get_current_user_id() );
 
@@ -687,8 +715,7 @@ class WC_Payments_Onboarding_Service {
 			update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => true ] );
 		}
 
-		// Clear the transient that is used to avoid duplicate requests.
-		delete_transient( WC_Payments_Account::ONBOARDING_STARTED_TRANSIENT );
+		$this->clear_onboarding_init_in_progress();
 
 		// Clear the account cache to force a refresh.
 		WC_Payments::get_account_service()->clear_cache();
@@ -814,9 +841,9 @@ class WC_Payments_Onboarding_Service {
 
 		// Discard any ongoing onboarding session.
 		delete_transient( WC_Payments_Account::ONBOARDING_STATE_TRANSIENT );
-		delete_transient( WC_Payments_Account::ONBOARDING_STARTED_TRANSIENT );
 		delete_option( WC_Payments_Account::EMBEDDED_KYC_IN_PROGRESS_OPTION );
 		delete_transient( WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT );
+		$this->clear_onboarding_init_in_progress();
 
 		// Clear the cache to avoid stale data.
 		WC_Payments::get_account_service()->clear_cache();

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -289,6 +289,14 @@ class WC_Payments_Onboarding_Service {
 			return [];
 		}
 
+		if ( $this->is_onboarding_init_in_progress() ) {
+			Logger::warning( 'Duplicate onboarding attempt detected.' );
+			// We can't allow multiple onboarding initializations to happen at the same time.
+			throw new Exception( __( 'Onboarding initialization is already in progress. Please wait for it to finish.', 'woocommerce-payments' ) );
+		}
+
+		$this->set_onboarding_init_in_progress();
+
 		$setup_mode = WC_Payments::mode()->is_live() ? 'live' : 'test';
 
 		// Make sure the onboarding test mode DB flag is set.
@@ -333,9 +341,13 @@ class WC_Payments_Onboarding_Service {
 				$this->get_referral_code()
 			);
 		} catch ( API_Exception $e ) {
+			$this->clear_onboarding_init_in_progress();
+
 			// If we fail to create the session, return an empty array.
 			return [];
 		}
+
+		$this->clear_onboarding_init_in_progress();
 
 		// Set the embedded KYC in progress flag.
 		$this->set_embedded_kyc_in_progress();

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -1094,8 +1094,11 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$_GET['promo']       = 'incentive_id';
 		$_GET['progressive'] = 'true';
 
-		// There isn't another onboarding started.
-		set_transient( WC_Payments_Account::ONBOARDING_STARTED_TRANSIENT, true, 10 );
+		// There is another onboarding started.
+		$this->mock_onboarding_service
+			->expects( $this->once() )
+			->method( 'is_onboarding_init_in_progress' )
+			->willReturn( true );
 
 		// The Jetpack connection is in working order.
 		$this->mock_jetpack_connection();


### PR DESCRIPTION
Closes [WOOPMNT-4935](https://linear.app/a8c/issue/WOOPMNT-4935/improve-caching-in-woopayments-reset-account-rest-api)

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We move the responsibility of locking and preventing multiple onboarding initializations from happening from the account service to the onboarding one.
Furthermore, there were places when this was not enforced, mainly the new onboarding REST API endpoint business logic (e.g., init test-drive account, reset onboarding, or disable test-drive account).
With these changes, we should gain sanity and predictability.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Testing the MOX flows

1. Use this PR's branch and the latest WooCommerce (9.8.3 at the time of writing these instructions).
1. Go to WooCommerce > Settings > Advanced > Features and make sure the "Payments Settings (beta)" feature is **disabled**.
1. Remove any WooPayments account you might have connected.
1. Test that you can successfully onboard an account from the Connect page using the live flow.
1. Reset onboarding from the Payments > Overview page.
1. Test that you can successfully onboard a test-drive account from the Connect page.

#### Testing the NOX flows

1. Use this PR's branch and the latest WooCommerce (9.8.3 when writing these instructions).
1. Go to WooCommerce > Settings > Advanced > Features and make sure the "Payments Settings (beta)" feature is **enabled**.
1. Remove any WooPayments account you might have connected.
1. Test that you can successfully onboard a test account from the new Payments Settings page.
1. From the new Payments Settings page, activate payments and test that you can successfully onboard a live account.

#### Testing the NOX in-context flows

1. Use this PR's branch and WooCommerce on the `add/onboarding-modal` working branch.
1. Go to WooCommerce > Settings > Advanced > Features and make sure the "Payments Settings (beta)" feature is **enabled**.
1. Remove any WooPayments account you might have connected.
1. Test that you can successfully onboard a test account from the new in-context modal.
1. Then activate payments and test that you can onboard a live account.
-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
