### PR TITLE
Set a notice `id` to prevent it being duplicated when moving between steps

### DIFF
--- a/changelog/new-evidence-show-saved-toast-only-once
+++ b/changelog/new-evidence-show-saved-toast-only-once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Prevent "Evidence saved" toast from appearing multiple times.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -315,6 +315,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					? __( 'Evidence submitted!', 'woocommerce-payments' )
 					: __( 'Evidence saved!', 'woocommerce-payments' ),
 				{
+					id: 'evidence-saved-' + query.id,
 					actions: submit
 						? [
 								{

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -315,7 +315,9 @@ export default ( { query }: { query: { id: string } } ) => {
 					? __( 'Evidence submitted!', 'woocommerce-payments' )
 					: __( 'Evidence saved!', 'woocommerce-payments' ),
 				{
-					id: 'evidence-saved-' + query.id,
+					id: submit
+						? 'evidence-submitted'
+						: 'evidence-saved-' + dispute.id,
 					actions: submit
 						? [
 								{

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -317,7 +317,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				{
 					id: submit
 						? 'evidence-submitted'
-						: `evidence-saved-${dispute.id}`,
+						: `evidence-saved-${ dispute.id }`,
 					actions: submit
 						? [
 								{

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -317,7 +317,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				{
 					id: submit
 						? 'evidence-submitted'
-						: 'evidence-saved-' + dispute.id,
+						: `evidence-saved-${dispute.id}`,
 					actions: submit
 						? [
 								{


### PR DESCRIPTION
Fixes [WOOPMNT-5109](https://linear.app/a8c/issue/WOOPMNT-5109/prevent-duplication-of-success-notice-when-moving-between-steps)
Related to WOOPMNT-5064

#### Changes proposed in this Pull Request

 - Set an `id` property on the success notice to prevent it from being duplicated when moving between steps.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a WordPress option `_wcpay_feature_new_evidence_submission_form` with a value `1`. E.g. by using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge Dispute.
* Move between challenge steps but do not submit the dispute yet.
* "Evidence saved!" notice should be present only once and remain visible when moving between steps.
* Upon submit and "Evidence submitted" notice should appear separately.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
