### PR TITLE
Remove CTA in the toast confirming that evidence was saved

### DIFF
--- a/changelog/woopmnt-5064-remove-return-to-evidence-submission-button-on-evidence
+++ b/changelog/woopmnt-5064-remove-return-to-evidence-submission-button-on-evidence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove CTA from the new evidence "Evidence saved!" toast.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -204,24 +204,21 @@ export default ( { query }: { query: { id: string } } ) => {
 					? __( 'Evidence submitted!', 'woocommerce-payments' )
 					: __( 'Evidence saved!', 'woocommerce-payments' ),
 				{
-					actions: [
-						{
-							label: submit
-								? __(
+					actions: submit
+						? [
+								{
+									label: __(
 										'View submitted evidence',
 										'woocommerce-payments'
-								  )
-								: __(
-										'Return to evidence submission',
-										'woocommerce-payments'
-								  ),
-							url: getAdminUrl( {
-								page: 'wc-admin',
-								path: '/payments/disputes/challenge',
-								id: query.id,
-							} ),
-						},
-					],
+									),
+									url: getAdminUrl( {
+										page: 'wc-admin',
+										path: '/payments/disputes/challenge',
+										id: query.id,
+									} ),
+								},
+						  ]
+						: [],
 				}
 			);
 


### PR DESCRIPTION
Fixes WOOPMNT-5064

#### Changes proposed in this Pull Request

Going through the steps of the dispute flow, each step triggers a "Save evidence for later" action, which can also be triggered manually. The CTA in the toast, appearing for this action, makes little sense, as the merchant remains in the flow to which the action will take them. In this change, the CTA is removed.

Before:

![image](https://github.com/user-attachments/assets/5917a9e7-0e6c-4989-bd14-a851ec4319e6)

After:

<img width="246" alt="image" src="https://github.com/user-attachments/assets/285998dc-956a-4052-9580-0e189fdcec77" />


#### Testing instructions

 - Create a transaction with a card that triggers dispute, e.g. `4000000000001976`
 - Set the `_wcpay_feature_new_evidence_submission_form` option to 1, e.g. with a query:
```sql
INSERT INTO `wp_options`(`option_name`, `option_value`) VALUES ('_wcpay_feature_new_evidence_submission_form', '1' );
```
 - Challenge the dispute and either use "Save for later" button or navigate between evidence collection steps.
 - Ensure that toast doesn't have a CTA.
 - Submit the evidence. Toast should contain a CTA to view submitted evidence.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
