### PR TITLE
chore: remove BNPLs PMME from checkout labels

### DIFF
--- a/changelog/chore-remove-bnpl-pmme-from-checkout-labels
+++ b/changelog/chore-remove-bnpl-pmme-from-checkout-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: remove BNPL payment method messaging element/offering from checkout labels

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -489,25 +489,4 @@ export default class WCPayAPI {
 			...productData,
 		} );
 	}
-
-	/**
-	 * Fetches the cart data from the woocommerce store api.
-	 *
-	 * @return {Object} JSON data.
-	 * @throws Error if the response is not ok.
-	 */
-	pmmeGetCartData() {
-		return fetch( `${ getUPEConfig( 'storeApiURL' ) }/cart`, {
-			method: 'GET',
-			credentials: 'same-origin',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-		} ).then( ( response ) => {
-			if ( ! response.ok ) {
-				throw new Error( response.statusText );
-			}
-			return response.json();
-		} );
-	}
 }

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -83,7 +83,6 @@ Object.entries( enabledPaymentMethodsConfig )
 				<PaymentMethodLabel
 					api={ api }
 					title={ upeConfig.title }
-					countries={ upeConfig.countries }
 					iconLight={ upeConfig.icon }
 					iconDark={ upeConfig.darkIcon }
 					upeName={ upeName }

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -50,10 +50,6 @@ button.wcpay-stripelink-modal-trigger:hover {
 					// hiding the badge when the payment method is not selected
 					display: inline-block;
 				}
-
-				&__pmme-container {
-					display: none;
-				}
 			}
 		}
 	}
@@ -93,15 +89,6 @@ button.wcpay-stripelink-modal-trigger:hover {
 				justify-self: start;
 				width: max-content;
 				display: none;
-			}
-
-			&__pmme-container {
-				width: 100%;
-				pointer-events: none;
-
-				@include breakpoint( '<480px' ) {
-					margin-top: 8px;
-				}
 			}
 		}
 	}

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import { getAppearance, getFontRulesFromPage } from '../upe-styles';
-import { normalizeCurrencyToMinorUnit } from 'wcpay/checkout/utils';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 import {
 	appendFingerprintInputToForm,
@@ -494,40 +493,6 @@ export async function mountStripePaymentElement(
 			savePaymentMethodWrapper.style.display = 'none';
 		}
 	} );
