### PR TITLE
dev: replace classNames with clsx

### DIFF
--- a/changelog/dev-replace-classnames-with-clsx
+++ b/changelog/dev-replace-classnames-with-clsx
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: dev: replace classNames with clsx
+
+

--- a/client/card-readers/list/list-item.tsx
+++ b/client/card-readers/list/list-item.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { CardReader } from 'wcpay/types/card-readers';
@@ -18,7 +18,7 @@ const CardReaderListItem: React.FunctionComponent< {
 		: __( 'Inactive', 'woocommerce-payments' );
 
 	return (
-		<li className={ classNames( 'card-readers-item', id ) }>
+		<li className={ clsx( 'card-readers-item', id ) }>
 			<div className="card-readers-item__id">
 				<span>{ id }</span>
 			</div>

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -8,7 +8,7 @@ import {
 } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -276,7 +276,7 @@ const PaymentProcessor = ( {
 		<>
 			{ isTestMode && (
 				<p
-					className={ classNames( 'content', {
+					className={ clsx( 'content', {
 						[ `theme--${ theme }` ]: theme,
 					} ) }
 					dangerouslySetInnerHTML={ {

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import React, { useCallback, useEffect, useState, useRef } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -370,7 +370,7 @@ export const WoopayExpressCheckoutButton = ( {
 				key={ `${ buttonType }-${ theme }-${ buttonSize }` }
 				aria-label={ buttonText }
 				onClick={ ( e ) => onClickCallbackRef.current( e ) }
-				className={ classNames( 'woopay-express-button', {
+				className={ clsx( 'woopay-express-button', {
 					'is-loading': isLoading,
 				} ) }
 				data-type={ buttonType }

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { useEffect, renderToString } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { Icon, Button } from '@wordpress/components';
 import { check, info } from '@wordpress/icons';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
@@ -127,11 +127,7 @@ const BannerNotice: React.FC< Props > = ( {
 
 	const iconToDisplay = icon === true ? statusIconMap[ status ] : icon;
 
-	const classes = classNames(
-		className,
-		'wcpay-banner-notice',
-		'is-' + status
-	);
+	const classes = clsx( className, 'wcpay-banner-notice', 'is-' + status );
 
 	const handleRemove = () => onRemove?.();
 

--- a/client/components/confirmation-modal/index.tsx
+++ b/client/components/confirmation-modal/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { Modal } from '@wordpress/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { HorizontalRule } from '@wordpress/primitives';
 
 /**
@@ -22,7 +22,7 @@ const ConfirmationModal: React.FunctionComponent< ConfirmationModalProps > = ( {
 	...props
 } ) => (
 	<Modal
-		className={ classNames( 'wcpay-confirmation-modal', className ) }
+		className={ clsx( 'wcpay-confirmation-modal', className ) }
 		{ ...props }
 	>
 		{ children }

--- a/client/components/copy-button/index.tsx
+++ b/client/components/copy-button/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ export const CopyButton: React.FC< CopyButtonProps > = ( {
 	return (
 		<button
 			type="button"
-			className={ classNames( 'woopayments-copy-button', {
+			className={ clsx( 'woopayments-copy-button', {
 				'state--copied': copied,
 			} ) }
 			aria-label={ label }

--- a/client/components/custom-select-control/index.tsx
+++ b/client/components/custom-select-control/index.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { Button } from '@wordpress/components';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, UseSelectState } from 'downshift';
 
@@ -145,7 +145,7 @@ function CustomSelectControl< ItemType extends Item >( {
 	}
 	return (
 		<div
-			className={ classNames(
+			className={ clsx(
 				'wcpay components-custom-select-control',
 				className
 			) }
@@ -166,7 +166,7 @@ function CustomSelectControl< ItemType extends Item >( {
 					'aria-label': label,
 					'aria-labelledby': undefined,
 					'aria-describedby': getDescribedBy(),
-					className: classNames(
+					className: clsx(
 						'components-custom-select-control__button',
 						{ placeholder: ! itemString }
 					),
@@ -191,7 +191,7 @@ function CustomSelectControl< ItemType extends Item >( {
 								item,
 								index,
 								key: item.key,
-								className: classNames(
+								className: clsx(
 									item.className,
 									'components-custom-select-control__item',
 									{

--- a/client/components/form/fields.tsx
+++ b/client/components/form/fields.tsx
@@ -3,7 +3,7 @@
  */
 import React, { forwardRef } from 'react';
 import { TextControl } from '@wordpress/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ const makeField = (
 			<Control
 				{ ...rest }
 				ref={ ref }
-				className={ classNames( rest.className, 'has-error' ) }
+				className={ clsx( rest.className, 'has-error' ) }
 			/>
 			{ <div className="components-form-field__error">{ error }</div> }
 		</>

--- a/client/components/grouped-select-control/index.tsx
+++ b/client/components/grouped-select-control/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useRef, useState } from 'react';
 import { check, chevronDown, chevronUp, Icon } from '@wordpress/icons';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { useSelect, UseSelectState } from 'downshift';
 
@@ -159,7 +159,7 @@ const GroupedSelectControl = < ItemType extends ListItem >( {
 
 	return (
 		<div
-			className={ classNames(
+			className={ clsx(
 				'wcpay-component-grouped-select-control',
 				className
 			) }
@@ -174,7 +174,7 @@ const GroupedSelectControl = < ItemType extends ListItem >( {
 			<button
 				{ ...getToggleButtonProps( {
 					type: 'button',
-					className: classNames(
+					className: clsx(
 						'components-text-control__input wcpay-component-grouped-select-control__button',
 						{ placeholder }
 					),
@@ -217,7 +217,7 @@ const GroupedSelectControl = < ItemType extends ListItem >( {
 											item,
 											index,
 											key: item.key,
-											className: classNames(
+											className: clsx(
 												'wcpay-component-grouped-select-control__item',
 												item.className,
 												{

--- a/client/components/inline-label-select/index.tsx
+++ b/client/components/inline-label-select/index.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { Button } from '@wordpress/components';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, UseSelectState } from 'downshift';
 
@@ -169,7 +169,7 @@ function InlineLabelSelect< ItemType extends SelectItem >( {
 	}
 	return (
 		<div
-			className={ classNames(
+			className={ clsx(
 				'wcpay-filter components-custom-select-control',
 				className
 			) }
@@ -180,7 +180,7 @@ function InlineLabelSelect< ItemType extends SelectItem >( {
 					'aria-label': label,
 					'aria-labelledby': undefined,
 					'aria-describedby': getDescribedBy(),
-					className: classNames(
+					className: clsx(
 						'wcpay-filter components-custom-select-control__button',
 						{ placeholder: ! itemString }
 					),
@@ -216,7 +216,7 @@ function InlineLabelSelect< ItemType extends SelectItem >( {
 								item,
 								index,
 								key: item.key,
-								className: classNames(
+								className: clsx(
 									item.className,
 									'wcpay-filter components-custom-select-control__item',
 									{

--- a/client/components/inline-notice/index.tsx
+++ b/client/components/inline-notice/index.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { Flex, FlexItem, Icon, Notice, Button } from '@wordpress/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import CheckmarkIcon from 'gridicons/dist/checkmark';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import InfoOutlineIcon from 'gridicons/dist/info-outline';
@@ -41,7 +41,7 @@ function InlineNotice( props: InlineNoticeProps ): JSX.Element {
 	const { icon, actions, children, buttonVariant, ...noticeProps } = props;
 
 	// Add the default class name to the notice.
-	noticeProps.className = classNames(
+	noticeProps.className = clsx(
 		'wcpay-inline-notice',
 		`wcpay-inline-${ noticeProps.status }-notice`,
 		noticeProps.className

--- a/client/components/load-bar/index.tsx
+++ b/client/components/load-bar/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { HTMLAttributes } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ export const LoadBar: React.FC< HTMLAttributes< HTMLDivElement > > = ( {
 } ) => {
 	return (
 		<div
-			className={ classNames( 'wcpay-component-load-bar', className ) }
+			className={ clsx( 'wcpay-component-load-bar', className ) }
 			{ ...rest }
 		/>
 	);

--- a/client/components/loadable-checkbox/index.js
+++ b/client/components/loadable-checkbox/index.js
@@ -6,7 +6,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import React, { useEffect, useState } from 'react';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -53,7 +53,7 @@ const LoadableCheckboxControl = ( {
 
 	return (
 		<div
-			className={ classNames( 'loadable-checkbox', {
+			className={ clsx( 'loadable-checkbox', {
 				'label-hidden': hideLabel,
 			} ) }
 		>

--- a/client/components/payment-activity/survey/emoticon.tsx
+++ b/client/components/payment-activity/survey/emoticon.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -35,7 +35,7 @@ const Emoticon: React.FC< Props > = ( {
 			disabled={ disabled }
 			type="button"
 			onClick={ onClick }
-			className={ classNames( 'components-button', 'has-icon', {
+			className={ clsx( 'components-button', 'has-icon', {
 				selected: isSelected,
 			} ) }
 		>

--- a/client/components/payment-confirm-illustration/index.tsx
+++ b/client/components/payment-confirm-illustration/index.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import HelpIcon from 'gridicons/dist/help';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ const PaymentConfirmIllustration: React.FunctionComponent< {
 		<div className="payment-confirm-illustration__wrapper">
 			<div className="payment-confirm-illustration__illustrations">
 				<Icon
-					className={ classNames(
+					className={ clsx(
 						'payment-confirm-illustration__payment-icon',
 						{
 							'has-border': hasBorder,

--- a/client/components/payment-delete-illustration/index.tsx
+++ b/client/components/payment-delete-illustration/index.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import CrossCircleIcon from 'gridicons/dist/cross-circle';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ const PaymentDeleteIllustration: React.FunctionComponent< {
 		<div className="payment-delete-illustration__wrapper">
 			<div className="payment-delete-illustration__illustrations">
 				<Icon
-					className={ classNames(
+					className={ clsx(
 						'payment-delete-illustration__payment-icon',
 						{
 							'has-border': hasBorder,

--- a/client/components/phone-number-control/index.tsx
+++ b/client/components/phone-number-control/index.tsx
@@ -5,7 +5,7 @@
 import React, { useState, useRef, useLayoutEffect } from 'react';
 import { BaseControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import 'intl-tel-input';
 
 /**
@@ -76,7 +76,7 @@ const PhoneNumberControl: React.FC< Props > = ( {
 	return (
 		<BaseControl id={ id } { ...rest }>
 			<div
-				className={ classNames(
+				className={ clsx(
 					'wcpay-component-phone-number-control',
 					'components-text-control__input',
 					{

--- a/client/components/pill/index.tsx
+++ b/client/components/pill/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FC, ReactNode } from 'react';
 import { Pill as WC_Pill } from '@woocommerce/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ type PillProps = {
 const Pill: FC< PillProps > = ( { type = '', className = '', children } ) => {
 	const types = [ 'primary', 'success', 'alert', 'danger', 'light' ];
 
-	const classes = classNames(
+	const classes = clsx(
 		`wcpay-pill${ types.includes( type ) ? '__' + type : '' }`,
 		className
 	);

--- a/client/components/tip-box/index.tsx
+++ b/client/components/tip-box/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -16,13 +16,7 @@ interface Props {
 }
 const TipBox: React.FC< Props > = ( { color, className, children } ) => {
 	return (
-		<div
-			className={ classNames(
-				'wcpay-component-tip-box',
-				color,
-				className
-			) }
-		>
+		<div className={ clsx( 'wcpay-component-tip-box', color, className ) }>
 			<LightbulbIcon />
 			<div className="wcpay-component-tip-box__content">{ children }</div>
 		</div>

--- a/client/components/tooltip/index.tsx
+++ b/client/components/tooltip/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState, useRef } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { noop } from 'lodash';
 import { Icon } from '@wordpress/components';
 
@@ -148,10 +148,7 @@ export const ClickTooltip: React.FC< TooltipProps > = ( {
 				onHide={ handleHide }
 				maxWidth={ maxWidth }
 				isVisible={ isVisible || isClicked }
-				className={ classNames(
-					'wcpay-tooltip--click__tooltip',
-					className
-				) }
+				className={ clsx( 'wcpay-tooltip--click__tooltip', className ) }
 			>
 				{ buttonIcon ? (
 					<div

--- a/client/components/tooltip/tooltip-base.tsx
+++ b/client/components/tooltip/tooltip-base.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useEffect, useRef, useState, memo } from 'react';
 import { createPortal } from 'react-dom';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { debounce, noop } from 'lodash';
 
 /**
@@ -264,14 +264,13 @@ const TooltipBase: React.FC< TooltipBaseProps > = ( {
 				<TooltipPortal parentElement={ parentElement }>
 					<div
 						ref={ tooltipWrapperRef }
-						className={ classNames(
-							'wcpay-tooltip__tooltip-wrapper',
-							{ 'is-hiding': ! isVisible }
-						) }
+						className={ clsx( 'wcpay-tooltip__tooltip-wrapper', {
+							'is-hiding': ! isVisible,
+						} ) }
 						role="tooltip"
 					>
 						<div
-							className={ classNames(
+							className={ clsx(
 								'wcpay-tooltip__tooltip',
 								className
 							) }

--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -88,7 +88,7 @@ const Consumer = () => {
 
 	return (
 		<div
-			className={ classNames( {
+			className={ clsx( {
 				'id-active': isActive,
 				'is-completed': isCompleted,
 			} ) }

--- a/client/components/wizard/collapsible-body.tsx
+++ b/client/components/wizard/collapsible-body.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ const CollapsibleBody: React.FC< React.HTMLAttributes< HTMLDivElement > > = ( {
 
 	return (
 		<div
-			className={ classNames( 'task-collapsible-body', className, {
+			className={ clsx( 'task-collapsible-body', className, {
 				'is-active': isActive,
 			} ) }
 			{ ...restProps }

--- a/client/components/wizard/task-item.tsx
+++ b/client/components/wizard/task-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { Icon, check } from '@wordpress/icons';
 
 /**
@@ -30,7 +30,7 @@ const WizardTaskItem: React.FC< WizardTaskItemProps > = ( {
 
 	return (
 		<li
-			className={ classNames( 'wcpay-wizard-task', className, {
+			className={ clsx( 'wcpay-wizard-task', className, {
 				'is-completed': isCompleted,
 				'is-active': isActive,
 			} ) }
@@ -55,7 +55,7 @@ const WizardTaskItem: React.FC< WizardTaskItemProps > = ( {
 			</div>
 			{ visibleDescription && ! isActive && (
 				<span
-					className={ classNames(
+					className={ clsx(
 						'wcpay-wizard-task__visible-description-element',
 						'is-muted-color'
 					) }

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -20,7 +20,7 @@ import {
 	OrderStatus,
 } from '@woocommerce/components';
 import interpolateComponents from '@automattic/interpolate-components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies.
@@ -88,7 +88,7 @@ const SummaryItem: React.FC< SummaryItemProps > = ( {
 			<div className="woocommerce-summary__item-label">{ label }</div>
 			<div className="woocommerce-summary__item-data">
 				<div
-					className={ classNames(
+					className={ clsx(
 						'woocommerce-summary__item-value',
 						valueClass
 					) }

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -10,7 +10,7 @@ import moment from 'moment';
 import { Button } from '@wordpress/components';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery, getHistory } from '@woocommerce/navigation';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 
 /**
@@ -51,7 +51,7 @@ const getHeaders = ( sortColumn?: string ): DisputesTableHeader[] => [
 		key: 'details',
 		label: '',
 		required: true,
-		cellClassName: classNames( 'info-button', {
+		cellClassName: clsx( 'info-button', {
 			'is-sorted': sortColumn === 'amount',
 		} ),
 		isLeftAligned: true,

--- a/client/payment-details/dispute-details/dispute-due-by-date.tsx
+++ b/client/payment-details/dispute-details/dispute-due-by-date.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import moment from 'moment';
 import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
 
@@ -24,7 +24,7 @@ const DisputeDueByDate: React.FC< {
 			{ showRemainingDays && (
 				// Make it red regardless how many days are left
 				<span
-					className={ classNames(
+					className={ clsx(
 						'dispute-steps__steps__response-date--urgent'
 					) }
 				>

--- a/client/payment-methods-icons.tsx
+++ b/client/payment-methods-icons.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ const iconComponent = (
 	border = true
 ): ReactImgFuncComponent => ( { className, ...props } ) => (
 	<img
-		className={ classNames(
+		className={ clsx(
 			'payment-method__icon',
 			border ? '' : 'no-border',
 			className

--- a/client/payment-methods-map.tsx
+++ b/client/payment-methods-map.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -31,10 +31,7 @@ const PaymentMethodInformationObject: Record<
 							.settings_icon_url
 					}
 					alt={ wooPaymentsPaymentMethodDefinitions[ key ].label }
-					className={ classNames(
-						'payment-method__icon',
-						className
-					) }
+					className={ clsx( 'payment-method__icon', className ) }
 				/>
 			),
 		};

--- a/client/settings/card-body/index.tsx
+++ b/client/settings/card-body/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { CardBody } from '@wordpress/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -18,10 +18,7 @@ const WcpayCardBody: React.FC< WcpayCardBodyProps > = ( {
 	className,
 	...props
 } ): JSX.Element => (
-	<CardBody
-		className={ classNames( 'wcpay-card-body', className ) }
-		{ ...props }
-	/>
+	<CardBody className={ clsx( 'wcpay-card-body', className ) } { ...props } />
 );
 
 export default WcpayCardBody;

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -10,7 +10,7 @@ import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { BaseControl, Button } from '@wordpress/components';
 import TrashIcon from 'gridicons/dist/trash';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -140,7 +140,7 @@ const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = (
 	return (
 		<div className="wcpay-branding-upload-field__wrapper">
 			<div
-				className={ classNames(
+				className={ clsx(
 					'woopay-settings__update-store-logo',
 					fileID && 'has-file'
 				) }

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import {
 	Card,
@@ -65,7 +65,7 @@ const WooPaySettings = ( { section } ) => {
 
 	return (
 		<Card
-			className={ classNames( {
+			className={ clsx( {
 				'woopay-settings': true,
 				'woopay-settings--appearance': section === 'appearance',
 			} ) }

--- a/client/settings/payment-method-icon/index.js
+++ b/client/settings/payment-method-icon/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -14,11 +14,7 @@ const PaymentMethodIcon = ( { Icon, label } ) => {
 	if ( ! Icon ) return null;
 
 	return (
-		<span
-			className={ classNames(
-				'woocommerce-payments__payment-method-icon'
-			) }
-		>
+		<span className={ clsx( 'woocommerce-payments__payment-method-icon' ) }>
 			<Icon />
 			{ label && (
 				<span className="woocommerce-payments__payment-method-icon__label">

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import clsx from 'clsx';
 import React, { useContext } from 'react';
 
 /**
@@ -303,7 +303,7 @@ const PaymentMethod = ( {
 
 	return (
 		<li
-			className={ classNames(
+			className={ clsx(
 				'payment-method__list-item',
 				{ 'has-icon-border': id !== 'card', overlay: needsOverlay },
 				className

--- a/client/settings/settings-section.tsx
+++ b/client/settings/settings-section.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ const SettingsSection: React.FunctionComponent< {
 	className,
 	id,
 } ) => (
-	<div className={ classNames( 'settings-section', className ) } id={ id }>
+	<div className={ clsx( 'settings-section', className ) } id={ id }>
 		<div className="settings-section__details">
 			<Description />
 		</div>

--- a/client/transactions/list/converted-amount.tsx
+++ b/client/transactions/list/converted-amount.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { Tooltip as FallbackTooltip } from '@wordpress/components';
 import SyncIcon from 'gridicons/dist/sync';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -78,7 +78,7 @@ const ConvertedAmount = ( {
 
 	return (
 		<div
-			className={ classNames(
+			className={ clsx(
 				'converted-amount',
 				! isUpdatedTooltipAvailable && 'converted-amount--fallback'
 			) }

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item-placeholder.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item-placeholder.js
@@ -2,13 +2,13 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { LoadableBlock } from 'multi-currency/interface/components';
 
 const EnabledCurrenciesListItemPlaceholder = ( { isLoading } ) => {
 	return (
 		<li
-			className={ classNames(
+			className={ clsx(
 				'enabled-currency-placeholder',
 				'enabled-currency'
 			) }

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
@@ -40,7 +40,7 @@ const EnabledCurrenciesListItem = ( {
 	};
 
 	return (
-		<li className={ classNames( 'enabled-currency', id ) }>
+		<li className={ clsx( 'enabled-currency', id ) }>
 			<div className="enabled-currency__container">
 				<div className="enabled-currency__flag">
 					{ flag !== '' ? (

--- a/includes/multi-currency/client/settings/single-currency/index.js
+++ b/includes/multi-currency/client/settings/single-currency/index.js
@@ -13,7 +13,7 @@ import moment from 'moment';
 import CurrencyPreview from './currency-preview';
 import './style.scss';
 import { Button, Card, CardBody } from '@wordpress/components';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import {
 	decimalCurrencyCharmOptions,
 	decimalCurrencyRoundingOptions,
@@ -236,7 +236,7 @@ const SingleCurrencySettings = () => {
 													</h4>
 												</div>
 												<p
-													className={ classNames(
+													className={ clsx(
 														'single-currency-settings-description',
 														'single-currency-settings-description-inset'
 													) }
@@ -305,7 +305,7 @@ const SingleCurrencySettings = () => {
 													</h4>
 												</div>
 												<p
-													className={ classNames(
+													className={ clsx(
 														'single-currency-settings-description',
 														'single-currency-settings-description-inset'
 													) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "babel-eslint": "10.1.0",
         "babel-loader": "8.2.2",
         "chalk": "4.1.2",
-        "classnames": "2.3.1",
+        "clsx": "2.1.1",
         "config": "3.3.6",
         "core-js": "3.9.0",
         "crypto-browserify": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.2",
     "chalk": "4.1.2",
-    "classnames": "2.3.1",
+    "clsx": "2.1.1",
     "config": "3.3.6",
     "core-js": "3.9.0",
     "crypto-browserify": "3.12.0",


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8898
Fixes WOOPMNT-4110

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Confirmed that `clsx` is a drop-in replacement for `classNames`.
The main difference is that `classNames` has a `.bind()` functionality, but we don't use it.

Quick change. Everything is still working as expected. I didn't notice any visual differences.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to WooCommerce > Settings > Payments > WooPayments
* The settings page should have no visual differences.
* Click on any of the sub-pages (like the "Customize" on the express checkouts)
* No visual differences
* Click on Payments > Transactions
* No visual differences

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
