### PR TITLE
Clear onboarding DB options data when onboarding is finalized

### DIFF
--- a/changelog/update-woopmnt-4260-clear-onboarding-field-info-from-database-cache
+++ b/changelog/update-woopmnt-4260-clear-onboarding-field-info-from-database-cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Clean up database options after completing onboarding.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -933,6 +933,7 @@ class WC_Payments_Admin {
 		}
 
 		$account_status_data = $this->account->get_account_status_data();
+		$account_is_valid    = $this->account->is_stripe_account_valid();
 
 		$test_mode = false;
 		try {
@@ -981,7 +982,7 @@ class WC_Payments_Admin {
 			'testMode'                           => $test_mode,
 			// Set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
 			'onBoardingDisabled'                 => WC_Payments_Account::is_on_boarding_disabled(),
-			'onboardingFieldsData'               => $this->onboarding_service->get_fields_data( get_user_locale() ),
+			'onboardingFieldsData'               => $account_is_valid ? null : $this->onboarding_service->get_fields_data( get_user_locale() ),
 			'onboardingEmbeddedKycInProgress'    => $this->onboarding_service->is_embedded_kyc_in_progress(),
 			'errorMessage'                       => $error_message,
 			'featureFlags'                       => $this->get_frontend_feature_flags(),
@@ -992,7 +993,7 @@ class WC_Payments_Admin {
 			'isJetpackConnected'                 => $this->account->has_working_jetpack_connection(),
 			'isJetpackIdcActive'                 => Jetpack_Identity_Crisis::has_identity_crisis(),
 			'isAccountConnected'                 => $this->account->has_account_data(),
-			'isAccountValid'                     => $this->account->is_stripe_account_valid(),
+			'isAccountValid'                     => $account_is_valid,
 			'accountStatus'                      => $account_status_data,
 			'accountFees'                        => $this->account->get_fees(),
 			'accountLoans'                       => $this->account->get_capital(),

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -219,7 +219,19 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	public function delete_by_prefix( string $key_prefix ) {
 		// Protection against accidentally deleting all options or options that are not related to WCPay caching.
 		// Feel free to update this statement as more prefix cache keys are used.
-		if ( strncmp( $key_prefix, self::PAYMENT_METHODS_KEY_PREFIX, strlen( self::PAYMENT_METHODS_KEY_PREFIX ) ) !== 0 ) {
+		$allowed_base_prefixes = [
+			self::PAYMENT_METHODS_KEY_PREFIX,
+			self::ONBOARDING_FIELDS_DATA_KEY,
+			self::RECOMMENDED_PAYMENT_METHODS,
+		];
+		$is_allowed            = false;
+		foreach ( $allowed_base_prefixes as $allowed_base_prefix ) {
+			if ( strncmp( $key_prefix, $allowed_base_prefix, strlen( $allowed_base_prefix ) ) === 0 ) {
+				$is_allowed = true;
+				break;
+			}
+		}
+		if ( ! $is_allowed ) {
 			return; // Maybe throw exception here...
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2194,9 +2194,12 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$event_properties
 		);
 
-		$params = $additional_args;
+		// Clean up data used only during the onboarding process.
+		$this->onboarding_service->cleanup_on_account_onboarded();
 
+		$params                             = $additional_args;
 		$params['wcpay-connection-success'] = '1';
+
 		return [
 			'success' => true,
 			'params'  => $params,
@@ -2273,6 +2276,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$this->redirect_service->redirect_to_connect_page( '', WC_Payments_Onboarding_Service::FROM_STRIPE, $params );
 			return;
 		}
+
+		// Clean up data used only during the onboarding process.
+		$this->onboarding_service->cleanup_on_account_onboarded();
 
 		$params['wcpay-connection-success'] = '1';
 		$this->redirect_service->redirect_to_overview_page( WC_Payments_Onboarding_Service::FROM_STRIPE, $params );

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -870,6 +870,24 @@ class WC_Payments_Onboarding_Service {
 	}
 
 	/**
+	 * Cleanup onboarding flow data after the account is onboarded.
+	 *
+	 * This is to avoid keeping unnecessary data in the database.
+	 * We focus on data stores in DB options. Transients have a limited lifetime and will be cleaned up automatically.
+	 *
+	 * @return void
+	 */
+	public function cleanup_on_account_onboarded() {
+		// Delete the onboarding fields data since it is used only during the initial onboarding.
+		// Delete it by prefix since it can have entries suffixed with the user locale.
+		$this->database_cache->delete_by_prefix( Database_Cache::ONBOARDING_FIELDS_DATA_KEY );
+
+		$this->database_cache->delete( Database_Cache::BUSINESS_TYPES_KEY );
+		// Delete it by prefix since it can have entries suffixed with the user locale.
+		$this->database_cache->delete_by_prefix( Database_Cache::RECOMMENDED_PAYMENT_METHODS );
+	}
+
+	/**
 	 * Determine whether an embedded KYC flow is in progress.
 	 *
 	 * @return bool True if embedded KYC is in progress, false otherwise.


### PR DESCRIPTION
Closes WOOPMNT-4260

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We introduce DB options cleanup logic when finalizing the onboarding flow (account connected). This way, we avoid leaving sufficiently large amounts of data in the DB.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR's branch on your local installation
* Make sure you disconnect any connected account you may have.
* Make an authenticated GET request to `http://localhost:8082/wp-json/wc/v3/payments/onboarding/business_types`. You should receive a response with a `data` entry consisting of a country-based tree of business types. 
* Go to the WooPayments Connect page (`http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`) and start onboarding a live account by clicking on "Verify business details".
* Once you see the first onboarding screen, open your local PHPMyAdmin (`http://localhost:8083/index.php?route=/sql&pos=0&db=wordpress&table=wp_options`), go to the `wp_options` table and search for `%wcpay_onboarding_fields_data%`. You should have an entry, prefixed with your WP user locale.
* You should also have an option named `wcpay_business_types_data`.
* Finish the onboarding process and make sure you end up with a connected account on the Payments > Overview page:
<img width="1395" alt="Screenshot 2025-05-21 at 00 07 45" src="https://github.com/user-attachments/assets/2a227563-6433-4a52-bda1-cb987084dc83" />
* Go back to PHPMyAdmin > wp_options and you should not have a `%wcpay_onboarding_fields_data%` entry.
* You also should not have a `wcpay_business_types_data` option entry.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
