### PR TITLE
chore: update WordPress 'tested up to' 6.8

### DIFF
--- a/changelog/chore-update-wp-tested-up-to-6-8
+++ b/changelog/chore-update-wp-tested-up-to-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+chore: update "Tested up to" WordPress 6.8

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 7.3
 Stable tag: 9.3.0
 License: GPLv2 or later


### PR DESCRIPTION
6.8 was released on Apr 15th: https://wordpress.org/news/2025/04/cecil/