### PR TITLE
WOOPMNT-4943: [WooPayments NOX] Fix capabilities query param type

### DIFF
--- a/changelog/fix-capabilities-type-controller
+++ b/changelog/fix-capabilities-type-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix capabilities query param type

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -177,9 +177,14 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 					],
 					'capabilities' => [
 						'description' => 'The capabilities to request and enable for the test-drive account. Leave empty to use the default capabilities.',
-						'type'        => 'array',
+						'type'        => 'object',
 						'default'     => [],
 						'required'    => false,
+						'properties'  => [
+							'*' => [
+								'type' => 'boolean',
+							],
+						],
 					],
 				],
 			]


### PR DESCRIPTION
Fixes WOOPMNT-4943

#### Changes proposed in this Pull Request

As part of the NOX In-Context flow, merchants can select which payment methods to enable. Then, this list is sent to the WooPayments plugin to create a test account.

The current capabilities definition expects an array like: `[ "card", "klarna" ]` while the [implementation](https://github.com/Automattic/woocommerce-payments/blob/71cf2690f2b7a3cff816bbc527365368604b31f9/includes/class-wc-payments-onboarding-service.php#L505) expects:
```
[
    "card" => 1,
    "klarna" => 1
]
```

This PR fixes the definition to unblock the API calls (currently failing with:
```
REST request POST /wc/v3/payments/onboarding/test_drive_account/init failed with: (rest_invalid_param) Invalid parameter(s): capabilities
``` 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site with https://github.com/woocommerce/woocommerce/pull/56229 and this PR
* Go to NOX In-Context, select specific PMs to enable, and click continue
* After the test account creation is finalized, close the modal, and click Manage
* Once on the WooPayments Settings page, double-check that the PMs selected are the only ones turned on.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
