### PR TITLE
fix: e2e tests, WC beta & WC 7.7.0: coupon link, MCCY widget

### DIFF
--- a/changelog/fix-e2e-wc-beta-tests-coupon-removal-spec
+++ b/changelog/fix-e2e-wc-beta-tests-coupon-removal-spec
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: coupon removal selector in e2e tests
+
+

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -62,11 +62,18 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 			await page.getByRole( 'button', { name: 'Close' } ).click();
 		}
 
-		await expect( page.locator( '[name="editor-canvas"]' ) ).toBeAttached();
-
-		const editor = page.locator( '[name="editor-canvas"]' ).contentFrame();
-
-		await editor.getByRole( 'button', { name: 'Add block' } ).click();
+		if ( await page.locator( '[name="editor-canvas"]' ).isVisible() ) {
+			await expect(
+				page.locator( '[name="editor-canvas"]' )
+			).toBeAttached();
+			const editor = page
+				.locator( '[name="editor-canvas"]' )
+				.contentFrame();
+			await editor.getByRole( 'button', { name: 'Add block' } ).click();
+		} else {
+			// Fallback for WC 7.7.0.
+			await page.getByRole( 'button', { name: 'Add block' } ).click();
+		}
 
 		await page
 			.locator( 'input[placeholder="Search"]' )

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -604,9 +604,7 @@ export const setDefaultPaymentMethod = async (
 };
 
 export const removeCoupon = async ( page: Page ) => {
-	const couponRemovalLink = page.getByRole( 'link', {
-		name: '[Remove]',
-	} );
+	const couponRemovalLink = page.locator( '.woocommerce-remove-coupon' );
 
 	if ( await couponRemovalLink.isVisible() ) {
 		await couponRemovalLink.click();


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In https://github.com/Automattic/woocommerce-payments/pull/10746 , we switched to API v3, but didn't test the full suite of e2e tests w/ WC 7.7.0. Fixing.

In https://github.com/woocommerce/woocommerce/pull/56875 , the "remove" link to remove the coupon has been renamed.
It shows "Remove", but it reads "Remove {coupon_code} coupon".

I had two options, here:
- Provide an argument to the existing `removeCoupon` function
- Change the selector to `.woocommerce-remove-coupon`

I went with the second option, because WC Core uses the same selector in their e2e tests 🤷 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Not much to test here, but here's the test suite passing: https://github.com/Automattic/woocommerce-payments/actions/runs/15119025512
In particular, look at the `WC - beta | wcpay - shopper` and at the `WC - 7.7.0 | wcpay - merchant` jobs.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
