### PR TITLE
Decouple (create) the new accordion component

### DIFF
--- a/changelog/decouple-new-accordion-component
+++ b/changelog/decouple-new-accordion-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Decouple the accordion component from the dispute details screen.

--- a/client/components/accordion/accordion.tsx
+++ b/client/components/accordion/accordion.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import React, { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { AccordionProps, AccordionBodyProps } from './types';
+import AccordionBody from './body';
+import './style.scss';
+
+/**
+ * `Accordion` expands and collapses multiple sections of content.
+ *
+ * ```jsx
+ * import { Accordion, AccordionBody, AccordionRow } from '@wordpress/components';
+ * import { more } from '@wordpress/icons';
+ *
+ * const MyAccordion = () => (
+ * 	<Accordion header="My Accordion">
+ * 		<AccordionBody title="My Block Settings" icon={ more } initialOpen={ true }>
+ * 			<AccordionRow>My Accordion Inputs and Labels</AccordionRow>
+ * 		</AccordionBody>
+ * 	</Accordion>
+ * );
+ * ```
+ */
+const Accordion = forwardRef< HTMLDivElement, AccordionProps >(
+	(
+		{ className, children, highDensity = false, defaultExpanded = false },
+		ref
+	) => {
+		const classNames = clsx( className, 'wcpay-accordion', {
+			'is-high-density': highDensity,
+		} );
+
+		const childrenWithProps = React.Children.map( children, ( child ) => {
+			if (
+				React.isValidElement< AccordionBodyProps >( child ) &&
+				child.type === AccordionBody
+			) {
+				return React.cloneElement( child, {
+					initialOpen: defaultExpanded,
+				} );
+			}
+			return child;
+		} );
+
+		return (
+			<div className={ classNames } ref={ ref }>
+				{ childrenWithProps }
+			</div>
+		);
+	}
+);
+
+Accordion.displayName = 'Accordion';
+
+export default Accordion;

--- a/client/components/accordion/body.tsx
+++ b/client/components/accordion/body.tsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import React, { useEffect, useRef, useState, forwardRef } from 'react';
+/**
+ * WordPress dependencies
+ */
+import { useMergeRefs } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import type { AccordionBodyProps } from './types';
+import './style.scss';
+import AccordionTitle from './title';
+
+const useUpdateEffect = (
+	effect: () => void | ( () => void ),
+	deps: React.DependencyList
+) => {
+	const isInitialMount = useRef( true );
+	useEffect( () => {
+		if ( isInitialMount.current ) {
+			isInitialMount.current = false;
+		} else {
+			return effect();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps );
+};
+
+const AccordionBody = forwardRef< HTMLDivElement, AccordionBodyProps >(
+	(
+		{
+			buttonProps = {},
+			children,
+			className,
+			icon,
+			initialOpen,
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			onToggle = () => {},
+			opened,
+			title,
+			subtitle,
+			md = true,
+			lg = false,
+			scrollAfterOpen = true,
+		},
+		ref
+	) => {
+		const defaultOpenState = initialOpen !== undefined ? initialOpen : true;
+		const [ internalOpened, setInternalOpened ] = useState(
+			opened !== undefined ? opened : defaultOpenState
+		);
+		const isControlled = opened !== undefined;
+		const isOpened = isControlled ? opened : internalOpened;
+		const setIsOpened = isControlled ? onToggle : setInternalOpened;
+		const nodeRef = useRef< HTMLElement >( null );
+
+		const handleOnToggle = ( event: React.MouseEvent ) => {
+			event.preventDefault();
+			const next = ! isOpened;
+			setIsOpened( next );
+		};
+
+		// Ref is used so that the effect does not re-run upon scrollAfterOpen changing value.
+		const scrollAfterOpenRef = useRef< boolean | undefined >();
+		scrollAfterOpenRef.current = scrollAfterOpen;
+		// Runs after initial render.
+		useUpdateEffect( () => {
+			if (
+				isOpened &&
+				scrollAfterOpenRef.current &&
+				nodeRef.current?.scrollIntoView
+			) {
+				/*
+				 * Scrolls the content into view when visible.
+				 * This improves the UX when there are multiple stacking <AccordionBody />
+				 * components in a scrollable container.
+				 */
+				nodeRef.current.scrollIntoView( {
+					inline: 'nearest',
+					block: 'nearest',
+					behavior: 'smooth',
+				} );
+			}
+		}, [ isOpened, 'smooth' ] );
+
+		const classes = clsx( 'wcpay-accordion__body', className, {
+			'is-opened': isOpened,
+		} );
+
+		return (
+			<div className={ classes } ref={ useMergeRefs( [ nodeRef, ref ] ) }>
+				<AccordionTitle
+					icon={ icon }
+					isOpened={ Boolean( isOpened ) }
+					onClick={ handleOnToggle }
+					title={ title }
+					subtitle={ subtitle }
+					md={ md }
+					lg={ lg }
+					{ ...( buttonProps && { ...buttonProps, ref: undefined } ) }
+				/>
+				{ typeof children === 'function'
+					? children( { opened: Boolean( isOpened ) } )
+					: isOpened && children }
+			</div>
+		);
+	}
+);
+
+AccordionBody.displayName = 'AccordionBody';
+
+export default AccordionBody;

--- a/client/components/accordion/index.tsx
+++ b/client/components/accordion/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import React, { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { AccordionProps, AccordionBodyProps } from './types';
+import AccordionBody from './body';
+import './style.scss';
+
+/**
+ * `Accordion` expands and collapses multiple sections of content.
+ *
+ * ```jsx
+ * import { Accordion, AccordionBody, AccordionRow } from '@wordpress/components';
+ * import { more } from '@wordpress/icons';
+ *
+ * const MyAccordion = () => (
+ * 	<Accordion header="My Accordion">
+ * 		<AccordionBody title="My Block Settings" icon={ more } initialOpen={ true }>
+ * 			<AccordionRow>My Accordion Inputs and Labels</AccordionRow>
+ * 		</AccordionBody>
+ * 	</Accordion>
+ * );
+ * ```
+ */
+const Accordion = forwardRef< HTMLDivElement, AccordionProps >(
+	(
+		{ className, children, highDensity = false, defaultExpanded = false },
+		ref
+	) => {
+		const classNames = clsx( className, 'wcpay-accordion', {
+			'is-high-density': highDensity,
+		} );
+
+		const childrenWithProps = React.Children.map( children, ( child ) => {
+			if (
+				React.isValidElement< AccordionBodyProps >( child ) &&
+				child.type === AccordionBody
+			) {
+				return React.cloneElement( child, {
+					initialOpen: defaultExpanded,
+				} );
+			}
+			return child;
+		} );
+
+		return (
+			<div className={ classNames } ref={ ref }>
+				{ childrenWithProps }
+			</div>
+		);
+	}
+);
+
+Accordion.displayName = 'Accordion';
+
+export default Accordion;

--- a/client/components/accordion/index.tsx
+++ b/client/components/accordion/index.tsx
@@ -1,61 +1,8 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-import React, { forwardRef } from 'react';
-
-/**
  * Internal dependencies
  */
-import type { AccordionProps, AccordionBodyProps } from './types';
+import Accordion from './accordion';
 import AccordionBody from './body';
-import './style.scss';
+import AccordionRow from './row';
 
-/**
- * `Accordion` expands and collapses multiple sections of content.
- *
- * ```jsx
- * import { Accordion, AccordionBody, AccordionRow } from '@wordpress/components';
- * import { more } from '@wordpress/icons';
- *
- * const MyAccordion = () => (
- * 	<Accordion header="My Accordion">
- * 		<AccordionBody title="My Block Settings" icon={ more } initialOpen={ true }>
- * 			<AccordionRow>My Accordion Inputs and Labels</AccordionRow>
- * 		</AccordionBody>
- * 	</Accordion>
- * );
- * ```
- */
-const Accordion = forwardRef< HTMLDivElement, AccordionProps >(
-	(
-		{ className, children, highDensity = false, defaultExpanded = false },
-		ref
-	) => {
-		const classNames = clsx( className, 'wcpay-accordion', {
-			'is-high-density': highDensity,
-		} );
-
-		const childrenWithProps = React.Children.map( children, ( child ) => {
-			if (
-				React.isValidElement< AccordionBodyProps >( child ) &&
-				child.type === AccordionBody
-			) {
-				return React.cloneElement( child, {
-					initialOpen: defaultExpanded,
-				} );
-			}
-			return child;
-		} );
-
-		return (
-			<div className={ classNames } ref={ ref }>
-				{ childrenWithProps }
-			</div>
-		);
-	}
-);
-
-Accordion.displayName = 'Accordion';
-
-export default Accordion;
+export { Accordion, AccordionBody, AccordionRow };

--- a/client/components/accordion/row.tsx
+++ b/client/components/accordion/row.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import React, { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { AccordionProps, AccordionBodyProps } from './types';
+import AccordionBody from './body';
+import './style.scss';
+
+/**
+ * `Accordion` expands and collapses multiple sections of content.
+ *
+ * ```jsx
+ * import { Accordion, AccordionBody, AccordionRow } from '@wordpress/components';
+ * import { more } from '@wordpress/icons';
+ *
+ * const MyAccordion = () => (
+ * 	<Accordion header="My Accordion">
+ * 		<AccordionBody title="My Block Settings" icon={ more } initialOpen={ true }>
+ * 			<AccordionRow>My Accordion Inputs and Labels</AccordionRow>
+ * 		</AccordionBody>
+ * 	</Accordion>
+ * );
+ * ```
+ */
+const Accordion = forwardRef< HTMLDivElement, AccordionProps >(
+	(
+		{ className, children, highDensity = false, defaultExpanded = false },
+		ref
+	) => {
+		const classNames = clsx( className, 'wcpay-accordion', {
+			'is-high-density': highDensity,
+		} );
+
+		const childrenWithProps = React.Children.map( children, ( child ) => {
+			if (
+				React.isValidElement< AccordionBodyProps >( child ) &&
+				child.type === AccordionBody
+			) {
+				return React.cloneElement( child, {
+					initialOpen: defaultExpanded,
+				} );
+			}
+			return child;
+		} );
+
+		return (
+			<div className={ classNames } ref={ ref }>
+				{ childrenWithProps }
+			</div>
+		);
+	}
+);
+
+Accordion.displayName = 'Accordion';
+
+export default Accordion;

--- a/client/components/accordion/row.tsx
+++ b/client/components/accordion/row.tsx
@@ -7,55 +7,25 @@ import React, { forwardRef } from 'react';
 /**
  * Internal dependencies
  */
-import type { AccordionProps, AccordionBodyProps } from './types';
-import AccordionBody from './body';
+import type { AccordionRowProps } from './types';
 import './style.scss';
-
 /**
- * `Accordion` expands and collapses multiple sections of content.
- *
- * ```jsx
- * import { Accordion, AccordionBody, AccordionRow } from '@wordpress/components';
- * import { more } from '@wordpress/icons';
- *
- * const MyAccordion = () => (
- * 	<Accordion header="My Accordion">
- * 		<AccordionBody title="My Block Settings" icon={ more } initialOpen={ true }>
- * 			<AccordionRow>My Accordion Inputs and Labels</AccordionRow>
- * 		</AccordionBody>
- * 	</Accordion>
- * );
- * ```
+ * `AccordionRow` is a generic container for rows within a `AccordionBody`.
+ * It is a flex container with a top margin for spacing.
  */
-const Accordion = forwardRef< HTMLDivElement, AccordionProps >(
-	(
-		{ className, children, highDensity = false, defaultExpanded = false },
-		ref
-	) => {
-		const classNames = clsx( className, 'wcpay-accordion', {
-			'is-high-density': highDensity,
-		} );
-
-		const childrenWithProps = React.Children.map( children, ( child ) => {
-			if (
-				React.isValidElement< AccordionBodyProps >( child ) &&
-				child.type === AccordionBody
-			) {
-				return React.cloneElement( child, {
-					initialOpen: defaultExpanded,
-				} );
-			}
-			return child;
-		} );
-
+const AccordionRow = forwardRef< HTMLDivElement, AccordionRowProps >(
+	( { className, children }, ref ) => {
 		return (
-			<div className={ classNames } ref={ ref }>
-				{ childrenWithProps }
+			<div
+				className={ clsx( 'wcpay-accordion__row', className ) }
+				ref={ ref }
+			>
+				{ children }
 			</div>
 		);
 	}
 );
 
-Accordion.displayName = 'Accordion';
+AccordionRow.displayName = 'AccordionRow';
 
-export default Accordion;
+export default AccordionRow;

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -1,0 +1,162 @@
+.wcpay-accordion {
+	background: $white;
+	border: $border-width solid $gray-200;
+	border-radius: 8px;
+	padding: $grid-unit-10;
+
+	&.is-high-density {
+		border-radius: 0;
+		padding: 0;
+	}
+
+	> .wcpay-accordion__body:first-child {
+		margin-top: -1px;
+	}
+
+	> .wcpay-accordion__body:last-child {
+		border-bottom-width: 0;
+	}
+}
+
+.wcpay-accordion + .wcpay-accordion {
+	margin-top: -1px;
+}
+
+.wcpay-accordion__body {
+	border-bottom: $border-width solid $gray-200;
+
+	&.is-opened {
+		padding: $grid-unit-20;
+	}
+}
+
+.wcpay-accordion__body + .wcpay-accordion__body {
+	margin-top: -$border-width;
+}
+
+.wcpay-accordion__body > .wcpay-accordion__body-title {
+	display: block;
+	padding: 0;
+	font-size: inherit;
+	margin-top: 0;
+	margin-bottom: 0;
+	transition: 0.3s background ease-in-out;
+}
+
+.wcpay-accordion__body.is-opened > .wcpay-accordion__body-title {
+	$value: -1 * $grid-unit-20;
+	margin: $value $value 0 $value;
+}
+
+// Hover States
+.wcpay-accordion__body > .wcpay-accordion__body-title:hover {
+	// Override the default button hover style
+	border: none;
+}
+
+.wcpay-accordion__body-toggle.components-button {
+	position: relative;
+	padding: $grid-unit-20 $grid-unit-60 $grid-unit-20 $grid-unit-20;
+	outline: none;
+	width: 100%;
+	font-weight: 500;
+	text-align: left;
+	color: $gray-900;
+	border: none;
+	box-shadow: none;
+
+	transition: 0.2s background ease-in-out;
+
+	height: auto;
+
+	.wcpay-accordion__title-content {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	&.is-md {
+		font-size: 13px;
+	}
+
+	&.is-lg {
+		font-size: 15px;
+	}
+
+	&:focus {
+		box-shadow: inset 0 0 0 var( --wp-admin-border-width-focus )
+			$components-color-accent;
+		border-radius: 0;
+	}
+
+	.wcpay-accordion__arrow {
+		position: absolute;
+		right: $grid-unit-20;
+		top: 50%;
+		transform: translateY( -50% );
+		color: $gray-900;
+		fill: currentColor;
+
+		transition: 0.2s color ease-in-out;
+	}
+
+	// mirror the arrow horizontally in RTL languages
+	/* rtl:begin:ignore */
+	body.rtl & .dashicons-arrow-right {
+		transform: scaleX( -1 );
+		-ms-filter: fliph;
+		filter: FlipH;
+		margin-top: -10px;
+	}
+	/* rtl:end:ignore */
+}
+
+.wcpay-accordion__subtitle {
+	color: $gray-700;
+	font-size: 13px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 20px;
+}
+
+.wcpay-accordion__icon {
+	color: $gray-700;
+	margin: -2px 0 -2px 6px;
+}
+
+.wcpay-accordion__body-toggle-icon {
+	margin-right: -5px;
+}
+
+.wcpay-accordion__color-title {
+	float: left;
+	height: 19px;
+}
+
+.wcpay-accordion__row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: $grid-unit-10;
+	min-height: $button-size;
+
+	select {
+		// Necessary for select to respond to flexbox
+		min-width: 0;
+	}
+
+	label {
+		margin-right: $grid-unit-15;
+		flex-shrink: 0;
+		max-width: 75%;
+	}
+
+	&:empty,
+	&:first-of-type {
+		margin-top: 0;
+	}
+}
+
+.wcpay-accordion .circle-picker {
+	padding-bottom: 20px;
+}

--- a/client/components/accordion/subtitle.tsx
+++ b/client/components/accordion/subtitle.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { AccordionSubtitleProps } from './types';
+import './style.scss';
+
+const AccordionSubtitle = forwardRef< HTMLDivElement, AccordionSubtitleProps >(
+	( { children }, ref ) => {
+		if ( ! children ) {
+			return null;
+		}
+
+		return (
+			<div className="wcpay-accordion__subtitle" ref={ ref }>
+				{ children }
+			</div>
+		);
+	}
+);
+
+AccordionSubtitle.displayName = 'AccordionSubtitle';
+
+export default AccordionSubtitle;

--- a/client/components/accordion/test/__snapshots__/accordion.test.tsx.snap
+++ b/client/components/accordion/test/__snapshots__/accordion.test.tsx.snap
@@ -1,0 +1,178 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Accordion renders with custom className 1`] = `
+<div>
+  <div
+    class="custom-class wcpay-accordion"
+  >
+    <div
+      class="wcpay-accordion__body"
+    >
+      <h2
+        class="wcpay-accordion__body-title"
+      >
+        <button
+          class="components-button wcpay-accordion__body-toggle is-md"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            <svg
+              aria-hidden="true"
+              class="wcpay-accordion__arrow"
+              focusable="false"
+              size="24"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+              />
+            </svg>
+          </span>
+          <div
+            class="wcpay-accordion__title-content"
+          >
+            Test Title
+          </div>
+        </button>
+      </h2>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Accordion renders with default expanded 1`] = `
+<div>
+  <div
+    class="wcpay-accordion"
+  >
+    <div
+      class="wcpay-accordion__body is-opened"
+    >
+      <h2
+        class="wcpay-accordion__body-title"
+      >
+        <button
+          class="components-button wcpay-accordion__body-toggle is-md"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            <svg
+              aria-hidden="true"
+              class="wcpay-accordion__arrow"
+              focusable="false"
+              size="24"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+              />
+            </svg>
+          </span>
+          <div
+            class="wcpay-accordion__title-content"
+          >
+            Test Title
+          </div>
+        </button>
+      </h2>
+      <div
+        class="wcpay-accordion__row"
+      >
+        Test Content
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Accordion renders with default props 1`] = `
+<div>
+  <div
+    class="wcpay-accordion"
+  >
+    <div
+      class="wcpay-accordion__body"
+    >
+      <h2
+        class="wcpay-accordion__body-title"
+      >
+        <button
+          class="components-button wcpay-accordion__body-toggle is-md"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            <svg
+              aria-hidden="true"
+              class="wcpay-accordion__arrow"
+              focusable="false"
+              size="24"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+              />
+            </svg>
+          </span>
+          <div
+            class="wcpay-accordion__title-content"
+          >
+            Test Title
+          </div>
+        </button>
+      </h2>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Accordion renders with high density 1`] = `
+<div>
+  <div
+    class="wcpay-accordion is-high-density"
+  >
+    <div
+      class="wcpay-accordion__body"
+    >
+      <h2
+        class="wcpay-accordion__body-title"
+      >
+        <button
+          class="components-button wcpay-accordion__body-toggle is-md"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            <svg
+              aria-hidden="true"
+              class="wcpay-accordion__arrow"
+              focusable="false"
+              size="24"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+              />
+            </svg>
+          </span>
+          <div
+            class="wcpay-accordion__title-content"
+          >
+            Test Title
+          </div>
+        </button>
+      </h2>
+    </div>
+  </div>
+</div>
+`;

--- a/client/components/accordion/test/__snapshots__/body.test.tsx.snap
+++ b/client/components/accordion/test/__snapshots__/body.test.tsx.snap
@@ -1,0 +1,282 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccordionBody renders with custom className 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__body custom-class is-opened"
+  >
+    <h2
+      class="wcpay-accordion__body-title"
+    >
+      <button
+        class="components-button wcpay-accordion__body-toggle is-md"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="wcpay-accordion__arrow"
+            focusable="false"
+            size="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        <div
+          class="wcpay-accordion__title-content"
+        >
+          Test Title
+        </div>
+      </button>
+    </h2>
+    <div
+      class="wcpay-accordion__row"
+    >
+      Test Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionBody renders with default props 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__body is-opened"
+  >
+    <h2
+      class="wcpay-accordion__body-title"
+    >
+      <button
+        class="components-button wcpay-accordion__body-toggle is-md"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="wcpay-accordion__arrow"
+            focusable="false"
+            size="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        <div
+          class="wcpay-accordion__title-content"
+        >
+          Test Title
+        </div>
+      </button>
+    </h2>
+    <div
+      class="wcpay-accordion__row"
+    >
+      Test Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionBody renders with function children 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__body is-opened"
+  >
+    <h2
+      class="wcpay-accordion__body-title"
+    >
+      <button
+        class="components-button wcpay-accordion__body-toggle is-md"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="wcpay-accordion__arrow"
+            focusable="false"
+            size="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        <div
+          class="wcpay-accordion__title-content"
+        >
+          Test Title
+        </div>
+      </button>
+    </h2>
+    <div
+      class="wcpay-accordion__row"
+    >
+      Opened Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionBody renders with icon 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__body is-opened"
+  >
+    <h2
+      class="wcpay-accordion__body-title"
+    >
+      <button
+        class="components-button wcpay-accordion__body-toggle is-md"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="wcpay-accordion__arrow"
+            focusable="false"
+            size="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        <div
+          class="wcpay-accordion__title-content"
+        >
+          Test Title
+        </div>
+        <svg
+          aria-hidden="true"
+          class="wcpay-accordion__icon"
+          focusable="false"
+          size="20"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4 9v1.5h16V9H4zm12 5.5h4V13h-4v1.5zm-6 0h4V13h-4v1.5zm-6 0h4V13H4v1.5z"
+          />
+        </svg>
+      </button>
+    </h2>
+    <div
+      class="wcpay-accordion__row"
+    >
+      Test Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionBody renders with large title 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__body is-opened"
+  >
+    <h2
+      class="wcpay-accordion__body-title"
+    >
+      <button
+        class="components-button wcpay-accordion__body-toggle is-md is-lg"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="wcpay-accordion__arrow"
+            focusable="false"
+            size="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        <div
+          class="wcpay-accordion__title-content"
+        >
+          Test Title
+        </div>
+      </button>
+    </h2>
+    <div
+      class="wcpay-accordion__row"
+    >
+      Test Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionBody renders with subtitle 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__body is-opened"
+  >
+    <h2
+      class="wcpay-accordion__body-title"
+    >
+      <button
+        class="components-button wcpay-accordion__body-toggle is-md"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="wcpay-accordion__arrow"
+            focusable="false"
+            size="24"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        <div
+          class="wcpay-accordion__title-content"
+        >
+          Test Title
+          <div
+            class="wcpay-accordion__subtitle"
+          >
+            Test Subtitle
+          </div>
+        </div>
+      </button>
+    </h2>
+    <div
+      class="wcpay-accordion__row"
+    >
+      Test Content
+    </div>
+  </div>
+</div>
+`;

--- a/client/components/accordion/test/__snapshots__/row.test.tsx.snap
+++ b/client/components/accordion/test/__snapshots__/row.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccordionRow renders with complex content 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__row"
+  >
+    <div>
+      <h3>
+        Title
+      </h3>
+      <p>
+        Description
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AccordionRow renders with custom className 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__row custom-class"
+  >
+    Test Content
+  </div>
+</div>
+`;
+
+exports[`AccordionRow renders with default props 1`] = `
+<div>
+  <div
+    class="wcpay-accordion__row"
+  >
+    Test Content
+  </div>
+</div>
+`;

--- a/client/components/accordion/test/accordion.test.tsx
+++ b/client/components/accordion/test/accordion.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Accordion, AccordionBody, AccordionRow } from '../';
+
+describe( 'Accordion', () => {
+	test( 'renders with default props', () => {
+		const { container } = render(
+			<Accordion>
+				<AccordionBody title="Test Title">
+					<AccordionRow>Test Content</AccordionRow>
+				</AccordionBody>
+			</Accordion>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with high density', () => {
+		const { container } = render(
+			<Accordion highDensity>
+				<AccordionBody title="Test Title">
+					<AccordionRow>Test Content</AccordionRow>
+				</AccordionBody>
+			</Accordion>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with default expanded', () => {
+		const { container } = render(
+			<Accordion defaultExpanded>
+				<AccordionBody title="Test Title">
+					<AccordionRow>Test Content</AccordionRow>
+				</AccordionBody>
+			</Accordion>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with custom className', () => {
+		const { container } = render(
+			<Accordion className="custom-class">
+				<AccordionBody title="Test Title">
+					<AccordionRow>Test Content</AccordionRow>
+				</AccordionBody>
+			</Accordion>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/components/accordion/test/body.test.tsx
+++ b/client/components/accordion/test/body.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { more } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { AccordionBody, AccordionRow } from '../';
+
+describe( 'AccordionBody', () => {
+	test( 'renders with default props', () => {
+		const { container } = render(
+			<AccordionBody title="Test Title">
+				<AccordionRow>Test Content</AccordionRow>
+			</AccordionBody>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with icon', () => {
+		const { container } = render(
+			<AccordionBody title="Test Title" icon={ more }>
+				<AccordionRow>Test Content</AccordionRow>
+			</AccordionBody>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with subtitle', () => {
+		const { container } = render(
+			<AccordionBody title="Test Title" subtitle="Test Subtitle">
+				<AccordionRow>Test Content</AccordionRow>
+			</AccordionBody>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with large title', () => {
+		const { container } = render(
+			<AccordionBody title="Test Title" lg>
+				<AccordionRow>Test Content</AccordionRow>
+			</AccordionBody>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with custom className', () => {
+		const { container } = render(
+			<AccordionBody title="Test Title" className="custom-class">
+				<AccordionRow>Test Content</AccordionRow>
+			</AccordionBody>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with function children', () => {
+		const { container } = render(
+			<AccordionBody title="Test Title">
+				{ ( { opened } ) => (
+					<AccordionRow>
+						{ opened ? 'Opened Content' : 'Closed Content' }
+					</AccordionRow>
+				) }
+			</AccordionBody>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/components/accordion/test/row.test.tsx
+++ b/client/components/accordion/test/row.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { AccordionRow } from '../';
+
+describe( 'AccordionRow', () => {
+	test( 'renders with default props', () => {
+		const { container } = render(
+			<AccordionRow>Test Content</AccordionRow>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with custom className', () => {
+		const { container } = render(
+			<AccordionRow className="custom-class">Test Content</AccordionRow>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders with complex content', () => {
+		const { container } = render(
+			<AccordionRow>
+				<div>
+					<h3>Title</h3>
+					<p>Description</p>
+				</div>
+			</AccordionRow>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/components/accordion/title.tsx
+++ b/client/components/accordion/title.tsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { forwardRef } from 'react';
+import clsx from 'clsx';
+/**
+ * WordPress dependencies
+ */
+import { chevronUp, chevronDown } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { AccordionTitleProps } from './types';
+import type { WordPressComponentProps } from '@wordpress/components/ui/context/wordpress-component';
+import { Button, Icon } from 'wcpay/components/wp-components-wrapped';
+import AccordionSubtitle from './subtitle';
+import './style.scss';
+
+const AccordionTitle = forwardRef<
+	HTMLButtonElement,
+	WordPressComponentProps< AccordionTitleProps, 'button', false >
+>(
+	(
+		{ isOpened, icon, title, subtitle, md = true, lg = false, ...props },
+		ref
+	) => {
+		if ( ! title ) {
+			return null;
+		}
+
+		return (
+			<h2 className="wcpay-accordion__body-title">
+				<Button
+					className={ clsx( 'wcpay-accordion__body-toggle', {
+						'is-md': md,
+						'is-lg': lg,
+					} ) }
+					ref={ ref }
+					{ ...props }
+				>
+					{ /*
+				Firefox + NVDA don't announce aria-expanded because the browser
+				repaints the whole element, so this wrapping span hides that.
+			*/ }
+					<span aria-hidden="true">
+						<Icon
+							className="wcpay-accordion__arrow"
+							icon={ isOpened ? chevronUp : chevronDown }
+						/>
+					</span>
+					<div className="wcpay-accordion__title-content">
+						{ title }
+						{ subtitle && (
+							<AccordionSubtitle>{ subtitle }</AccordionSubtitle>
+						) }
+					</div>
+					{ icon && (
+						<Icon
+							icon={ icon }
+							className="wcpay-accordion__icon"
+							size={ 20 }
+						/>
+					) }
+				</Button>
+			</h2>
+		);
+	}
+);
+
+AccordionTitle.displayName = 'AccordionTitle';
+
+export default AccordionTitle;

--- a/client/components/accordion/types.ts
+++ b/client/components/accordion/types.ts
@@ -1,0 +1,174 @@
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line import/no-unresolved
+import { WordPressComponentProps } from '@wordpress/components/ui/context/wordpress-component';
+import { Button } from '@wordpress/components';
+
+export type AccordionProps = {
+	/**
+	 * The CSS class to apply to the wrapper element.
+	 */
+	className?: string;
+	/**
+	 * The content to display within the accordion.
+	 */
+	children: React.ReactNode;
+	/**
+	 * Ref to be forwarded to the root element
+	 */
+	ref?: React.Ref< HTMLDivElement >;
+	/**
+	 * Whether to use high density styling (smaller padding, no border radius).
+	 *
+	 * @default false
+	 */
+	highDensity?: boolean;
+	/**
+	 * Whether all accordion sections should be expanded by default.
+	 *
+	 * @default false
+	 */
+	defaultExpanded?: boolean;
+};
+
+export type AccordionRowProps = {
+	/**
+	 * The CSS class to apply to the wrapper element.
+	 */
+	className?: string;
+	/**
+	 * The content to display within the accordion row.
+	 */
+	children: React.ReactNode;
+	/**
+	 * Ref to be forwarded to the row element
+	 */
+	ref?: React.Ref< HTMLDivElement >;
+};
+
+export type AccordionBodyProps = {
+	/**
+	 * Props that are passed to the `Button` component in title within the
+	 * `AccordionBody`.
+	 *
+	 * @default {}
+	 */
+	buttonProps?: Omit<
+		WordPressComponentProps<
+			Omit< Button.ButtonProps, 'icon' >,
+			'button',
+			false
+		>,
+		'size'
+	>;
+	/**
+	 * The content to display in the `AccordionBody`.If a function is provided for
+	 * this prop, it will receive an object with the `opened` prop as an argument.
+	 */
+	children?:
+		| React.ReactNode
+		| ( ( props: { opened: boolean } ) => React.ReactNode );
+
+	/**
+	 * The CSS class to apply to the wrapper element.
+	 */
+	className?: string;
+	/**
+	 * An icon to be shown next to the title.
+	 */
+	icon?: JSX.Element;
+	/**
+	 * Whether or not the accordion will start open.
+	 */
+	initialOpen?: boolean;
+	/**
+	 * A function that is called any time the component is toggled from its closed
+	 * state to its opened state, or vice versa.
+	 *
+	 * @default noop
+	 */
+	onToggle?: ( next: boolean ) => void;
+	/**
+	 * When set to `true`, the component will remain open regardless of the
+	 * `initialOpen` prop and the accordion will be prevented from being closed.
+	 */
+	opened?: boolean;
+	/**
+	 * Title text. It shows even when it is closed.
+	 */
+	title?: string;
+	/**
+	 * Scrolls the content into view when visible. This improves the UX when
+	 * multiple `AccordionBody` components are stacked in a scrollable container.
+	 *
+	 * @default true
+	 */
+	scrollAfterOpen?: boolean;
+	/**
+	 * Optional subtitle text that appears below the title.
+	 */
+	subtitle?: string;
+	/**
+	 * Ref to be forwarded to the body element
+	 */
+	ref?: React.Ref< HTMLDivElement >;
+	/**
+	 * Whether to use large title size (15px).
+	 *
+	 * @default false
+	 */
+	lg?: boolean;
+	/**
+	 * Whether to use medium title size (13px).
+	 *
+	 * @default true
+	 */
+	md?: boolean;
+};
+
+export type AccordionTitleProps = Omit< Button.ButtonProps, 'icon' > & {
+	/**
+	 * An icon to be shown next to the title.
+	 */
+	icon?: JSX.Element;
+	/**
+	 * Whether or not the `AccordionBody` is currently opened or not.
+	 */
+	isOpened?: boolean;
+	/**
+	 * The title text.
+	 */
+	title?: string;
+	/**
+	 * Optional subtitle text that appears below the title.
+	 */
+	subtitle?: string;
+	/**
+	 * Whether to use large title size (15px).
+	 *
+	 * @default false
+	 */
+	lg?: boolean;
+	/**
+	 * Whether to use medium title size (13px).
+	 *
+	 * @default true
+	 */
+	md?: boolean;
+	/**
+	 * Ref to be forwarded to the title button element
+	 */
+	ref?: React.LegacyRef< HTMLButtonElement >;
+};
+
+export type AccordionSubtitleProps = {
+	/**
+	 * The content to display within the subtitle.
+	 */
+	children?: React.ReactNode;
+	/**
+	 * Ref to be forwarded to the subtitle element
+	 */
+	ref?: React.Ref< HTMLDivElement >;
+};

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -3,17 +3,11 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, Button } from 'wcpay/components/wp-components-wrapped';
-import {
-	chevronDown,
-	chevronUp,
-	envelope,
-	comment,
-	page,
-} from '@wordpress/icons';
+import { envelope, comment, page } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -23,6 +23,9 @@ import { ChargeBillingDetails } from 'wcpay/types/charges';
 import { formatExplicitCurrency } from 'multi-currency/interface/functions';
 import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
 import InlineNotice from 'components/inline-notice';
+import AccordionRow from 'wcpay/components/accordion/row';
+import AccordionBody from 'wcpay/components/accordion/body';
+import Accordion from 'wcpay/components/accordion';
 
 interface Props {
 	dispute: Dispute;
@@ -37,8 +40,6 @@ export const DisputeSteps: React.FC< Props > = ( {
 	chargeCreated,
 	bankName,
 } ) => {
-	const [ isExpanded, setIsExpanded ] = useState( false );
-
 	let emailLink;
 	if ( customer?.email ) {
 		const chargeDate = formatDateTimeFromTimestamp( chargeCreated );
@@ -71,164 +72,140 @@ export const DisputeSteps: React.FC< Props > = ( {
 		) }&body=${ encodeURIComponent( emailBody ) }`;
 	}
 
-	const toggleExpand = () => {
-		setIsExpanded( ! isExpanded );
-	};
-
 	return (
 		<div className="dispute-steps">
-			<div
-				className="dispute-steps__header"
-				onClick={ toggleExpand }
-				role="button"
-				tabIndex={ 0 }
-				onKeyDown={ ( e ) => {
-					if ( e.key === 'Enter' || e.key === ' ' ) {
-						toggleExpand();
-					}
-				} }
-			>
-				<div className="dispute-steps__header-content">
-					<div className="dispute-steps__header-title">
-						{ __( 'Steps you can take', 'woocommerce-payments' ) }
-					</div>
-					<div className="dispute-steps__header-subtitle">
-						{ __(
-							'Review these steps you can take to respond to disputes effectively',
-							'woocommerce-payments'
-						) }
-					</div>
-				</div>
-				<div className="dispute-steps__header-icon">
-					<Icon
-						icon={ isExpanded ? chevronUp : chevronDown }
-						className="dispute-steps__header-icon-svg"
-					/>
-				</div>
-			</div>
-			<div
-				className={ `dispute-steps__content ${
-					isExpanded ? 'dispute-steps__content--expanded' : ''
-				}` }
-			>
-				<div className="dispute-steps__items">
-					{ /* Step 1: Reach out to your customer */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ envelope } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Reach out to your customer',
-									'woocommerce-payments'
-								) }
+			<Accordion>
+				<AccordionBody
+					lg
+					title="Steps you can take"
+					subtitle="Review these steps you can take to respond to disputes effectively"
+				>
+					<AccordionRow>
+						<div className="dispute-steps__content">
+							<div className="dispute-steps__items">
+								{ /* Step 1: Reach out to your customer */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ envelope } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Reach out to your customer',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Identify the issue and work towards a resolution where possible.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										{ customer?.email ? (
+											<Button
+												variant="secondary"
+												href={ emailLink }
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												{ __(
+													'Email customer',
+													'woocommerce-payments'
+												) }
+											</Button>
+										) : null }
+									</div>
+								</div>
+
+								{ /* Step 2: Pursue a dispute withdrawal */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ comment } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Pursue a dispute withdrawal',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'See if the customer will withdraw their dispute.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										<Button
+											variant="secondary"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#withdrawals"
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</Button>
+									</div>
+								</div>
+
+								{ /* Step 3: Challenge or accept the dispute */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ page } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Challenge or accept the dispute',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Challenge the dispute if you consider the claim to be invalid. Accepting the dispute will automatically close it and the order amount and the dispute fee will not be returned to you.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+								</div>
 							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Identify the issue and work towards a resolution where possible.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-						<div className="dispute-steps__item-action">
-							{ customer?.email ? (
-								<Button
-									variant="secondary"
-									href={ emailLink }
-									target="_blank"
-									rel="noopener noreferrer"
+
+							{ /* Dispute notice */ }
+							<div className="dispute-steps__notice">
+								<InlineNotice
+									icon
+									isDismissible={ false }
+									status="info"
+									className="dispute-steps__notice-content"
 								>
-									{ __(
-										'Email customer',
-										'woocommerce-payments'
-									) }
-								</Button>
-							) : null }
-						</div>
-					</div>
-
-					{ /* Step 2: Pursue a dispute withdrawal */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ comment } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Pursue a dispute withdrawal',
-									'woocommerce-payments'
-								) }
-							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'See if the customer will withdraw their dispute.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-						<div className="dispute-steps__item-action">
-							<Button
-								variant="secondary"
-								href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#withdrawals"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ __( 'Learn more', 'woocommerce-payments' ) }
-							</Button>
-						</div>
-					</div>
-
-					{ /* Step 3: Challenge or accept the dispute */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ page } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Challenge or accept the dispute',
-									'woocommerce-payments'
-								) }
-							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Challenge the dispute if you consider the claim to be invalid. Accepting the dispute will automatically close it and the order amount and the dispute fee will not be returned to you.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-					</div>
-				</div>
-
-				{ /* Dispute notice */ }
-				<div className="dispute-steps__notice">
-					<InlineNotice
-						icon
-						isDismissible={ false }
-						status="info"
-						className="dispute-steps__notice-content"
-					>
-						{ createInterpolateElement(
-							bankName
-								? sprintf(
-										__(
-											'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
-											'woocommerce-payments'
-										),
+									{ createInterpolateElement(
 										bankName
-								  )
-								: __(
-										"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
-										'woocommerce-payments'
-								  ),
-							{
-								strong: <strong />,
-							}
-						) }
-					</InlineNotice>
-				</div>
-			</div>
+											? sprintf(
+													__(
+														'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
+														'woocommerce-payments'
+													),
+													bankName
+											  )
+											: __(
+													"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
+													'woocommerce-payments'
+											  ),
+										{
+											strong: <strong />,
+										}
+									) }
+								</InlineNotice>
+							</div>
+						</div>
+					</AccordionRow>
+				</AccordionBody>
+			</Accordion>
 		</div>
 	);
 };