-}
-
-export async function mountStripePaymentMethodMessagingElement(
-	api,
-	domElement,
-	cartData,
-	location
-) {
-	const paymentMethodType = domElement.dataset.paymentMethodType;
-	const appearance = await initializeAppearance( api, location );
-
-	try {
-		const stripe = await api.getStripe();
-		const paymentMethodMessagingElement = stripe
-			.elements( {
-				appearance: appearance,
-				fonts: getFontRulesFromPage(),
-			} )
-			.create( 'paymentMethodMessaging', {
-				currency: cartData.currency,
-				amount: normalizeCurrencyToMinorUnit(
-					cartData.amount,
-					cartData.decimalPlaces
-				),
-				countryCode: cartData.country, // Customer's country or base country of the store.
-				paymentMethodTypes: [ paymentMethodType ],
-				displayType: 'promotional_text',
-			} );
-
-		return paymentMethodMessagingElement.mount( domElement );
-	} finally {
-		// Resolve the promise even if the element mounting fails.
-		return Promise.resolve();
-	}
 }
 
 /**

--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -70,64 +70,6 @@
 	}
 }
 
-// Payment methods with PMME styles.
-li.wc_payment_method:has( label .stripe-pmme-container ) {
-	display: grid;
-	grid-template-columns: max-content 1fr;
-	grid-template-areas: 'li-input li-label'; // List Item grid.
-	align-items: baseline;
-
-	.input-radio {
-		grid-area: li-input;
-	}
-
-	> label {
-		grid-area: li-label;
-
-		display: grid !important;
-		grid-template-columns: max-content 1fr;
-		grid-template-areas: 'label-spacer label-inner'; // Label grid.
-
-		> span.spacer {
-			grid-area: label-spacer;
-		}
-
-		> .woopayments-inner-label {
-			grid-area: label-inner;
-			display: grid;
-			grid-template-columns: 1fr max-content;
-			grid-template-areas:
-				'inner-text inner-logo'
-				'inner-pmme inner-logo'; // Inner label grid.
-			align-items: center;
-
-			> img {
-				grid-area: inner-logo;
-				justify-self: right;
-			}
-
-			> .stripe-pmme-container {
-				width: 100%;
-				grid-area: inner-pmme;
-				pointer-events: none;
-			}
-		}
-	}
-}
-
-// Hide the PMMe container when the payment method is checked.
-li.wc_payment_method:has( .input-radio:checked
-		+ label
-		.stripe-pmme-container ) {
-	.input-radio:checked {
-		+ label {
-			.stripe-pmme-container {
-				display: none;
-			}
-		}
-	}
-}
-
 // Pseudo-element radio button compatibility.
 // Unfortunately, there is no direct way to detect the existence of pseudo-elements like ::before using CSS selectors,
 // so we use the theme class to add the necessary styles.

--- a/client/checkout/utils/index.js
+++ b/client/checkout/utils/index.js
@@ -1,19 +1,3 @@
-/**
- * Normalizes the amount to the accuracy of the minor unit.
- *
- * @param {integer} amount The amount to normalize
- * @param {integer} minorUnit The number of decimal places amount currently represents
- * @param {integer} accuracy The number of decimal places to normalize to
- * @return {integer} The normalized amount
- */
-export const normalizeCurrencyToMinorUnit = (
-	amount,
-	minorUnit = 2,
-	accuracy = 2
-) => {
-	return parseInt( amount * Math.pow( 10, accuracy - minorUnit ), 10 );
-};
-
 export const getAppearanceType = () => {
 	if ( document.querySelector( '.wp-block-woocommerce-checkout' ) ) {
 		return 'blocks_checkout';


### PR DESCRIPTION
Fixes PAY-336

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Removing the payment method messaging element for BNPL payment methods from the checkout.
It does not meet Klarna's terms of service that requires the offer T&Cs to be at most one click away. It is currently two clicks away.

This change should also slightly improve the page's rendering time.

I'll add a "new in woopayments" post for visibility.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have a US-based Stripe account (for simplicity)
- Ensure you have a few BNPL payment methods enabled in Payments > Settings (Klarna/Affirm/Afterpay)
- Ensure you're using USD in your store as a presentment currency (i.e.: prices are displayed in USD to the customer)
- Navigate to the "Belt" product (or a product with more than $50 value)
- You should see the PMME on the product page (no change made here)
<img width="1018" alt="Screenshot 2025-05-09 at 11 12 41 AM" src="https://github.com/user-attachments/assets/6716f4ca-4e78-4692-9173-1c0e1f9834e0" />

- Add the product to the cart
- Navigate to a block-based or shortcode-based cart page
- You should see the PMME on the page, close to the "proceed to checkout" button (no change made here)
<img width="513" alt="Screenshot 2025-05-09 at 11 13 07 AM" src="https://github.com/user-attachments/assets/654aaa46-580f-42d5-bbc4-76c05bd25b5d" />
<img width="526" alt="Screenshot 2025-05-09 at 11 12 58 AM" src="https://github.com/user-attachments/assets/753ac511-b5aa-46cd-84de-4073bb42151e" />

- Navigate to a block-based or shortcode-based checkout page
- The PMME element should no longer be displayed on the payment method label for BNPL methods

Before:
<img width="855" alt="Screenshot 2025-05-09 at 11 31 20 AM" src="https://github.com/user-attachments/assets/dadaef94-439f-4bd4-8171-5b1dcfbe206a" />
<img width="1049" alt="Screenshot 2025-05-09 at 11 31 37 AM" src="https://github.com/user-attachments/assets/55c9b94a-cea2-4a60-923c-cd5ab99dacbf" />


After:
<img width="1029" alt="Screenshot 2025-05-09 at 11 12 10 AM" src="https://github.com/user-attachments/assets/d4942620-4fcf-4510-ac81-71c35653f68b" />
<img width="850" alt="Screenshot 2025-05-09 at 11 11 44 AM" src="https://github.com/user-attachments/assets/6fac000f-6e3c-48ed-a9a8-8347977b0bbb" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
