### PR TITLE
Set payment method title for order before status change.

### DIFF
--- a/changelog/woopmnt-4857-3ds-challenge-flow-causes-payment-method-field-to-disappear
+++ b/changelog/woopmnt-4857-3ds-challenge-flow-causes-payment-method-field-to-disappear
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Set payment method title for order before order status change to make it visible for status change actions.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1966,8 +1966,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( Intent_Status::SUCCEEDED === $status ) {
 					$this->duplicate_payment_prevention_service->remove_session_processing_order( $order->get_id() );
 				}
-				$this->order_service->update_order_status_from_intent( $order, $intent );
 				$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
+				$this->order_service->update_order_status_from_intent( $order, $intent );
 				$this->order_service->attach_transaction_fee_to_order( $order, $charge );
 
 				if ( Intent_Status::REQUIRES_ACTION === $status ) {


### PR DESCRIPTION
 - Attempts to fix #10560 
 - Attempts to fix WOOPMNT-4857

#### Changes proposed in this Pull Request

In the linked issue, a merchant reports that new order emails do not contain payment method information in some cases, possibly related to the 3DS flow. I couldn't replicate the scenario in the test mode, by using various test card combinations and 3DS failures/approvals. However, I found that the line with the payment method is added [when a payment method title is available in the order data](https://github.com/woocommerce/woocommerce/blob/7b58022e3f80dca9754b6304bd57844d25359db3/plugins/woocommerce/includes/class-wc-order.php#L2385). And in the WooPayments we set order status, which triggers the new order email, before setting a payment method title.

With this change, the payment method title will be set before the order status switch and should be available for the email template.


#### Testing instructions

As I don't have a way to replicate the original issue, the focus of the testing steps is on making sure that there is no regression.

 * Install a "WP Mail Logging" plugin to be able to view generated emails.
 * Create an order in the store.
 * Try to pay it with WooPayments, using different card combinations, e.g.:
   * Use a declined card for the first payment and successful for the second attempt.
   * Trigger 3DS authentication, e.g. with card `4000002760003184` and fail it first, but complete on the second attempt.
   * Other scenarios that might come to mind.
  * Check that "New order" emails, directed to the store admin, always contain an appropriate payment method title.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or _does not apply_)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
