### PR TITLE
Fix layout shift

### DIFF
--- a/changelog/fix-layout-shift-when-uploading-a-file
+++ b/changelog/fix-layout-shift-when-uploading-a-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a layout shift when uploading evidence for a dispute on the new challenge dispute screen

--- a/client/disputes/new-evidence/file-upload-control.tsx
+++ b/client/disputes/new-evidence/file-upload-control.tsx
@@ -37,7 +37,7 @@ const FileUploadControl: React.FC< FileUploadControlProps > = ( {
 } ) => {
 	return (
 		<div className="wcpay-dispute-evidence-file-upload-control">
-			{ isDone && fileName ? <Icon icon={ check } size={ 48 } /> : null }
+			{ isDone && fileName ? <Icon icon={ check } size={ 36 } /> : null }
 			<label className="wcpay-dispute-evidence-file-upload-control__label">
 				{ label }
 			</label>

--- a/client/disputes/new-evidence/file-upload-control.tsx
+++ b/client/disputes/new-evidence/file-upload-control.tsx
@@ -37,7 +37,12 @@ const FileUploadControl: React.FC< FileUploadControlProps > = ( {
 } ) => {
 	return (
 		<div className="wcpay-dispute-evidence-file-upload-control">
-			{ isDone && fileName ? <Icon icon={ check } size={ 36 } /> : null }
+			{ isDone && fileName ? (
+				<Icon
+					className="wcpay-dispute-evidence-file-upload-control__check"
+					icon={ check }
+				/>
+			) : null }
 			<label className="wcpay-dispute-evidence-file-upload-control__label">
 				{ label }
 			</label>

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -273,6 +273,10 @@
 		white-space: nowrap;
 		color: var( --wp-admin-theme-color );
 	}
+
+	&__check {
+		width: 48px;
+	}
 }
 
 .wcpay-dispute-evidence-cover-letter__printonly {


### PR DESCRIPTION
See WOOPMNT-5037

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes a layout shift when uploading a file for dispute evidence

Before

![file-upload-bug](https://github.com/user-attachments/assets/6388e602-48aa-47f0-8c54-7e6270ea784e)

After

![file-upload-fixed](https://github.com/user-attachments/assets/fa0a2255-2891-44a5-a56c-c0ef2505f559)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document].(https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Go to Payments > Disputes, select one of the disputes listed and hit [Challenge dispute].
* Try to upload a file on the first step and check if the layout shift is gone.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
