### PR TITLE
Add specific texts for collecting Norway and New Zealand tax data

### DIFF
--- a/changelog/add-wording-tax-for-nz-no
+++ b/changelog/add-wording-tax-for-nz-no
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add specific texts for collecting Norway and New Zealand tax data

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -34,6 +34,8 @@ const getVatPrefix = () => {
 		case 'JP':
 			// Corporate numbers are not prefixed.
 			return '';
+		case 'NZ':
+			return '';
 		case 'GR':
 			return 'EL ';
 		case 'CH':
@@ -52,6 +54,8 @@ const getVatTaxIDName = () => {
 			return __( 'ABN', 'woocommerce-payments' );
 		case 'JP':
 			return __( 'Corporate Number', 'woocommerce-payments' );
+		case 'NZ':
+			return __( 'IRD Number', 'woocommerce-payments' );
 		default:
 			return __( 'VAT Number', 'woocommerce-payments' );
 	}
@@ -71,6 +75,11 @@ const getVatTaxIDRequirementHint = () => {
 		case 'NO':
 			return __(
 				'By inputting your VAT number you confirm you are a Norway VAT registered business and that you are going to account for the VAT',
+				'woocommerce-payments'
+			);
+		case 'NZ':
+			return __(
+				'By inputting your IRD Number number you confirm that you are going to account for the GST.',
 				'woocommerce-payments'
 			);
 		default:
@@ -93,7 +102,12 @@ const getVatTaxIDValidationHint = () => {
 			);
 		case 'JP':
 			return __(
-				'A 13 digit number, for example 1234567890123.',
+				'13-digit number, for example 1234567890123.',
+				'woocommerce-payments'
+			);
+		case 'NZ':
+			return __(
+				'8-digit or 9-digit number, for example 99-999-999 or 999-999-999.',
 				'woocommerce-payments'
 			);
 		default:

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -68,6 +68,11 @@ const getVatTaxIDRequirementHint = () => {
 			// Leaving this blank intentionally, as I don't know what the requirements are in JP.
 			// Better to add this info later than clutter the dialog with vague/assumed legal requirements.
 			return __( '', 'woocommerce-payments' );
+		case 'NO':
+			return __(
+				'By inputting your VAT number you confirm you are a Norway VAT registered business and that you are going to account for the VAT',
+				'woocommerce-payments'
+			);
 		default:
 			// Note: this message is a little alarming and doesn't provide guidance for confused merchants.
 			// Logged: https://github.com/Automattic/woocommerce-payments/issues/9161.

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -76,7 +76,7 @@ const getVatTaxIDRequirementHint = () => {
 			return __( '', 'woocommerce-payments' );
 		case 'NO':
 			return __(
-				'By inputting your VAT number you confirm you are a Norway VAT registered business and that you are going to account for the VAT',
+				'By inputting your VAT number you confirm you are a Norway VAT registered business and that you are going to account for the VAT.',
 				'woocommerce-payments'
 			);
 		case 'NZ':
@@ -119,7 +119,7 @@ const getVatTaxIDValidationHint = () => {
 			);
 		case 'SG':
 			return __(
-				'Enter your UEN (e.g., 200312345A) or GST Registration Number (e.g., M91234567X)',
+				'Enter your UEN (e.g., 200312345A) or GST Registration Number (e.g., M91234567X).',
 				'woocommerce-payments'
 			);
 		default:

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -81,7 +81,7 @@ const getVatTaxIDRequirementHint = () => {
 			);
 		case 'NZ':
 			return __(
-				'By inputting your IRD Number number you confirm that you are going to account for the GST.',
+				'By inputting your IRD number you confirm that you are going to account for the GST.',
 				'woocommerce-payments'
 			);
 		case 'SG':


### PR DESCRIPTION
Fixes WOOPMNT-4875
Fixes WOOPMNT-4877

#### Changes proposed in this Pull Request

- Add specific wordings for Norway and New Zealand merchants. 
- Norway merchants are basically similar to EU countries but Taxamo recommends adding `By inputting your VAT number you confirm you are a Norway VAT registered business and that you are going to account for the VAT` hint. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use secret store id 12889 to set up for the tax validation test private key for your local server. See server PR 7337
* Tested with an NO or NZ account. Otherwise, try to apply this diff 37f25-pb/#diff
* NZ: valid `123-456-786`, invalid `1234567851111`
* NO: valid `977074010`, invalid `823456786`. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
