### PR TITLE
Bump WC tested up to version to 9.8.5

### DIFF
--- a/changelog/dev-bump-wc-version-9-8-5
+++ b/changelog/dev-bump-wc-version-9-8-5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 9.8.5

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 9.8.2
+ * WC tested up to: 9.8.5
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 9.4.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR bumps WC tested up to 9.8.5, which is the [latest stable release of WooCommerce](https://github.com/woocommerce/woocommerce/releases/latest) at the time of this PR.

According to the WooCommerce Release plan (sidebar) 7bje6-p2, WooCommerce 9.9.0 will be released on June 2, 2025.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.