### PR TITLE
Settings - Persist Payment Method Checkbox After Capability Request

### DIFF
--- a/changelog/update-persist-wechat-pay-alipay-checked-state
+++ b/changelog/update-persist-wechat-pay-alipay-checked-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Perist payment method checkbox after capability request

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -310,15 +310,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/request-capability',
-			[
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $this, 'request_capability' ],
-				'permission_callback' => [ $this, 'check_permission' ],
-			]
-		);
 	}
 
 	/**
@@ -1045,29 +1036,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		if ( $request ) {
 			return new WP_REST_Response( [], 200 );
 		}
-	}
-
-	/**
-	 * Request a specific capability.
-	 *
-	 * @param WP_REST_Request $request The request object. Optional. If passed, the function will return a REST response.
-	 *
-	 * @return WP_REST_Response|WP_Error The response object, if this is a REST request.
-	 */
-	public function request_capability( ?WP_REST_Request $request = null ) {
-		$request_result          = null;
-		$id                      = $request->get_param( 'id' );
-		$capability_key_map      = $this->wcpay_gateway->get_payment_method_capability_key_map();
-		$payment_method_statuses = $this->wcpay_gateway->get_upe_enabled_payment_method_statuses();
-		$stripe_key              = $capability_key_map[ $id ] ?? null;
-
-		if ( array_key_exists( $stripe_key, $payment_method_statuses )
-			&& 'unrequested' === $payment_method_statuses[ $stripe_key ]['status'] ) {
-			$request_result = $this->api_client->request_capability( $stripe_key, true );
-			$this->wcpay_gateway->refresh_cached_account_data();
-		}
-
-		return rest_ensure_response( $request_result );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -615,16 +615,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		);
 
 		$this->request_unrequested_payment_methods( $payment_method_ids_to_enable );
-		$capability_key_map      = $this->wcpay_gateway->get_payment_method_capability_key_map();
-		$payment_method_statuses = $this->wcpay_gateway->get_upe_enabled_payment_method_statuses();
-
-		$payment_method_ids_to_enable = array_filter(
-			$payment_method_ids_to_enable,
-			function ( $payment_method_id_to_enable ) use ( $capability_key_map, $payment_method_statuses ) {
-				$stripe_key = $capability_key_map[ $payment_method_id_to_enable ] ?? null;
-				return array_key_exists( $stripe_key, $payment_method_statuses ) && 'active' === $payment_method_statuses[ $stripe_key ]['status'];
-			}
-		);
 
 		$active_payment_methods   = $this->wcpay_gateway->get_upe_enabled_payment_method_ids();
 		$disabled_payment_methods = array_diff( $active_payment_methods, $payment_method_ids_to_enable );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -862,8 +862,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( ! WC_Payments::get_gateway()->is_enabled() ) {
 			return false;
 		}
-		$processing_payment_method = $this->payment_methods[ $this->payment_method->get_id() ];
+
+		$payment_method_id         = $this->payment_method->get_id();
+		$processing_payment_method = $this->payment_methods[ $payment_method_id ];
 		if ( ! $processing_payment_method->is_enabled_at_checkout( $this->get_account_country() ) ) {
+			return false;
+		}
+
+		$payment_method_statuses  = $this->get_upe_enabled_payment_method_statuses();
+		$stripe_key               = $this->get_payment_method_capability_key_map()[ $payment_method_id ] ?? null;
+		$is_payment_method_active = array_key_exists( $stripe_key, $payment_method_statuses ) && 'active' === $payment_method_statuses[ $stripe_key ]['status'];
+		if ( false === $is_payment_method_active ) {
 			return false;
 		}
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -383,12 +383,11 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		$request = new WP_REST_Request();
 
-		// Ideal will not have the capability status, 'active', and will therefore not added to the list of enabled payment methods.
 		$request->set_param( 'enabled_payment_method_ids', [ Payment_Method::CARD, Payment_Method::IDEAL ] );
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( [ Payment_Method::CARD ], WC_Payments::get_gateway()->get_option( 'upe_enabled_payment_method_ids' ) );
+		$this->assertEquals( [ Payment_Method::CARD, Payment_Method::IDEAL ], WC_Payments::get_gateway()->get_option( 'upe_enabled_payment_method_ids' ) );
 	}
 
 	public function test_update_settings_fails_if_user_cannot_manage_woocommerce() {


### PR DESCRIPTION
Fixes WOOPMNT-4963

#### Changes proposed in this Pull Request

- Move the check of active payment method from the Settings Controller method in `update_enabled_payment_methods` to the `gateway->is_available`
- This change allows the merchant to save selected payment methods when these payment methods require additional reviews, i.e. in the pending state for a while. This applies to Alipay and Wechat Pay. 
- When the payment method capability changes from `pending` to `active`, it keeps being selected and can display in the checkout. Before the capability switches to `active`, it will be filtered out from the checkout page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable WeChat Pay and Alipay via the metadata in your local server. Needs to use a US-based account. 
- In WP Admin > WooPayments > Settings, try to enable WeChat Pay or Alipay or both. 
- Expect: the selected payment method shows Pending Verification.
- Expect: the checkout page does not display WeChat Pay or Alipay. 
- Go to WP Admin > WooPayments > Overview, update more info to remove the Restricted status and more info.
- Expect: WP Admin > WooPayments > Settings, WeChat Pay / Alipay are still checked.
- Expect: the checkout page displays WeChat Pay / Alipay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
