### PR TITLE
Fix Apple Pay and Google Pay not requested from NOX In-context flow

### DIFF
--- a/changelog/fix-apple-google-pay-toggle-nox
+++ b/changelog/fix-apple-google-pay-toggle-nox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix Apple Pay and Google Pay not requested from NOX In-context flow.

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1409,7 +1409,7 @@ class WC_Payments_Onboarding_Service {
 		}
 
 		// Update gateway option with the Apple/Google Pay capability.
-		if ( ! empty( $capabilities['apple_google'] ) ) {
+		if ( ! empty( $capabilities['apple_google'] ) || ( ! empty( $capabilities['apple_pay'] ) || ! empty( $capabilities['google_pay'] ) ) ) {
 			$gateway->update_option( 'payment_request', 'yes' );
 		} else {
 			$gateway->update_option( 'payment_request', 'no' );


### PR DESCRIPTION
Fixes WOOPMNT-4944

#### Changes proposed in this Pull Request
This PR resolves an issue where Apple Pay and Google Pay were not being correctly requested during the onboarding process via the NOX In-context flow, even when those options were selected by the merchant.

#### Testing instructions
**Prerequisites**
1. Check out this PR locally.
2. Check out WooCommerce core `trunk` branch locally.
3. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature if it is disabled. Click Save changes.
4. If you have a WooPayments account connected, please disconnect it.

**Testing instructions**
1. Check out this PR branch.
1. Go to WooCommerce > Settings > Payments in the admin dashboard.
2. Click the Enable or Complete setup button for the WooPayments payment method.
3. Confirm that the Onboarding Modal opens and displays the Select payment methods screen.
4. Enable Apple Pay & Google Pay toggle from the list and click Continue.
6. Ensure the test account creation kicks in.
7. After a successful account creation, close the modal and click the Manage button.
8. Scroll down and ensure the Apple Pay and Google Pay payment methods are requested and the checkbox is checked.
9. Go to WooCommerce > Settings > Payments.
10. Click the three dots button next to the WooPayments gateway and Reset account.
11. Click the Complete setup button for the WooPayments payment method.
12. Disable Apple Pay & Google Pay toggle from the list and click Continue.
13. After a successful account creation, close the modal and click the Manage button.
14. Scroll down and ensure the Apple Pay and Google Pay checkbox is not checked.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
