### PR TITLE
Do not change shipping costs structure when applying multi-currency presentation

### DIFF
--- a/changelog/woopmnt-4977-cannot-tax-shipping-when-woopayments-is-the-payment-gateway
+++ b/changelog/woopmnt-4977-cannot-tax-shipping-when-woopayments-is-the-payment-gateway
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep the shipping costs structure intact when applying multi-currency adjustments.

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -276,6 +276,11 @@ class FrontendPrices {
 	 */
 	public function convert_shipping_method_rate_cost( $args ) {
 		if ( isset( $args['cost'] ) ) {
+			/**
+			 * We need to keep `cost` structure intact when applying
+			 * multi-currency, because downstream it is important for
+			 * WooCommerce to keep the taxes flow consistent.
+			 */
 			$args['cost'] = is_array( $args['cost'] )
 				? array_map(
 					function ( $cost ) {

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -275,13 +275,15 @@ class FrontendPrices {
 	 * @return array Shipping rate args with converted cost.
 	 */
 	public function convert_shipping_method_rate_cost( $args ) {
-		$cost = is_array( $args['cost'] ) ? array_sum( $args['cost'] ) : $args['cost'];
-		$args = wp_parse_args(
-			[
-				'cost' => $this->multi_currency->get_price( $cost, 'shipping' ),
-			],
-			$args
-		);
+		if ( isset( $args['cost'] ) ) {
+			$args['cost'] = is_array( $args['cost'] )
+				? array_map(
+					function ( $cost ) {
+						return $this->multi_currency->get_price( $cost, 'shipping' ); },
+					$args['cost']
+				)
+				: $this->multi_currency->get_price( $args['cost'], 'shipping' );
+		}
 		return $args;
 	}
 

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -277,18 +277,22 @@ class FrontendPrices {
 	public function convert_shipping_method_rate_cost( $args ) {
 		if ( isset( $args['cost'] ) ) {
 			/**
-			 * We need to keep `cost` structure intact when applying
-			 * multi-currency, because downstream it is important for
-			 * WooCommerce to keep the taxes flow consistent.
+			 * We need to keep the `cost` structure intact when applying
+			 * multi-currency conversions, because downstream it is important
+			 * for WooCommerce to keep the taxes flow consistent.
 			 */
-			$args['cost'] = is_array( $args['cost'] )
-				? array_map(
+			if ( is_array( $args['cost'] ) ) {
+				$args['cost'] = array_map(
 					function ( $cost ) {
-						return $this->multi_currency->get_price( $cost, 'shipping' ); },
+						return $this->multi_currency->get_price( $cost, 'shipping' );
+					},
 					$args['cost']
-				)
-				: $this->multi_currency->get_price( $args['cost'], 'shipping' );
+				);
+			} else {
+				$args['cost'] = $this->multi_currency->get_price( $args['cost'], 'shipping' );
+			}
 		}
+
 		return $args;
 	}
 


### PR DESCRIPTION
Fixes WOOPMNT-4977

#### Changes proposed in this Pull Request

In #4697 a multi-currency filter included with WooPayments started to flatten a value of the `$args['cost']` in the shipping costs calculation. This change made WooCommerce [skip the tax on the shipping costs](https://github.com/woocommerce/woocommerce/blob/fc221eddf43ca4955f74f73f11842ceb8f9abbd8/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php#L367), even if those should be taxable.

In this change, multi-currency modifications are applied per cost line instead. With the structure intact, WooCommerce can apply shipping tax properly.

Before the change:

<img width="472" alt="image" src="https://github.com/user-attachments/assets/aaef633f-b633-43cf-a5ec-038f209c6c98" />


After the change:

<img width="470" alt="image" src="https://github.com/user-attachments/assets/cec0f08c-d042-4352-baf1-733cfeb27ecb" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Set-up a store and create a shipping class, e.g. "Test shipping class". Apply it to all products, e.g. with the bulk edit feature.
 * Enable tax calculations and create a tax rate, which applies to the shipping.
 * Install a table rate plugin and create a table rate for the shipping zone. Example settings:

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/3feedcf8-1f43-4e52-8899-d21e45862f33" />

 * Add products to the cart and go to checkout page:
   - On the `develop` branch, the tax amount won't include taxes on the shipping costs.
   - On this branch, taxes will also be applied to the shipping costs.
 - Enable multi-currency in the WooPayments settings and check that currency conversion is properly applied to the shipping costs.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
