### PR TITLE
Preselected Payment Methods ignored during account creation via KYC session

### DIFF
--- a/changelog/enhance-WOOPLUG-4531-pms-not-enabled-kyc
+++ b/changelog/enhance-WOOPLUG-4531-pms-not-enabled-kyc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix preselected Payment Methods ignored during account creation via KYC session.

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -86,6 +86,17 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 							],
 						],
 					],
+					'capabilities'    => [
+						'description' => 'The capabilities to request and enable for the test-drive account. Leave empty to use the default capabilities.',
+						'type'        => 'object',
+						'default'     => [],
+						'required'    => false,
+						'properties'  => [
+							'*' => [
+								'type' => 'boolean',
+							],
+						],
+					],
 				],
 			]
 		);
@@ -215,10 +226,12 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	public function create_embedded_kyc_session( WP_REST_Request $request ) {
 		$self_assessment_data = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
 		$progressive          = ! empty( $request->get_param( 'progressive' ) ) && filter_var( $request->get_param( 'progressive' ), FILTER_VALIDATE_BOOLEAN );
+		$capabilities         = ! empty( $request->get_param( 'capabilities' ) ) ? wc_clean( wp_unslash( $request->get_param( 'capabilities' ) ) ) : [];
 
 		$account_session = $this->onboarding_service->create_embedded_kyc_session(
 			$self_assessment_data,
-			$progressive
+			$progressive,
+			$capabilities
 		);
 
 		if ( $account_session ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -278,12 +278,15 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * @param array   $self_assessment_data Self assessment data.
 	 * @param boolean $progressive Whether the onboarding is progressive.
+	 * @param array   $capabilities Optional. List keyed by capabilities IDs (payment methods) with boolean values
+	 *                             indicating whether the capability should be requested when the account is created
+	 *                             and enabled in the settings.
 	 *
 	 * @return array Session data.
 	 *
 	 * @throws API_Exception|Exception
 	 */
-	public function create_embedded_kyc_session( array $self_assessment_data, bool $progressive = false ): array {
+	public function create_embedded_kyc_session( array $self_assessment_data, bool $progressive = false, array $capabilities = [] ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
 			return [];
 		}
@@ -309,7 +312,7 @@ class WC_Payments_Onboarding_Service {
 		$account_data   = $this->get_account_data(
 			$setup_mode,
 			$self_assessment_data,
-			$this->get_capabilities_from_request()
+			$capabilities
 		);
 		$actioned_notes = self::get_actioned_notes();
 
@@ -321,8 +324,7 @@ class WC_Payments_Onboarding_Service {
 		 * @see self::update_enabled_payment_methods_ids
 		 * ==================
 		 */
-		$capabilities = $this->get_capabilities_from_request();
-		$gateway      = WC_Payments::get_gateway();
+		$gateway = WC_Payments::get_gateway();
 
 		// Activate enabled Payment Methods IDs.
 		if ( ! empty( $capabilities ) ) {
@@ -718,7 +720,7 @@ class WC_Payments_Onboarding_Service {
 		// the WooPay capability value from the request.
 		$should_enable_woopay = $this->should_enable_woopay(
 			filter_var( $onboarding_data['woopay_enabled_by_default'] ?? false, FILTER_VALIDATE_BOOLEAN ),
-			$this->get_capabilities_from_request()
+			$capabilities
 		);
 
 		if ( $should_enable_woopay ) {


### PR DESCRIPTION
Fixes WOOPLUG-4531

#### Changes proposed in this Pull Request
This PR addresses an issue where preselected payment methods are not enabled/requested when creating an account through the KYC session endpoint, where the capabilities are passed from WooCommerce as an endpoint parameter.

#### Testing instructions
1. Create a new JN store with this PR's branch build (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce=enhance/WOOPLUG-4531-provide-capabilities-kyc)).
2. Go to Plugins and install and activate this version of WooPayments
[woocommerce-payments.zip](https://github.com/user-attachments/files/20655741/woocommerce-payments.zip)
3. Verify the WooPayments Dev Tools is installed, if not please install the [WCPay Dev Tools plugin](https://github.com/Automattic/woocommerce-payments-dev-tools/tree/trunk).
4. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to United States, California.
6. Go to "WooCommerce > Home" and click on Launch your store task.
![image](https://github.com/user-attachments/assets/5b18ce73-c2f8-4d73-baa6-589257dd5eb1)

8. Click on the "Set up payments".
![image](https://github.com/user-attachments/assets/299000c8-8dcd-4c63-9143-c2ec2625824d)

10. On the "Payment Methods selection" screen, click "Show more" and enable all available payment methods.
11. Continue with the "Jetpack connection".
12. Fill in your details in the embedded onboarding step until the account is fully onboarded.
13. Once onboarding is complete, exit the Launch Your Store flow and go to "Payments > Settings".
14. Confirm that all payment methods selected during LYS onboarding are enabled.
<img width="1362" alt="Screenshot 2025-06-09 at 16 43 15" src="https://github.com/user-attachments/assets/30883abf-0322-4fe8-a6a2-34e9debbacd7" />

16. Go to "Payments > Overview" and click the Reset account button. Confirm the reset.
17. Navigate to "WCPay Dev Tools" and select "Delete saved WCPay Gateway settings".
<img width="1312" alt="Screenshot 2025-06-09 at 16 23 21" src="https://github.com/user-attachments/assets/037ab052-5f34-45a3-9026-20cee1e34d71" />

19. Go to WooCommerce > Home, click the Launch your store task, then select Set up payments.
21. On the "Payment Methods selection" screen, disable all methods except "Credit/debit card".
22. Once the account is fully onboarded, exit the Launch Your Store flow and go to "Payments > Settings".
23. Confirm that all payment methods except "Card" are disabled.
<img width="1279" alt="Screenshot 2025-06-09 at 16 27 47" src="https://github.com/user-attachments/assets/245c434a-f540-4853-a8e3-58f82c0f20f6" />

25. Go to "Payments > Overview" and click the Reset account button. Confirm the reset.
13. Navigate to "WCPay Dev Tools" and select "Delete saved WCPay Gateway settings".
14. Click on "Payments" and click "Continue setup" next to the WooPayments gateway.
15. On the "Payment Methods selection" screen, click "Show more" and enable all available payment methods.
16. Go through the Test account creation step.
17. Once the test account is create successfully, click on the Activate payments button.
19. Fill in your details in the embedded onboarding step until the account is fully onboarded.
26. Once onboarding is complete, click on the "Close this window" button.
27. Go to "Paymnets > Settings" and verify all the payment methods are enabled.
<img width="1362" alt="Screenshot 2025-06-09 at 16 43 15" src="https://github.com/user-attachments/assets/2d441b91-49c8-48ad-b8a1-1cbad968854f" />

29. Now, go to "Payments > Overview" and click the Reset account button. Confirm the reset.
30. Navigate to "WCPay Dev Tools" and select "Delete saved WCPay Gateway settings".
31. Click on "Payments" and click "Continue setup" next to the WooPayments gateway.
32. On the "Payment Methods selection" screen, click "Show more" and uncheck/disable all available payment methods.
33. Go through the Test account creation step.
34. Once the test account is create successfully, click on the Activate payments button.
35. Fill in your details in the embedded onboarding step until the account is fully onboarded.
36. Once onboarding is complete, click on the "Close this window" button.
37. Go to "Paymnets > Settings" and confirm that all payment methods except "Card" are disabled.
<img width="1279" alt="Screenshot 2025-06-09 at 16 27 47" src="https://github.com/user-attachments/assets/3a805452-d3c1-4fbd-9be7-8965ab5b2256" />
*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
