### PR TITLE
Add NO VAT description for Norway in tax descriptions

### DIFF
--- a/changelog/woopmnt-5070-add-missing-tax-description-mapping-for-norway-vat
+++ b/changelog/woopmnt-5070-add-missing-tax-description-mapping-for-norway-vat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add NO VAT description for Norway in tax descriptions

--- a/client/payment-details/utils/tax-descriptions.ts
+++ b/client/payment-details/utils/tax-descriptions.ts
@@ -34,6 +34,7 @@ const taxDescriptions: Record< string, string > = {
 	'LU VAT': __( 'LU VAT', 'woocommerce-payments' ), // Luxembourg
 	'LV VAT': __( 'LV VAT', 'woocommerce-payments' ), // Latvia
 	'MT VAT': __( 'MT VAT', 'woocommerce-payments' ), // Malta
+	'NO VAT': __( 'NO VAT', 'woocommerce-payments' ), // Norway
 	'NL VAT': __( 'NL VAT', 'woocommerce-payments' ), // Netherlands
 	'PL VAT': __( 'PL VAT', 'woocommerce-payments' ), // Poland
 	'PT VAT': __( 'PT VAT', 'woocommerce-payments' ), // Portugal

--- a/includes/class-wc-payments-captured-event-note.php
+++ b/includes/class-wc-payments-captured-event-note.php
@@ -550,6 +550,7 @@ class WC_Payments_Captured_Event_Note {
 			'LU VAT' => __( 'LU VAT', 'woocommerce-payments' ), // Luxembourg.
 			'LV VAT' => __( 'LV VAT', 'woocommerce-payments' ), // Latvia.
 			'MT VAT' => __( 'MT VAT', 'woocommerce-payments' ), // Malta.
+			'NO VAT' => __( 'NO VAT', 'woocommerce-payments' ), // Norway.
 			'NL VAT' => __( 'NL VAT', 'woocommerce-payments' ), // Netherlands.
 			'PL VAT' => __( 'PL VAT', 'woocommerce-payments' ), // Poland.
 			'PT VAT' => __( 'PT VAT', 'woocommerce-payments' ), // Portugal.


### PR DESCRIPTION
Fixes #WOOPMNT-5070

#### Changes proposed in this Pull Request

Add missing mapping for NO VAT description

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<img width="260" alt="Screenshot 2025-06-13 at 16 36 54" src="https://github.com/user-attachments/assets/62d863ee-be0c-4174-93ed-3934446c4044" />

<img width="535" alt="Screenshot 2025-06-13 at 16 37 35" src="https://github.com/user-attachments/assets/d332ad5e-5afe-4b89-92d7-6927b210c4a6" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Onboard with a Norway (NO) account
* Enable the tax on fee flag: `npm run cli wp wcpay set_account_meta <YOUR_ACCOUNT_ID> --key=tax_on_fee_enabled --value=1`
* Check out an order
* Navigate to the order details page
* In the fee breakdown note, the line that contains the applied tax displays something like this: `Tax NO VAT (25%): -kr 1,37`
* Navigate to the payment details page of the order
* In the timeline, the tax is displayed correctly `Tax NO VAT (25%): -kr 1,37`

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
