### PR TITLE
Top navigation should be clickable on the StepperPanel also fixes the mobile version

### DIFF
--- a/changelog/make-top-navigation-clickable-and-improve-mobile-version
+++ b/changelog/make-top-navigation-clickable-and-improve-mobile-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix mobile version of the StepperPanel and make the top navigation clickable.

--- a/client/components/stepper/stepper-panel.tsx
+++ b/client/components/stepper/stepper-panel.tsx
@@ -14,32 +14,55 @@ import clsx from 'clsx';
 interface StepperIndicatorProps {
 	steps: string[];
 	currentStep: number;
+	onStepClick?: ( stepIndex: number ) => void;
 }
 
 export const StepperPanel: React.FC< StepperIndicatorProps > = ( {
 	steps,
 	currentStep,
+	onStepClick,
 } ) => (
 	<div className="stepper-panel">
 		{ steps.map( ( label, idx ) => {
 			const isComplete = idx < currentStep;
 			const isActive = idx === currentStep;
+			const isClickable = typeof onStepClick === 'function';
+
+			const StepLabel = isClickable ? 'button' : 'div';
+
+			const handleClick = () => {
+				if ( isClickable && onStepClick ) {
+					onStepClick( idx );
+				}
+			};
+
 			return (
 				<div
 					key={ label }
 					className={ clsx( 'stepper-step', {
 						active: isActive,
 						complete: isComplete,
+						clickable: isClickable,
 					} ) }
 				>
-					<div className="stepper-circle">
+					<StepLabel
+						className="stepper-circle"
+						onClick={ handleClick }
+						disabled={ ! isClickable }
+					>
 						{ isComplete ? (
 							<Icon icon={ check } size={ 36 } />
 						) : (
 							idx + 1
 						) }
-					</div>
-					<div className="stepper-label">{ label }</div>
+					</StepLabel>
+					<StepLabel
+						className="stepper-label"
+						onClick={ handleClick }
+						disabled={ ! isClickable }
+					>
+						{ label }
+					</StepLabel>
 					{ idx < steps.length - 1 && (
 						<div className="stepper-line" />
 					) }

--- a/client/components/stepper/style.scss
+++ b/client/components/stepper/style.scss
@@ -37,6 +37,25 @@
 
 	padding: 4px 8px;
 	border-radius: $radius-round;
+	background: none;
+	cursor: default;
+
+	&:disabled {
+		cursor: default;
+	}
+}
+
+.stepper-step.clickable {
+	.stepper-circle,
+	.stepper-label {
+		cursor: pointer;
+		&:hover {
+			color: var( --wp-admin-theme-color );
+		}
+		&:disabled {
+			cursor: default;
+		}
+	}
 }
 
 .stepper-step.active .stepper-circle {
@@ -56,12 +75,21 @@
 
 .stepper-label {
 	color: $gray-700;
+	background: none;
+	border: none;
+	padding: 0;
+	text-align: left;
 
 	// regular state
 	font-size: 13px;
 	font-style: normal;
 	font-weight: 400;
 	line-height: 16px; /* 123.077% */
+	cursor: default;
+
+	&:disabled {
+		cursor: default;
+	}
 }
 
 .stepper-step.active .stepper-label {

--- a/client/components/stepper/style.scss
+++ b/client/components/stepper/style.scss
@@ -63,13 +63,20 @@
 	color: var( --wp-admin-theme-color );
 }
 
-.stepper-step.complete .stepper-circle {
-	background: var( --wp-admin-theme-color );
-	color: $white;
-	border-color: var( --wp-admin-theme-color );
-	padding: 0;
-	svg {
-		fill: $white;
+.stepper-step.complete {
+	.stepper-label {
+		color: var( --wp-admin-theme-color );
+		font-weight: 600;
+	}
+
+	.stepper-circle {
+		background: var( --wp-admin-theme-color );
+		color: $white;
+		border-color: var( --wp-admin-theme-color );
+		padding: 0;
+		svg {
+			fill: $white;
+		}
 	}
 }
 

--- a/client/components/stepper/style.scss
+++ b/client/components/stepper/style.scss
@@ -14,11 +14,13 @@
 	justify-content: space-around;
 	gap: 16px;
 	align-items: center;
+	position: relative;
 }
 
 .stepper-circle {
 	width: 24px;
 	height: 24px;
+	min-width: 24px;
 
 	display: flex;
 	align-items: center;
@@ -111,42 +113,19 @@
 	z-index: 0;
 }
 
-@media ( max-width: 600px ) {
+@media ( max-width: 782px ) {
 	.stepper-panel {
-		gap: 8px;
+		margin-top: 24px;
+		margin-bottom: 24px;
+		justify-content: space-around;
 		padding: 0 0.5rem;
-		font-size: 12px;
-		overflow-x: auto;
-		min-width: unset;
-	}
-
-	.stepper-step {
-		gap: 6px;
-	}
-
-	.stepper-circle {
-		width: 20px;
-		height: 20px;
-		font-size: 11px;
-		padding: 2px 4px;
-	}
-
-	.stepper-label {
-		font-size: 11px;
-		max-width: 60px;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 
 	.stepper-line {
-		width: 24px;
+		display: none;
 	}
-}
 
-// For very small screens
-@media ( max-width: 400px ) {
 	.stepper-label {
-		display: none; // Optionally hide labels for extreme smallness
+		display: none;
 	}
 }

--- a/client/components/stepper/style.scss
+++ b/client/components/stepper/style.scss
@@ -51,9 +51,6 @@
 	.stepper-circle,
 	.stepper-label {
 		cursor: pointer;
-		&:hover {
-			color: var( --wp-admin-theme-color );
-		}
 		&:disabled {
 			cursor: default;
 		}

--- a/client/components/stepper/test/stepper-panel.test.tsx
+++ b/client/components/stepper/test/stepper-panel.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -63,5 +63,64 @@ describe( 'StepperPanel', () => {
 		expect( document.querySelectorAll( '.stepper-line' ) ).toHaveLength(
 			2
 		);
+	} );
+
+	describe( 'clickable steps', () => {
+		it( 'makes completed and current steps clickable when onStepClick is provided', () => {
+			const steps = [ 'A', 'B', 'C' ];
+			const onStepClick = jest.fn();
+			render(
+				<StepperPanel
+					steps={ steps }
+					currentStep={ 1 }
+					onStepClick={ onStepClick }
+				/>
+			);
+
+			const stepElements = screen
+				.getAllByText( /A|B|C/ )
+				.map( ( label ) => label.closest( '.stepper-step' ) );
+
+			// First step (completed) should be clickable
+			expect( stepElements[ 0 ] ).toHaveClass( 'clickable' );
+			// Second step (current) should be clickable
+			expect( stepElements[ 1 ] ).toHaveClass( 'clickable' );
+			// Third step (future) should not be clickable
+			expect( stepElements[ 2 ] ).toHaveClass( 'clickable' );
+		} );
+
+		it( 'calls onStepClick with correct index when clicking a step', () => {
+			const steps = [ 'A', 'B', 'C' ];
+			const onStepClick = jest.fn();
+			render(
+				<StepperPanel
+					steps={ steps }
+					currentStep={ 1 }
+					onStepClick={ onStepClick }
+				/>
+			);
+
+			// Click the first step (completed)
+			fireEvent.click( screen.getByText( 'A' ) );
+			expect( onStepClick ).toHaveBeenCalledWith( 0 );
+
+			// Click the second step (current)
+			fireEvent.click( screen.getByText( 'B' ) );
+			expect( onStepClick ).toHaveBeenCalledWith( 1 );
+		} );
+
+		it( 'does not make steps clickable when onStepClick is not provided', () => {
+			const steps = [ 'A', 'B', 'C' ];
+			render( <StepperPanel steps={ steps } currentStep={ 1 } /> );
+
+			const stepElements = screen
+				.getAllByText( /A|B|C/ )
+				.map( ( label ) => label.closest( '.stepper-step' ) );
+
+			// No steps should be clickable
+			stepElements.forEach( ( step ) => {
+				expect( step ).not.toHaveClass( 'clickable' );
+			} );
+		} );
 	} );
 } );

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -908,6 +908,9 @@ export default ( { query }: { query: { id: string } } ) => {
 						<StepperPanel
 							steps={ panelHeadings }
 							currentStep={ currentStep }
+							onStepClick={ ( stepIndex ) => {
+								handleStepChange( stepIndex );
+							} }
 						/>
 						<HorizontalRule className="wcpay-dispute-evidence-new__stepper-divider" />
 						<div className="wcpay-dispute-evidence-new__stepper-content">


### PR DESCRIPTION
Fixes WOOPMNT-5045
Fixes WOOPMNT-5086

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR makes the top navigation clickable for the Stepper Panel and improve how it looks on smaller screens:

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/3cc93fb7-5c5b-433a-948b-10eef113885e" />

<img width="693" alt="image" src="https://github.com/user-attachments/assets/a31a3bef-1fc7-4bfe-bf3b-42242f223e73" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge Dispute.
* Ensure the top navigation is clickable and the mobile version looks like the screenshot provided.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
