### PR TITLE
chore: remove sofort deprecation notices from settings

### DIFF
--- a/changelog/chore-remove-sofort-deprecation-notices-from-frontend
+++ b/changelog/chore-remove-sofort-deprecation-notices-from-frontend
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: remove sofort deprecation notices from the settings UI, since Sofort can no longer be displayed there.
+
+

--- a/client/settings/payment-methods-list/delete-modal.tsx
+++ b/client/settings/payment-methods-list/delete-modal.tsx
@@ -12,7 +12,6 @@ import interpolateComponents from '@automattic/interpolate-components';
  */
 import PaymentDeleteIllustration from 'wcpay/components/payment-delete-illustration';
 import ConfirmationModal from 'wcpay/components/confirmation-modal';
-import InlineNotice from 'wcpay/components/inline-notice';
 
 const ConfirmPaymentMethodDeleteModal: React.FunctionComponent< {
 	id: string;

--- a/client/settings/payment-methods-list/delete-modal.tsx
+++ b/client/settings/payment-methods-list/delete-modal.tsx
@@ -21,8 +21,6 @@ const ConfirmPaymentMethodDeleteModal: React.FunctionComponent< {
 	onConfirm: () => void;
 	onCancel: () => void;
 } > = ( { id, label, icon: Icon, onConfirm, onCancel } ): JSX.Element => {
-	const shouldDisplayNotice = id === 'sofort';
-
 	return (
 		<ConfirmationModal
 			title={ sprintf(
@@ -80,29 +78,6 @@ const ConfirmPaymentMethodDeleteModal: React.FunctionComponent< {
 					},
 				} ) }
 			</p>
-			{ shouldDisplayNotice && (
-				<InlineNotice
-					status="warning"
-					icon={ true }
-					isDismissible={ false }
-					className="sofort__notice"
-				>
-					<span>
-						{ __(
-							'As of October 20th 2023, Sofort is no longer supported for merchants who are not already using it. This means that if you disable Sofort, you will not be able to re-enable it later. ',
-							'woocommerce-payments'
-						) }
-						<a
-							// eslint-disable-next-line max-len
-							href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-migration"
-							target="_blank"
-							rel="external noreferrer noopener"
-						>
-							{ __( 'Learn more', 'woocommerce-payments' ) }
-						</a>
-					</span>
-				</InlineNotice>
-			) }
 		</ConfirmationModal>
 	);
 };

--- a/client/settings/payment-methods-list/payment-method.scss
+++ b/client/settings/payment-methods-list/payment-method.scss
@@ -7,10 +7,6 @@
 	&:not( :last-child ) {
 		box-shadow: inset 0 -1px 0 #e8eaeb;
 	}
-
-	& .sofort__notice {
-		margin-top: 20px;
-	}
 }
 
 .payment-method {

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -22,7 +22,6 @@ import WCPaySettingsContext from '../wcpay-settings-context';
 import Chip from 'wcpay/components/chip';
 import LoadableCheckboxControl from 'wcpay/components/loadable-checkbox';
 import Pill from 'wcpay/components/pill';
-import InlineNotice from 'wcpay/components/inline-notice';
 import './payment-method.scss';
 import DuplicateNotice from 'wcpay/components/duplicate-notice';
 import DuplicatedPaymentMethodsContext from '../settings-manager/duplicated-payment-methods-context';

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -186,7 +186,6 @@ const PaymentMethod = ( {
 		needsMoreInformation ||
 		isPoInProgress ||
 		upeCapabilityStatuses.REJECTED === status;
-	const shouldDisplayNotice = id === 'sofort';
 	const {
 		duplicates,
 		dismissedDuplicateNotices,
@@ -394,29 +393,6 @@ const PaymentMethod = ( {
 					</div>
 				</div>
 			</div>
-			{ shouldDisplayNotice && (
-				<InlineNotice
-					status="warning"
-					icon={ true }
-					isDismissible={ false }
-					className="sofort__notice"
-				>
-					<span>
-						{ __(
-							'Support for Sofort is ending soon. ',
-							'woocommerce-payments'
-						) }
-						<a
-							// eslint-disable-next-line max-len
-							href="https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#sofort-migration"
-							target="_blank"
-							rel="external noreferrer noopener"
-						>
-							{ __( 'Learn more', 'woocommerce-payments' ) }
-						</a>
-					</span>
-				</InlineNotice>
-			) }
 			{ isDuplicate && (
 				<DuplicateNotice
 					paymentMethod={ id }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed here: p1746633782106289-slack-CGGCLBN58
Since as of https://github.com/automattic/woocommerce-payments/pull/9820 and https://github.com/Automattic/transact-platform-server/pull/6916 we no longer display Sofort in the settings, these notices will no longer be displayed.

Let's clean up some stuff.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.