@@ -239,8 +216,6 @@ export const InquirySteps: React.FC< Props > = ( {
 	chargeCreated,
 	bankName,
 } ) => {
-	const [ isExpanded, setIsExpanded ] = useState( false );
-
 	let emailLink;
 	if ( customer?.email ) {
 		const chargeDate = formatDateTimeFromTimestamp( chargeCreated, {
@@ -277,143 +252,119 @@ export const InquirySteps: React.FC< Props > = ( {
 		) }&body=${ encodeURIComponent( emailBody ) }`;
 	}
 
-	const toggleExpand = () => {
-		setIsExpanded( ! isExpanded );
-	};
-
 	return (
 		<div className="dispute-steps">
-			<div
-				className="dispute-steps__header"
-				onClick={ toggleExpand }
-				role="button"
-				tabIndex={ 0 }
-				onKeyDown={ ( e ) => {
-					if ( e.key === 'Enter' || e.key === ' ' ) {
-						toggleExpand();
-					}
-				} }
-			>
-				<div className="dispute-steps__header-content">
-					<div className="dispute-steps__header-title">
-						{ __( 'Steps you can take', 'woocommerce-payments' ) }
-					</div>
-					<div className="dispute-steps__header-subtitle">
-						{ __(
-							'Review these steps you can take to respond to disputes effectively',
-							'woocommerce-payments'
-						) }
-					</div>
-				</div>
-				<div className="dispute-steps__header-icon">
-					<Icon
-						icon={ isExpanded ? chevronUp : chevronDown }
-						className="dispute-steps__header-icon-svg"
-					/>
-				</div>
-			</div>
-			<div
-				className={ `dispute-steps__content ${
-					isExpanded ? 'dispute-steps__content--expanded' : ''
-				}` }
-			>
-				<div className="dispute-steps__items">
-					{ /* Step 1: Reach out to your customer */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ envelope } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Reach out to your customer',
-									'woocommerce-payments'
-								) }
+			<Accordion>
+				<AccordionBody
+					lg
+					title="Steps you can take"
+					subtitle="Review these steps you can take to respond to disputes effectively"
+				>
+					<AccordionRow>
+						<div className="dispute-steps__content">
+							<div className="dispute-steps__items">
+								{ /* Step 1: Reach out to your customer */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ envelope } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Reach out to your customer',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Identify the issue and work towards a resolution where possible.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										{ customer?.email ? (
+											<Button
+												variant="secondary"
+												href={ emailLink }
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												{ __(
+													'Email customer',
+													'woocommerce-payments'
+												) }
+											</Button>
+										) : null }
+									</div>
+								</div>
+
+								{ /* Step 2: Provide guidance for inquiry withdrawal */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ page } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Submit evidence or issue a refund',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Submit the evidence by providing the requested information.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										<Button
+											variant="secondary"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries"
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</Button>
+									</div>
+								</div>
 							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Identify the issue and work towards a resolution where possible.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-						<div className="dispute-steps__item-action">
-							{ customer?.email ? (
-								<Button
-									variant="secondary"
-									href={ emailLink }
-									target="_blank"
-									rel="noopener noreferrer"
+
+							{ /* Dispute notice */ }
+							<div className="dispute-steps__notice">
+								<InlineNotice
+									icon
+									isDismissible={ false }
+									status="info"
+									className="dispute-steps__notice-content"
 								>
-									{ __(
-										'Email customer',
-										'woocommerce-payments'
-									) }
-								</Button>
-							) : null }
-						</div>
-					</div>
-
-					{ /* Step 2: Provide guidance for inquiry withdrawal */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ page } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Submit evidence or issue a refund',
-									'woocommerce-payments'
-								) }
-							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Submit the evidence by providing the requested information.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-						<div className="dispute-steps__item-action">
-							<Button
-								variant="secondary"
-								href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ __( 'Learn more', 'woocommerce-payments' ) }
-							</Button>
-						</div>
-					</div>
-				</div>
-
-				{ /* Dispute notice */ }
-				<div className="dispute-steps__notice">
-					<InlineNotice
-						icon
-						isDismissible={ false }
-						status="info"
-						className="dispute-steps__notice-content"
-					>
-						{ createInterpolateElement(
-							bankName
-								? sprintf(
-										__(
-											'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
-											'woocommerce-payments'
-										),
+									{ createInterpolateElement(
 										bankName
-								  )
-								: __(
-										"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
-										'woocommerce-payments'
-								  ),
-							{
-								strong: <strong />,
-							}
-						) }
-					</InlineNotice>
-				</div>
-			</div>
+											? sprintf(
+													__(
+														'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
+														'woocommerce-payments'
+													),
+													bankName
+											  )
+											: __(
+													"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
+													'woocommerce-payments'
+											  ),
+										{
+											strong: <strong />,
+										}
+									) }
+								</InlineNotice>
+							</div>
+						</div>
+					</AccordionRow>
+				</AccordionBody>
+			</Accordion>
 		</div>
 	);
 };
@@ -424,8 +375,6 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 	chargeCreated,
 	bankName,
 } ) => {
-	const [ isExpanded, setIsExpanded ] = useState( false );
-
 	let emailLink;
 	if ( customer?.email ) {
 		const chargeDate = formatDateTimeFromTimestamp( chargeCreated, {
@@ -462,164 +411,140 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 		) }&body=${ encodeURIComponent( emailBody ) }`;
 	}
 
-	const toggleExpand = () => {
-		setIsExpanded( ! isExpanded );
-	};
-
 	return (
 		<div className="dispute-steps">
-			<div
-				className="dispute-steps__header"
-				onClick={ toggleExpand }
-				role="button"
-				tabIndex={ 0 }
-				onKeyDown={ ( e ) => {
-					if ( e.key === 'Enter' || e.key === ' ' ) {
-						toggleExpand();
-					}
-				} }
-			>
-				<div className="dispute-steps__header-content">
-					<div className="dispute-steps__header-title">
-						{ __( 'Steps you can take', 'woocommerce-payments' ) }
-					</div>
-					<div className="dispute-steps__header-subtitle">
-						{ __(
-							'Review these steps you can take to respond to disputes effectively',
-							'woocommerce-payments'
-						) }
-					</div>
-				</div>
-				<div className="dispute-steps__header-icon">
-					<Icon
-						icon={ isExpanded ? chevronUp : chevronDown }
-						className="dispute-steps__header-icon-svg"
-					/>
-				</div>
-			</div>
-			<div
-				className={ `dispute-steps__content ${
-					isExpanded ? 'dispute-steps__content--expanded' : ''
-				}` }
-			>
-				<div className="dispute-steps__items">
-					{ /* Step 1: Reach out to your customer */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ envelope } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Reach out to your customer',
-									'woocommerce-payments'
-								) }
+			<Accordion>
+				<AccordionBody
+					lg
+					title="Steps you can take"
+					subtitle="Review these steps you can take to respond to disputes effectively"
+				>
+					<AccordionRow>
+						<div className="dispute-steps__content">
+							<div className="dispute-steps__items">
+								{ /* Step 1: Reach out to your customer */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ envelope } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Reach out to your customer',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Identify the issue and work towards a resolution where possible.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										{ customer?.email ? (
+											<Button
+												variant="secondary"
+												href={ emailLink }
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												{ __(
+													'Email customer',
+													'woocommerce-payments'
+												) }
+											</Button>
+										) : null }
+									</div>
+								</div>
+
+								{ /* Step 2: Issue refund */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ page } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Issue a refund',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Issue a refund if the item is returned.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+								</div>
+
+								{ /* Step 3: Challenge the dispute if the item is not returned */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ envelope } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Challenge the dispute if the item is not returned',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Allow this inquiry to become a dispute in 21 days if you don’t receive the item.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										<Button
+											variant="secondary"
+											href="https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#klarna-inquiries-returns"
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</Button>
+									</div>
+								</div>
 							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Identify the issue and work towards a resolution where possible.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-						<div className="dispute-steps__item-action">
