### PR TITLE
Update reviewers for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
         - dependency-name: "@woocommerce/*"
       # Reviewers for issues created
       reviewers:
-        - 'Automattic/harmony'
+        - 'Automattic/gamma'
+        - 'Automattic/moltres'
 
     # Enable version updates for composer
     - package-ecosystem: 'composer'
@@ -25,7 +26,8 @@ updates:
         interval: 'weekly'
       # Reviewers for issues created
       reviewers:
-          - 'Automattic/harmony'
+        - 'Automattic/gamma'
+        - 'Automattic/moltres'
 
     # Enable version updates for Docker
     - package-ecosystem: 'docker'
@@ -36,4 +38,5 @@ updates:
           interval: 'weekly'
       # Reviewers for issues created
       reviewers:
-          - 'Automattic/harmony'
+        - 'Automattic/gamma'
+        - 'Automattic/moltres'

--- a/changelog/update-dependabot-reviewers
+++ b/changelog/update-dependabot-reviewers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update reviewers for dependabot


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

- Just update reviewers for `dependabot`. I noticed this while working on WOOPMNT-5035
- All current PRs by it are not having reviewers at the moment https://github.com/Automattic/woocommerce-payments/pulls/app%2Fdependabot 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nothing specific.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
