### PR TITLE
chore: remove `setup_required` & `setup_tooltip ` attrs

### DIFF
--- a/changelog/chore-remove-unused-is_setup_required-and-setup_tooltip-attributes
+++ b/changelog/chore-remove-unused-is_setup_required-and-setup_tooltip-attributes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: remove unused `setup_required` and `setup_tooltip` from paymentMethodsConfiguration
+
+

--- a/client/settings/payment-methods-list/index.js
+++ b/client/settings/payment-methods-list/index.js
@@ -110,10 +110,10 @@ const PaymentMethodsList = ( { methodIds } ) => {
 						icon: Icon,
 						description,
 						allows_manual_capture: isAllowingManualCapture,
-						setup_required: isSetupRequired,
-						setup_tooltip: setupTooltip,
 						currencies,
 					} ) => {
+						let isSetupRequired = false;
+						let setupTooltip = '';
 						if (
 							! wcpaySettings.isMultiCurrencyEnabled &&
 							id !== PAYMENT_METHOD_IDS.CARD


### PR DESCRIPTION
Related to WOOPMNT-4968

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

`setup_required` and `setup_tooltip` are not attributes that are part of the `PaymentMethodInformationObject`.

You can search for those attributes in the codebase, you won't find them anywhere but here.

Those attributes were introduced long time ago, but didn't get cleaned up.

Cleaning up now.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Search for `setup_required` in the codebase
  - There should be nothing come up
- Search for `setup_tooltip` in the codebase
  - There should be nothing come up
- Inspect `PaymentMethodInformationObject`
 - There should be no `setup_required` nor `setup_tooltip` for any of the payment methods in that object

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
