### PR TITLE
Fix padding on the recommended document section

### DIFF
--- a/changelog/fix-padding-on-the-recommended-document-section
+++ b/changelog/fix-padding-on-the-recommended-document-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix padding on the recommended document section

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -209,7 +209,7 @@
 }
 
 .wcpay-dispute-evidence-recommended-documents {
-	margin-bottom: 40px;
+	margin-bottom: 45px;
 
 	&__heading {
 		@include heading-md;
@@ -221,6 +221,11 @@
 		color: var( --Scales-Grays-gray-700, $gray-700 );
 		@include body-md;
 	}
+
+	&__item {
+		margin-left: 15px;
+		margin-bottom: 10px;
+	}
 }
 
 .wcpay-dispute-evidence-file-upload-control {
@@ -228,7 +233,7 @@
 	align-items: center;
 	justify-content: flex-end;
 	gap: 12px;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 
 	&__label {
 		flex: 1 0 220px;

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -214,7 +214,7 @@
 	&__heading {
 		@include heading-md;
 		color: var( --Scales-Grays-gray-900, $gray-900 );
-		margin-bottom: 16px;
+		margin-bottom: 8px;
 	}
 
 	&__subheading {
@@ -225,6 +225,11 @@
 	&__item {
 		margin-left: 15px;
 		margin-bottom: 10px;
+	}
+
+	&__list {
+		margin-top: 16px;
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
See WOOPMNT-5048

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes the padding for the recommended document section

Figma

<img width="538" alt="image" src="https://github.com/user-attachments/assets/26cb4c38-454f-4e89-85e0-e56af6d5a5b4" />

Fixed padding

<img width="534" alt="image" src="https://github.com/user-attachments/assets/7d88f99c-5556-4be5-87b7-36938ec89dd3" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document].(https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Go to Payments > Disputes, select one of the disputes listed.
* Hit Challenge Dispute
* Ensure the steps you can take match the screenshots provided

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
