### PR TITLE
Add new feature flag and new evidence form barebones

### DIFF
--- a/changelog/create-feature-flag-for-new-evidence-submission-form
+++ b/changelog/create-feature-flag-for-new-evidence-submission-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Create a new feature flag for the evidence submission form

--- a/client/disputes/new-evidence/index.js
+++ b/client/disputes/new-evidence/index.js
@@ -1,0 +1,13 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies.
+ */
+import '../style.scss';
+
+// Temporary MVP data wrapper
+export default ( {} ) => <>TBD</>;

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -20,6 +20,7 @@ declare global {
 			paymentTimeline: boolean;
 			isDisputeIssuerEvidenceEnabled: boolean;
 			isPaymentOverviewWidgetEnabled?: boolean;
+			isNewEvidenceSubmissionFormEnabled: boolean;
 			multiCurrency?: boolean;
 		};
 		accountFees: Record< string, any >;

--- a/client/index.js
+++ b/client/index.js
@@ -21,7 +21,8 @@ import TransactionsPage from 'transactions';
 import PaymentDetailsPage from 'payment-details';
 import DisputesPage from 'disputes';
 import RedirectToTransactionDetails from 'disputes/redirect-to-transaction-details';
-import DisputeEvidencePage from 'disputes/evidence';
+import DisputeEvidencePage from 'wcpay/disputes/evidence';
+import DisputeNewEvidencePage from 'wcpay/disputes/new-evidence';
 import { MultiCurrencySetupPage } from 'multi-currency/interface/components';
 import CardReadersPage from 'card-readers';
 import CapitalPage from 'capital';
@@ -192,28 +193,57 @@ addFilter(
 			capability: 'manage_woocommerce',
 		} );
 
