### PR TITLE
Fix handling of orders containing items with negative tax

### DIFF
--- a/changelog/fix-WOOPMNT-4989
+++ b/changelog/fix-WOOPMNT-4989
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed handling of orders containing items with negative tax

--- a/src/Internal/Service/Level3Service.php
+++ b/src/Internal/Service/Level3Service.php
@@ -160,12 +160,12 @@ class Level3Service {
 			// It's possible to create products with negative price - represent it as free one with discount.
 			$discount_amount = abs( $this->prepare_amount( $subtotal / $quantity, $currency ) );
 			$unit_cost       = 0;
+		}
 
-			// Tax also shouldn't be negative so add it to the discount amount.
-			if ( $tax_amount < 0 ) {
-				$discount_amount += abs( $tax_amount );
-				$tax_amount       = 0;
-			}
+		// Tax also shouldn't be negative so represent it as a discount.
+		if ( $tax_amount < 0 ) {
+			$discount_amount += abs( $tax_amount );
+			$tax_amount       = 0;
 		}
 
 		$line_item  = (object) [

--- a/src/Internal/Service/Level3Service.php
+++ b/src/Internal/Service/Level3Service.php
@@ -160,6 +160,12 @@ class Level3Service {
 			// It's possible to create products with negative price - represent it as free one with discount.
 			$discount_amount = abs( $this->prepare_amount( $subtotal / $quantity, $currency ) );
 			$unit_cost       = 0;
+
+			// Tax also shouldn't be negative so add it to the discount amount.
+			if ( $tax_amount < 0 ) {
+				$discount_amount += abs( $tax_amount );
+				$tax_amount       = 0;
+			}
 		}
 
 		$line_item  = (object) [

--- a/tests/unit/src/Internal/Service/Level3ServiceTest.php
+++ b/tests/unit/src/Internal/Service/Level3ServiceTest.php
@@ -160,6 +160,7 @@ class Level3ServiceTest extends WCPAY_UnitTestCase {
 
 		if ( $with_negative_price_product ) {
 			$mock_items[] = $this->create_mock_item( 'Negative Product Price', $quantity, -18.99, 2.7, 42 );
+			$mock_items[] = $this->create_mock_item( 'Negative Product Price and Tax', $quantity, -18.99, -2.7, 42 );
 		}
 
 		if ( $basket_size > 1 ) {
@@ -339,6 +340,14 @@ class Level3ServiceTest extends WCPAY_UnitTestCase {
 					'quantity'            => 1,
 					'tax_amount'          => 270,
 					'discount_amount'     => 1899,
+				],
+				(object) [
+					'product_code'        => 42,
+					'product_description' => 'Negative Product Price and Tax',
+					'unit_cost'           => 0,
+					'quantity'            => 1,
+					'tax_amount'          => 0,
+					'discount_amount'     => 1899 + 270,
 				],
 			],
 			'shipping_address_zip' => '98012',

--- a/tests/unit/src/Internal/Service/Level3ServiceTest.php
+++ b/tests/unit/src/Internal/Service/Level3ServiceTest.php
@@ -160,7 +160,7 @@ class Level3ServiceTest extends WCPAY_UnitTestCase {
 
 		if ( $with_negative_price_product ) {
 			$mock_items[] = $this->create_mock_item( 'Negative Product Price', $quantity, -18.99, 2.7, 42 );
-			$mock_items[] = $this->create_mock_item( 'Negative Product Price and Tax', $quantity, -18.99, -2.7, 42 );
+			$mock_items[] = $this->create_mock_item( 'Negative Product Price+Tax', $quantity, -18.99, -2.7, 42 );
 		}
 
 		if ( $basket_size > 1 ) {
@@ -343,7 +343,7 @@ class Level3ServiceTest extends WCPAY_UnitTestCase {
 				],
 				(object) [
 					'product_code'        => 42,
-					'product_description' => 'Negative Product Price and Tax',
+					'product_description' => 'Negative Product Price+Tax',
 					'unit_cost'           => 0,
 					'quantity'            => 1,
 					'tax_amount'          => 0,


### PR DESCRIPTION
Fixes WOOPMNT-4989

#### Changes proposed in this Pull Request

* Fixes level3 data generation when an item has a negative price and taxes are enabled (resulting in the tax amount being negative)

#### Testing instructions

* In WooCommerce general settings, enable taxes, then in the tax tab configure a tax rate
* Make sure your merchant account is based in the US or comment out [these lines](https://github.com/Automattic/woocommerce-payments/blob/55a22266b2323437b19739e1fc7644fd37546e3d/src/Internal/Service/Level3Service.php#L72-L74)
* Create a product with a negative price
* Place an order containing the item above and some other item so that the total is greater than 0
* The payment should be processed successfully