### PR TITLE
chore: remove unused overlay and icon border CSS

### DIFF
--- a/changelog/chore-remove-overlay-and-icon-border-css
+++ b/changelog/chore-remove-overlay-and-icon-border-css
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: remove .overlay and .has-icon-border CSS rules from .payment-method__list-item
+
+

--- a/client/settings/payment-methods-list/payment-method.scss
+++ b/client/settings/payment-methods-list/payment-method.scss
@@ -162,28 +162,6 @@
 		}
 	}
 
-	&.has-icon-border &__icon {
-		box-shadow: 0 0 0 1px #ddd;
-	}
-
-	&.overlay {
-		position: relative;
-
-		&::after {
-			content: '';
-			position: absolute;
-			// adds some spacing for the borders, so that they're not part of the opacity
-			top: 1px;
-			bottom: 1px;
-			// ensures that the info icon isn't part of the opacity
-			left: 55px;
-			right: 0;
-			background: #fff;
-			opacity: 0.5;
-			pointer-events: none;
-		}
-	}
-
 	.chip {
 		margin-left: $gap-smaller;
 		padding: 2px $gap-smaller;

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -12,7 +12,6 @@ import interpolateComponents from '@automattic/interpolate-components';
 import { __, sprintf } from '@wordpress/i18n';
 import { HoverTooltip } from 'components/tooltip';
 import { upeCapabilityStatuses } from 'wcpay/settings/constants';
-import { useManualCapture } from 'wcpay/data';
 import { FeeStructure } from 'wcpay/types/fees';
 import {
 	formatMethodFeesDescription,
@@ -173,7 +172,6 @@ const PaymentMethod = ( {
 	}: { accountFees?: Record< string, FeeStructure > } = useContext(
 		WCPaySettingsContext
 	);
-	const [ isManualCaptureEnabled ] = useManualCapture();
 
 	const needsMoreInformation = [
 		upeCapabilityStatuses.INACTIVE,
@@ -191,11 +189,6 @@ const PaymentMethod = ( {
 		setDismissedDuplicateNotices,
 	} = useContext( DuplicatedPaymentMethodsContext );
 	const isDuplicate = Object.keys( duplicates ).includes( id );
-
-	const needsOverlay =
-		( isManualCaptureEnabled && ! isAllowingManualCapture ) ||
-		isSetupRequired ||
-		needsAttention;
 
 	const handleChange = ( newStatus: string ) => {
 		// If the payment method control is locked, reject any changes.
@@ -302,13 +295,7 @@ const PaymentMethod = ( {
 	};
 
 	return (
-		<li
-			className={ clsx(
-				'payment-method__list-item',
-				{ 'has-icon-border': id !== 'card', overlay: needsOverlay },
-				className
-			) }
-		>
+		<li className={ clsx( 'payment-method__list-item', className ) }>
 			<div className="payment-method">
 				<div className="payment-method__checkbox">
 					<LoadableCheckboxControl


### PR DESCRIPTION
Related to WOOPMNT-4968

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The `.has-icon-border` and `.overlay` classes are applied by the JS to the `.payment-method__list-item` element.
Too bad that those modifiers are instead written in the CSS to target the `.payment-method` class!

So the CSS was outputted as:
```css
.payment-method.overlay {...}
.payment-method.has-icon-border {...}
```

But there will be no element with those selectors!
The JS was expecting something like:
```css
.payment-method__list-item.overlay {...}
.payment-method__list-item.has-icon-border {...}
```

There _used_ to be an element with those selectors - but the JS got refactored and a regression got introduced.

So let's clean up those unused selectors and logic, since they do nothing good.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to WooCommerce > Settings > Payments > WooPayments
- The UI looks exactly as `develop`
- Enable the "Manual capture" in the settings
- The UI looks exactly as `develop`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