-		pages.push( {
-			container: ( { query } ) => (
-				<WordPressComponentsContext.Provider value={ wp.components }>
-					<DisputeEvidencePage query={ query } />
-				</WordPressComponentsContext.Provider>
-			),
-			path: '/payments/disputes/challenge',
-			wpOpenMenu: menuID,
-			breadcrumbs: [
-				rootLink,
-				[
-					'/payments/disputes',
-					__( 'Disputes', 'woocommerce-payments' ),
+		if ( wcpaySettings.featureFlags.isNewEvidenceSubmissionFormEnabled ) {
+			pages.push( {
+				container: ( { query } ) => (
+					<WordPressComponentsContext.Provider
+						value={ wp.components }
+					>
+						<DisputeNewEvidencePage query={ query } />
+					</WordPressComponentsContext.Provider>
+				),
+				path: '/payments/disputes/challenge',
+				wpOpenMenu: menuID,
+				breadcrumbs: [
+					rootLink,
+					[
+						'/payments/disputes',
+						__( 'Disputes', 'woocommerce-payments' ),
+					],
+					__( 'Challenge dispute', 'woocommerce-payments' ),
 				],
-				__( 'Challenge dispute', 'woocommerce-payments' ),
-			],
-			navArgs: {
-				id: 'wc-payments-disputes-challenge',
-				parentPath: '/payments/disputes',
-			},
-			capability: 'manage_woocommerce',
-		} );
+				navArgs: {
+					id: 'wc-payments-disputes-challenge',
+					parentPath: '/payments/disputes',
+				},
+				capability: 'manage_woocommerce',
+			} );
+		} else {
+			pages.push( {
+				container: ( { query } ) => (
+					<WordPressComponentsContext.Provider
+						value={ wp.components }
+					>
+						<DisputeEvidencePage query={ query } />
+					</WordPressComponentsContext.Provider>
+				),
+				path: '/payments/disputes/challenge',
+				wpOpenMenu: menuID,
+				breadcrumbs: [
+					rootLink,
+					[
+						'/payments/disputes',
+						__( 'Disputes', 'woocommerce-payments' ),
+					],
+					__( 'Challenge dispute', 'woocommerce-payments' ),
+				],
+				navArgs: {
+					id: 'wc-payments-disputes-challenge',
+					parentPath: '/payments/disputes',
+				},
+				capability: 'manage_woocommerce',
+			} );
+		}
 		pages.push( {
 			container: MultiCurrencySetupPage,
 			path: '/payments/multi-currency-setup',

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -31,6 +31,7 @@ class WC_Payments_Features {
 	const TOKENIZED_CART_ECE_FLAG_NAME          = '_wcpay_feature_tokenized_cart_ece';
 	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME     = '_wcpay_feature_payment_overview_widget';
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME = '_wcpay_feature_woopay_global_theme_support';
+	const NEW_EVIDENCE_SUBMISSION_FORM_FLAG_NAME = '_wcpay_feature_new_evidence_submission_form';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -364,6 +365,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the new evidence submission form feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_new_evidence_submission_form_enabled(): bool {
+		return '1' === get_option( self::NEW_EVIDENCE_SUBMISSION_FORM_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -378,6 +388,7 @@ class WC_Payments_Features {
 				'isAuthAndCaptureEnabled'        => self::is_auth_and_capture_enabled(),
 				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 				'isPaymentOverviewWidgetEnabled' => self::is_payment_overview_widget_ui_enabled(),
+				'isNewEvidenceSubmissionFormEnabled' => self::is_new_evidence_submission_form_enabled(),
 			]
 		);
 	}

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -21,16 +21,16 @@ class WC_Payments_Features {
 	 *   - The next version of WooPayments.
 	 *   - The flag to be deleted.
 	 */
-	const WCPAY_SUBSCRIPTIONS_FLAG_NAME         = '_wcpay_feature_subscriptions';
-	const STRIPE_BILLING_FLAG_NAME              = '_wcpay_feature_stripe_billing';
-	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME     = '_wcpay_feature_woopay_express_checkout';
-	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME     = '_wcpay_feature_woopay_first_party_auth';
-	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME      = '_wcpay_feature_woopay_direct_checkout';
-	const AUTH_AND_CAPTURE_FLAG_NAME            = '_wcpay_feature_auth_and_capture';
-	const DISPUTE_ISSUER_EVIDENCE               = '_wcpay_feature_dispute_issuer_evidence';
-	const TOKENIZED_CART_ECE_FLAG_NAME          = '_wcpay_feature_tokenized_cart_ece';
-	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME     = '_wcpay_feature_payment_overview_widget';
-	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME = '_wcpay_feature_woopay_global_theme_support';
+	const WCPAY_SUBSCRIPTIONS_FLAG_NAME          = '_wcpay_feature_subscriptions';
+	const STRIPE_BILLING_FLAG_NAME               = '_wcpay_feature_stripe_billing';
+	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME      = '_wcpay_feature_woopay_express_checkout';
+	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME      = '_wcpay_feature_woopay_first_party_auth';
+	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME       = '_wcpay_feature_woopay_direct_checkout';
+	const AUTH_AND_CAPTURE_FLAG_NAME             = '_wcpay_feature_auth_and_capture';
+	const DISPUTE_ISSUER_EVIDENCE                = '_wcpay_feature_dispute_issuer_evidence';
+	const TOKENIZED_CART_ECE_FLAG_NAME           = '_wcpay_feature_tokenized_cart_ece';
+	const PAYMENT_OVERVIEW_WIDGET_FLAG_NAME      = '_wcpay_feature_payment_overview_widget';
+	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME  = '_wcpay_feature_woopay_global_theme_support';
 	const NEW_EVIDENCE_SUBMISSION_FORM_FLAG_NAME = '_wcpay_feature_new_evidence_submission_form';
 
 	/**
@@ -381,13 +381,13 @@ class WC_Payments_Features {
 	public static function to_array() {
 		return array_filter(
 			[
-				'multiCurrency'                  => self::is_customer_multi_currency_enabled(),
-				'woopay'                         => self::is_woopay_eligible(),
-				'documents'                      => self::is_documents_section_enabled(),
-				'woopayExpressCheckout'          => self::is_woopay_express_checkout_enabled(),
-				'isAuthAndCaptureEnabled'        => self::is_auth_and_capture_enabled(),
-				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
-				'isPaymentOverviewWidgetEnabled' => self::is_payment_overview_widget_ui_enabled(),
+				'multiCurrency'                      => self::is_customer_multi_currency_enabled(),
+				'woopay'                             => self::is_woopay_eligible(),
+				'documents'                          => self::is_documents_section_enabled(),
+				'woopayExpressCheckout'              => self::is_woopay_express_checkout_enabled(),
+				'isAuthAndCaptureEnabled'            => self::is_auth_and_capture_enabled(),
+				'isDisputeIssuerEvidenceEnabled'     => self::is_dispute_issuer_evidence_enabled(),
+				'isPaymentOverviewWidgetEnabled'     => self::is_payment_overview_widget_ui_enabled(),
 				'isNewEvidenceSubmissionFormEnabled' => self::is_new_evidence_submission_form_enabled(),
 			]
 		);


### PR DESCRIPTION
See WOOPMNT-5013

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Add new feature flag for the evidence form submission. This FF will be used for the iterative work on the new evidence form.

The default value is `0`.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you don't have any test disputes, please follow [the critical flows document].(https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Go to Payments > Disputes, select one of the disputes listed and hit [Challenge dispute].
* Nothing should have changed.
* Now using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* Refresh the evidence submission form and you should be able to see _TBD_.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
