### PR TITLE
Fix UI shift when uploading/removing a file

### DIFF
--- a/changelog/fix-ui-shift-when-uploadingremoving-a-file
+++ b/changelog/fix-ui-shift-when-uploadingremoving-a-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix vertical UI shift when uploading a file

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -235,7 +235,8 @@
 
 	&__item {
 		padding-bottom: 16px;
-		margin-bottom: 16px;
+		padding-top: 10px;
+		margin-bottom: 0;
 		border-bottom: 1px solid var( --Scales-Grays-gray-100, $gray-100 );
 
 		&:last-child {
@@ -306,6 +307,8 @@
 		gap: 4px;
 	}
 	&__info-header {
+		height: 32px;
+		max-height: 32px;
 		display: flex;
 		flex-direction: row;
 		align-items: center;


### PR DESCRIPTION
Fixes WOOPMNT-5094

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes a vertical UI shift when uploading a file on the recomended documents section.

The problem:

![2025-06-18 20 32 22](https://github.com/user-attachments/assets/ec5795aa-ab1e-453c-b9ae-2c51dda3d464)

Recomendation from design:

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/f0c77046-6049-46a0-bdef-7ce50bb8404b" />

The solution:

![2025-06-30 20 17 11](https://github.com/user-attachments/assets/8de56f97-2431-4bb4-a94e-d975b713b735)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge Dispute.
* Check the new design of the recommended documents section.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
