### PR TITLE
Ensure deactivation modal resizes properly after content update

### DIFF
--- a/changelog/fix-WOOPMNT-4837-deactivation-modal-not-resizing
+++ b/changelog/fix-WOOPMNT-4837-deactivation-modal-not-resizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjusted deactivation modal behavior to correctly resize when its content updates.

--- a/client/plugins-page/deactivation-survey/index.tsx
+++ b/client/plugins-page/deactivation-survey/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 
@@ -21,7 +21,30 @@ interface PluginDisableSurveyProps {
 const PluginDisableSurvey = ( {
 	onRequestClose,
 }: PluginDisableSurveyProps ) => {
-	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ iframeHeight, setIframeHeight ] = useState( 600 ); // Default height.
+
+	// Listen for messages from the iframe to set height on load/reload.
+	useEffect( () => {
+		const handleMessage = ( event: MessageEvent ) => {
+			// Verify the origin for security.
+			if ( event.origin !== 'https://automattic.survey.fm' ) {
+				return;
+			}
+
+			// Set height whenever iframe sends embed-size message (load/reload).
+			if ( event.data.type === 'embed-size' && event.data.height ) {
+				const newHeight = Math.max( event.data.height, 600 ); // Minimum height is 600px.
+				setIframeHeight( newHeight );
+			}
+		};
+
+		window.addEventListener( 'message', handleMessage );
+
+		return () => {
+			window.removeEventListener( 'message', handleMessage );
+		};
+	}, [] );
 
 	return (
 		<Modal
@@ -47,8 +70,8 @@ const PluginDisableSurvey = ( {
 					) }
 					src="https://automattic.survey.fm/woopayments-exit-feedback"
 					className="woopayments-disable-survey-iframe"
-					onLoad={ () => {
-						setIsLoading( false );
+					style={ {
+						height: `${ iframeHeight }px`,
 					} }
 				/>
 			</Loadable>

--- a/client/plugins-page/deactivation-survey/index.tsx
+++ b/client/plugins-page/deactivation-survey/index.tsx
@@ -9,7 +9,7 @@ import { Modal } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import Loadable from 'wcpay/components/loadable';
+import StripeSpinner from 'wcpay/components/stripe-spinner';
 import WooPaymentsIcon from 'assets/images/woopayments.svg?asset';
 
 interface PluginDisableSurveyProps {
@@ -21,7 +21,7 @@ interface PluginDisableSurveyProps {
 const PluginDisableSurvey = ( {
 	onRequestClose,
 }: PluginDisableSurveyProps ) => {
-	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
 	const [ iframeHeight, setIframeHeight ] = useState( 600 ); // Default height.
 
 	// Listen for messages from the iframe to set height on load/reload.
@@ -62,19 +62,26 @@ const PluginDisableSurvey = ( {
 			onRequestClose={ onRequestClose }
 			className="woopayments-disable-survey"
 		>
-			<Loadable isLoading={ isLoading }>
-				<iframe
-					title={ __(
-						'WooPayments Disable Survey',
-						'woocommerce-payments'
-					) }
-					src="https://automattic.survey.fm/woopayments-exit-feedback"
-					className="woopayments-disable-survey-iframe"
-					style={ {
-						height: `${ iframeHeight }px`,
-					} }
-				/>
-			</Loadable>
+			{ isLoading && (
+				<div className="woopayments-disable-survey-loader">
+					<StripeSpinner />
+				</div>
+			) }
+			<iframe
+				title={ __(
+					'WooPayments Disable Survey',
+					'woocommerce-payments'
+				) }
+				src="https://automattic.survey.fm/woopayments-exit-feedback"
+				className="woopayments-disable-survey-iframe"
+				style={ {
+					height: `${ iframeHeight }px`,
+					opacity: isLoading ? 0 : 1,
+				} }
+				onLoad={ () => {
+					setIsLoading( false );
+				} }
+			/>
 		</Modal>
 	);
 };

--- a/client/plugins-page/deactivation-survey/style.scss
+++ b/client/plugins-page/deactivation-survey/style.scss
@@ -8,9 +8,19 @@
 		overflow-x: hidden;
 	}
 
+	&-loader {
+		position: fixed;
+		width: 100%;
+		height: 80%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
 	&-iframe {
 		width: 100%;
 		height: 100%;
+		transition: 'opacity 0.3s ease-in-out';
 
 		@media ( min-width: 600px ) {
 			width: 600px;

--- a/client/plugins-page/deactivation-survey/style.scss
+++ b/client/plugins-page/deactivation-survey/style.scss
@@ -5,6 +5,7 @@
 
 	.components-modal__content {
 		padding: 0;
+		overflow-x: hidden;
 	}
 
 	&-iframe {


### PR DESCRIPTION
Fixes WOOPMNT-4837

#### Changes proposed in this Pull Request
This PR fixes an issue where the WooPayments deactivation modal does not correctly resize when its iframe content updates. This typically occurs when a user attempts to submit the form without selecting a deactivation reason, causing the modal to refresh but not adjust its height, which can hide the submit button and disrupt the user experience.

#### Testing instructions
- Switch to the PR branch locally.
- Go to the Plugins page and click “Deactivate” for the WooPayments plugin.
- When the deactivation survey modal appears, attempt to submit without choosing a reason.
- Confirm that the iframe resizes correctly and the “Finish survey” button remains visible.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