-							{ customer?.email ? (
-								<Button
-									variant="secondary"
-									href={ emailLink }
-									target="_blank"
-									rel="noopener noreferrer"
+
+							{ /* Dispute notice */ }
+							<div className="dispute-steps__notice">
+								<InlineNotice
+									icon
+									isDismissible={ false }
+									status="info"
+									className="dispute-steps__notice-content"
 								>
-									{ __(
-										'Email customer',
-										'woocommerce-payments'
-									) }
-								</Button>
-							) : null }
-						</div>
-					</div>
-
-					{ /* Step 2: Issue refund */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ page } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Issue a refund',
-									'woocommerce-payments'
-								) }
-							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Issue a refund if the item is returned.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-					</div>
-
-					{ /* Step 3: Challenge the dispute if the item is not returned */ }
-					<div className="dispute-steps__item">
-						<div className="dispute-steps__item-icon">
-							<Icon icon={ envelope } />
-						</div>
-						<div className="dispute-steps__item-content">
-							<div className="dispute-steps__item-name">
-								{ __(
-									'Challenge the dispute if the item is not returned',
-									'woocommerce-payments'
-								) }
-							</div>
-							<div className="dispute-steps__item-description">
-								{ __(
-									'Allow this inquiry to become a dispute in 21 days if you don’t receive the item.',
-									'woocommerce-payments'
-								) }
-							</div>
-						</div>
-						<div className="dispute-steps__item-action">
-							<Button
-								variant="secondary"
-								href="https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#klarna-inquiries-returns"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ __( 'Learn more', 'woocommerce-payments' ) }
-							</Button>
-						</div>
-					</div>
-				</div>
-
-				{ /* Dispute notice */ }
-				<div className="dispute-steps__notice">
-					<InlineNotice
-						icon
-						isDismissible={ false }
-						status="info"
-						className="dispute-steps__notice-content"
-					>
-						{ createInterpolateElement(
-							bankName
-								? sprintf(
-										__(
-											'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
-											'woocommerce-payments'
-										),
+									{ createInterpolateElement(
 										bankName
-								  )
-								: __(
-										"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
-										'woocommerce-payments'
-								  ),
-							{
-								strong: <strong />,
-							}
-						) }
-					</InlineNotice>
-				</div>
-			</div>
+											? sprintf(
+													__(
+														'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
+														'woocommerce-payments'
+													),
+													bankName
+											  )
+											: __(
+													"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
+													'woocommerce-payments'
+											  ),
+										{
+											strong: <strong />,
+										}
+									) }
+								</InlineNotice>
+							</div>
+						</div>
+					</AccordionRow>
+				</AccordionBody>
+			</Accordion>
 		</div>
 	);
 };

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -17,9 +17,11 @@ import { ChargeBillingDetails } from 'wcpay/types/charges';
 import { formatExplicitCurrency } from 'multi-currency/interface/functions';
 import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
 import InlineNotice from 'components/inline-notice';
