### PR TITLE
Fix error message render issue when duplicate onboarding session is detected

### DIFF
--- a/changelog/woopmnt-4313-possible-render-issue-when-duplicate-onboarding-session-is
+++ b/changelog/woopmnt-4313-possible-render-issue-when-duplicate-onboarding-session-is
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Ensure duplicate account session error message is properly formated.
+
+

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -37,6 +37,7 @@ import { sanitizeHTML } from 'wcpay/utils/sanitize';
 import { isInTestModeOnboarding } from 'wcpay/utils';
 import ResetAccountModal from 'wcpay/overview/modal/reset-account';
 import SandboxModeSwitchToLiveNotice from 'wcpay/components/sandbox-mode-switch-to-live-notice';
+import { decodeEntities } from '@wordpress/html-entities';
 
 interface AccountData {
 	status: string;
@@ -478,7 +479,9 @@ const ConnectAccountPage: React.FC = () => {
 				>
 					<div
 						// eslint-disable-next-line react/no-danger
-						dangerouslySetInnerHTML={ sanitizeHTML( errorMessage ) }
+						dangerouslySetInnerHTML={ sanitizeHTML(
+							decodeEntities( errorMessage )
+						) }
 					></div>
 				</BannerNotice>
 			) }


### PR DESCRIPTION
Fixes WOOPMNT-4313

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We properly decode the HTML entities of the duplicate account session error message provided from the backend.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR's branch on your local installation and build the client assets by running `npm run build`
* Make sure you have no account connected.
* Go to the Connect page (`http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`) and start a live onboarding session.
* Proceed until you reach the embedded Stripe KYC screens.
* Open a new browser tab and open the Connect page (`http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`)
![Screenshot 2025-05-19 at 12 19 59](https://github.com/user-attachments/assets/5ed97a63-8262-48af-b932-a0f6988372a7)
* Click on "Finish business details verifications", the page should refresh, and you should see an error message (`Another account setup session is already in progress...`), properly formatted:
![Screenshot 2025-05-19 at 12 13 39](https://github.com/user-attachments/assets/380197e2-4081-47fb-9636-e60b0e3c5569)
* Click on "click here to start again" and you should be _redirected_ to the Stripe KYC.
* Open a new browser tab and open the Connect page (`http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`)
* Click on "Finish business details verifications", the page should refresh, and you should see the error message again.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
