### PR TITLE
refactor: use WP components from a few locations

### DIFF
--- a/changelog/refactor-selectively-use-card-component
+++ b/changelog/refactor-selectively-use-card-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+refactor: start using @wordpress/components from the WP installation on a few select locations

--- a/client/components/card/index.tsx
+++ b/client/components/card/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { ComponentProps, useContext } from 'react';
+import { Card as WordPressComponentsCard } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
+
+const WcpayCard = (
+	props: ComponentProps< typeof WordPressComponentsCard >
+) => {
+	const { Card } = useContext( WordPressComponentsContext );
+
+	return <Card { ...props } />;
+};
+
+export default WcpayCard;

--- a/client/components/card/index.tsx
+++ b/client/components/card/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ComponentProps, useContext } from 'react';
-import { Card as WordPressComponentsCard } from '@wordpress/components';
+import { Card as BundledWordPressComponentsCard } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,9 +10,15 @@ import { Card as WordPressComponentsCard } from '@wordpress/components';
 import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
 
 const WcpayCard = (
-	props: ComponentProps< typeof WordPressComponentsCard >
+	props: ComponentProps< typeof BundledWordPressComponentsCard >
 ) => {
-	const { Card } = useContext( WordPressComponentsContext );
+	const context = useContext( WordPressComponentsContext );
+
+	if ( ! context ) {
+		return <BundledWordPressComponentsCard { ...props } />;
+	}
+
+	const { Card } = context;
 
 	return <Card { ...props } />;
 };

--- a/client/components/page/index.tsx
+++ b/client/components/page/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/page/index.tsx
+++ b/client/components/page/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import React from 'react';
+import * as React from 'react';
 
 /**
  * Internal dependencies

--- a/client/index.js
+++ b/client/index.js
@@ -31,6 +31,7 @@ import OnboardingPage from 'onboarding';
 import OnboardingKycPage from 'onboarding/kyc';
 import FraudProtectionAdvancedSettingsPage from './settings/fraud-protection/advanced-settings';
 import { getTasks } from 'overview/task-list/tasks';
+import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
 
 addFilter(
 	'woocommerce_admin_pages_list',
@@ -136,7 +137,11 @@ addFilter(
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
-			container: PaymentDetailsPage,
+			container: ( { query } ) => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<PaymentDetailsPage query={ query } />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/transactions/details',
 			wpOpenMenu: menuID,
 			breadcrumbs: [

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -5,7 +5,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Card,
 	CardBody,
 	CardDivider,
 	Flex,
@@ -68,6 +67,7 @@ import {
 	formatDateTimeFromString,
 	formatDateTimeFromTimestamp,
 } from 'wcpay/utils/date-time';
+import Card from 'wcpay/components/card';
 
 declare const window: any;
 

--- a/client/settings/card-body/index.tsx
+++ b/client/settings/card-body/index.tsx
@@ -21,7 +21,8 @@ const WcpayCardBody: React.FC< WcpayCardBodyProps > = ( {
 } ): JSX.Element => {
 	const context = useContext( WordPressComponentsContext );
 
-	// including the woopayments-specific styles only for the card body. leaving the `CardBody` bundled within the WP installation as "pristine" as possible, instead.
+	// including the woopayments-specific styles only for the "bundled" CardBody component.
+	// leaving the `CardBody` bundled within the WP installation as "pristine" as possible, instead.
 	if ( ! context ) {
 		return (
 			<BundledWordPressComponentsCardBody

--- a/client/settings/card-body/index.tsx
+++ b/client/settings/card-body/index.tsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { CardBody } from '@wordpress/components';
+import React, { useContext } from 'react';
+import { CardBody as BundledWordPressComponentsCardBody } from '@wordpress/components';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import './styles.scss';
+import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
 
 interface WcpayCardBodyProps {
 	className?: string;
@@ -17,11 +18,22 @@ interface WcpayCardBodyProps {
 const WcpayCardBody: React.FC< WcpayCardBodyProps > = ( {
 	className,
 	...props
-} ): JSX.Element => (
-	<CardBody
-		className={ classNames( 'wcpay-card-body', className ) }
-		{ ...props }
-	/>
-);
+} ): JSX.Element => {
+	const context = useContext( WordPressComponentsContext );
+
+	// including the woopayments-specific styles only for the card body. leaving the `CardBody` bundled within the WP installation as "pristine" as possible, instead.
+	if ( ! context ) {
+		return (
+			<BundledWordPressComponentsCardBody
+				className={ classNames( 'wcpay-card-body', className ) }
+				{ ...props }
+			/>
+		);
+	}
+
+	const { CardBody } = context;
+
+	return <CardBody className={ className } { ...props } />;
+};
 
 export default WcpayCardBody;

--- a/client/wordpress-components-context/context.tsx
+++ b/client/wordpress-components-context/context.tsx
@@ -2,6 +2,5 @@
  * External dependencies
  */
 import { createContext } from 'react';
-import * as WordpressComponents from '@wordpress/components';
 
-export const WordPressComponentsContext = createContext( WordpressComponents );
+export const WordPressComponentsContext = createContext< any >( undefined );

--- a/client/wordpress-components-context/context.tsx
+++ b/client/wordpress-components-context/context.tsx
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ */
+import { createContext } from 'react';
+import * as WordpressComponents from '@wordpress/components';
+
+export const WordPressComponentsContext = createContext( WordpressComponents );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use `4000000000002685` to file a dispute
- Inspect the dispute details (or transaction details) page

<img width="1088" alt="Screenshot 2025-05-08 at 5 39 20 PM" src="https://github.com/user-attachments/assets/83b14945-0d2a-4691-812d-8aa45059c503" />


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
