### PR TITLE
Clear account cache on embedded KYC session creation and finalize

### DIFF
--- a/changelog/update-clear-account-cache-on-embedded-kyc-stages
+++ b/changelog/update-clear-account-cache-on-embedded-kyc-stages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Clear the account cache on embedded KYC session creation and finish.
+
+

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -633,11 +633,27 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 
 		foreach ( $enabled_payment_methods as $payment_method_id ) {
 			$gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
+			if ( ! $gateway ) {
+				if ( function_exists( 'wc_get_logger' ) ) {
+					$logger = wc_get_logger();
+					/* translators: 1: Payment method ID, 2: Error message */
+					$logger->warning( sprintf( 'Failed to enable payment method %1$s: %2$s', $payment_method_id, 'payment gateway instance not available' ), [ 'source' => 'woopayments' ] );
+				}
+				continue;
+			}
 			$gateway->enable();
 		}
 
 		foreach ( $disabled_payment_methods as $payment_method_id ) {
 			$gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
+			if ( ! $gateway ) {
+				if ( function_exists( 'wc_get_logger' ) ) {
+					$logger = wc_get_logger();
+					/* translators: 1: Payment method ID, 2: Error message */
+					$logger->warning( sprintf( 'Failed to disable payment method %1$s: %2$s', $payment_method_id, 'payment gateway instance not available' ), [ 'source' => 'woopayments' ] );
+				}
+				continue;
+			}
 			$gateway->disable();
 		}
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -358,6 +358,11 @@ class WC_Payments_Onboarding_Service {
 			DAY_IN_SECONDS
 		);
 
+		// If we have a new account, clear the account cache to force a refresh.
+		if ( ! empty( $account_session['account_created'] ) ) {
+			WC_Payments::get_account_service()->clear_cache();
+		}
+
 		return [
 			'clientSecret'   => $account_session['client_secret'] ?? '',
 			'expiresAt'      => $account_session['expires_at'] ?? 0,

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -403,6 +403,10 @@ class WC_Payments_Onboarding_Service {
 		// Clear the embedded KYC in progress option, since the onboarding flow is now complete.
 		$this->clear_embedded_kyc_in_progress();
 
+		// Clear the account cache to make sure the account data is fresh
+		// and not depend on webhooks that might not have been received yet.
+		WC_Payments::get_account_service()->clear_cache();
+
 		return [
 			'success'           => $success,
 			'details_submitted' => $details_submitted,


### PR DESCRIPTION
Contributes to WOOPLUG-3599

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

If during an embedded KYC session creation we also create a new account, we clear the account cache to make sure we keep the state current as quickly as possible, in case the user bails mid-session. Also, when finalizing an embedded KYC session we make sure to clear the account cache since there are likely account state changes as a result.

Additional: We introduce defensive checks on settings save to avoid errors related to payment methods that are not available due to their underlying capabilities being rejected or inactive. We do log such things to be able to investigate.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On you local installation, checkout the `develop` branch.
1. Use the latest WooCommerce `trunk` version (make sure you build it with `pnpm install --frozen-lockfile && npm run build` from the `plugins/woocommerce` directory)
1. Remove any onboarded accounts
1. Go to WooCommerce > Settings > Payments and select UK as the business location
1. Click on "Complete setup" for WooPayments:
![Screenshot 2025-05-23 at 14 02 56](https://github.com/user-attachments/assets/33cb8926-077e-4993-9564-89378b36e3ab)
1. Click "Continue" on the "Choose your payment methods" step, wait for the test account step to complete, click "Activate payments", then again click on "Activate payments":
![Screenshot 2025-05-23 at 14 04 37](https://github.com/user-attachments/assets/ae6e42ce-343f-4178-9f08-ed218db931f1)
![Screenshot 2025-05-23 at 14 04 55](https://github.com/user-attachments/assets/138c263b-8b68-4b05-905e-59d61d2efb97)
![Screenshot 2025-05-23 at 14 05 48](https://github.com/user-attachments/assets/0825b406-30c0-4b49-8155-c8866a088dfb)
1. Fill in the form and click continue:
![Screenshot 2025-05-23 at 14 06 32](https://github.com/user-attachments/assets/593b2234-6423-4ae1-9278-86f5c8ef54cf)
1. Once presented with the embedded KYC component ("Add information to start accepting money"), close the modal:
![Screenshot 2025-05-23 at 14 08 00](https://github.com/user-attachments/assets/3e7cb4ea-1d37-45d1-a229-17e83049f9d7)
1. Notice that under the ellipsis context menu for WooPayments there is no "Reset account" menu item.
1. Go to WCPay Dev Tools and notice that there is no account info (it is an empty array). Clear the cache and you should have all the account details.
1. Go to WooCommerce > Settings > Payments and you should have a "Reset account" menu item in the WooPayments context menu:
![Screenshot 2025-05-23 at 14 11 30](https://github.com/user-attachments/assets/ec57faa1-7619-4365-8ef0-fcef00fcef4d)
1. Click the "Reset account" menu item.
1. Checkout this PR's branch and repeat steps 5 through 8.
1. Notice that now there is a "Reset account" menu item in the WooPayments context menu.
1. Go to WCPay Dev Tools and notice that there is account info cached.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
