### PR TITLE
chore: typed children in React.FC

### DIFF
--- a/changelog/chore-type-children-in-React.FC-and-type-adjustments-for-React18
+++ b/changelog/chore-type-children-in-React.FC-and-type-adjustments-for-React18
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: typed `children` on React.FC and other type adjustments in preparation of React18.
+
+

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __, _n } from '@wordpress/i18n';
 import { TableCard } from '@woocommerce/components';
 

--- a/client/checkout/blocks/payment-methods-logos/logo-popover.tsx
+++ b/client/checkout/blocks/payment-methods-logos/logo-popover.tsx
@@ -19,15 +19,9 @@ interface LogoPopoverProps {
 	dataTestId?: string;
 }
 
-export const LogoPopover: React.FC< LogoPopoverProps > = ( {
-	id,
-	className,
-	children,
-	anchor,
-	open,
-	onClose,
-	dataTestId,
-} ) => {
+export const LogoPopover: React.FC< React.PropsWithChildren<
+	LogoPopoverProps
+> > = ( { id, className, children, anchor, open, onClose, dataTestId } ) => {
 	const popoverRef = useRef< HTMLDivElement >( null );
 	const [ isPositioned, setIsPositioned ] = useState( false );
 

--- a/client/components/account-balances/balance-block.tsx
+++ b/client/components/account-balances/balance-block.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/active-loan-summary/index.tsx
+++ b/client/components/active-loan-summary/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import {
 	Button,
 	Card,

--- a/client/components/amount-input/index.tsx
+++ b/client/components/amount-input/index.tsx
@@ -23,7 +23,7 @@ const AmountInput: React.FC< AmountInputProps > = ( {
 } ) => {
 	// Only allow digits, a single dot, and more digits (or an empty value).
 	const validateInput = useCallback(
-		( subject ) => /^(\d+\.?\d*)?$/m.test( subject ),
+		( subject: string ) => /^(\d+\.?\d*)?$/m.test( subject ),
 		[]
 	);
 

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -6,7 +6,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
 import { __ } from '@wordpress/i18n';
 import { useEffect, renderToString } from '@wordpress/element';
@@ -101,7 +101,7 @@ interface Props {
 	actions?: ReadonlyArray< {
 		label: string;
 		className?: string;
-		variant?: Button.Props[ 'variant' ];
+		variant?: ComponentProps< typeof Button >[ 'variant' ];
 		url?: string;
 		urlTarget?: string;
 		onClick?: React.MouseEventHandler< HTMLAnchorElement >;
@@ -114,7 +114,7 @@ interface Props {
 	onRemove?: () => void;
 }
 
-const BannerNotice: React.FC< Props > = ( {
+const BannerNotice: React.FC< React.PropsWithChildren< Props > > = ( {
 	icon,
 	children,
 	actions = [],

--- a/client/components/cancel-authorization-button/index.tsx
+++ b/client/components/cancel-authorization-button/index.tsx
@@ -20,7 +20,9 @@ interface CancelAuthorizationButtonProps {
 	onClick?: () => void;
 }
 
-const CancelAuthorizationButton: React.FC< CancelAuthorizationButtonProps > = ( {
+const CancelAuthorizationButton: React.FC< React.PropsWithChildren<
+	CancelAuthorizationButtonProps
+> > = ( {
 	orderId,
 	children,
 	paymentIntentId,

--- a/client/components/capture-authorization-button/index.tsx
+++ b/client/components/capture-authorization-button/index.tsx
@@ -20,7 +20,9 @@ interface CaptureAuthorizationButtonProps {
 	onClick?: () => void;
 }
 
-const CaptureAuthorizationButton: React.FC< CaptureAuthorizationButtonProps > = ( {
+const CaptureAuthorizationButton: React.FC< React.PropsWithChildren<
+	CaptureAuthorizationButtonProps
+> > = ( {
 	orderId,
 	children,
 	paymentIntentId,

--- a/client/components/card-notice/index.tsx
+++ b/client/components/card-notice/index.tsx
@@ -14,7 +14,10 @@ interface CardNoticeProps {
 	actions?: JSX.Element;
 }
 
-const CardNotice: React.FC< CardNoticeProps > = ( { children, actions } ) => {
+const CardNotice: React.FC< React.PropsWithChildren< CardNoticeProps > > = ( {
+	children,
+	actions,
+} ) => {
 	return (
 		<CardFooter className="card-notice">
 			<div className="card-notice__section">

--- a/client/components/chip/index.tsx
+++ b/client/components/chip/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 	className?: string;
 	tooltip?: string;
 }
-const Chip: React.FC< Props > = ( {
+const Chip: React.FC< React.PropsWithChildren< Props > > = ( {
 	message,
 	type = 'primary',
 	className,

--- a/client/components/confirmation-modal/index.tsx
+++ b/client/components/confirmation-modal/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { Modal } from '@wordpress/components';
 import clsx from 'clsx';
 import { HorizontalRule } from '@wordpress/primitives';
@@ -11,16 +11,13 @@ import { HorizontalRule } from '@wordpress/primitives';
  */
 import './styles.scss';
 
-interface ConfirmationModalProps extends Modal.Props {
+interface ConfirmationModalProps {
 	actions: JSX.Element;
 }
 
-const ConfirmationModal: React.FunctionComponent< ConfirmationModalProps > = ( {
-	children,
-	actions,
-	className,
-	...props
-} ) => (
+const ConfirmationModal: React.FunctionComponent<
+	ConfirmationModalProps & ComponentProps< typeof Modal >
+> = ( { children, actions, className, ...props } ) => (
 	<Modal
 		className={ clsx( 'wcpay-confirmation-modal', className ) }
 		{ ...props }

--- a/client/components/custom-select-control/index.tsx
+++ b/client/components/custom-select-control/index.tsx
@@ -130,7 +130,7 @@ function CustomSelectControl< ItemType extends Item >( {
 	} );
 
 	const onKeyDownHandler = useCallback(
-		( e ) => {
+		( e: any ) => {
 			e.stopPropagation();
 			menuProps?.onKeyDown?.( e );
 		},

--- a/client/components/deposit-status-chip/index.tsx
+++ b/client/components/deposit-status-chip/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import {
 	Button,
 	Card,

--- a/client/components/deposits-overview/recent-deposits-list.tsx
+++ b/client/components/deposits-overview/recent-deposits-list.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import {
 	CardBody,
 	CardDivider,

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -38,9 +38,10 @@ const getIntervalType = ( interval: DepositsIntervals ): string => {
 	}
 };
 
-const DepositsStatusEnabled: React.FC< DepositsStatusProps > = ( props ) => {
-	const { iconSize, interval } = props;
-
+const DepositsStatusEnabled: React.FC< DepositsStatusProps > = ( {
+	iconSize,
+	interval,
+} ) => {
 	const description = getIntervalType( interval );
 	return (
 		<span className={ 'account-status__info__green' }>
@@ -50,9 +51,9 @@ const DepositsStatusEnabled: React.FC< DepositsStatusProps > = ( props ) => {
 	);
 };
 
-const DepositsStatusDisabled: React.FC< DepositsStatusProps > = ( props ) => {
-	const { iconSize } = props;
-
+const DepositsStatusDisabled: React.FC< DepositsStatusProps > = ( {
+	iconSize,
+} ) => {
 	return (
 		<span className={ 'account-status__info__red' }>
 			<GridiconNotice size={ iconSize } />
@@ -61,9 +62,9 @@ const DepositsStatusDisabled: React.FC< DepositsStatusProps > = ( props ) => {
 	);
 };
 
-const DepositsStatusSuspended: React.FC< DepositsStatusProps > = ( props ) => {
-	const { iconSize } = props;
-
+const DepositsStatusSuspended: React.FC< DepositsStatusProps > = ( {
+	iconSize,
+} ) => {
 	const description =
 		/* translators: <a> - suspended accounts FAQ URL */
 		__( 'Temporarily suspended', 'woocommerce-payments' );
@@ -109,9 +110,9 @@ const DepositsStatusSuspended: React.FC< DepositsStatusProps > = ( props ) => {
 	);
 };
 
-const DepositsStatusPending: React.FC< DepositsStatusProps > = ( props ) => {
-	const { iconSize } = props;
-
+const DepositsStatusPending: React.FC< DepositsStatusProps > = ( {
+	iconSize,
+} ) => {
 	return (
 		<span className={ 'account-status__info__gray' }>
 			<GridiconNotice size={ iconSize } />

--- a/client/components/download-button/index.tsx
+++ b/client/components/download-button/index.tsx
@@ -18,11 +18,9 @@ interface DownloadButtonProps {
 	onClick: ( event: any ) => void;
 }
 
-const DownloadButton: React.FunctionComponent< DownloadButtonProps > = ( {
-	isDisabled,
-	isBusy,
-	onClick,
-} ) => (
+const DownloadButton: React.FunctionComponent< React.PropsWithChildren<
+	DownloadButtonProps
+> > = ( { isDisabled, isBusy, onClick } ) => (
 	<Button
 		className="woocommerce-table__download-button"
 		disabled={ isDisabled }

--- a/client/components/file-upload/index.tsx
+++ b/client/components/file-upload/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,

--- a/client/components/file-upload/preview.tsx
+++ b/client/components/file-upload/preview.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies.

--- a/client/components/file-upload/test/index.tsx
+++ b/client/components/file-upload/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -80,7 +80,9 @@ describe( 'FileUploadControl', () => {
 		const fakeEvent = { target: { files: [ fakeFile ] } };
 
 		// Note: FormFileUpload does not associate file input with label so workaround is required to select it.
-		const input = control.querySelector( 'input[type="file"]' );
+		const input = control.querySelector< HTMLInputElement >(
+			'input[type="file"]'
+		);
 		if ( input !== null ) {
 			fireEvent.change( input, fakeEvent );
 		}
@@ -102,7 +104,9 @@ describe( 'FileUploadControl', () => {
 		} );
 
 		// Note: FormFileUpload does not associate file input with label so workaround is required to select it.
-		const input = control.querySelector( 'input[type="file"]' );
+		const input = control.querySelector< HTMLInputElement >(
+			'input[type="file"]'
+		);
 		if ( input !== null ) {
 			await userEvent.upload( input, file );
 			await userEvent.upload( input, file );

--- a/client/components/file-upload/upload-error.tsx
+++ b/client/components/file-upload/upload-error.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 interface UploadErrorProps {
 	error?: string;

--- a/client/components/form/fields.tsx
+++ b/client/components/form/fields.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { forwardRef } from 'react';
+import React, { ComponentProps, forwardRef } from 'react';
 import { TextControl } from '@wordpress/components';
 import clsx from 'clsx';
 
@@ -22,7 +22,7 @@ interface CommonProps {
 	error?: string;
 }
 
-export type TextFieldProps = TextControl.Props & CommonProps;
+export type TextFieldProps = ComponentProps< typeof TextControl > & CommonProps;
 export type SelectFieldProps< ItemType > = SelectControlProps< ItemType > &
 	CommonProps;
 export type GroupedSelectFieldProps< ItemType > = GroupedSelectControlProps<

--- a/client/components/horizontal-list/index.tsx
+++ b/client/components/horizontal-list/index.tsx
@@ -29,7 +29,8 @@ interface Props {
 	items: HorizontalListItem[];
 }
 
-export const HorizontalList: React.FunctionComponent< Props > = ( props ) => {
-	const { items } = props;
+export const HorizontalList: React.FunctionComponent< Props > = ( {
+	items,
+} ) => {
 	return <List className="woocommerce-list--horizontal" items={ items } />;
 };

--- a/client/components/inline-label-select/index.tsx
+++ b/client/components/inline-label-select/index.tsx
@@ -154,7 +154,7 @@ function InlineLabelSelect< ItemType extends SelectItem >( {
 	} );
 
 	const onKeyDownHandler = useCallback(
-		( e ) => {
+		( e: any ) => {
 			e.stopPropagation();
 			menuProps?.onKeyDown?.( e );
 		},

--- a/client/components/inline-notice/index.tsx
+++ b/client/components/inline-notice/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React, { ComponentProps } from 'react';
 import {
 	Flex as BundledWordPressComponentsFlex,
 	FlexItem as BundledWordPressComponentsFlexItem,
@@ -23,7 +23,7 @@ import './styles.scss';
 import ButtonVariant = BundledWordPressComponentsButton.ButtonVariant;
 import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
 
-interface InlineNoticeProps extends BundledWordPressComponentsNotice.Props {
+interface InlineNoticeProps {
 	/**
 	 * Whether to display the default icon based on status prop or the icon to display.
 	 * Supported values are: boolean, JSX.Element and `undefined`.
@@ -45,7 +45,10 @@ interface InlineNoticeProps extends BundledWordPressComponentsNotice.Props {
 /**
  * Renders a banner notice.
  */
-function InlineNotice( props: InlineNoticeProps ): JSX.Element {
+function InlineNotice(
+	props: InlineNoticeProps &
+		ComponentProps< typeof BundledWordPressComponentsNotice >
+): JSX.Element {
 	const { icon, actions, children, buttonVariant, ...noticeProps } = props;
 	const context = React.useContext( WordPressComponentsContext );
 

--- a/client/components/load-bar/index.tsx
+++ b/client/components/load-bar/index.tsx
@@ -9,10 +9,9 @@ import clsx from 'clsx';
  */
 import './style.scss';
 
-export const LoadBar: React.FC< HTMLAttributes< HTMLDivElement > > = ( {
-	className,
-	...rest
-} ) => {
+export const LoadBar: React.FC< React.PropsWithChildren<
+	HTMLAttributes< HTMLDivElement >
+> > = ( { className, ...rest } ) => {
 	return (
 		<div
 			className={ clsx( 'wcpay-component-load-bar', className ) }

--- a/client/components/loadable/index.tsx
+++ b/client/components/loadable/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/loadable/test/index.tsx
+++ b/client/components/loadable/test/index.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 
 /**

--- a/client/components/page/index.tsx
+++ b/client/components/page/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ interface PageProps {
 
 // The React.FunctionComponent is helpful here to make the type declaration of the props a bit
 // more concise; we get the `children` prop for free.
-const Page: React.FC< PageProps > = ( {
+const Page: React.FC< React.PropsWithChildren< PageProps > > = ( {
 	children,
 	id = '',
 	maxWidth,

--- a/client/components/paragraphs/index.tsx
+++ b/client/components/paragraphs/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 
 interface ParagraphsProps {
 	children?: any[];
@@ -16,7 +16,7 @@ interface ParagraphsProps {
  *
  * @return	{Array} Paragraph elements.
  */
-const Paragraphs: React.FC< ParagraphsProps > = ( {
+const Paragraphs: React.FC< React.PropsWithChildren< ParagraphsProps > > = ( {
 	children = [],
 } ): JSX.Element => {
 	return (

--- a/client/components/paragraphs/test/index.tsx
+++ b/client/components/paragraphs/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 
 /**

--- a/client/components/payment-activity/payment-activity-data.tsx
+++ b/client/components/payment-activity/payment-activity-data.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import moment from 'moment';
 import { __ } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';

--- a/client/components/payment-activity/payment-data-tile.tsx
+++ b/client/components/payment-activity/payment-data-tile.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { recordEvent } from 'wcpay/tracks';
@@ -48,7 +48,9 @@ interface PaymentDataTileProps {
 	tracksSource?: string;
 }
 
-const PaymentDataTile: React.FC< PaymentDataTileProps > = ( {
+const PaymentDataTile: React.FC< React.PropsWithChildren<
+	PaymentDataTileProps
+> > = ( {
 	id,
 	label,
 	currencyCode,

--- a/client/components/payment-activity/survey/context.tsx
+++ b/client/components/payment-activity/survey/context.tsx
@@ -61,9 +61,9 @@ type ContextValue = ReturnType< typeof useContextValue >;
 
 const WcPayOverviewSurveyContext = createContext< ContextValue | null >( null );
 
-export const WcPayOverviewSurveyContextProvider: React.FC< {
+export const WcPayOverviewSurveyContextProvider: React.FC< React.PropsWithChildren< {
 	initialData?: OverviewSurveyFields;
-} > = ( { children, initialData } ) => {
+} > > = ( { children, initialData } ) => {
 	return (
 		<WcPayOverviewSurveyContext.Provider
 			value={ useContextValue( initialData ) }

--- a/client/components/payment-confirm-illustration/test/index.tsx
+++ b/client/components/payment-confirm-illustration/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 
 /**

--- a/client/components/payment-delete-illustration/test/index.tsx
+++ b/client/components/payment-delete-illustration/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 
 /**

--- a/client/components/payments-status/index.tsx
+++ b/client/components/payments-status/index.tsx
@@ -18,9 +18,7 @@ interface PaymentsStatusProps {
 	iconSize: number;
 }
 
-const PaymentsStatusEnabled: React.FC< PaymentsStatusProps > = ( props ) => {
-	const { iconSize } = props;
-
+const PaymentsStatusEnabled = ( { iconSize }: PaymentsStatusProps ) => {
 	return (
 		<span className={ 'account-status__info__green' }>
 			<GridiconCheckmarkCircle size={ iconSize } />
@@ -29,9 +27,7 @@ const PaymentsStatusEnabled: React.FC< PaymentsStatusProps > = ( props ) => {
 	);
 };
 
-const PaymentsStatusDisabled: React.FC< PaymentsStatusProps > = ( props ) => {
-	const { iconSize } = props;
-
+const PaymentsStatusDisabled = ( { iconSize }: PaymentsStatusProps ) => {
 	return (
 		<span className={ 'account-status__info__red' }>
 			<GridiconNotice size={ iconSize } />
@@ -40,9 +36,7 @@ const PaymentsStatusDisabled: React.FC< PaymentsStatusProps > = ( props ) => {
 	);
 };
 
-const PaymentsStatusPending: React.FC< PaymentsStatusProps > = ( props ) => {
-	const { iconSize } = props;
-
+const PaymentsStatusPending = ( { iconSize }: PaymentsStatusProps ) => {
 	return (
 		<span className={ 'account-status__info__gray' }>
 			<GridiconNotice size={ iconSize } />
@@ -57,17 +51,19 @@ interface Props {
 	iconSize: number;
 }
 
-const PaymentsStatus: React.FC< Props > = ( props ) => {
-	const { paymentsEnabled, accountStatus } = props;
-
+const PaymentsStatus = ( {
+	paymentsEnabled,
+	accountStatus,
+	iconSize,
+}: Props ) => {
 	if ( paymentsEnabled ) {
-		return <PaymentsStatusEnabled iconSize={ props.iconSize } />;
+		return <PaymentsStatusEnabled iconSize={ iconSize } />;
 	}
 
 	return accountStatus === 'pending_verification' ? (
-		<PaymentsStatusPending iconSize={ props.iconSize } />
+		<PaymentsStatusPending iconSize={ iconSize } />
 	) : (
-		<PaymentsStatusDisabled iconSize={ props.iconSize } />
+		<PaymentsStatusDisabled iconSize={ iconSize } />
 	);
 };
 

--- a/client/components/pill/index.tsx
+++ b/client/components/pill/index.tsx
@@ -18,7 +18,11 @@ type PillProps = {
 	children?: ReactNode;
 };
 
-const Pill: FC< PillProps > = ( { type = '', className = '', children } ) => {
+const Pill: FC< React.PropsWithChildren< PillProps > > = ( {
+	type = '',
+	className = '',
+	children,
+} ) => {
 	const types = [ 'primary', 'success', 'alert', 'danger', 'light' ];
 
 	const classes = clsx(

--- a/client/components/stepper/index.tsx
+++ b/client/components/stepper/index.tsx
@@ -88,7 +88,10 @@ const childrenToSteps = ( children: StepperProps[ 'children' ] ) => {
 	);
 };
 
-export const Stepper: React.FC< StepperProps > = ( { children, ...rest } ) => {
+export const Stepper: React.FC< React.PropsWithChildren< StepperProps > > = ( {
+	children,
+	...rest
+} ) => {
 	const steps = childrenToSteps( children );
 	const value = useContextValue( {
 		steps,

--- a/client/components/tip-box/index.tsx
+++ b/client/components/tip-box/index.tsx
@@ -14,7 +14,11 @@ interface Props {
 	color: 'purple' | 'blue' | 'gray' | 'yellow';
 	className?: string;
 }
-const TipBox: React.FC< Props > = ( { color, className, children } ) => {
+const TipBox: React.FC< React.PropsWithChildren< Props > > = ( {
+	color,
+	className,
+	children,
+} ) => {
 	return (
 		<div className={ clsx( 'wcpay-component-tip-box', color, className ) }>
 			<LightbulbIcon />

--- a/client/components/tooltip/index.tsx
+++ b/client/components/tooltip/index.tsx
@@ -37,7 +37,9 @@ type TooltipProps = TooltipBaseProps & {
  * @param {TooltipProps} props Component props.
  * @return {JSX.Element} Tooltip component.
  */
-export const HoverTooltip: React.FC< TooltipProps > = ( {
+export const HoverTooltip: React.FC< React.PropsWithChildren<
+	TooltipProps
+> > = ( {
 	isVisible,
 	onHide = noop,
 	children,
@@ -106,7 +108,9 @@ export const HoverTooltip: React.FC< TooltipProps > = ( {
  * @param {TooltipProps} props Component props.
  * @return {JSX.Element} Tooltip component.
  */
-export const ClickTooltip: React.FC< TooltipProps > = ( {
+export const ClickTooltip: React.FC< React.PropsWithChildren<
+	TooltipProps
+> > = ( {
 	isVisible,
 	onHide = noop,
 	buttonIcon,

--- a/client/components/tooltip/tooltip-base.tsx
+++ b/client/components/tooltip/tooltip-base.tsx
@@ -138,27 +138,27 @@ type TooltipPortalProps = {
 	parentElement: HTMLElement;
 };
 
-const TooltipPortal: React.FC< TooltipPortalProps > = memo(
-	( { children, parentElement } ) => {
-		const node = useRef< HTMLElement | null >( null );
-		if ( ! node.current ) {
-			node.current = document.createElement( 'div' );
-			parentElement.appendChild( node.current );
-		}
-
-		// on component unmount, clear any reference to the created node
-		useEffect( () => {
-			return () => {
-				if ( node.current ) {
-					parentElement.removeChild( node.current );
-					node.current = null;
-				}
-			};
-		}, [ parentElement ] );
-
-		return createPortal( children, node.current );
+const TooltipPortal: React.FC< React.PropsWithChildren<
+	TooltipPortalProps
+> > = memo( ( { children, parentElement } ) => {
+	const node = useRef< HTMLElement | null >( null );
+	if ( ! node.current ) {
+		node.current = document.createElement( 'div' );
+		parentElement.appendChild( node.current );
 	}
-);
+
+	// on component unmount, clear any reference to the created node
+	useEffect( () => {
+		return () => {
+			if ( node.current ) {
+				parentElement.removeChild( node.current );
+				node.current = null;
+			}
+		};
+	}, [ parentElement ] );
+
+	return createPortal( children, node.current );
+} );
 
 export type TooltipBaseProps = {
 	className?: string;
@@ -171,7 +171,7 @@ export type TooltipBaseProps = {
 	maxWidth?: string;
 };
 
-const TooltipBase: React.FC< TooltipBaseProps > = ( {
+const TooltipBase: React.FC< React.PropsWithChildren< TooltipBaseProps > > = ( {
 	className,
 	children,
 	content,

--- a/client/components/wizard/collapsible-body.tsx
+++ b/client/components/wizard/collapsible-body.tsx
@@ -10,10 +10,9 @@ import clsx from 'clsx';
 import WizardTaskContext from './task/context';
 import './collapsible-body.scss';
 
-const CollapsibleBody: React.FC< React.HTMLAttributes< HTMLDivElement > > = ( {
-	className,
-	...restProps
-} ) => {
+const CollapsibleBody: React.FC< React.PropsWithChildren<
+	React.HTMLAttributes< HTMLDivElement >
+> > = ( { className, ...restProps } ) => {
 	const { isActive } = useContext( WizardTaskContext );
 
 	return (

--- a/client/components/wizard/task-item.tsx
+++ b/client/components/wizard/task-item.tsx
@@ -19,13 +19,9 @@ interface WizardTaskItemProps {
 	visibleDescription?: string;
 }
 
-const WizardTaskItem: React.FC< WizardTaskItemProps > = ( {
-	children,
-	title,
-	index,
-	className,
-	visibleDescription,
-} ) => {
+const WizardTaskItem: React.FC< React.PropsWithChildren<
+	WizardTaskItemProps
+> > = ( { children, title, index, className, visibleDescription } ) => {
 	const { isCompleted, isActive } = useContext( WizardTaskContext );
 
 	return (

--- a/client/declarations.d.ts
+++ b/client/declarations.d.ts
@@ -21,5 +21,5 @@ declare module '*?asset' {
 }
 
 type ReactImgFuncComponent = React.FunctionComponent<
-	React.ImgHTMLAttributes< HTMLImageElement >
+	React.PropsWithChildren< React.ImgHTMLAttributes< HTMLImageElement > >
 >;

--- a/client/deposits/declarations.d.ts
+++ b/client/deposits/declarations.d.ts
@@ -59,7 +59,7 @@ declare module '@woocommerce/components' {
 		className: string;
 	}
 
-	const Pill: React.FC< PillProps >;
+	const Pill: React.FC< React.PropsWithChildren< PillProps > >;
 
 	interface TourKitOptions {
 		classNames?: string | string[];
@@ -99,5 +99,5 @@ declare module '@woocommerce/components' {
 		items: any[];
 	}
 
-	const List: React.FC< ListProps >;
+	const List: React.FC< React.PropsWithChildren< ListProps > >;
 }

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -325,7 +325,6 @@ export const DepositDetails: React.FC< DepositDetailsProps > = ( {
 					<DepositOverview deposit={ deposit } />
 				) }
 			</ErrorBoundary>
-
 			{ deposit && (
 				<ErrorBoundary>
 					{ isInstantDeposit ? (

--- a/client/disputes/info/index.tsx
+++ b/client/disputes/info/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';

--- a/client/icons/shield-icon.tsx
+++ b/client/icons/shield-icon.tsx
@@ -3,7 +3,9 @@
  */
 import React, { HTMLAttributes } from 'react';
 
-const ShieldIcon: React.FC< HTMLAttributes< SVGElement > > = ( props ) => {
+const ShieldIcon: React.FC< React.PropsWithChildren<
+	HTMLAttributes< SVGElement >
+> > = ( props ) => {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/client/onboarding/context.tsx
+++ b/client/onboarding/context.tsx
@@ -31,9 +31,9 @@ type ContextValue = ReturnType< typeof useContextValue >;
 
 const OnboardingContext = createContext< ContextValue | null >( null );
 
-export const OnboardingContextProvider: React.FC< {
+export const OnboardingContextProvider: React.FC< React.PropsWithChildren< {
 	initialData?: OnboardingFields;
-} > = ( { children, initialData } ) => {
+} > > = ( { children, initialData } ) => {
 	return (
 		<OnboardingContext.Provider value={ useContextValue( initialData ) }>
 			{ children }

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -25,7 +25,9 @@ import { useValidation } from './validation';
 import { trackStepCompleted } from './tracking';
 import strings from './strings';
 
-export const OnboardingForm: React.FC = ( { children } ) => {
+export const OnboardingForm: React.FC< { children?: React.ReactNode } > = ( {
+	children,
+} ) => {
 	const { errors, touched, setTouched } = useOnboardingContext();
 	const { currentStep, nextStep } = useStepperContext();
 
@@ -56,13 +58,13 @@ export const OnboardingForm: React.FC = ( { children } ) => {
 	);
 };
 
-interface OnboardingTextFieldProps extends Partial< TextFieldProps > {
+interface OnboardingTextFieldProps {
 	name: keyof OnboardingFields;
 }
 
-export const OnboardingTextField: React.FC< OnboardingTextFieldProps > = (
-	props
-) => {
+export const OnboardingTextField: React.FC<
+	OnboardingTextFieldProps & Partial< TextFieldProps >
+> = ( props ) => {
 	const { name } = props;
 	const { data, setData, touched } = useOnboardingContext();
 	const { validate, error } = useValidation( name );

--- a/client/onboarding/step.tsx
+++ b/client/onboarding/step.tsx
@@ -19,7 +19,11 @@ interface Props {
 	showHeading?: boolean;
 }
 
-const Step: React.FC< Props > = ( { name, children, showHeading = true } ) => {
+const Step: React.FC< React.PropsWithChildren< Props > > = ( {
+	name,
+	children,
+	showHeading = true,
+} ) => {
 	const { trackAbandoned } = useTrackAbandoned();
 	const { exit } = useStepperContext();
 	const handleExit = () => {

--- a/client/onboarding/steps/loading.tsx
+++ b/client/onboarding/steps/loading.tsx
@@ -13,11 +13,7 @@ import { trackRedirected, useTrackAbandoned } from '../tracking';
 import LoadBar from 'components/load-bar';
 import strings from '../strings';
 
-interface Props {
-	name: string;
-}
-
-const LoadingStep: React.FC< Props > = () => {
+const LoadingStep: React.FC = () => {
 	const { data } = useOnboardingContext();
 
 	const { removeTrackListener } = useTrackAbandoned();

--- a/client/onboarding/steps/test/loading.tsx
+++ b/client/onboarding/steps/test/loading.tsx
@@ -73,7 +73,7 @@ describe( 'Loading', () => {
 			mcc: 'most_popular__software_services',
 		};
 
-		render( <Loading name="loading" /> );
+		render( <Loading /> );
 
 		checkLinkToContainNecessaryParams( window.location.href );
 	} );

--- a/client/onboarding/utils.ts
+++ b/client/onboarding/utils.ts
@@ -19,9 +19,6 @@ export const fromDotNotation = (
 		return value != null ? set( result, key, value ) : result;
 	}, {} );
 
-const hasUndefinedValues = ( obj: Record< string, any > ): boolean =>
-	Object.values( obj ).some( ( value ) => value === undefined );
-
 export const getAvailableCountries = (): Country[] =>
 	Object.entries( wcpaySettings?.connect.availableCountries || [] )
 		.map( ( [ key, name ] ) => ( { key, name, types: [] } ) )

--- a/client/order/order-status-confirmation-modal/index.tsx
+++ b/client/order/order-status-confirmation-modal/index.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 /**

--- a/client/payment-details/readers/index.js
+++ b/client/payment-details/readers/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '@wordpress/components';
 import { getQuery } from '@woocommerce/navigation';

--- a/client/payment-details/readers/test/index.js
+++ b/client/payment-details/readers/test/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { updateQueryString } from '@woocommerce/navigation';
 import os from 'os';

--- a/client/settings/card-body/index.tsx
+++ b/client/settings/card-body/index.tsx
@@ -15,10 +15,9 @@ interface WcpayCardBodyProps {
 	className?: string;
 }
 
-const WcpayCardBody: React.FC< WcpayCardBodyProps > = ( {
-	className,
-	...props
-} ): JSX.Element => {
+const WcpayCardBody: React.FC< React.PropsWithChildren<
+	WcpayCardBodyProps
+> > = ( { className, ...props } ): JSX.Element => {
 	const context = useContext( WordPressComponentsContext );
 
 	// including the woopayments-specific styles only for the "bundled" CardBody component.

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -28,20 +28,16 @@ interface WooPayFileUploadProps {
 	updateFileID: ( id: string ) => void;
 }
 
-const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = (
-	props
-) => {
-	const {
-		fieldKey,
-		label,
-		accept,
-		disabled,
-		help,
-		purpose,
-		fileID,
-		updateFileID,
-	} = props;
-
+const WooPayFileUpload: React.FunctionComponent< WooPayFileUploadProps > = ( {
+	fieldKey,
+	label,
+	accept,
+	disabled,
+	help,
+	purpose,
+	fileID,
+	updateFileID,
+} ) => {
 	const [ isLoading, setLoading ] = useState( false );
 	const [ uploadError, setUploadError ] = useState< boolean | string >(
 		false

--- a/client/settings/fraud-protection/advanced-settings/rule-card-notice.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-card-notice.tsx
@@ -19,10 +19,9 @@ interface FraudProtectionRuleCardNoticeProps {
 	type: NoticeType;
 }
 
-const FraudProtectionRuleCardNotice: React.FC< FraudProtectionRuleCardNoticeProps > = ( {
-	type,
-	children,
-} ) => {
+const FraudProtectionRuleCardNotice: React.FC< React.PropsWithChildren<
+	FraudProtectionRuleCardNoticeProps
+> > = ( { type, children } ) => {
 	if ( ! supportedTypes.includes( type ) ) {
 		return null;
 	}

--- a/client/settings/fraud-protection/advanced-settings/rule-card.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-card.tsx
@@ -15,11 +15,9 @@ interface FraudProtectionRuleCardProps {
 	id: string;
 }
 
-const FraudProtectionRuleCard: React.FC< FraudProtectionRuleCardProps > = ( {
-	title,
-	children,
-	id,
-} ) => {
+const FraudProtectionRuleCard: React.FC< React.PropsWithChildren<
+	FraudProtectionRuleCardProps
+> > = ( { title, children, id } ) => {
 	return (
 		<Card id={ id } className="fraud-protection-rule-card">
 			<CardBody>

--- a/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
@@ -43,12 +43,9 @@ const getFilterAction = (
 	return settingUI.block ? filterActions.BLOCK : filterActions.REVIEW;
 };
 
-const FraudProtectionRuleToggle: React.FC< FraudProtectionRuleToggleProps > = ( {
-	setting,
-	label,
-	description,
-	children,
-} ) => {
+const FraudProtectionRuleToggle: React.FC< React.PropsWithChildren<
+	FraudProtectionRuleToggleProps
+> > = ( { setting, label, description, children } ) => {
 	const {
 		protectionSettingsUI,
 		setProtectionSettingsUI,

--- a/client/transactions/autocompleter.tsx
+++ b/client/transactions/autocompleter.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';

--- a/client/transactions/fraud-protection/autocompleter.tsx
+++ b/client/transactions/fraud-protection/autocompleter.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 

--- a/client/transactions/list/test/converted-amount.tsx
+++ b/client/transactions/list/test/converted-amount.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 /**

--- a/client/transactions/list/test/deposit.tsx
+++ b/client/transactions/list/test/deposit.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 
 /**

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';

--- a/client/transactions/test/index.tsx
+++ b/client/transactions/test/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { updateQueryString } from '@woocommerce/navigation';
 import { useUserPreferences } from '@woocommerce/data';

--- a/client/transactions/uncaptured/test/index.test.tsx
+++ b/client/transactions/uncaptured/test/index.test.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';

--- a/client/types/wp-components.d.ts
+++ b/client/types/wp-components.d.ts
@@ -14,9 +14,11 @@ declare module '@wordpress/components' {
 	 * Any component that lives on wp.components but isn’t in the package’s types.
 	 * You can declare as many as you need here.
 	 */
-	export const Line: ComponentType< any >;
-	export const ProgressBar: ComponentType< any >;
-	export const GradientPicker: ComponentType< any >;
+	export const Line: ComponentType< React.PropsWithChildren< any > >;
+	export const ProgressBar: ComponentType< React.PropsWithChildren< any > >;
+	export const GradientPicker: ComponentType< React.PropsWithChildren<
+		any
+	> >;
 	// …etc…
 }
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In order to upgrade to React18, we need to make some adjustments to the types in the codebase.
First off, `chilren` has been removed from `React.FC`. So if a component types itself with `React.FC` and it uses the `children` prop, it needs to define it.
I used the `React.PropsWithChildren` utility for this.
I also used the `npx types-react-codemod preset-18` codemod ( https://github.com/eps1lon/types-react-codemod ) to adjust some types automatically.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

All the adjustments have been made to the types, so no change in functionality should happen.
As long as you can `npm run start` and run the tests in CI, we should be golden.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
