### PR TITLE
Evidence submission form - credit_not_processed

### DIFF
--- a/changelog/evidence-submission-form-credit-not-processed
+++ b/changelog/evidence-submission-form-credit-not-processed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Credit not processed logic for the new evidence submission form.

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -24,6 +24,7 @@ import {
 	TextControl as BundledWordPressComponentsTextControl,
 	TextareaControl as BundledWordPressComponentsTextareaControl,
 	FormFileUpload as BundledWordPressComponentsFormFileUpload,
+	RadioControl as BundledWordPressComponentsRadioControl,
 } from '@wordpress/components';
 import BundledWordPressComponentsCardNotice from 'wcpay/components/card-notice';
 
@@ -409,6 +410,23 @@ const WrappedFormFileUpload = (
 	return <FormFileUpload { ...rest } />;
 };
 
+const WrappedRadioControl = (
+	props: ComponentProps< typeof BundledWordPressComponentsRadioControl > & {
+		useBundledComponent?: boolean;
+	}
+) => {
+	const { useBundledComponent, ...rest } = props;
+	const context = useContext( WordPressComponentsContext );
+
+	if ( ! context || useBundledComponent ) {
+		return <BundledWordPressComponentsRadioControl { ...rest } />;
+	}
+
+	const { RadioControl } = context;
+
+	return <RadioControl { ...rest } />;
+};
+
 export {
 	WrappedCard as Card,
 	WrappedCardBody as CardBody,
@@ -432,4 +450,5 @@ export {
 	WrappedTextControl as TextControl,
 	WrappedTextareaControl as TextareaControl,
 	WrappedFormFileUpload as FormFileUpload,
+	WrappedRadioControl as RadioControl,
 };

--- a/client/disputes/new-evidence/cover-letter-generator.ts
+++ b/client/disputes/new-evidence/cover-letter-generator.ts
@@ -154,6 +154,72 @@ export const generateBody = (
 	dispute: ExtendedDispute,
 	attachmentsList: string
 ): string => {
+	if ( dispute.reason === 'credit_not_processed' ) {
+		if ( data.refundStatus === 'refund_has_been_issued' ) {
+			return `${ __(
+				'We are submitting evidence in response to chargeback',
+				'woocommerce-payments'
+			) } #${ data.caseNumber } ${ __(
+				'for transaction',
+				'woocommerce-payments'
+			) } #${ data.transactionId } ${ __(
+				'on',
+				'woocommerce-payments'
+			) } ${ data.transactionDate }.
+
+${ __( 'Our records indicate that the customer,', 'woocommerce-payments' ) } ${
+				data.customerName
+			}, ${ __( 'was refunded on', 'woocommerce-payments' ) } ${
+				data.orderDate
+			} ${ __( 'for the amount of', 'woocommerce-payments' ) } ${
+				dispute.amount
+					? `${ ( dispute.amount / 100 ).toFixed(
+							2
+					  ) } ${ dispute.currency?.toUpperCase() }`
+					: __( '[Refund Amount]', 'woocommerce-payments' )
+			}. ${ __(
+				"The refund was processed through our payment provider and should be visible on the customer's statement within 7 - 10 business days.",
+				'woocommerce-payments'
+			) }
+
+${ __(
+	'To support our case, we are providing the following documentation:',
+	'woocommerce-payments'
+) }
+${ attachmentsList }
+
+${ __(
+	'Based on this information, we respectfully request that the chargeback be reversed. Please let us know if any further details are required.',
+	'woocommerce-payments'
+) }`;
+		}
+		// refund_was_not_owed
+		return `${ __(
+			'We are submitting evidence in response to chargeback',
+			'woocommerce-payments'
+		) } #${ data.caseNumber } ${ __(
+			'for transaction',
+			'woocommerce-payments'
+		) } #${ data.transactionId } ${ __( 'on', 'woocommerce-payments' ) } ${
+			data.transactionDate
+		}.
+${ __(
+	'The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.',
+	'woocommerce-payments'
+) }
+
+${ __(
+	'To support our case, we are providing the following documentation:',
+	'woocommerce-payments'
+) }
+${ attachmentsList }
+
+${ __(
+	'Based on this information, we respectfully request that the chargeback be reversed. Please let us know if any further details are required.',
+	'woocommerce-payments'
+) }`;
+	}
+
 	if ( dispute.reason === 'product_not_received' ) {
 		return `${ __(
 			'We are submitting evidence in response to chargeback',
@@ -260,7 +326,8 @@ export const generateCoverLetter = (
 	dispute: ExtendedDispute,
 	accountDetails: AccountDetails,
 	settings: any,
-	bankName: string | null
+	bankName: string | null,
+	refundStatus?: string
 ): string => {
 	const todayUnixTimestamp = Math.floor( Date.now() / 1000 );
 	const todayFormatted = formatDateTimeFromTimestamp( todayUnixTimestamp, {
@@ -313,6 +380,7 @@ export const generateCoverLetter = (
 				? dispute.evidence.shipping_date
 				: undefined
 		),
+		refundStatus: refundStatus,
 	};
 
 	const attachmentsList = generateAttachments( dispute );

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -594,7 +594,7 @@ export default ( { query }: { query: { id: string } } ) => {
 	// --- Accordion summary content ---
 	const summaryItems = useMemo( () => {
 		if ( ! dispute ) return [];
-		const disputeReasonSummary = reasons[ dispute.reason ]?.summary || [];
+		const disputeReasonSummary = reasons[ disputeReason ]?.summary || [];
 		return [
 			{
 				title: __( 'Dispute Amount', 'woocommerce-payments' ),
@@ -616,7 +616,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				title: __( 'Reason', 'woocommerce-payments' ),
 				content: (
 					<>
-						{ reasons[ dispute.reason ]?.display || dispute.reason }
+						{ reasons[ disputeReason ]?.display || disputeReason }
 						{ disputeReasonSummary.length > 0 && (
 							<ClickTooltip
 								buttonLabel={ __(
@@ -626,8 +626,8 @@ export default ( { query }: { query: { id: string } } ) => {
 								content={
 									<div className="dispute-reason-tooltip">
 										<p>
-											{ reasons[ dispute.reason ]
-												?.display || dispute.reason }
+											{ reasons[ disputeReason ]
+												?.display || disputeReason }
 										</p>
 										<Paragraphs>
 											{ disputeReasonSummary }
@@ -664,7 +664,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				content: <OrderLink order={ dispute.order } />,
 			},
 		];
-	}, [ dispute ] );
+	}, [ dispute, disputeReason ] );
 
 	// --- Recommended documents ---
 	const recommendedDocumentFields = getRecommendedDocumentFields(

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -55,6 +55,7 @@ import {
 import { RecommendedDocument } from './types';
 
 import './style.scss';
+import RefundStatus from './refund-status';
 
 // --- Utility: Determine if shipping is required for a given reason ---
 const ReasonsNeedShipping = [
@@ -136,6 +137,9 @@ export default ( { query }: { query: { id: string } } ) => {
 	} = useDispatch( 'core/notices' );
 	const settings = useGetSettings();
 	const bankName = dispute?.charge ? getBankName( dispute.charge ) : null;
+	const [ refundStatus, setRefundStatus ] = useState(
+		'refund_has_been_issued'
+	);
 
 	// --- Data loading ---
 	useEffect( () => {
@@ -188,7 +192,8 @@ export default ( { query }: { query: { id: string } } ) => {
 						d,
 						getBusinessDetails(),
 						settings,
-						bankName
+						bankName,
+						refundStatus
 					);
 					setIsCoverLetterManuallyEdited(
 						savedCoverLetter !== generatedContent
@@ -199,7 +204,8 @@ export default ( { query }: { query: { id: string } } ) => {
 						d,
 						getBusinessDetails(),
 						settings,
-						bankName
+						bankName,
+						refundStatus
 					);
 					setCoverLetter( generatedCoverLetter );
 					setIsCoverLetterManuallyEdited( false );
@@ -209,7 +215,7 @@ export default ( { query }: { query: { id: string } } ) => {
 			}
 		};
 		fetchDispute();
-	}, [ path, createErrorNotice, settings, bankName ] );
+	}, [ path, createErrorNotice, settings, bankName, refundStatus ] );
 
 	// --- File name display logic ---
 	useEffect( () => {
@@ -259,7 +265,8 @@ export default ( { query }: { query: { id: string } } ) => {
 			dispute,
 			getBusinessDetails(),
 			settings,
-			bankName
+			bankName,
+			refundStatus
 		);
 		setCoverLetter( generatedCoverLetter );
 	}, [
@@ -273,6 +280,7 @@ export default ( { query }: { query: { id: string } } ) => {
 		shippingDate,
 		shippingTrackingNumber,
 		shippingAddress,
+		refundStatus,
 	] );
 
 	// --- Step logic ---
@@ -755,6 +763,16 @@ export default ( { query }: { query: { id: string } } ) => {
 						onProductDescriptionChange={ updateProductDescription }
 						readOnly={ readOnly }
 					/>
+					{ /* only show if the dispute reason is credit_not_processed */ }
+					{ disputeReason === 'credit_not_processed' && (
+						<RefundStatus
+							refundStatus={ refundStatus }
+							onRefundStatusChange={
+								setRefundStatus as ( value: string ) => void
+							}
+							readOnly={ readOnly }
+						/>
+					) }
 					<RecommendedDocuments
 						fields={ recommendedDocumentsFields }
 						readOnly={ readOnly }
@@ -830,7 +848,8 @@ export default ( { query }: { query: { id: string } } ) => {
 									dispute,
 									getBusinessDetails(),
 									settings,
-									bankName
+									bankName,
+									refundStatus
 								);
 								setCoverLetter( generatedContent );
 								setIsCoverLetterManuallyEdited( false );
@@ -842,7 +861,8 @@ export default ( { query }: { query: { id: string } } ) => {
 								dispute,
 								getBusinessDetails(),
 								settings,
-								bankName
+								bankName,
+								refundStatus
 							);
 							setCoverLetter( newValue );
 							setIsCoverLetterManuallyEdited(

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -90,6 +90,15 @@ const getRecommendedDocumentFields = (
 				),
 				order: 40,
 			},
+			{
+				key: DOCUMENT_FIELD_KEYS.SERVICE_DOCUMENTATION,
+				label: __( 'Item condition', 'woocommerce-payments' ),
+				description: __(
+					'A screenshot of the item condition.',
+					'woocommerce-payments'
+				),
+				order: 50,
+			},
 		],
 		duplicate: [
 			{

--- a/client/disputes/new-evidence/refund-status.tsx
+++ b/client/disputes/new-evidence/refund-status.tsx
@@ -20,6 +20,12 @@ const RefundStatus: React.FC< RefundStatusProps > = ( {
 	onRefundStatusChange,
 	readOnly = false,
 } ) => {
+	const handleRefundStatusChange = ( value: string ) => {
+		if ( ! readOnly ) {
+			onRefundStatusChange( value );
+		}
+	};
+
 	return (
 		<section className="wcpay-dispute-evidence-refund-status">
 			<h3 className="wcpay-dispute-evidence-refund-status__heading">
@@ -44,7 +50,7 @@ const RefundStatus: React.FC< RefundStatusProps > = ( {
 							value: 'refund_was_not_owed',
 						},
 					] }
-					onChange={ onRefundStatusChange }
+					onChange={ handleRefundStatusChange }
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					// @ts-ignore - disabled is not a valid prop for RadioControl, but it is in the HTML Input element
 					disabled={ readOnly }

--- a/client/disputes/new-evidence/refund-status.tsx
+++ b/client/disputes/new-evidence/refund-status.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { RadioControl } from 'wcpay/components/wp-components-wrapped';
+
+interface RefundStatusProps {
+	refundStatus: string;
+	onRefundStatusChange: ( value: string ) => void;
+	readOnly?: boolean;
+}
+
+const RefundStatus: React.FC< RefundStatusProps > = ( {
+	refundStatus,
+	onRefundStatusChange,
+	readOnly = false,
+} ) => {
+	return (
+		<section className="wcpay-dispute-evidence-refund-status">
+			<h3 className="wcpay-dispute-evidence-refund-status__heading">
+				{ __( 'Refund status', 'woocommerce-payments' ) }
+			</h3>
+			<div className="wcpay-dispute-evidence-refund-status__field-group">
+				<RadioControl
+					selected={ refundStatus }
+					options={ [
+						{
+							label: __(
+								'Refund has been issued',
+								'woocommerce-payments'
+							),
+							value: 'refund_has_been_issued',
+						},
+						{
+							label: __(
+								'Refund was not owed',
+								'woocommerce-payments'
+							),
+							value: 'refund_was_not_owed',
+						},
+					] }
+					onChange={ onRefundStatusChange }
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore - disabled is not a valid prop for RadioControl, but it is in the HTML Input element
+					disabled={ readOnly }
+				/>
+			</div>
+		</section>
+	);
+};
+
+export default RefundStatus;

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -251,6 +251,17 @@
 	}
 }
 
+// Recommended documents section
+.wcpay-dispute-evidence-refund-status {
+	margin-bottom: 40px;
+
+	&__heading {
+		@include heading-md;
+		color: var( --Scales-Grays-gray-900, $gray-900 );
+		margin-bottom: 8px;
+	}
+}
+
 .wcpay-dispute-evidence-file-upload-control {
 	display: flex;
 	align-items: center;

--- a/client/disputes/new-evidence/test/cover-letter-generator.test.ts
+++ b/client/disputes/new-evidence/test/cover-letter-generator.test.ts
@@ -307,6 +307,75 @@ describe( 'Cover Letter Generator', () => {
 			);
 		} );
 
+		it( 'should generate body for credit not processed dispute with refund issued', () => {
+			const attachmentsList = '• Test Attachment';
+			const creditNotProcessedDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'credit_not_processed' as DisputeReason,
+			};
+			const coverLetterDataWithRefundStatus = {
+				...mockCoverLetterData,
+				refundStatus: 'refund_has_been_issued',
+			};
+			const result = generateBody(
+				coverLetterDataWithRefundStatus,
+				creditNotProcessedDispute,
+				attachmentsList
+			);
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain( 'John Doe' );
+			expect( result ).toContain( 'was refunded on' );
+			expect( result ).toContain( '10.00 USD' );
+			expect( result ).toContain(
+				"The refund was processed through our payment provider and should be visible on the customer's statement within 7 - 10 business days."
+			);
+		} );
+
+		it( 'should generate body for credit not processed dispute with refund not owed', () => {
+			const attachmentsList = '• Test Attachment';
+			const creditNotProcessedDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'credit_not_processed' as DisputeReason,
+			};
+			const coverLetterDataWithRefundStatus = {
+				...mockCoverLetterData,
+				refundStatus: 'refund_was_not_owed',
+			};
+			const result = generateBody(
+				coverLetterDataWithRefundStatus,
+				creditNotProcessedDispute,
+				attachmentsList
+			);
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain(
+				'The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.'
+			);
+		} );
+
+		it( 'should generate body for credit not processed dispute with missing refund status', () => {
+			const attachmentsList = '• Test Attachment';
+			const creditNotProcessedDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'credit_not_processed' as DisputeReason,
+			};
+			const coverLetterDataWithoutRefundStatus = {
+				...mockCoverLetterData,
+				refundStatus: undefined,
+			};
+			const result = generateBody(
+				coverLetterDataWithoutRefundStatus,
+				creditNotProcessedDispute,
+				attachmentsList
+			);
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain(
+				'The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.'
+			);
+		} );
+
 		it( 'should generate body for non-product-not-received dispute', () => {
 			const disputeWithDifferentReason = {
 				...mockDispute,
@@ -424,6 +493,68 @@ describe( 'Cover Letter Generator', () => {
 				'Test Bank'
 			);
 			expect( result ).toContain( '<Transaction Date>' );
+		} );
+
+		it( 'should generate cover letter for credit not processed dispute with refund issued', () => {
+			const creditNotProcessedDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'credit_not_processed' as DisputeReason,
+			};
+			const result = generateCoverLetter(
+				creditNotProcessedDispute,
+				mockAccountDetails,
+				mockSettings,
+				'Test Bank',
+				'refund_has_been_issued'
+			);
+			expect( result ).toContain( 'Test Store' );
+			expect( result ).toContain( 'Test Bank' );
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain( 'John Doe' );
+			expect( result ).toContain( 'was refunded on' );
+			expect( result ).toContain( '10.00 USD' );
+		} );
+
+		it( 'should generate cover letter for credit not processed dispute with refund not owed', () => {
+			const creditNotProcessedDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'credit_not_processed' as DisputeReason,
+			};
+			const result = generateCoverLetter(
+				creditNotProcessedDispute,
+				mockAccountDetails,
+				mockSettings,
+				'Test Bank',
+				'refund_was_not_owed'
+			);
+			expect( result ).toContain( 'Test Store' );
+			expect( result ).toContain( 'Test Bank' );
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain(
+				'The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.'
+			);
+		} );
+
+		it( 'should handle credit not processed dispute with missing refund status', () => {
+			const creditNotProcessedDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'credit_not_processed' as DisputeReason,
+			};
+			const result = generateCoverLetter(
+				creditNotProcessedDispute,
+				mockAccountDetails,
+				mockSettings,
+				'Test Bank'
+			);
+			expect( result ).toContain( 'Test Store' );
+			expect( result ).toContain( 'Test Bank' );
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain(
+				'The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.'
+			);
 		} );
 	} );
 } );

--- a/client/disputes/new-evidence/test/refund-status.test.tsx
+++ b/client/disputes/new-evidence/test/refund-status.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import RefundStatus from '../refund-status';
+
+describe( 'RefundStatus', () => {
+	const baseProps = {
+		refundStatus: 'refund_has_been_issued',
+		onRefundStatusChange: jest.fn(),
+		readOnly: false,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders refund status heading', () => {
+		render( <RefundStatus { ...baseProps } /> );
+		expect( screen.getByText( 'Refund status' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders both radio options', () => {
+		render( <RefundStatus { ...baseProps } /> );
+		expect(
+			screen.getByLabelText( 'Refund has been issued' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText( 'Refund was not owed' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'selects the correct radio option based on refundStatus prop', () => {
+		render( <RefundStatus { ...baseProps } /> );
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+
+		expect( refundIssuedRadio ).toBeChecked();
+		expect( refundNotOwedRadio ).not.toBeChecked();
+	} );
+
+	it( 'selects refund was not owed when that status is provided', () => {
+		render(
+			<RefundStatus { ...baseProps } refundStatus="refund_was_not_owed" />
+		);
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+
+		expect( refundIssuedRadio ).not.toBeChecked();
+		expect( refundNotOwedRadio ).toBeChecked();
+	} );
+
+	it( 'calls onRefundStatusChange when radio options are clicked', () => {
+		render( <RefundStatus { ...baseProps } /> );
+
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+		fireEvent.click( refundNotOwedRadio );
+
+		expect( baseProps.onRefundStatusChange ).toHaveBeenCalledWith(
+			'refund_was_not_owed'
+		);
+	} );
+
+	it( 'calls onRefundStatusChange when refund has been issued is clicked', () => {
+		render(
+			<RefundStatus { ...baseProps } refundStatus="refund_was_not_owed" />
+		);
+
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		fireEvent.click( refundIssuedRadio );
+
+		expect( baseProps.onRefundStatusChange ).toHaveBeenCalledWith(
+			'refund_has_been_issued'
+		);
+	} );
+
+	it( 'disables radio options when readOnly is true', () => {
+		render( <RefundStatus { ...baseProps } readOnly={ true } /> );
+
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+
+		expect( refundIssuedRadio ).toBeDisabled();
+		expect( refundNotOwedRadio ).toBeDisabled();
+	} );
+
+	it( 'enables radio options when readOnly is false', () => {
+		render( <RefundStatus { ...baseProps } readOnly={ false } /> );
+
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+
+		expect( refundIssuedRadio ).not.toBeDisabled();
+		expect( refundNotOwedRadio ).not.toBeDisabled();
+	} );
+
+	it( 'enables radio options when readOnly is not provided', () => {
+		render( <RefundStatus { ...baseProps } /> );
+
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+
+		expect( refundIssuedRadio ).not.toBeDisabled();
+		expect( refundNotOwedRadio ).not.toBeDisabled();
+	} );
+
+	it( 'does not call onRefundStatusChange when readOnly is true', () => {
+		render( <RefundStatus { ...baseProps } readOnly={ true } /> );
+
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+		fireEvent.click( refundNotOwedRadio );
+
+		expect( baseProps.onRefundStatusChange ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders with correct CSS classes', () => {
+		render( <RefundStatus { ...baseProps } /> );
+
+		const section = screen
+			.getByText( 'Refund status' )
+			.closest( 'section' );
+		expect( section ).toHaveClass( 'wcpay-dispute-evidence-refund-status' );
+
+		const heading = screen.getByText( 'Refund status' );
+		expect( heading ).toHaveClass(
+			'wcpay-dispute-evidence-refund-status__heading'
+		);
+
+		const fieldGroup = heading.nextElementSibling;
+		expect( fieldGroup ).toHaveClass(
+			'wcpay-dispute-evidence-refund-status__field-group'
+		);
+	} );
+
+	it( 'handles multiple rapid clicks correctly', () => {
+		render( <RefundStatus { ...baseProps } /> );
+
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+
+		// Click multiple times rapidly
+		fireEvent.click( refundNotOwedRadio );
+		fireEvent.click( refundIssuedRadio );
+		fireEvent.click( refundNotOwedRadio );
+
+		expect( baseProps.onRefundStatusChange ).toHaveBeenCalledTimes( 3 );
+		expect( baseProps.onRefundStatusChange ).toHaveBeenNthCalledWith(
+			1,
+			'refund_was_not_owed'
+		);
+		expect( baseProps.onRefundStatusChange ).toHaveBeenNthCalledWith(
+			2,
+			'refund_has_been_issued'
+		);
+		expect( baseProps.onRefundStatusChange ).toHaveBeenNthCalledWith(
+			3,
+			'refund_was_not_owed'
+		);
+	} );
+
+	it( 'maintains accessibility attributes', () => {
+		render( <RefundStatus { ...baseProps } /> );
+
+		const refundIssuedRadio = screen.getByLabelText(
+			'Refund has been issued'
+		);
+		const refundNotOwedRadio = screen.getByLabelText(
+			'Refund was not owed'
+		);
+
+		// Check that radio buttons have proper accessibility attributes
+		expect( refundIssuedRadio ).toHaveAttribute( 'type', 'radio' );
+		expect( refundNotOwedRadio ).toHaveAttribute( 'type', 'radio' );
+
+		// Check that they are part of the same radio group
+		expect( refundIssuedRadio ).toHaveAttribute( 'name' );
+		expect( refundNotOwedRadio ).toHaveAttribute( 'name' );
+		expect( refundIssuedRadio.getAttribute( 'name' ) ).toBe(
+			refundNotOwedRadio.getAttribute( 'name' )
+		);
+	} );
+} );

--- a/client/disputes/new-evidence/test/refund-status.test.tsx
+++ b/client/disputes/new-evidence/test/refund-status.test.tsx
@@ -164,7 +164,24 @@ describe( 'RefundStatus', () => {
 	} );
 
 	it( 'handles multiple rapid clicks correctly', () => {
-		render( <RefundStatus { ...baseProps } /> );
+		// Wrapper to manage refundStatus state
+		const Wrapper: React.FC = () => {
+			const [ refundStatus, setRefundStatus ] = React.useState(
+				'refund_has_been_issued'
+			);
+			return (
+				<RefundStatus
+					refundStatus={ refundStatus }
+					onRefundStatusChange={ ( value ) => {
+						baseProps.onRefundStatusChange( value );
+						setRefundStatus( value );
+					} }
+					readOnly={ false }
+				/>
+			);
+		};
+
+		render( <Wrapper /> );
 
 		const refundNotOwedRadio = screen.getByLabelText(
 			'Refund was not owed'
@@ -173,10 +190,10 @@ describe( 'RefundStatus', () => {
 			'Refund has been issued'
 		);
 
-		// Click multiple times rapidly
-		fireEvent.click( refundNotOwedRadio );
-		fireEvent.click( refundIssuedRadio );
-		fireEvent.click( refundNotOwedRadio );
+		// Click multiple times rapidly - only changes should trigger onChange
+		fireEvent.click( refundNotOwedRadio ); // Should change from 'refund_has_been_issued' to 'refund_was_not_owed'
+		fireEvent.click( refundIssuedRadio ); // Should change from 'refund_was_not_owed' to 'refund_has_been_issued'
+		fireEvent.click( refundNotOwedRadio ); // Should change from 'refund_has_been_issued' to 'refund_was_not_owed'
 
 		expect( baseProps.onRefundStatusChange ).toHaveBeenCalledTimes( 3 );
 		expect( baseProps.onRefundStatusChange ).toHaveBeenNthCalledWith(

--- a/client/disputes/new-evidence/types.ts
+++ b/client/disputes/new-evidence/types.ts
@@ -47,6 +47,7 @@ export interface CoverLetterData {
 	product: string;
 	orderDate: string;
 	deliveryDate: string;
+	refundStatus?: string;
 }
 
 export interface CoverLetterProps {


### PR DESCRIPTION
See WOOPMNT-4995

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Ensure the evidence submission form generates the correct cover letter
- Add support for credit_not_processed on the cover letter generation
- Add the correct recommended documents for credit_not_processed

Template A

```
Scenario A: A refund has already been issued

[Your Business Name] [Your Address] [Your Email] [Your Phone Number] [Date]

To: [Acquiring Bank or Payment Processor Name]  
Subject: Chargeback Dispute – Case # [Chargeback Case Number]

Dear Dispute Resolution Team,

We are submitting evidence in response to chargeback # [Chargeback Case Number] for transaction # [Transaction ID] on [Transaction Date].

Our records indicate that the customer, [Customer Name], was refunded on [Refund Date] for the amount of [Refund Amount]. The refund was processed through our payment provider and should be visible on the customer’s statement within 7 - 10 business days.  
To support our case, we are providing the following documentation:
• <Attachment description> (Attachment A)
• <Attachment description> (Attachment B)

Based on this information, we respectfully request that the chargeback be reversed. Please let us know if any further details are required.

Thank you,  
[Your Name]  
[Your Business Name]
```

Template B

```
Scenario B: A refund was not owed

[Your Business Name] [Your Address] [Your Email] [Your Phone Number] [Date]

To: [Acquiring Bank or Payment Processor Name]  
Subject: Chargeback Dispute – Case # [Chargeback Case Number]

Dear Dispute Resolution Team,

We are submitting evidence in response to chargeback # [Chargeback Case Number] for transaction # [Transaction ID] on [Transaction Date].
The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.

To support our case, we are providing the following documentation:
• <Attachment description> (Attachment A)
• <Attachment description> (Attachment B)

Based on this information, we respectfully request that the chargeback be reversed. Please let us know if any further details are required.

Thank you,  
[Your Name]  
[Your Business Name]
```

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document].(https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute in test mode.
* Since Stripe doesn't have a specific cards for testing this case you SHOULD hardcode the chargeback reason (credit_not_processed) in two different places: [here](https://github.com/Automattic/woocommerce-payments/blob/85ec6420dfb7574962cc081fa7c7e71a1504d35b/client/disputes/new-evidence/index.tsx#L287) and [here](https://github.com/Automattic/woocommerce-payments/blob/85ec6420dfb7574962cc081fa7c7e71a1504d35b/client/disputes/new-evidence/cover-letter-generator.ts#L325)
* Go to Payments > Disputes, select any dispute (since you hardcoded the reason) listed.
* Hit Challenge Dispute
* Fill out the form and on the final step check the cover letter follows the template on the description.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
