### PR TITLE
Prevent fatal errors upon missing orders

### DIFF
--- a/changelog/woopmnt-5041-prevent-fatal-error-call-to-a-member-function-get_currency
+++ b/changelog/woopmnt-5041-prevent-fatal-error-call-to-a-member-function-get_currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error on the Pay for Order page upon deleted orders.

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -272,6 +272,9 @@ class UPE_Payment_Method {
 	 */
 	public function is_currency_valid( string $account_domestic_currency, $order_id = null ) {
 		$current_store_currency = $this->get_currency( $order_id );
+		if ( null === $current_store_currency ) {
+			return false;
+		}
 
 		if ( $this->has_domestic_transactions_restrictions() ) {
 			if ( strtolower( $current_store_currency ) !== strtolower( $account_domestic_currency ) ) {
@@ -457,7 +460,7 @@ class UPE_Payment_Method {
 	 *
 	 * @param int $order_id Optional order ID, if order currency should take precedence.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	private function get_currency( $order_id = null ) {
 		if ( is_wc_endpoint_url( 'order-pay' ) || null !== $order_id ) {
@@ -466,6 +469,9 @@ class UPE_Payment_Method {
 				$order_id = absint( $wp->query_vars['order-pay'] );
 			}
 			$order = wc_get_order( $order_id );
+			if ( false === $order ) {
+				return null;
+			}
 			return $order->get_currency();
 		}
 		return get_woocommerce_currency();


### PR DESCRIPTION
Fixes WOOPMNT-5041

#### Changes proposed in this Pull Request

Check whether orders exist within `UPE_Payment_Method->get_currency()` before loading the order currency.

#### Testing instructions

1. Attempt checkout with a card that will trigger a decline (ex. `4000000000009995` for insufficient funds).
2. Navigate to My Account -> Orders and click the "Pay" button next to the order. Keep the page open.
3. In a separate tab, navigate to WP admin and delete the order. Make sure to empty the trash.
4. Reload the Pay for Order tab, and make sure that it does not trigger a fatal error.

Note regarding unit tests: The change is very simple, related to non-existing orders, and relatively deep within `UPE_Payment_Method->is_currency_valid()`. I have not added tests, as there are plenty of reasons why the method might return `false`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)