### PR TITLE
Fix spacing on disputes expandable block

### DIFF
--- a/changelog/fix-bug-spacing-on-disputes-expandable-block
+++ b/changelog/fix-bug-spacing-on-disputes-expandable-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix spacing on disputes expandable block

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -124,11 +124,12 @@
 		border-bottom: 1px solid var( --Scales-Grays-gray-200, #e0e0e0 );
 
 		&:first-child {
-			padding: 4px 0 16px;
+			padding: 12px 0 16px;
 		}
 
 		&:last-child {
 			border-bottom: none;
+			padding-bottom: 28px;
 		}
 
 		@media screen and ( max-width: $break-small ) {


### PR DESCRIPTION
See WOOPMNT-5042

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fix a spacing issue on the disputes details screen

Before

![image](https://github.com/user-attachments/assets/7a46256e-35fc-4f72-a6bd-a8db81d894f5)

After

<img width="1533" alt="image" src="https://github.com/user-attachments/assets/85af1ce8-b72d-4739-bb2e-e71bd8fe8f21" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document].(https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Go to Payments > Disputes, select one of the disputes listed.
* Expand "Steps you can take" and ensure the spacing meets the requirements.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
