### PR TITLE
fix: is_store_api_request on multisite w/ subdirs

### DIFF
--- a/changelog/fix-is-store-api-request-on-multisite
+++ b/changelog/fix-is-store-api-request-on-multisite
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-fix: is_store_api_request utility on multisite w/ sub-directory install
+fix: is_store_api_request utility on multisite with subdirectory install

--- a/changelog/fix-is-store-api-request-on-multisite
+++ b/changelog/fix-is-store-api-request-on-multisite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+fix: is_store_api_request utility on multisite w/ sub-directory install

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1381,7 +1381,18 @@ class WC_Payments_Utils {
 			$url_parts    = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$request_path = ! empty( $url_parts['path'] ) ? rtrim( $url_parts['path'], '/' ) : '';
 			// Remove the REST API prefix from the request path to end up with the route.
-			$rest_route = str_replace( trailingslashit( rest_get_url_prefix() ), '', $request_path );
+			// For multisite subdirectory setups, we need to handle the subdirectory prefix.
+			$rest_prefix = trailingslashit( rest_get_url_prefix() );
+			$rest_route  = str_replace( $rest_prefix, '', $request_path );
+
+			// If we still have a leading slash followed by path segments before our expected route,
+			// it's likely a multisite subdirectory. Extract everything after wp-json.
+			if ( strpos( $rest_route, '/' ) === 0 && strpos( $request_path, '/' . $rest_prefix ) !== false ) {
+				$wp_json_pos = strpos( $request_path, '/' . rtrim( $rest_prefix, '/' ) );
+				if ( false !== $wp_json_pos ) {
+					$rest_route = substr( $request_path, $wp_json_pos + strlen( $rest_prefix ) );
+				}
+			}
 		}
 
 		// Bail early if the rest route is empty.

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1377,22 +1377,7 @@ class WC_Payments_Utils {
 		if ( isset( $_REQUEST['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$rest_route = sanitize_text_field( $_REQUEST['rest_route'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.NonceVerification
 		} else {
-			// Extract the request path from the request URL.
-			$url_parts    = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			$request_path = ! empty( $url_parts['path'] ) ? rtrim( $url_parts['path'], '/' ) : '';
-			// Remove the REST API prefix from the request path to end up with the route.
-			// For multisite subdirectory setups, we need to handle the subdirectory prefix.
-			$rest_prefix = trailingslashit( rest_get_url_prefix() );
-			$rest_route  = str_replace( $rest_prefix, '', $request_path );
-
-			// If we still have a leading slash followed by path segments before our expected route,
-			// it's likely a multisite subdirectory. Extract everything after wp-json.
-			if ( strpos( $rest_route, '/' ) === 0 && strpos( $request_path, '/' . $rest_prefix ) !== false ) {
-				$wp_json_pos = strpos( $request_path, '/' . rtrim( $rest_prefix, '/' ) );
-				if ( false !== $wp_json_pos ) {
-					$rest_route = substr( $request_path, $wp_json_pos + strlen( $rest_prefix ) );
-				}
-			}
+			$rest_route = self::extract_rest_route_from_url();
 		}
 
 		// Bail early if the rest route is empty.
@@ -1409,6 +1394,37 @@ class WC_Payments_Utils {
 
 		// If no match was found, this is not a Store API request.
 		return false;
+	}
+
+	/**
+	 * Extract the REST route from the current request URL.
+	 *
+	 * @return string The REST route, or empty string if not found.
+	 */
+	private static function extract_rest_route_from_url(): string {
+		// Extract the request path from the request URL.
+		$url_parts = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		if ( empty( $url_parts['path'] ) ) {
+			return '';
+		}
+
+		$request_path = rtrim( $url_parts['path'], '/' );
+		if ( empty( $request_path ) ) {
+			return '';
+		}
+
+		// Remove the REST API prefix from the request path to end up with the route.
+		$rest_prefix = trailingslashit( rest_get_url_prefix() );
+
+		// For multisite subdirectory setups, we need to handle the subdirectory prefix.
+		// Look for the wp-json prefix in the path and extract everything after it.
+		$wp_json_pos = strpos( $request_path, '/' . rtrim( $rest_prefix, '/' ) );
+		if ( false !== $wp_json_pos ) {
+			return substr( $request_path, $wp_json_pos + strlen( $rest_prefix ) );
+		}
+
+		// Fallback: simple prefix replacement for non-multisite cases.
+		return str_replace( $rest_prefix, '', $request_path );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -1122,6 +1122,20 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
 	}
 
+	public function test_is_store_api_request_with_multisite_subdirectory() {
+		// Test multisite subdirectory setup where the path includes the site subdirectory.
+		$_SERVER['REQUEST_URI'] = '/child-1/wp-json/wc/store/v1/cart/add-item';
+		$this->assertTrue( WC_Payments_Utils::is_store_api_request() );
+
+		// Test multisite subdirectory with non-store API endpoint.
+		$_SERVER['REQUEST_URI'] = '/child-1/wp-json/wp/v2/posts';
+		$this->assertFalse( WC_Payments_Utils::is_store_api_request() );
+
+		// Test deeply nested subdirectory.
+		$_SERVER['REQUEST_URI'] = '/network/child-site/wp-json/wc/store/v1/cart';
+		$this->assertTrue( WC_Payments_Utils::is_store_api_request() );
+	}
+
 	public function test_is_any_bnpl_supporting_country() {
 		// Test supported country and currency combination (US with USD).
 		$this->assertTrue(


### PR DESCRIPTION
Fixes #10753

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The `is_store_api_request()` utility checks the request URL to ensure it matches with a set of Store API requests.
The problem arises on multisite setups when the multisite is set up with subdirectories.
The incoming `$request_path` holds value `/{child-site-slug}/wp-json/wc/store/v1/cart/add-item`. 
But `rest_get_url_prefix()` returns just `wp-json`. The `str_replace` only removes `wp-json/` but leaves `/{child-site-slug}/` at the beginning, resulting in `/{child-site-slug}/wc/store/v1/cart/add-item`, which doesn't match the patterns that expect to start with `/wc/store/`.

The fix handles multisite subdirectory setups by:

- First trying the normal `str_replace` to remove the REST prefix
- If the result still has a leading slash and path segments (indicating a subdirectory wasn't properly handled), it looks for the position of `/wp-json` in the original path
- It then extracts everything after the REST prefix from that position

This will correctly transform `/{child-site-slug}/wp-json/wc/store/v1/cart/add-item` into `wc/store/v1/cart/add-item`, matching the Store API route patterns.

I ended up extracting the logic in a `extract_rest_route_from_url` sub-utility, because the nesting was making the function less legible.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You could set this up locally, but it's a bit more complicated.
I recommend testing these changes on a Jurassic Ninja setup, which will set up the multisite from scratch.

- Navigate to https://jurassic.ninja/
- Expand the options, choose:
  - WooCommerce
  - Jetpack Beta
  - Use the `fix/is-store-api-request-on-multisite` branch for WooCommerce Payments
  - WooPayments Dev Tools
  - WooPayments JN Options
- Choose "Launch Multisite on subdirs"

Once the site is ready:
- On the top navbar, navigate to "My Sites > Network Admin > Sites"
- Click "Add site"
- Fill the data, you can use `child-1` for the URL
- Navigate to "My sites > Network Admin > Plugins"
- Network-activate WooCommerce
- Navigate to the child site's `wp-admin`
- Activate "WooPayments" on the child site
- Onboard (configure) WooPayments on the child site
- Load some products on the site, ensure you have a Variable product
  - Add a "Color" attribute: "Red | Blue | Yellow"
  - Generate some variations, maybe with different prices
- As a customer, navigate to the product page of the variable product
- Select different variations

![2025-05-27 11 48 14](https://github.com/user-attachments/assets/4c19c07d-f2bf-46a3-9efd-9ed0304f688c)

- Reload the page (or navigate to a different page)
- The cart should be empty

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
