### PR TITLE
Make evidence submission form use global wp.components

### DIFF
--- a/changelog/make-evidence-submission-form-use-global-wpcomponents
+++ b/changelog/make-evidence-submission-form-use-global-wpcomponents
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Evidence submission form now should use the global wp.components

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -20,6 +20,9 @@ import {
 	MenuGroup as BundledWordPressComponentsMenuGroup,
 	MenuItem as BundledWordPressComponentsMenuItem,
 	Notice as BundledWordPressComponentsNotice,
+	SelectControl as BundledWordPressComponentsSelectControl,
+	TextControl as BundledWordPressComponentsTextControl,
+	TextareaControl as BundledWordPressComponentsTextareaControl,
 } from '@wordpress/components';
 import BundledWordPressComponentsCardNotice from 'wcpay/components/card-notice';
 
@@ -335,6 +338,59 @@ const WrappedNotice = (
 	return <Notice { ...rest } />;
 };
 
+const WrappedSelectControl = (
+	props: ComponentProps< typeof BundledWordPressComponentsSelectControl > & {
+		useBundledComponent?: boolean;
+	}
+) => {
+	const { useBundledComponent, ...rest } = props;
+	const context = useContext( WordPressComponentsContext );
+
+	if ( ! context || useBundledComponent ) {
+		return <BundledWordPressComponentsSelectControl { ...rest } />;
+	}
+
+	const { SelectControl } = context;
+
+	return <SelectControl { ...rest } />;
+};
+
+const WrappedTextControl = (
+	props: ComponentProps< typeof BundledWordPressComponentsTextControl > & {
+		useBundledComponent?: boolean;
+	}
+) => {
+	const { useBundledComponent, ...rest } = props;
+	const context = useContext( WordPressComponentsContext );
+
+	if ( ! context || useBundledComponent ) {
+		return <BundledWordPressComponentsTextControl { ...rest } />;
+	}
+
+	const { TextControl } = context;
+
+	return <TextControl { ...rest } />;
+};
+
+const WrappedTextareaControl = (
+	props: ComponentProps<
+		typeof BundledWordPressComponentsTextareaControl
+	> & {
+		useBundledComponent?: boolean;
+	}
+) => {
+	const { useBundledComponent, ...rest } = props;
+	const context = useContext( WordPressComponentsContext );
+
+	if ( ! context || useBundledComponent ) {
+		return <BundledWordPressComponentsTextareaControl { ...rest } />;
+	}
+
+	const { TextareaControl } = context;
+
+	return <TextareaControl { ...rest } />;
+};
+
 export {
 	WrappedCard as Card,
 	WrappedCardBody as CardBody,
@@ -354,4 +410,7 @@ export {
 	WrappedMenuItem as MenuItem,
 	WrappedCardNotice as CardNotice,
 	WrappedNotice as Notice,
+	WrappedSelectControl as SelectControl,
+	WrappedTextControl as TextControl,
+	WrappedTextareaControl as TextareaControl,
 };

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -17,7 +17,7 @@ import {
 	TextareaControl,
 	SelectControl,
 	Notice,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { merge, some, flatten, isMatchWith } from 'lodash';
 
 /**

--- a/client/index.js
+++ b/client/index.js
@@ -193,7 +193,11 @@ addFilter(
 		} );
 
 		pages.push( {
-			container: DisputeEvidencePage,
+			container: ( { query } ) => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<DisputeEvidencePage query={ query } />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/disputes/challenge',
 			wpOpenMenu: menuID,
 			breadcrumbs: [


### PR DESCRIPTION
See WOOPMNT-5012

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Following the same approach mentioned on #10757 we're making the evidence form submission use the global wp.components

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

So far nothing should change on the current behavior, but the most evident visual change is on the Card compent that is now rounded:

<img width="859" alt="image" src="https://github.com/user-attachments/assets/b78ff609-286e-4ca7-aa65-9c3330ced600" />

* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Go to Payments > Disputes, select one of the disputes listed and hit [Challenge dispute]

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
