### PR TITLE
Add missing arrow icons for Back and Next buttons

### DIFF
--- a/changelog/add-missing-icon-evidence-form
+++ b/changelog/add-missing-icon-evidence-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add missing arrow icons from the new evidence form

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -787,7 +787,7 @@ export default ( { query }: { query: { id: string } } ) => {
 							onClick={ () =>
 								handleStepChange( currentStep + 1 )
 							}
-							icon={ <Icon icon={ chevronRight } /> }
+							icon={ chevronRight }
 							iconPosition="right"
 						>
 							{ __( 'Next', 'woocommerce-payments' ) }
@@ -802,7 +802,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					<Button
 						variant="secondary"
 						onClick={ () => setCurrentStep( ( s ) => s - 1 ) }
-						icon={ <Icon icon={ chevronLeft } /> }
+						icon={ chevronLeft }
 						iconPosition="left"
 					>
 						{ __( 'Back', 'woocommerce-payments' ) }
@@ -821,7 +821,7 @@ export default ( { query }: { query: { id: string } } ) => {
 						) }
 						<Button
 							variant="primary"
-							icon={ <Icon icon={ chevronRight } /> }
+							icon={ chevronRight }
 							iconPosition="right"
 							onClick={ () =>
 								handleStepChange( currentStep + 1 )
@@ -837,7 +837,7 @@ export default ( { query }: { query: { id: string } } ) => {
 			<div className="wcpay-dispute-evidence-new__button-row">
 				<Button
 					variant="secondary"
-					icon={ <Icon icon={ chevronLeft } /> }
+					icon={ chevronLeft }
 					iconPosition="left"
 					onClick={ () => setCurrentStep( ( s ) => s - 1 ) }
 				>

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -7,6 +7,11 @@ import React, { useState, useEffect, useMemo } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
+import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
 import useConfirmNavigation from 'utils/use-confirm-navigation';
 import { recordEvent } from 'tracks';
 import { TestModeNotice } from 'components/test-mode-notice';
@@ -27,10 +32,6 @@ import RecommendedDocuments from './recommended-documents';
 import InlineNotice from 'components/inline-notice';
 import ShippingDetails from './shipping-details';
 import CoverLetter from './cover-letter';
-
-/**
- * Internal dependencies.
- */
 import { Button, HorizontalRule } from 'wcpay/components/wp-components-wrapped';
 import { getAdminUrl } from 'wcpay/utils';
 import { StepperPanel } from 'wcpay/components/stepper';
@@ -786,6 +787,8 @@ export default ( { query }: { query: { id: string } } ) => {
 							onClick={ () =>
 								handleStepChange( currentStep + 1 )
 							}
+							icon={ <Icon icon={ chevronRight } /> }
+							iconPosition="right"
 						>
 							{ __( 'Next', 'woocommerce-payments' ) }
 						</Button>
@@ -799,6 +802,8 @@ export default ( { query }: { query: { id: string } } ) => {
 					<Button
 						variant="secondary"
 						onClick={ () => setCurrentStep( ( s ) => s - 1 ) }
+						icon={ <Icon icon={ chevronLeft } /> }
+						iconPosition="left"
 					>
 						{ __( 'Back', 'woocommerce-payments' ) }
 					</Button>
@@ -816,6 +821,8 @@ export default ( { query }: { query: { id: string } } ) => {
 						) }
 						<Button
 							variant="primary"
+							icon={ <Icon icon={ chevronRight } /> }
+							iconPosition="right"
 							onClick={ () =>
 								handleStepChange( currentStep + 1 )
 							}
@@ -830,6 +837,8 @@ export default ( { query }: { query: { id: string } } ) => {
 			<div className="wcpay-dispute-evidence-new__button-row">
 				<Button
 					variant="secondary"
+					icon={ <Icon icon={ chevronLeft } /> }
+					iconPosition="left"
 					onClick={ () => setCurrentStep( ( s ) => s - 1 ) }
 				>
 					{ __( 'Back', 'woocommerce-payments' ) }


### PR DESCRIPTION
See WOOPMNT-5049

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR adds the missing arrow icons from the Next and Back buttons

<img width="622" alt="image" src="https://github.com/user-attachments/assets/7cb28f25-e69c-4cc3-a8e3-0147221d1925" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document].(https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating disputes in test mode.
* Go to Payments > Disputes, select one of the disputes listed.
* Hit Challenge Dispute
* Check that both navigation buttons Next and Back have the arrow icon next to them

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
