### PR TITLE
Updates to remove collection of self-assessment data during onboarding

### DIFF
--- a/changelog/dev-remove-self-assessment-fields
+++ b/changelog/dev-remove-self-assessment-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove self-assessment fields from the onboarding flow

--- a/client/embedded-components/index.tsx
+++ b/client/embedded-components/index.tsx
@@ -35,7 +35,6 @@ interface EmbeddedAccountOnboardingProps extends EmbeddedComponentProps {
 	onExit: () => void;
 	onStepChange?: ( step: string ) => void;
 	collectPayoutRequirements?: boolean;
-	isPoEligible?: boolean;
 }
 
 interface EmbeddedAccountNotificationBannerProps

--- a/client/embedded-components/test/index.tsx
+++ b/client/embedded-components/test/index.tsx
@@ -64,7 +64,6 @@ describe( 'EmbeddedAccountOnboarding', () => {
 			<EmbeddedAccountOnboarding
 				onboardingData={ mockOnboardingData }
 				onExit={ mockOnExit }
-				isPoEligible={ true }
 				collectPayoutRequirements={ false }
 				onStepChange={ mockOnStepChange }
 			/>
@@ -85,7 +84,6 @@ describe( 'EmbeddedAccountOnboarding', () => {
 			<EmbeddedAccountOnboarding
 				onboardingData={ mockOnboardingData }
 				onExit={ mockOnExit }
-				isPoEligible={ true }
 				collectPayoutRequirements={ true }
 				onStepChange={ mockOnStepChange }
 			/>

--- a/client/onboarding/steps/business-details.tsx
+++ b/client/onboarding/steps/business-details.tsx
@@ -51,20 +51,6 @@ const BusinessDetails: React.FC = () => {
 		selectedBusinessType?.structures.find(
 			( structure ) => structure.key === data[ 'company.structure' ]
 		);
-	const selectedMcc = mccsFlatList.find( ( mcc ) => mcc.key === data.mcc );
-
-	const annualRevenues = Object.entries( strings.annualRevenues ).map(
-		( [ key, name ] ) => ( {
-			key,
-			name,
-		} )
-	);
-	const goLiveTimeframes = Object.entries( strings.goLiveTimeframes ).map(
-		( [ key, name ] ) => ( {
-			key,
-			name,
-		} )
-	);
 
 	const handleTiedChange = (
 		name: keyof OnboardingFields,
@@ -121,28 +107,14 @@ const BusinessDetails: React.FC = () => {
 			{ selectedCountry &&
 				selectedBusinessType &&
 				selectedBusinessStructure && (
-					<span data-testid={ 'mcc-select' }>
-						<OnboardingGroupedSelectField
-							name="mcc"
-							options={ mccsFlatList }
-							searchable
-						/>
-					</span>
-				) }
-
-			{ selectedCountry &&
-				selectedBusinessType &&
-				selectedBusinessStructure &&
-				selectedMcc && (
 					<>
-						<OnboardingSelectField
-							name="annual_revenue"
-							options={ annualRevenues }
-						/>
-						<OnboardingSelectField
-							name="go_live_timeframe"
-							options={ goLiveTimeframes }
-						/>
+						<span data-testid={ 'mcc-select' }>
+							<OnboardingGroupedSelectField
+								name="mcc"
+								options={ mccsFlatList }
+								searchable
+							/>
+						</span>
 						<span className={ 'wcpay-onboarding__tos' }>
 							{ strings.tos }
 						</span>

--- a/client/onboarding/steps/test/business-details.tsx
+++ b/client/onboarding/steps/test/business-details.tsx
@@ -15,7 +15,6 @@ import {
 	getBusinessTypes,
 	getMccsFlatList,
 } from 'onboarding/utils';
-import strings from '../../strings';
 
 jest.mock( 'onboarding/utils', () => ( {
 	getAvailableCountries: jest.fn(),
@@ -231,29 +230,5 @@ describe( 'BusinessDetails', () => {
 			'Single member LLC'
 		);
 		expect( mccField ).toHaveTextContent( 'Popular Software' );
-
-		const annualRevenueField = screen.getByText(
-			strings.placeholders.annual_revenue
-		);
-		const goLiveTimeframeField = screen.getByText(
-			strings.placeholders.go_live_timeframe
-		);
-
-		user.click( annualRevenueField );
-		user.click(
-			screen.getByText( strings.annualRevenues.from_250k_to_1m )
-		);
-
-		user.click( goLiveTimeframeField );
-		user.click(
-			screen.getByText( strings.goLiveTimeframes.within_1month )
-		);
-
-		expect( annualRevenueField ).toHaveTextContent(
-			strings.annualRevenues.from_250k_to_1m
-		);
-		expect( goLiveTimeframeField ).toHaveTextContent(
-			strings.goLiveTimeframes.within_1month
-		);
 	} );
 } );

--- a/client/onboarding/steps/test/loading.tsx
+++ b/client/onboarding/steps/test/loading.tsx
@@ -39,9 +39,7 @@ const checkLinkToContainNecessaryParams = ( link: string ) => {
 	expect( link ).toContain( 'self_assessment' );
 	expect( link ).toContain( 'country' );
 	expect( link ).toContain( 'mcc' );
-	expect( link ).toContain( 'annual_revenue' );
 	expect( link ).toContain( 'business_type' );
-	expect( link ).toContain( 'go_live_timeframe' );
 };
 
 describe( 'Loading', () => {
@@ -73,8 +71,6 @@ describe( 'Loading', () => {
 			country: 'US',
 			business_type: 'individual',
 			mcc: 'most_popular__software_services',
-			annual_revenue: 'less_than_250k',
-			go_live_timeframe: 'within_1month',
 		};
 
 		render( <Loading name="loading" /> );

--- a/client/onboarding/strings.tsx
+++ b/client/onboarding/strings.tsx
@@ -76,14 +76,6 @@ export default {
 			'What type of goods or services does your business sell? ',
 			'woocommerce-payments'
 		),
-		annual_revenue: __(
-			'What is your estimated annual Ecommerce revenue (USD)?',
-			'woocommerce-payments'
-		),
-		go_live_timeframe: __(
-			'What is the estimated timeline for taking your store live?',
-			'woocommerce-payments'
-		),
 	},
 	errors: {
 		generic: __( 'Please provide a response', 'woocommerce-payments' ),
@@ -100,11 +92,6 @@ export default {
 	placeholders: {
 		generic: __( 'Select an option', 'woocommerce-payments' ),
 		country: __( 'Select a country', 'woocommerce-payments' ),
-		annual_revenue: __(
-			'Select your annual revenue',
-			'woocommerce-payments'
-		),
-		go_live_timeframe: __( 'Select a timeline', 'woocommerce-payments' ),
 	},
 	annualRevenues: {
 		less_than_250k: __( 'Less than $250k', 'woocommerce-payments' ),

--- a/client/onboarding/test/form.tsx
+++ b/client/onboarding/test/form.tsx
@@ -113,42 +113,42 @@ describe( 'Onboarding Form', () => {
 
 	describe( 'OnboardingTextField', () => {
 		it( 'renders component with provided props ', () => {
-			data = { annual_revenue: 'Less than $250k' };
+			data = { country: 'United States' };
 			error.mockReturnValue( 'error message' );
 
-			render( <OnboardingTextField name="annual_revenue" /> );
+			render( <OnboardingTextField name="country" /> );
 
 			const textField = screen.getByLabelText(
-				'What is your estimated annual Ecommerce revenue (USD)?'
+				'Where is your business located?'
 			);
 			const errorMessage = screen.getByText( 'error message' );
 
-			expect( textField ).toHaveValue( 'Less than $250k' );
+			expect( textField ).toHaveValue( 'United States' );
 			expect( errorMessage ).toBeInTheDocument();
 		} );
 
 		it( 'calls setData on change', () => {
-			render( <OnboardingTextField name="annual_revenue" /> );
+			render( <OnboardingTextField name="country" /> );
 
 			const textField = screen.getByLabelText(
-				'What is your estimated annual Ecommerce revenue (USD)?'
+				'Where is your business located?'
 			);
 			textField.focus(); // Workaround for `type` not triggering focus.
-			userEvent.type( textField, 'Less than $250k' );
+			userEvent.type( textField, 'United States' );
 
 			expect( setData ).toHaveBeenCalledWith( {
-				annual_revenue: 'Less than $250k',
+				country: 'United States',
 			} );
 
 			expect( validate ).not.toHaveBeenCalled();
 		} );
 
 		it( 'calls validate on change if touched', () => {
-			touched = { annual_revenue: true };
-			render( <OnboardingTextField name="annual_revenue" /> );
+			touched = { country: true };
+			render( <OnboardingTextField name="country" /> );
 
 			const textField = screen.getByLabelText(
-				'What is your estimated annual Ecommerce revenue (USD)?'
+				'Where is your business located?'
 			);
 			userEvent.type( textField, 'John' );
 
@@ -156,10 +156,10 @@ describe( 'Onboarding Form', () => {
 		} );
 
 		it( 'calls validate on change if not focused', () => {
-			render( <OnboardingTextField name="annual_revenue" /> );
+			render( <OnboardingTextField name="country" /> );
 
 			const textField = screen.getByLabelText(
-				'What is your estimated annual Ecommerce revenue (USD)?'
+				'Where is your business located?'
 			);
 			userEvent.type( textField, 'John' );
 
@@ -167,10 +167,10 @@ describe( 'Onboarding Form', () => {
 		} );
 
 		it( 'calls validate on blur', () => {
-			render( <OnboardingTextField name="annual_revenue" /> );
+			render( <OnboardingTextField name="country" /> );
 
 			const textField = screen.getByLabelText(
-				'What is your estimated annual Ecommerce revenue (USD)?'
+				'Where is your business located?'
 			);
 			userEvent.type( textField, 'John' );
 			userEvent.tab();

--- a/client/onboarding/test/validation.ts
+++ b/client/onboarding/test/validation.ts
@@ -10,16 +10,13 @@ import { useValidation } from '../validation';
 import { OnboardingContextProvider } from '../context';
 
 describe( 'useValidation', () => {
-	it( 'uses a generic string for a non existing error', () => {
-		const { result } = renderHook(
-			() => useValidation( 'annual_revenue' ),
-			{
-				wrapper: OnboardingContextProvider,
-			}
-		);
+	it( 'uses correct string for error', () => {
+		const { result } = renderHook( () => useValidation( 'country' ), {
+			wrapper: OnboardingContextProvider,
+		} );
 
 		act( () => result.current.validate() );
 
-		expect( result.current.error() ).toEqual( 'Please provide a response' );
+		expect( result.current.error() ).toEqual( 'Please provide a country' );
 	} );
 } );

--- a/client/onboarding/types.ts
+++ b/client/onboarding/types.ts
@@ -9,25 +9,7 @@ export type OnboardingFields = {
 	business_type?: string;
 	'company.structure'?: string;
 	mcc?: string;
-	annual_revenue?: string;
-	go_live_timeframe?: string;
 };
-
-export interface PoEligibleResponse {
-	result: 'eligible' | 'not_eligible';
-}
-
-export interface PoEligibleData {
-	business: {
-		country: string;
-		type: string;
-		mcc: string;
-	};
-	store: {
-		annual_revenue: string;
-		go_live_timeframe: string;
-	};
-}
 
 export interface Country {
 	key: string;

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -68,27 +68,19 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 						'description' => 'The self-assessment data.',
 						'type'        => 'object',
 						'properties'  => [
-							'country'           => [
+							'country'       => [
 								'type'        => 'string',
 								'description' => 'The country code where the company is legally registered.',
 							],
-							'business_type'     => [
+							'business_type' => [
 								'type'        => 'string',
 								'description' => 'The company incorporation type.',
 							],
-							'mcc'               => [
+							'mcc'           => [
 								'type'        => 'string',
 								'description' => 'The merchant category code. This can either be a true MCC or an MCCs tree item id from the onboarding form.',
 							],
-							'annual_revenue'    => [
-								'type'        => 'string',
-								'description' => 'The estimated annual revenue bucket id.',
-							],
-							'go_live_timeframe' => [
-								'type'        => 'string',
-								'description' => 'The timeframe bucket for the estimated first live transaction.',
-							],
-							'site'              => [
+							'site'          => [
 								'type'        => 'string',
 								'description' => 'The URL of the site.',
 							],

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -549,10 +549,6 @@ class WC_Payments_Onboarding_Service {
 						'last_name'  => $self_assessment_data['individual']['last_name'] ?? null,
 						'phone'      => $self_assessment_data['phone'] ?? null,
 					],
-					'store'         => [
-						'annual_revenue'    => $self_assessment_data['annual_revenue'] ?? null,
-						'go_live_timeframe' => $self_assessment_data['go_live_timeframe'] ?? null,
-					],
 				]
 			);
 		} elseif ( 'test_drive' === $setup_mode ) {

--- a/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-progressive-onboarding.spec.ts
@@ -47,25 +47,6 @@ test.describe(
 			await page.getByText( 'Software' ).click();
 			// Accept terms and conditions
 			await page.getByRole( 'button', { name: 'Continue' } ).click();
-			// Pick annual revenue
-			await page
-				.getByRole( 'button', {
-					name: 'What is your estimated annual',
-				} )
-				.click();
-			await page
-				.getByRole( 'option', { name: 'Less than $250k' } )
-				.click();
-			// Pick estimated time to launch
-			await page
-				.getByRole( 'button', {
-					name: 'What is the estimated timeline',
-				} )
-				.click();
-			await page
-				.getByRole( 'option', { name: 'Within 1 month' } )
-				.click();
-			await page.getByRole( 'button', { name: 'Continue' } ).click();
 
 			// Check that Stripe Embedded KYC iframe is loaded.
 			await expect(

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 9.8.1
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 9.2.1
+ * Version: 9.3.0
  * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
Closes WOOPMNT-4947

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- A small follow-up to #10718 which removes self-assessment questions (go-live readiness and expected TPV) from the onboarding form, since they are no longer required now that we no longer allow PO onboarding.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new JN site using this branch.
* Go to `WooCommerce > Settings > Advanced > Features` and disable the new payments experience, if it is enabled.
* Reload the page, then go to `Payments` - you should be taken to the WooPayments connect page.
* Start an onboarding, verify that you do NOT see the self-assessment store readiness questions. It should look something like this:

<img width="799" alt="Screenshot 2025-05-01 at 15 25 56" src="https://github.com/user-attachments/assets/e1ba1fa5-cad1-4d05-8222-73bd1544716b" />

* Verify that you can successfully complete an onboarding. 
* Reset the account from the WooPayments Overview page, then go back to the `Payments` tab, and onboard a test drive account and verify this works as expected.
-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
