### PR TITLE
Fix broken Alipay block checkout test

### DIFF
--- a/changelog/fix-WOOPMNT-5019-broken-alipay-checkout-test
+++ b/changelog/fix-WOOPMNT-5019-broken-alipay-checkout-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Condition AliPay block tests under shouldRunWCBlocksTests

--- a/tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts
@@ -7,10 +7,11 @@ import { test, expect, Page } from '@playwright/test';
  * Internal dependencies
  */
 import * as shopper from '../../../utils/shopper';
-import { getMerchant, getShopper } from '../../../utils/helpers';
+import { describeif, getMerchant, getShopper } from '../../../utils/helpers';
 import * as merchant from '../../../utils/merchant';
 import { config } from '../../../config/default';
 import { goToCheckoutWCB } from '../../../utils/shopper-navigation';
+import { shouldRunWCBlocksTests } from '../../../utils/constants';
 
 test.describe( 'Alipay Checkout', () => {
 	let merchantPage: Page;
@@ -62,11 +63,27 @@ test.describe( 'Alipay Checkout', () => {
 			).toBeVisible();
 		}
 	);
+} );
 
-	test(
-		'checkout on block-based checkout page',
-		{ tag: '@critical' },
-		async () => {
+describeif( shouldRunWCBlocksTests )(
+	'Alipay Block Checkout',
+	{ tag: '@critical' },
+	() => {
+		let shopperPage: Page;
+		let merchantPage: Page;
+
+		test.beforeAll( async ( { browser } ) => {
+			shopperPage = ( await getShopper( browser ) ).shopperPage;
+			merchantPage = ( await getMerchant( browser ) ).merchantPage;
+			await merchant.enablePaymentMethods( merchantPage, [ 'alipay' ] );
+		} );
+
+		test.afterAll( async () => {
+			await shopper.emptyCart( shopperPage );
+			await merchant.disablePaymentMethods( merchantPage, [ 'alipay' ] );
+		} );
+
+		test( 'checkout on block-based checkout page', async () => {
 			await shopper.setupProductCheckout(
 				shopperPage,
 				[ [ config.products.cap, 1 ] ],
@@ -102,6 +119,6 @@ test.describe( 'Alipay Checkout', () => {
 					name: 'Alipay',
 				} )
 			).toBeVisible();
-		}
-	);
-} );
+		} );
+	}
+);

--- a/tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts
@@ -63,62 +63,48 @@ test.describe( 'Alipay Checkout', () => {
 			).toBeVisible();
 		}
 	);
+
+	describeif( shouldRunWCBlocksTests )(
+		'checkout on block-based checkout page',
+		{ tag: '@critical' },
+		() => {
+			test( 'completes payment successfully', async () => {
+				await shopper.setupProductCheckout(
+					shopperPage,
+					[ [ config.products.cap, 1 ] ],
+					config.addresses.customer.billing
+				);
+				await goToCheckoutWCB( shopperPage );
+				await shopper.fillBillingAddressWCB(
+					shopperPage,
+					config.addresses.customer.billing
+				);
+
+				await shopperPage
+					.getByRole( 'radio', {
+						name: 'Alipay',
+					} )
+					.click();
+
+				await shopper.placeOrderWCB( shopperPage, false );
+
+				await expect(
+					shopperPage.getByText( /Alipay test payment page/ )
+				).toBeVisible();
+
+				await shopperPage.getByText( 'Authorize Test Payment' ).click();
+
+				await expect(
+					shopperPage.getByRole( 'heading', {
+						name: 'Order received',
+					} )
+				).toBeVisible();
+				await expect(
+					shopperPage.getByRole( 'img', {
+						name: 'Alipay',
+					} )
+				).toBeVisible();
+			} );
+		}
+	);
 } );
-
-describeif( shouldRunWCBlocksTests )(
-	'Alipay Block Checkout',
-	{ tag: '@critical' },
-	() => {
-		let shopperPage: Page;
-		let merchantPage: Page;
-
-		test.beforeAll( async ( { browser } ) => {
-			shopperPage = ( await getShopper( browser ) ).shopperPage;
-			merchantPage = ( await getMerchant( browser ) ).merchantPage;
-			await merchant.enablePaymentMethods( merchantPage, [ 'alipay' ] );
-		} );
-
-		test.afterAll( async () => {
-			await shopper.emptyCart( shopperPage );
-			await merchant.disablePaymentMethods( merchantPage, [ 'alipay' ] );
-		} );
-
-		test( 'checkout on block-based checkout page', async () => {
-			await shopper.setupProductCheckout(
-				shopperPage,
-				[ [ config.products.cap, 1 ] ],
-				config.addresses.customer.billing
-			);
-			await goToCheckoutWCB( shopperPage );
-			await shopper.fillBillingAddressWCB(
-				shopperPage,
-				config.addresses.customer.billing
-			);
-
-			await shopperPage
-				.getByRole( 'radio', {
-					name: 'Alipay',
-				} )
-				.click();
-
-			await shopper.placeOrderWCB( shopperPage, false );
-
-			await expect(
-				shopperPage.getByText( /Alipay test payment page/ )
-			).toBeVisible();
-
-			await shopperPage.getByText( 'Authorize Test Payment' ).click();
-
-			await expect(
-				shopperPage.getByRole( 'heading', {
-					name: 'Order received',
-				} )
-			).toBeVisible();
-			await expect(
-				shopperPage.getByRole( 'img', {
-					name: 'Alipay',
-				} )
-			).toBeVisible();
-		} );
-	}
-);


### PR DESCRIPTION
Fixes WOOPMNT-5019

#### Changes proposed in this Pull Request

Condition AliPay block checkout tests using the same logic as other block e2e tests

#### Testing instructions

* Changes should make sense
* Tests should pass
* `npm run test:e2e-ui tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts` should run successfully locally

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
