### PR TITLE
Fix: Use wc_maybe_reduce_stock_levels to avoid potential double stock reductions during 3DS flow

### DIFF
--- a/changelog/fix-double-stock-reduction
+++ b/changelog/fix-double-stock-reduction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent double stock reduction after (3DS) authentication.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3556,7 +3556,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->order_service->update_order_status_from_intent( $order, $intent );
 
 			if ( $intent->is_authorized() ) {
-				wc_reduce_stock_levels( $order_id );
+				wc_maybe_reduce_stock_levels( $order_id );
 				WC()->cart->empty_cart();
 
 				$is_subscription            = function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order );


### PR DESCRIPTION
Fixes: Related to [#8292](https://github.com/Automattic/woocommerce-payments/issues/8292)
Also informed by merged fix in [#8335](https://github.com/Automattic/woocommerce-payments/pull/8335)

Changes proposed in this Pull Request
This PR replaces a direct call to wc_reduce_stock_levels() with wc_maybe_reduce_stock_levels() inside the update_order_status() method in class-wc-payment-gateway-wcpay.php.

This change aligns with [PR #8335](https://github.com/Automattic/woocommerce-payments/pull/8335), which implemented the same adjustment in a different part of the WooPayments flow. It mitigates a rare issue in which stock can be deducted twice when two handlers run in close succession during the 3DS flow. We’ve observed this only on certain orders — and only after migrating to a new server environment using LiteSpeed + Redis, which may have increased susceptibility to race conditions.

While the precise sequence of operations that triggers the double deduction is difficult to force consistently, the proposed fix ensures that each call checks for prior deductions before acting — helping prevent side effects in edge cases.

I understand this may not be universally reproducible, but believe the change is low-risk and broadly beneficial.

Testing instructions
* Enable WooPayments.
* Use Stripe 3DS test cards such as 4000 0027 6000 3184.
* Complete checkout using 3DS, and watch the order notes and stock levels.
* In environments prone to concurrency issues (e.g. Redis/LiteSpeed with object cache), observe whether stock is reduced twice in order notes or inventory.

Expected outcome:
With this change, only one reduction note should appear, and stock should only decrement once, even if the relevant order handler is called multiple times.

Below is an example of the logged double-call tracing:
```
2025-05-21T15:59:51+00:00 INFO Order #35518 (PI=unknown) triggered stock reduction - caller=do_action('wp_ajax_nopriv_update_order_status'), WP_Hook->do_action, WP_Hook->apply_filters, WC_Payment_Gateway_WCPay->update_order_status, WC_Payments_Order_Service->update_order_status_from_intent, WC_Payments_Order_Service->mark_payment_completed, WC_Payments_Order_Service->update_order_status, WC_Order->payment_complete, WC_Order->save, WC_Order->status_transition, do_action('woocommerce_order_status_processing'), WP_Hook->do_action, WP_Hook->apply_filters, wc_maybe_reduce_stock_levels, wc_reduce_stock_levels, do_action('woocommerce_reduce_order_stock')
2025-05-21T15:59:56+00:00 INFO Order #35518 (PI=unknown) triggered stock reduction - caller=do_action('wp_ajax_nopriv_update_order_status'), WP_Hook->do_action, WP_Hook->apply_filters, WC_Payment_Gateway_WCPay->update_order_status, wc_reduce_stock_levels, do_action('woocommerce_reduce_order_stock')
```