-import AccordionRow from 'wcpay/components/accordion/row';
-import AccordionBody from 'wcpay/components/accordion/body';
-import Accordion from 'wcpay/components/accordion';
+import {
+	Accordion,
+	AccordionBody,
+	AccordionRow,
+} from 'wcpay/components/accordion';
 
 interface Props {
 	dispute: Dispute;

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -29,16 +29,11 @@
 			padding: 0;
 		}
 		.wcpay-inline-notice.components-notice {
-			margin: 0 0 10px 0;
 			.components-notice__content {
 				letter-spacing: 0.02em;
 				font-size: 14px;
 				line-height: 1.5em;
 				margin: 16px;
-			}
-
-			&:last-child {
-				margin-bottom: 24px;
 			}
 		}
 
@@ -121,84 +116,6 @@
 
 .dispute-steps {
 	margin-top: 40px;
-	border-radius: var( --radius-l, 8px );
-	border: 1px solid var( --Scales-Grays-gray-200, #e0e0e0 );
-	background: var( --scales-black-white-white, #fff );
-	overflow: hidden;
-	transition: all 0.3s ease;
-
-	&__header {
-		display: flex;
-		width: 100%;
-		padding: var( --Scales-grid-unit-20, 24px )
-			var( --Scales-grid-unit-30, 24px );
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: center;
-		cursor: pointer;
-		user-select: none;
-
-		&:hover {
-			// Make the text blue
-			.dispute-steps__header-title {
-				color: var( --wp-admin-theme-color, #007cba );
-			}
-		}
-
-		&-content {
-			display: flex;
-			flex-direction: column;
-			gap: 4px;
-		}
-
-		&-title {
-			letter-spacing: 0.01em;
-
-			// Heading LG
-			font-size: var( --l, 15px );
-			font-style: normal;
-			font-weight: var( --Medium, 500 );
-			line-height: var( --s, 20px ); /* 133.333% */
-			color: var( --Scales-Grays-gray-900, #1e1e1e );
-		}
-
-		&-subtitle {
-			color: var( --Scales-Grays-gray-700, #757575 );
-			/* Body MD */
-			font-size: var( --m, 13px );
-			font-style: normal;
-			font-weight: var( --Regular, 400 );
-			line-height: var( --s, 20px ); /* 153.846% */
-		}
-
-		&-icon {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			color: var( --Scales-Grays-gray-500, #757575 );
-		}
-	}
-
-	&__content {
-		max-height: 0;
-		overflow: hidden;
-		transition: max-height 0.3s ease-out;
-
-		&--expanded {
-			max-height: 2000px; // Increased to accommodate all content
-			transition: max-height 0.5s ease-in;
-		}
-	}
-
-	&__items {
-		padding: 0 var( --Scales-grid-unit-30, 24px )
-			var( --Scales-grid-unit-20, 12px );
-
-		@media screen and ( max-width: $break-small ) {
-			padding: 0 var( --Scales-grid-unit-20, 16px )
-				var( --Scales-grid-unit-20, 12px );
-		}
-	}
 
 	&__item {
 		display: flex;
@@ -302,12 +219,6 @@
 	}
 
 	&__notice {
-		margin: 0 var( --Scales-grid-unit-30, 24px );
-
-		@media screen and ( max-width: $break-small ) {
-			margin: 0 var( --Scales-grid-unit-20, 16px );
-		}
-
 		.dispute-steps__notice-content {
 			.components-notice__content {
 				letter-spacing: 0.02em;
@@ -319,39 +230,6 @@
 					margin: 8px 16px 8px 0;
 					line-height: 1.4;
 				}
-			}
-		}
-	}
-
-	&__steps {
-		list-style-position: inside;
-		margin: 0;
-		padding: 0 var( --Scales-grid-unit-30, 24px )
-			var( --Scales-grid-unit-20, 16px );
-
-		> li {
-			margin: 0;
-			padding: 16px 10px 16px 4px;
-			border-bottom: 1px solid $wp-gray-5;
-		}
-
-		.wcpay-tooltip__content-wrapper > [role='button'] {
-			margin: 0;
-		}
-
-		&__response-date {
-			display: inline-flex;
-			align-items: center;
-			gap: var( --grid-unit-05, 4px );
-			flex-wrap: wrap;
-			font-weight: 600;
-
-			&--warning {
-				color: $alert-red;
-				font-weight: 700;
-			}
-			&--urgent {
-				color: $alert-red;
 			}
 		}
 	}

--- a/client/payment-details/summary/__tests__/index.test.js
+++ b/client/payment-details/summary/__tests__/index.test.js
@@ -152,6 +152,14 @@ function renderCharge( charge, metadata = {}, isLoading = false, props = {} ) {
 	return container;
 }
 
+// Add this helper function to expand the accordion
+const expandAccordion = ( title ) => {
+	const accordionTitle = screen.getByText( title, {
+		selector: '.wcpay-accordion__title-content',
+	} );
+	fireEvent.click( accordionTitle );
+};
+
 describe( 'PaymentDetailsSummary', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -389,23 +397,12 @@ describe( 'PaymentDetailsSummary', () => {
 			} )
 		).toBeNull();
 
-		// Dispute Summary Row
-		expect(
-			screen.getByText( /Dispute Amount/i ).nextSibling
-		).toHaveTextContent( /\$20.00/ );
-		expect(
-			screen.getByText( /Disputed On/i ).nextSibling
-		).toHaveTextContent( /Aug 31, 2023/ );
-		expect( screen.getByText( /Reason/i ).nextSibling ).toHaveTextContent(
-			/Transaction unauthorized/
-		);
-		expect(
-			screen.getByText( /Respond By/i ).nextSibling
-		).toHaveTextContent( /Sep 9, 2023/ );
+		// Expand the steps accordion
+		expandAccordion( 'Steps you can take' );
 
 		// Steps to resolve
 		screen.getByText( /Steps you can take/i, {
-			selector: '.dispute-steps__header-title',
+			selector: '.wcpay-accordion__title-content',
 		} );
 
 		screen.getByText( /Reach out to your customer/i, {
@@ -841,9 +838,12 @@ describe( 'PaymentDetailsSummary', () => {
 			{ ignore: '.a11y-speak-region' }
 		);
 
+		// Expand the steps accordion
+		expandAccordion( 'Steps you can take' );
+
 		// Steps to resolve
 		screen.getByText( /Steps you can take/i, {
-			selector: '.dispute-steps__header-title',
+			selector: '.wcpay-accordion__title-content',
 		} );
 		screen.getByRole( 'link', {
 			name: /Email customer/i,


### PR DESCRIPTION
Fixes WOOPMNT-4982

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The accordion component will also be used on the envidence submission form. This PR decouple it from the dispute details screen and add the missing features for the envidence submission form.

This component was extracted from this PR: https://github.com/Automattic/woocommerce-payments/pull/10748

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Hit Payments > Disputes, select one of the disputes listed
* The visual of the component should stay intact.

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/8f724319-7680-4b3d-bfd1-e0dfeb41d993" />

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
