### PR TITLE
Allow optional block sections in the checkout button class name for E2E test

### DIFF
--- a/changelog/chore-fix-checkout-button-check-regexp
+++ b/changelog/chore-fix-checkout-button-check-regexp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix the regexp checking for the loading state of the checkout button to cover changes in latest WooCommerce.

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -631,7 +631,7 @@ export const confirmCardAuthenticationWCB = async (
 	);
 	await expect( placeOrderButton ).toBeDisabled();
 	await expect( placeOrderButton ).toHaveClass(
-		/wc-block-components-button--loading/
+		/\bwc-block-components-(?:[-\w]*-)?button--loading\b/
 	);
 	await confirmCardAuthentication( page, authorize );
 };

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -630,8 +630,13 @@ export const confirmCardAuthenticationWCB = async (
 		'.wc-block-components-checkout-place-order-button'
 	);
 	await expect( placeOrderButton ).toBeDisabled();
+	/**
+	 * Starting around version 9.9.0 WooCommerce Blocks class names changed to
+	 * be more specific. To cover both case, this check allows for additional
+	 * sections in the "loading" class name.
+	 */
 	await expect( placeOrderButton ).toHaveClass(
-		/\bwc-block-components-(?:[-\w]*-)?button--loading\b/
+		/\bwc-block-components-(?:[-\w]+-)?button--loading\b/
 	);
 	await confirmCardAuthentication( page, authorize );
 };


### PR DESCRIPTION
Fixes [WOOPMNT-5068](https://linear.app/a8c/issue/WOOPMNT-5068/update-e2e-tests-for-optional-block-sections-in-checkout-button-class)

#### Changes proposed in this Pull Request

In the latest versions of WooCommerce block checkout CSS class names have been updated. Where our tests expect `wc-block-components-button--loading` there is now `wc-block-components-checkout-place-order-button--loading`

To keep the backwards compatibility, tests were updated to allow optional block names sections in the class name. Word boundaries have been added to avoid accidental greedy matching.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E tests shall pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
