### PR TITLE
Delete NOX profile during account reset from Overview or Connect page

### DIFF
--- a/changelog/fix-account-reset-remove-nox-profile
+++ b/changelog/fix-account-reset-remove-nox-profile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Delete NOX profile during account reset from Overview or Connect page.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -40,6 +40,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	const TRACKS_EVENT_ACCOUNT_CONNECT_FINISHED                 = 'wcpay_account_connect_finished';
 	const TRACKS_EVENT_KYC_REMINDER_MERCHANT_RETURNED           = 'wcpay_kyc_reminder_merchant_returned';
 	const TRACKS_EVENT_ACCOUNT_REFERRAL                         = 'wcpay_account_referral';
+	const NOX_PROFILE_OPTION_KEY                                = 'woocommerce_woopayments_nox_profile';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -1378,6 +1379,10 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 				$this->onboarding_service->cleanup_on_account_reset();
 				delete_transient( self::ONBOARDING_TEST_DRIVE_SETTINGS_FOR_LIVE_ACCOUNT );
+
+				// Delete the NOX profile option on account reset.
+				// This is needed to ensure merchants are not stuck with account reset and profile option set.
+				delete_option( self::NOX_PROFILE_OPTION_KEY );
 
 				// Track the onboarding (not account) reset.
 				$this->tracks_event(


### PR DESCRIPTION
Fixes WOOPMNT-4942

#### Changes proposed in this Pull Request
This PR ensures that the `woocommerce_woopayments_nox_profile` option is deleted when the account is reset from the Overview or Connect pages. Previously, this option was only cleared via the NOX settings page, which could lead to unexpected behavior in the NOX In-context flows when resets occurred elsewhere.

#### Testing instructions
**Prerequisites**
1. Check out this PR locally.
2. Check out WooCommerce core `add/onboarding-modal` branch locally.
3. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature if it is disabled. Click Save changes.
4. If you have a WooPayments account connected, please disconnect it.

**Testing instructions**
1. Checkout this PR branch.
1. Go to WooCommerce > Settings > Payments in the admin dashboard.
2. Click the Enable or Complete setup button for the WooPayments payment method.
3. Confirm that the Onboarding Modal opens and displays the Select payment methods screen.
4. Select any PMs from the list and click Continue.
6. Ensure the test account creation kicks in.
7. After a successful account creation, navigate to Payments > Overview page.
8. Click "Reset account" button under "Account Tools". Confirm the reset with "Yes, reset account" button.
9. Go to WooCommerce > Settings > Payments.
10. Click Complete setup next to WooPayments gateway.
11. Ensure the onboarding starts from payment methods selection screen.
12. Pick some PMs and click Continue.
13. Ensure a test account is onboarded successfully.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
