### PR TITLE
update: ensure wp components internal usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -102,6 +102,10 @@
 			{
 				"selector": "ImportDeclaration[source.value=/gridicons(?!\\u002F)/]",
 				"message": "Do not import whole Gridicons, import them individually with 'gridicons/dist/icon-name'."
+			},
+			{
+				"selector": "ImportDeclaration[source.value='@wordpress/components']",
+				"message": "Do not import from '@wordpress/components' directly. Use components from 'wcpay/components/wp-components-wrapped' instead."
 			}
 		]
 	},

--- a/changelog/update-ensure-wp-components-internal-usage
+++ b/changelog/update-ensure-wp-components-internal-usage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: update: ensure @wordpress/components are imported from `wcpay/components/wp-components-wrapped` instead of being used directly
+
+

--- a/client/card-readers/index.tsx
+++ b/client/card-readers/index.tsx
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Page from 'components/page';
 import ReadersList from './list';
-import { TabPanel } from '@wordpress/components';
+import { TabPanel } from 'wcpay/components/wp-components-wrapped';
 
 import './style.scss';
 

--- a/client/card-readers/list/index.tsx
+++ b/client/card-readers/list/index.tsx
@@ -4,7 +4,11 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card, CardBody, CardDivider } from '@wordpress/components';
+import {
+	Card,
+	CardBody,
+	CardDivider,
+} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/accordion/body.tsx
+++ b/client/components/accordion/body.tsx
@@ -3,9 +3,6 @@
  */
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState, forwardRef } from 'react';
-/**
- * WordPress dependencies
- */
 import { useMergeRefs } from '@wordpress/compose';
 
 /**

--- a/client/components/accordion/title.tsx
+++ b/client/components/accordion/title.tsx
@@ -3,6 +3,7 @@
  */
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+
 /**
  * WordPress dependencies
  */
@@ -45,6 +46,7 @@ const AccordionTitle = forwardRef<
 			*/ }
 					<span aria-hidden="true">
 						<Icon
+							// @ts-expect-error: className is not a prop defined in the WP Icon component.
 							className="wcpay-accordion__arrow"
 							icon={ isOpened ? chevronUp : chevronDown }
 						/>
@@ -58,6 +60,7 @@ const AccordionTitle = forwardRef<
 					{ icon && (
 						<Icon
 							icon={ icon }
+							// @ts-expect-error: className is not a prop defined in the WP Icon component.
 							className="wcpay-accordion__icon"
 							size={ 20 }
 						/>

--- a/client/components/accordion/title.tsx
+++ b/client/components/accordion/title.tsx
@@ -3,18 +3,16 @@
  */
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-
-/**
- * WordPress dependencies
- */
 import { chevronUp, chevronDown } from '@wordpress/icons';
+// eslint-disable-next-line no-restricted-syntax
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import type { AccordionTitleProps } from './types';
 import type { WordPressComponentProps } from '@wordpress/components/ui/context/wordpress-component';
-import { Button, Icon } from 'wcpay/components/wp-components-wrapped';
+import { Icon } from 'wcpay/components/wp-components-wrapped';
 import AccordionSubtitle from './subtitle';
 import './style.scss';
 
@@ -37,7 +35,7 @@ const AccordionTitle = forwardRef<
 						'is-md': md,
 						'is-lg': lg,
 					} ) }
-					ref={ ref }
+					ref={ ref as React.Ref< HTMLButtonElement > }
 					{ ...props }
 				>
 					{ /*

--- a/client/components/accordion/types.ts
+++ b/client/components/accordion/types.ts
@@ -3,6 +3,7 @@
  */
 // eslint-disable-next-line import/no-unresolved
 import { WordPressComponentProps } from '@wordpress/components/ui/context/wordpress-component';
+// eslint-disable-next-line no-restricted-syntax
 import { Button } from '@wordpress/components';
 
 export type AccordionProps = {

--- a/client/components/accordion/types.ts
+++ b/client/components/accordion/types.ts
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 // eslint-disable-next-line import/no-unresolved
 import { WordPressComponentProps } from '@wordpress/components/ui/context/wordpress-component';

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Card, CardBody, CardHeader, Flex } from '@wordpress/components';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	Flex,
+} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';

--- a/client/components/account-status/account-fees/index.js
+++ b/client/components/account-status/account-fees/index.js
@@ -19,7 +19,7 @@ import {
 	getCurrentBaseFee,
 	getTransactionsPaymentMethodName,
 } from 'utils/account-fees';
-import { CardDivider } from '@wordpress/components';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped';
 import './styles.scss';
 
 const AccountFee = ( props ) => {

--- a/client/components/account-status/account-status-item.js
+++ b/client/components/account-status/account-status-item.js
@@ -3,7 +3,11 @@
 /**
  * External dependencies
  */
-import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
+import {
+	Flex,
+	FlexBlock,
+	FlexItem,
+} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, CardDivider } from '@wordpress/components';
+import { Button, CardDivider } from 'wcpay/components/wp-components-wrapped';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -10,7 +10,7 @@ import {
 	CardHeader,
 	FlexBlock,
 	FlexItem,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/components/active-loan-summary/index.tsx
+++ b/client/components/active-loan-summary/index.tsx
@@ -10,7 +10,7 @@ import {
 	Flex,
 	FlexBlock,
 	FlexItem,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, renderToString } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
 import clsx from 'clsx';
-import { Icon, Button } from '@wordpress/components';
+import { Icon, Button } from 'wcpay/components/wp-components-wrapped';
 import { check, info } from '@wordpress/icons';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import NoticeIcon from 'gridicons/dist/notice';
@@ -136,6 +136,7 @@ const BannerNotice: React.FC< React.PropsWithChildren< Props > > = ( {
 			{ iconToDisplay && (
 				<Icon
 					icon={ iconToDisplay }
+					// @ts-expect-error: className is not a prop defined in the WP Icon component.
 					className="wcpay-banner-notice__icon"
 				/>
 			) }

--- a/client/components/cancel-authorization-button/index.tsx
+++ b/client/components/cancel-authorization-button/index.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/capture-authorization-button/index.tsx
+++ b/client/components/capture-authorization-button/index.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/card-notice/index.tsx
+++ b/client/components/card-notice/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import './styles.scss';
-import { CardFooter } from '@wordpress/components';
+import { CardFooter } from 'wcpay/components/wp-components-wrapped';
 
 interface CardNoticeProps {
 	children: React.ReactNode;

--- a/client/components/card-notice/test/index.tsx
+++ b/client/components/card-notice/test/index.tsx
@@ -9,7 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CardNotice from '../';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 describe( 'CardNotice component', () => {
 	test( 'should render child', () => {

--- a/client/components/confirmation-modal/index.tsx
+++ b/client/components/confirmation-modal/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ComponentProps } from 'react';
-import { Modal } from 'wcpay/components/wp-components-wrapped';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import clsx from 'clsx';
 import { HorizontalRule } from '@wordpress/primitives';
 

--- a/client/components/confirmation-modal/index.tsx
+++ b/client/components/confirmation-modal/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ComponentProps } from 'react';
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wcpay/components/wp-components-wrapped';
 import clsx from 'clsx';
 import { HorizontalRule } from '@wordpress/primitives';
 

--- a/client/components/custom-select-control/index.tsx
+++ b/client/components/custom-select-control/index.tsx
@@ -10,7 +10,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import clsx from 'clsx';

--- a/client/components/custom-select-control/test/index.tsx
+++ b/client/components/custom-select-control/test/index.tsx
@@ -10,7 +10,7 @@ import user from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import CustomSelectControl from '../';
+import CustomSelectControl from '..';
 
 interface Item {
 	key: string;

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -8,7 +8,7 @@ import {
 	CardBody,
 	CardFooter,
 	CardHeader,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import { getHistory } from '@woocommerce/navigation';
 

--- a/client/components/deposits-overview/recent-deposits-list.tsx
+++ b/client/components/deposits-overview/recent-deposits-list.tsx
@@ -8,7 +8,7 @@ import {
 	Flex,
 	FlexItem,
 	Icon,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { calendar } from '@wordpress/icons';
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';

--- a/client/components/download-button/index.tsx
+++ b/client/components/download-button/index.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/error-boundary/index.js
+++ b/client/components/error-boundary/index.js
@@ -1,9 +1,13 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import InlineNotice from 'components/inline-notice';
+
+/**
+ * Internal dependencies
+ */
+import InlineNotice from 'wcpay/components/inline-notice';
 
 class ErrorBoundary extends Component {
 	constructor() {

--- a/client/components/file-upload/index.tsx
+++ b/client/components/file-upload/index.tsx
@@ -8,7 +8,7 @@ import {
 	Button,
 	DropZone,
 	FormFileUpload,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import CheckmarkIcon from 'gridicons/dist/checkmark';
 import ImageIcon from 'gridicons/dist/image';
 import AddOutlineIcon from 'gridicons/dist/add-outline';

--- a/client/components/form/fields.tsx
+++ b/client/components/form/fields.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ComponentProps, forwardRef } from 'react';
-import { TextControl } from '@wordpress/components';
+import { TextControl } from 'wcpay/components/wp-components-wrapped';
 import clsx from 'clsx';
 
 /**

--- a/client/components/inline-label-select/index.tsx
+++ b/client/components/inline-label-select/index.tsx
@@ -10,7 +10,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import clsx from 'clsx';

--- a/client/components/inline-notice/index.tsx
+++ b/client/components/inline-notice/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { ComponentProps } from 'react';
+// eslint-disable-next-line no-restricted-syntax
 import {
 	Flex as BundledWordPressComponentsFlex,
 	FlexItem as BundledWordPressComponentsFlexItem,

--- a/client/components/jetpack-idc-notice/index.tsx
+++ b/client/components/jetpack-idc-notice/index.tsx
@@ -3,8 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-// eslint-disable-next-line no-restricted-syntax
-import { Notice } from '@wordpress/components';
+import { Notice } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/jetpack-idc-notice/index.tsx
+++ b/client/components/jetpack-idc-notice/index.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-syntax
 import { Notice } from '@wordpress/components';
 
 /**

--- a/client/components/payment-method-logos/index.tsx
+++ b/client/components/payment-method-logos/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState, useEffect, useRef } from 'react';
-import { Popover } from '@wordpress/components';
+import { Popover } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/components/phone-number-control/index.tsx
+++ b/client/components/phone-number-control/index.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState, useRef, useLayoutEffect } from 'react';
-import { BaseControl } from '@wordpress/components';
+import { BaseControl } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import 'intl-tel-input';

--- a/client/components/sandbox-mode-switch-to-live-notice/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 

--- a/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
 import { Icon, currencyDollar } from '@wordpress/icons';
 
 /**

--- a/client/components/tooltip/index.tsx
+++ b/client/components/tooltip/index.tsx
@@ -4,7 +4,9 @@
 import React, { useState, useRef } from 'react';
 import clsx from 'clsx';
 import { noop } from 'lodash';
-import { Icon } from '@wordpress/components';
+import { Icon } from 'wcpay/components/wp-components-wrapped';
+// eslint-disable-next-line no-restricted-syntax
+import { Icon as IconType } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +19,7 @@ type TooltipProps = TooltipBaseProps & {
 	/**
 	 * An icon that will be used as the tooltip button. Replaces the component children.
 	 */
-	buttonIcon?: Icon.IconType< unknown >;
+	buttonIcon?: IconType.IconType< unknown >;
 	/**
 	 * A label for the tooltip button, visible to screen readers.
 	 */

--- a/client/components/welcome/index.tsx
+++ b/client/components/welcome/index.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import React from 'react';
-import { CardHeader, Flex, FlexItem } from '@wordpress/components';
+import {
+	CardHeader,
+	Flex,
+	FlexItem,
+} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**

--- a/client/components/wp-components-wrapped/components/base-control.tsx
+++ b/client/components/wp-components-wrapped/components/base-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { BaseControl as BundledBaseControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const BaseControl = makeWrappedComponent(
+	BundledBaseControl,
+	'BaseControl'
+);

--- a/client/components/wp-components-wrapped/components/button.tsx
+++ b/client/components/wp-components-wrapped/components/button.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Button as BundledButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Button = makeWrappedComponent( BundledButton, 'Button' );

--- a/client/components/wp-components-wrapped/components/card-body.tsx
+++ b/client/components/wp-components-wrapped/components/card-body.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { CardBody as BundledCardBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const CardBody = makeWrappedComponent( BundledCardBody, 'CardBody' );

--- a/client/components/wp-components-wrapped/components/card-divider.tsx
+++ b/client/components/wp-components-wrapped/components/card-divider.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { CardDivider as BundledCardDivider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const CardDivider = makeWrappedComponent(
+	BundledCardDivider,
+	'CardDivider'
+);

--- a/client/components/wp-components-wrapped/components/card-footer.tsx
+++ b/client/components/wp-components-wrapped/components/card-footer.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { CardFooter as BundledCardFooter } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const CardFooter = makeWrappedComponent(
+	BundledCardFooter,
+	'CardFooter'
+);

--- a/client/components/wp-components-wrapped/components/card-header.tsx
+++ b/client/components/wp-components-wrapped/components/card-header.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { CardHeader as BundledCardHeader } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const CardHeader = makeWrappedComponent(
+	BundledCardHeader,
+	'CardHeader'
+);

--- a/client/components/wp-components-wrapped/components/card-notice.tsx
+++ b/client/components/wp-components-wrapped/components/card-notice.tsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import BundledCardNotice from 'wcpay/components/card-notice';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const CardNotice = makeWrappedComponent(
+	BundledCardNotice,
+	'CardNotice'
+);

--- a/client/components/wp-components-wrapped/components/card.tsx
+++ b/client/components/wp-components-wrapped/components/card.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Card as BundledCard } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Card = makeWrappedComponent( BundledCard, 'Card' );

--- a/client/components/wp-components-wrapped/components/checkbox-control.tsx
+++ b/client/components/wp-components-wrapped/components/checkbox-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { CheckboxControl as BundledCheckboxControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const CheckboxControl = makeWrappedComponent(
+	BundledCheckboxControl,
+	'CheckboxControl'
+);

--- a/client/components/wp-components-wrapped/components/drop-zone.tsx
+++ b/client/components/wp-components-wrapped/components/drop-zone.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { DropZone as BundledDropZone } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const DropZone = makeWrappedComponent( BundledDropZone, 'DropZone' );

--- a/client/components/wp-components-wrapped/components/dropdown-menu.tsx
+++ b/client/components/wp-components-wrapped/components/dropdown-menu.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { DropdownMenu as BundledDropdownMenu } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const DropdownMenu = makeWrappedComponent(
+	BundledDropdownMenu,
+	'DropdownMenu'
+);

--- a/client/components/wp-components-wrapped/components/external-link.tsx
+++ b/client/components/wp-components-wrapped/components/external-link.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { ExternalLink as BundledExternalLink } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const ExternalLink = makeWrappedComponent(
+	BundledExternalLink,
+	'ExternalLink'
+);

--- a/client/components/wp-components-wrapped/components/flex-block.tsx
+++ b/client/components/wp-components-wrapped/components/flex-block.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { FlexBlock as BundledFlexBlock } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const FlexBlock = makeWrappedComponent( BundledFlexBlock, 'FlexBlock' );

--- a/client/components/wp-components-wrapped/components/flex-item.tsx
+++ b/client/components/wp-components-wrapped/components/flex-item.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { FlexItem as BundledFlexItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const FlexItem = makeWrappedComponent( BundledFlexItem, 'FlexItem' );

--- a/client/components/wp-components-wrapped/components/flex.tsx
+++ b/client/components/wp-components-wrapped/components/flex.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Flex as BundledFlex } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Flex = makeWrappedComponent( BundledFlex, 'Flex' );

--- a/client/components/wp-components-wrapped/components/form-file-upload.tsx
+++ b/client/components/wp-components-wrapped/components/form-file-upload.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { FormFileUpload as BundledFormFileUpload } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const FormFileUpload = makeWrappedComponent(
+	BundledFormFileUpload,
+	'FormFileUpload'
+);

--- a/client/components/wp-components-wrapped/components/horizontal-rule.tsx
+++ b/client/components/wp-components-wrapped/components/horizontal-rule.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { HorizontalRule as BundledHorizontalRule } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const HorizontalRule = makeWrappedComponent(
+	// @ts-expect-error: suppressing because of how the HorizontalRule component is defined, but it's no problem.
+	BundledHorizontalRule,
+	'HorizontalRule'
+);

--- a/client/components/wp-components-wrapped/components/icon.tsx
+++ b/client/components/wp-components-wrapped/components/icon.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Icon as BundledIcon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Icon = makeWrappedComponent( BundledIcon, 'Icon' );

--- a/client/components/wp-components-wrapped/components/menu-group.tsx
+++ b/client/components/wp-components-wrapped/components/menu-group.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { MenuGroup as BundledMenuGroup } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const MenuGroup = makeWrappedComponent( BundledMenuGroup, 'MenuGroup' );

--- a/client/components/wp-components-wrapped/components/menu-item.tsx
+++ b/client/components/wp-components-wrapped/components/menu-item.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { MenuItem as BundledMenuItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const MenuItem = makeWrappedComponent( BundledMenuItem, 'MenuItem' );

--- a/client/components/wp-components-wrapped/components/modal.tsx
+++ b/client/components/wp-components-wrapped/components/modal.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Modal as BundledModal } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Modal = makeWrappedComponent( BundledModal, 'Modal' );

--- a/client/components/wp-components-wrapped/components/notice.tsx
+++ b/client/components/wp-components-wrapped/components/notice.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Notice as BundledNotice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Notice = makeWrappedComponent( BundledNotice, 'Notice' );

--- a/client/components/wp-components-wrapped/components/panel-body.tsx
+++ b/client/components/wp-components-wrapped/components/panel-body.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { PanelBody as BundledPanelBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const PanelBody = makeWrappedComponent( BundledPanelBody, 'PanelBody' );

--- a/client/components/wp-components-wrapped/components/panel.tsx
+++ b/client/components/wp-components-wrapped/components/panel.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Panel as BundledPanel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Panel = makeWrappedComponent( BundledPanel, 'Panel' );

--- a/client/components/wp-components-wrapped/components/popover.tsx
+++ b/client/components/wp-components-wrapped/components/popover.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Popover as BundledPopover } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Popover = makeWrappedComponent( BundledPopover, 'Popover' );

--- a/client/components/wp-components-wrapped/components/radio-control.tsx
+++ b/client/components/wp-components-wrapped/components/radio-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { RadioControl as BundledRadioControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const RadioControl = makeWrappedComponent(
+	BundledRadioControl,
+	'RadioControl'
+);

--- a/client/components/wp-components-wrapped/components/range-control.tsx
+++ b/client/components/wp-components-wrapped/components/range-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { RangeControl as BundledRangeControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const RangeControl = makeWrappedComponent(
+	BundledRangeControl,
+	'RangeControl'
+);

--- a/client/components/wp-components-wrapped/components/select-control.tsx
+++ b/client/components/wp-components-wrapped/components/select-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { SelectControl as BundledSelectControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const SelectControl = makeWrappedComponent(
+	BundledSelectControl,
+	'SelectControl'
+);

--- a/client/components/wp-components-wrapped/components/snackbar-list.tsx
+++ b/client/components/wp-components-wrapped/components/snackbar-list.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { SnackbarList as BundledSnackbarList } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const SnackbarList = makeWrappedComponent(
+	BundledSnackbarList,
+	'SnackbarList'
+);

--- a/client/components/wp-components-wrapped/components/spinner.tsx
+++ b/client/components/wp-components-wrapped/components/spinner.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Spinner as BundledSpinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Spinner = makeWrappedComponent( BundledSpinner, 'Spinner' );

--- a/client/components/wp-components-wrapped/components/tab-panel.tsx
+++ b/client/components/wp-components-wrapped/components/tab-panel.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { TabPanel as BundledTabPanel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const TabPanel = makeWrappedComponent( BundledTabPanel, 'TabPanel' );

--- a/client/components/wp-components-wrapped/components/text-control.tsx
+++ b/client/components/wp-components-wrapped/components/text-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { TextControl as BundledTextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const TextControl = makeWrappedComponent(
+	BundledTextControl,
+	'TextControl'
+);

--- a/client/components/wp-components-wrapped/components/textarea-control.tsx
+++ b/client/components/wp-components-wrapped/components/textarea-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { TextareaControl as BundledTextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const TextareaControl = makeWrappedComponent(
+	BundledTextareaControl,
+	'TextareaControl'
+);

--- a/client/components/wp-components-wrapped/components/toggle-control.tsx
+++ b/client/components/wp-components-wrapped/components/toggle-control.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { ToggleControl as BundledToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const ToggleControl = makeWrappedComponent(
+	BundledToggleControl,
+	'ToggleControl'
+);

--- a/client/components/wp-components-wrapped/components/tooltip.tsx
+++ b/client/components/wp-components-wrapped/components/tooltip.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-syntax
+import { Tooltip as BundledTooltip } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Tooltip = makeWrappedComponent( BundledTooltip, 'Tooltip' );

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -1,195 +1,35 @@
-/**
- * External dependencies
- */
-import React, { ComponentProps, useContext } from 'react';
-// eslint-disable-next-line no-restricted-syntax
-import {
-	BaseControl as BundledBaseControl,
-	CheckboxControl as BundledCheckboxControl,
-	Card as BundledCard,
-	CardBody as BundledCardBody,
-	Button as BundledButton,
-	PanelBody as BundledPanelBody,
-	ExternalLink as BundledExternalLink,
-	Flex as BundledFlex,
-	FlexItem as BundledFlexItem,
-	Icon as BundledIcon,
-	Modal as BundledModal,
-	CardFooter as BundledCardFooter,
-	CardHeader as BundledCardHeader,
-	CardDivider as BundledCardDivider,
-	DropdownMenu as BundledDropdownMenu,
-	MenuGroup as BundledMenuGroup,
-	MenuItem as BundledMenuItem,
-	Notice as BundledNotice,
-	SelectControl as BundledSelectControl,
-	TextControl as BundledTextControl,
-	TextareaControl as BundledTextareaControl,
-	FormFileUpload as BundledFormFileUpload,
-	Tooltip as BundledTooltip,
-	RadioControl as BundledRadioControl,
-	ToggleControl as BundledToggleControl,
-	FlexBlock as BundledFlexBlock,
-	DropZone as BundledDropZone,
-	Popover as BundledPopover,
-	TabPanel as BundledTabPanel,
-	HorizontalRule as BundledHorizontalRule,
-	Spinner as BundledSpinner,
-	Panel as BundledPanel,
-	SnackbarList as BundledSnackbarList,
-	RangeControl as BundledRangeControl,
-} from '@wordpress/components';
-import BundledCardNotice from 'wcpay/components/card-notice';
-
-/**
- * Internal dependencies
- */
-import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
-
-const makeWrappedComponent = <
-	T extends React.ComponentType< any >,
-	N extends string
->(
-	BundledComponent: T,
-	componentName: N
-) =>
-	React.forwardRef<
-		any,
-		ComponentProps< T > & { useBundledComponent?: boolean }
-	>( ( props, ref ) => {
-		const { useBundledComponent, ...rest } = props;
-		const context = useContext( WordPressComponentsContext );
-
-		if ( ! context || useBundledComponent ) {
-			// @ts-expect-error: the type of props is not always well-defined, ignoring the error.
-			return <BundledComponent { ...rest } ref={ ref } />;
-		}
-
-		const ContextComponent = context[
-			componentName as keyof typeof context
-		] as React.ComponentType< any >;
-
-		return <ContextComponent { ...rest } ref={ ref } />;
-	} );
-
-export const BaseControl = makeWrappedComponent(
-	BundledBaseControl,
-	'BaseControl'
-);
-
-export const Tooltip = makeWrappedComponent( BundledTooltip, 'Tooltip' );
-
-export const ToggleControl = makeWrappedComponent(
-	BundledToggleControl,
-	'ToggleControl'
-);
-
-export const RadioControl = makeWrappedComponent(
-	BundledRadioControl,
-	'RadioControl'
-);
-
-export const CheckboxControl = makeWrappedComponent(
-	BundledCheckboxControl,
-	'CheckboxControl'
-);
-
-export const Card = makeWrappedComponent( BundledCard, 'Card' );
-
-export const CardBody = makeWrappedComponent( BundledCardBody, 'CardBody' );
-
-export const Button = makeWrappedComponent( BundledButton, 'Button' );
-
-export const PanelBody = makeWrappedComponent( BundledPanelBody, 'PanelBody' );
-
-export const ExternalLink = makeWrappedComponent(
-	BundledExternalLink,
-	'ExternalLink'
-);
-
-export const Flex = makeWrappedComponent( BundledFlex, 'Flex' );
-
-export const FlexItem = makeWrappedComponent( BundledFlexItem, 'FlexItem' );
-
-export const Icon = makeWrappedComponent( BundledIcon, 'Icon' );
-
-export const Modal = makeWrappedComponent( BundledModal, 'Modal' );
-
-export const CardFooter = makeWrappedComponent(
-	BundledCardFooter,
-	'CardFooter'
-);
-
-export const CardHeader = makeWrappedComponent(
-	BundledCardHeader,
-	'CardHeader'
-);
-
-export const CardDivider = makeWrappedComponent(
-	BundledCardDivider,
-	'CardDivider'
-);
-
-export const DropdownMenu = makeWrappedComponent(
-	BundledDropdownMenu,
-	'DropdownMenu'
-);
-
-export const MenuGroup = makeWrappedComponent( BundledMenuGroup, 'MenuGroup' );
-
-export const MenuItem = makeWrappedComponent( BundledMenuItem, 'MenuItem' );
-
-export const CardNotice = makeWrappedComponent(
-	BundledCardNotice,
-	'CardNotice'
-);
-
-export const Notice = makeWrappedComponent( BundledNotice, 'Notice' );
-
-export const SelectControl = makeWrappedComponent(
-	BundledSelectControl,
-	'SelectControl'
-);
-
-export const TextControl = makeWrappedComponent(
-	BundledTextControl,
-	'TextControl'
-);
-
-export const TextareaControl = makeWrappedComponent(
-	BundledTextareaControl,
-	'TextareaControl'
-);
-
-export const FormFileUpload = makeWrappedComponent(
-	BundledFormFileUpload,
-	'FormFileUpload'
-);
-
-export const FlexBlock = makeWrappedComponent( BundledFlexBlock, 'FlexBlock' );
-
-export const DropZone = makeWrappedComponent( BundledDropZone, 'DropZone' );
-
-export const Popover = makeWrappedComponent( BundledPopover, 'Popover' );
-
-export const TabPanel = makeWrappedComponent( BundledTabPanel, 'TabPanel' );
-
-export const HorizontalRule = makeWrappedComponent(
-	// @ts-expect-error: suppressing because of how the HorizontalRule component is defined, but it's no problem.
-	BundledHorizontalRule,
-	'HorizontalRule'
-);
-
-export const Spinner = makeWrappedComponent( BundledSpinner, 'Spinner' );
-
-export const Panel = makeWrappedComponent( BundledPanel, 'Panel' );
-
-export const SnackbarList = makeWrappedComponent(
-	BundledSnackbarList,
-	'SnackbarList'
-);
-
-export const RangeControl = makeWrappedComponent(
-	BundledRangeControl,
-	'RangeControl'
-);
+export { BaseControl } from './components/base-control';
+export { Button } from './components/button';
+export { Card } from './components/card';
+export { CardBody } from './components/card-body';
+export { CardDivider } from './components/card-divider';
+export { CardFooter } from './components/card-footer';
+export { CardHeader } from './components/card-header';
+export { CardNotice } from './components/card-notice';
+export { CheckboxControl } from './components/checkbox-control';
+export { DropdownMenu } from './components/dropdown-menu';
+export { DropZone } from './components/drop-zone';
+export { ExternalLink } from './components/external-link';
+export { Flex } from './components/flex';
+export { FlexBlock } from './components/flex-block';
+export { FlexItem } from './components/flex-item';
+export { FormFileUpload } from './components/form-file-upload';
+export { HorizontalRule } from './components/horizontal-rule';
+export { Icon } from './components/icon';
+export { MenuGroup } from './components/menu-group';
+export { MenuItem } from './components/menu-item';
+export { Modal } from './components/modal';
+export { Notice } from './components/notice';
+export { Panel } from './components/panel';
+export { PanelBody } from './components/panel-body';
+export { Popover } from './components/popover';
+export { RadioControl } from './components/radio-control';
+export { RangeControl } from './components/range-control';
+export { SelectControl } from './components/select-control';
+export { SnackbarList } from './components/snackbar-list';
+export { Spinner } from './components/spinner';
+export { TabPanel } from './components/tab-panel';
+export { TextControl } from './components/text-control';
+export { TextareaControl } from './components/textarea-control';
+export { ToggleControl } from './components/toggle-control';
+export { Tooltip } from './components/tooltip';

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -2,434 +2,189 @@
  * External dependencies
  */
 import React, { ComponentProps, useContext } from 'react';
+// eslint-disable-next-line no-restricted-syntax
 import {
-	Card as BundledWordPressComponentsCard,
-	CardBody as BundledWordPressComponentsCardBody,
-	Button as BundledWordPressComponentsButton,
-	PanelBody as BundledWordPressComponentsPanelBody,
-	ExternalLink as BundledWordPressComponentsExternalLink,
-	Flex as BundledWordPressComponentsFlex,
-	FlexItem as BundledWordPressComponentsFlexItem,
-	Icon as BundledWordPressComponentsIcon,
-	Modal as BundledWordPressComponentsModal,
-	HorizontalRule as BundledWordPressComponentsHorizontalRule,
-	CardFooter as BundledWordPressComponentsCardFooter,
-	CardHeader as BundledWordPressComponentsCardHeader,
-	CardDivider as BundledWordPressComponentsCardDivider,
-	DropdownMenu as BundledWordPressComponentsDropdownMenu,
-	MenuGroup as BundledWordPressComponentsMenuGroup,
-	MenuItem as BundledWordPressComponentsMenuItem,
-	Notice as BundledWordPressComponentsNotice,
-	SelectControl as BundledWordPressComponentsSelectControl,
-	TextControl as BundledWordPressComponentsTextControl,
-	TextareaControl as BundledWordPressComponentsTextareaControl,
-	FormFileUpload as BundledWordPressComponentsFormFileUpload,
+	BaseControl as BundledBaseControl,
+	CheckboxControl as BundledCheckboxControl,
+	Card as BundledCard,
+	CardBody as BundledCardBody,
+	Button as BundledButton,
+	PanelBody as BundledPanelBody,
+	ExternalLink as BundledExternalLink,
+	Flex as BundledFlex,
+	FlexItem as BundledFlexItem,
+	Icon as BundledIcon,
+	Modal as BundledModal,
+	CardFooter as BundledCardFooter,
+	CardHeader as BundledCardHeader,
+	CardDivider as BundledCardDivider,
+	DropdownMenu as BundledDropdownMenu,
+	MenuGroup as BundledMenuGroup,
+	MenuItem as BundledMenuItem,
+	Notice as BundledNotice,
+	SelectControl as BundledSelectControl,
+	TextControl as BundledTextControl,
+	TextareaControl as BundledTextareaControl,
+	FormFileUpload as BundledFormFileUpload,
+	Tooltip as BundledTooltip,
+	RadioControl as BundledRadioControl,
+	ToggleControl as BundledToggleControl,
+	FlexBlock as BundledFlexBlock,
+	DropZone as BundledDropZone,
+	Popover as BundledPopover,
+	TabPanel as BundledTabPanel,
+	HorizontalRule as BundledHorizontalRule,
+	Spinner as BundledSpinner,
+	Panel as BundledPanel,
+	SnackbarList as BundledSnackbarList,
+	RangeControl as BundledRangeControl,
 } from '@wordpress/components';
-import BundledWordPressComponentsCardNotice from 'wcpay/components/card-notice';
+import BundledCardNotice from 'wcpay/components/card-notice';
 
 /**
  * Internal dependencies
  */
 import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
 
-const WrappedCard = (
-	props: ComponentProps< typeof BundledWordPressComponentsCard > & {
-		useBundledComponent?: boolean;
-	}
-) => {
+const makeWrappedComponent = <
+	T extends React.ComponentType< any >,
+	N extends string
+>(
+	BundledComponent: T,
+	componentName: N
+) => ( props: ComponentProps< T > & { useBundledComponent?: boolean } ) => {
 	const { useBundledComponent, ...rest } = props;
 	const context = useContext( WordPressComponentsContext );
 
 	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsCard { ...rest } />;
+		return <BundledComponent { ...( rest as any ) } />;
 	}
 
-	const { Card } = context;
+	const ContextComponent = context[
+		componentName as keyof typeof context
+	] as React.ComponentType< any >;
 
-	return <Card { ...rest } />;
+	return <ContextComponent { ...rest } />;
 };
 
-const WrappedCardBody = (
-	props: ComponentProps< typeof BundledWordPressComponentsCardBody > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsCardBody { ...rest } />;
-	}
-
-	const { CardBody } = context;
-
-	return <CardBody { ...rest } />;
-};
-
-const WrappedButton = (
-	props: ComponentProps< typeof BundledWordPressComponentsButton > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsButton { ...rest } />;
-	}
-
-	const { Button } = context;
-
-	return <Button { ...rest } />;
-};
-
-const WrappedPanelBody = (
-	props: ComponentProps< typeof BundledWordPressComponentsPanelBody > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsPanelBody { ...rest } />;
-	}
-
-	const { PanelBody } = context;
-
-	return <PanelBody { ...rest } />;
-};
-
-const WrappedExternalLink = (
-	props: ComponentProps< typeof BundledWordPressComponentsExternalLink > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsExternalLink { ...rest } />;
-	}
-
-	const { ExternalLink } = context;
-
-	return <ExternalLink { ...rest } />;
-};
-
-const WrappedFlex = (
-	props: ComponentProps< typeof BundledWordPressComponentsFlex > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsFlex { ...rest } />;
-	}
-
-	const { Flex } = context;
-
-	return <Flex { ...rest } />;
-};
-
-const WrappedFlexItem = (
-	props: ComponentProps< typeof BundledWordPressComponentsFlexItem > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsFlexItem { ...rest } />;
-	}
-
-	const { FlexItem } = context;
-
-	return <FlexItem { ...rest } />;
-};
-
-const WrappedIcon = (
-	props: ComponentProps< typeof BundledWordPressComponentsIcon > & {
-		useBundledComponent?: boolean;
-		className?: string;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsIcon { ...rest } />;
-	}
-
-	const { Icon } = context;
-
-	return <Icon { ...rest } />;
-};
-
-const WrappedModal = (
-	props: ComponentProps< typeof BundledWordPressComponentsModal > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsModal { ...rest } />;
-	}
-
-	const { Modal } = context;
-
-	return <Modal { ...rest } />;
-};
-
-const WrappedHorizontalRule = (
-	props: ComponentProps< typeof BundledWordPressComponentsHorizontalRule > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsHorizontalRule { ...rest } />;
-	}
-
-	const { HorizontalRule } = context;
-
-	return <HorizontalRule { ...rest } />;
-};
-
-const WrappedCardFooter = (
-	props: ComponentProps< typeof BundledWordPressComponentsCardFooter > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsCardFooter { ...rest } />;
-	}
-
-	const { CardFooter } = context;
-
-	return <CardFooter { ...rest } />;
-};
-
-const WrappedCardHeader = (
-	props: ComponentProps< typeof BundledWordPressComponentsCardHeader > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsCardHeader { ...rest } />;
-	}
-
-	const { CardHeader } = context;
-
-	return <CardHeader { ...rest } />;
-};
-
-const WrappedCardDivider = (
-	props: ComponentProps< typeof BundledWordPressComponentsCardDivider > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsCardDivider { ...rest } />;
-	}
-
-	const { CardDivider } = context;
-
-	return <CardDivider { ...rest } />;
-};
-
-const WrappedDropdownMenu = (
-	props: ComponentProps< typeof BundledWordPressComponentsDropdownMenu > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsDropdownMenu { ...rest } />;
-	}
-
-	const { DropdownMenu } = context;
-
-	return <DropdownMenu { ...rest } />;
-};
-
-const WrappedMenuGroup = (
-	props: ComponentProps< typeof BundledWordPressComponentsMenuGroup > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsMenuGroup { ...rest } />;
-	}
-
-	const { MenuGroup } = context;
-
-	return <MenuGroup { ...rest } />;
-};
-
-const WrappedMenuItem = (
-	props: ComponentProps< typeof BundledWordPressComponentsMenuItem > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsMenuItem { ...rest } />;
-	}
-
-	const { MenuItem } = context;
-
-	return <MenuItem { ...rest } />;
-};
-
-const WrappedCardNotice = (
-	props: ComponentProps< typeof BundledWordPressComponentsCardNotice > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsCardNotice { ...rest } />;
-	}
-
-	const { CardNotice } = context;
-
-	return <CardNotice { ...rest } />;
-};
-
-const WrappedNotice = (
-	props: ComponentProps< typeof BundledWordPressComponentsNotice > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsNotice { ...rest } />;
-	}
-
-	const { Notice } = context;
-
-	return <Notice { ...rest } />;
-};
-
-const WrappedSelectControl = (
-	props: ComponentProps< typeof BundledWordPressComponentsSelectControl > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsSelectControl { ...rest } />;
-	}
-
-	const { SelectControl } = context;
-
-	return <SelectControl { ...rest } />;
-};
-
-const WrappedTextControl = (
-	props: ComponentProps< typeof BundledWordPressComponentsTextControl > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsTextControl { ...rest } />;
-	}
-
-	const { TextControl } = context;
-
-	return <TextControl { ...rest } />;
-};
-
-const WrappedTextareaControl = (
-	props: ComponentProps<
-		typeof BundledWordPressComponentsTextareaControl
-	> & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsTextareaControl { ...rest } />;
-	}
-
-	const { TextareaControl } = context;
-
-	return <TextareaControl { ...rest } />;
-};
-
-const WrappedFormFileUpload = (
-	props: ComponentProps< typeof BundledWordPressComponentsFormFileUpload > & {
-		useBundledComponent?: boolean;
-	}
-) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
-
-	if ( ! context || useBundledComponent ) {
-		return <BundledWordPressComponentsFormFileUpload { ...rest } />;
-	}
-
-	const { FormFileUpload } = context;
-
-	return <FormFileUpload { ...rest } />;
-};
-
-export {
-	WrappedCard as Card,
-	WrappedCardBody as CardBody,
-	WrappedButton as Button,
-	WrappedPanelBody as PanelBody,
-	WrappedExternalLink as ExternalLink,
-	WrappedFlex as Flex,
-	WrappedFlexItem as FlexItem,
-	WrappedIcon as Icon,
-	WrappedModal as Modal,
-	WrappedHorizontalRule as HorizontalRule,
-	WrappedCardFooter as CardFooter,
-	WrappedCardHeader as CardHeader,
-	WrappedCardDivider as CardDivider,
-	WrappedDropdownMenu as DropdownMenu,
-	WrappedMenuGroup as MenuGroup,
-	WrappedMenuItem as MenuItem,
-	WrappedCardNotice as CardNotice,
-	WrappedNotice as Notice,
-	WrappedSelectControl as SelectControl,
-	WrappedTextControl as TextControl,
-	WrappedTextareaControl as TextareaControl,
-	WrappedFormFileUpload as FormFileUpload,
-};
+export const BaseControl = makeWrappedComponent(
+	BundledBaseControl,
+	'BaseControl'
+);
+
+export const Tooltip = makeWrappedComponent( BundledTooltip, 'Tooltip' );
+
+export const ToggleControl = makeWrappedComponent(
+	BundledToggleControl,
+	'ToggleControl'
+);
+
+export const RadioControl = makeWrappedComponent(
+	BundledRadioControl,
+	'RadioControl'
+);
+
+export const CheckboxControl = makeWrappedComponent(
+	BundledCheckboxControl,
+	'CheckboxControl'
+);
+
+export const Card = makeWrappedComponent( BundledCard, 'Card' );
+
+export const CardBody = makeWrappedComponent( BundledCardBody, 'CardBody' );
+
+export const Button = makeWrappedComponent( BundledButton, 'Button' );
+
+export const PanelBody = makeWrappedComponent( BundledPanelBody, 'PanelBody' );
+
+export const ExternalLink = makeWrappedComponent(
+	BundledExternalLink,
+	'ExternalLink'
+);
+
+export const Flex = makeWrappedComponent( BundledFlex, 'Flex' );
+
+export const FlexItem = makeWrappedComponent( BundledFlexItem, 'FlexItem' );
+
+export const Icon = makeWrappedComponent( BundledIcon, 'Icon' );
+
+export const Modal = makeWrappedComponent( BundledModal, 'Modal' );
+
+export const CardFooter = makeWrappedComponent(
+	BundledCardFooter,
+	'CardFooter'
+);
+
+export const CardHeader = makeWrappedComponent(
+	BundledCardHeader,
+	'CardHeader'
+);
+
+export const CardDivider = makeWrappedComponent(
+	BundledCardDivider,
+	'CardDivider'
+);
+
+export const DropdownMenu = makeWrappedComponent(
+	BundledDropdownMenu,
+	'DropdownMenu'
+);
+
+export const MenuGroup = makeWrappedComponent( BundledMenuGroup, 'MenuGroup' );
+
+export const MenuItem = makeWrappedComponent( BundledMenuItem, 'MenuItem' );
+
+export const CardNotice = makeWrappedComponent(
+	BundledCardNotice,
+	'CardNotice'
+);
+
+export const Notice = makeWrappedComponent( BundledNotice, 'Notice' );
+
+export const SelectControl = makeWrappedComponent(
+	BundledSelectControl,
+	'SelectControl'
+);
+
+export const TextControl = makeWrappedComponent(
+	BundledTextControl,
+	'TextControl'
+);
+
+export const TextareaControl = makeWrappedComponent(
+	BundledTextareaControl,
+	'TextareaControl'
+);
+
+export const FormFileUpload = makeWrappedComponent(
+	BundledFormFileUpload,
+	'FormFileUpload'
+);
+
+export const FlexBlock = makeWrappedComponent( BundledFlexBlock, 'FlexBlock' );
+
+export const DropZone = makeWrappedComponent( BundledDropZone, 'DropZone' );
+
+export const Popover = makeWrappedComponent( BundledPopover, 'Popover' );
+
+export const TabPanel = makeWrappedComponent( BundledTabPanel, 'TabPanel' );
+
+export const HorizontalRule = makeWrappedComponent(
+	// @ts-expect-error: suppressing because of how the HorizontalRule component is defined, but it's no problem.
+	BundledHorizontalRule,
+	'HorizontalRule'
+);
+
+export const Spinner = makeWrappedComponent( BundledSpinner, 'Spinner' );
+
+export const Panel = makeWrappedComponent( BundledPanel, 'Panel' );
+
+export const SnackbarList = makeWrappedComponent(
+	BundledSnackbarList,
+	'SnackbarList'
+);
+
+export const RangeControl = makeWrappedComponent(
+	BundledRangeControl,
+	'RangeControl'
+);

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -52,20 +52,25 @@ const makeWrappedComponent = <
 >(
 	BundledComponent: T,
 	componentName: N
-) => ( props: ComponentProps< T > & { useBundledComponent?: boolean } ) => {
-	const { useBundledComponent, ...rest } = props;
-	const context = useContext( WordPressComponentsContext );
+) =>
+	React.forwardRef<
+		any,
+		ComponentProps< T > & { useBundledComponent?: boolean }
+	>( ( props, ref ) => {
+		const { useBundledComponent, ...rest } = props;
+		const context = useContext( WordPressComponentsContext );
 
-	if ( ! context || useBundledComponent ) {
-		return <BundledComponent { ...( rest as any ) } />;
-	}
+		if ( ! context || useBundledComponent ) {
+			// @ts-expect-error: the type of props is not always well-defined, ignoring the error.
+			return <BundledComponent { ...rest } ref={ ref } />;
+		}
 
-	const ContextComponent = context[
-		componentName as keyof typeof context
-	] as React.ComponentType< any >;
+		const ContextComponent = context[
+			componentName as keyof typeof context
+		] as React.ComponentType< any >;
 
-	return <ContextComponent { ...rest } />;
-};
+		return <ContextComponent { ...rest } ref={ ref } />;
+	} );
 
 export const BaseControl = makeWrappedComponent(
 	BundledBaseControl,

--- a/client/components/wp-components-wrapped/make-wrapped-component.tsx
+++ b/client/components/wp-components-wrapped/make-wrapped-component.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React, { ComponentProps, useContext } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
+
+export const makeWrappedComponent = <
+	T extends React.ComponentType< any >,
+	N extends string
+>(
+	BundledComponent: T,
+	componentName: N
+) =>
+	React.forwardRef<
+		any,
+		ComponentProps< T > & { useBundledComponent?: boolean }
+	>( ( props, ref ) => {
+		const { useBundledComponent, ...rest } = props;
+		const context = useContext( WordPressComponentsContext );
+
+		if ( ! context || useBundledComponent ) {
+			// @ts-expect-error: the type of props is not always well-defined, ignoring the error.
+			return <BundledComponent { ...rest } ref={ ref } />;
+		}
+
+		const ContextComponent = context[
+			componentName as keyof typeof context
+		] as React.ComponentType< any >;
+
+		return <ContextComponent { ...rest } ref={ ref } />;
+	} );

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -11,7 +11,7 @@ import {
 	CardBody,
 	Panel,
 	PanelBody,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Loader } from '@woocommerce/onboarding';

--- a/client/connect-account-page/info-notice-modal.tsx
+++ b/client/connect-account-page/info-notice-modal.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Button, Modal, Notice } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/connect-account-page/modal/index.js
+++ b/client/connect-account-page/modal/index.js
@@ -6,7 +6,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 /**
  * Internal dependencies
  */
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link, List } from '@woocommerce/components';
 import { useState } from '@wordpress/element';

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -5,15 +5,18 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-syntax
+import {
+	// @ts-expect-error: Suppressing Module '"@wordpress/components"' has no exported member '__experimentalText'.
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- used by TableCard component which we replicate here.
+	__experimentalText as Text,
+} from '@wordpress/components';
 import {
 	Card,
 	CardBody,
 	CardHeader,
 	ExternalLink,
-	// @ts-expect-error: Suppressing Module '"@wordpress/components"' has no exported member '__experimentalText'.
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- used by TableCard component which we replicate here.
-	__experimentalText as Text,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import {
 	SummaryListPlaceholder,
 	SummaryList,

--- a/client/deposits/index.tsx
+++ b/client/deposits/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/client/deposits/instant-payouts/index.tsx
+++ b/client/deposits/instant-payouts/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 

--- a/client/deposits/instant-payouts/modal.tsx
+++ b/client/deposits/instant-payouts/modal.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 

--- a/client/disable-confirmation-modal/index.js
+++ b/client/disable-confirmation-modal/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/disable-confirmation-modal/index.js
+++ b/client/disable-confirmation-modal/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { recordEvent } from 'tracks';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery, getHistory } from '@woocommerce/navigation';
 import clsx from 'clsx';

--- a/client/disputes/redirect-to-transaction-details/index.tsx
+++ b/client/disputes/redirect-to-transaction-details/index.tsx
@@ -3,7 +3,12 @@
  */
 import React, { useEffect } from 'react';
 import { getHistory } from '@woocommerce/navigation';
-import { Spinner, Icon, Flex, FlexItem } from '@wordpress/components';
+import {
+	Spinner,
+	Icon,
+	Flex,
+	FlexItem,
+} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies.
@@ -46,6 +51,7 @@ const RedirectToTransactionDetails: React.FC< { query: { id: string } } > = ( {
 				{ error ? (
 					<>
 						<FlexItem>
+							{ /* @ts-expect-error: type is not a prop defined in the WP Icon component. */ }
 							<Icon icon={ warning } type="warning" size={ 32 } />
 						</FlexItem>
 						<FlexItem>

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { TableCard, TableCardColumn } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/merchant-feedback-prompt/index.tsx
+++ b/client/merchant-feedback-prompt/index.tsx
@@ -7,9 +7,10 @@ import {
 	Button,
 	Flex,
 	FlexItem,
-	NoticeList,
 	SnackbarList,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
+// eslint-disable-next-line no-restricted-syntax
+import { NoticeList } from '@wordpress/components';
 import { Icon, thumbsUp, thumbsDown } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';

--- a/client/merchant-feedback-prompt/negative-modal.tsx
+++ b/client/merchant-feedback-prompt/negative-modal.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wcpay/components/wp-components-wrapped';
 import { dispatch } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -3,7 +3,12 @@
  */
 import React, { useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
+import {
+	Button,
+	Flex,
+	FlexItem,
+	Modal,
+} from 'wcpay/components/wp-components-wrapped';
 import {
 	Icon,
 	commentContent,

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { isEmpty, mapValues } from 'lodash';
 
 /**

--- a/client/order/order-status-confirmation-modal/index.tsx
+++ b/client/order/order-status-confirmation-modal/index.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { useState } from '@wordpress/element';
 /**
  * Internal dependencies

--- a/client/order/order-status-confirmation-modal/index.tsx
+++ b/client/order/order-status-confirmation-modal/index.tsx
@@ -3,8 +3,9 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { useState } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */

--- a/client/order/refund-confirm-modal/index.js
+++ b/client/order/refund-confirm-modal/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { useState } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 

--- a/client/order/refund-confirm-modal/index.js
+++ b/client/order/refund-confirm-modal/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { useState } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { Card, Notice } from '@wordpress/components';
+import { Card, Notice } from 'wcpay/components/wp-components-wrapped';
 import { getQuery } from '@woocommerce/navigation';
 import { __, sprintf } from '@wordpress/i18n';
 import { dispatch } from '@wordpress/data';

--- a/client/overview/modal/connection-success/index.tsx
+++ b/client/overview/modal/connection-success/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Modal, Button } from '@wordpress/components';
+import { Modal, Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
 import { Icon, store, currencyDollar } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/overview/modal/reset-account/index.tsx
+++ b/client/overview/modal/reset-account/index.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, CardDivider, Modal } from '@wordpress/components';
+import {
+	Button,
+	CardDivider,
+	Modal,
+} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Button, Modal, Notice } from 'wcpay/components/wp-components-wrapped';
 import { sprintf } from '@wordpress/i18n';
 
 /**

--- a/client/payment-details/payment-details/index.tsx
+++ b/client/payment-details/payment-details/index.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { TestModeNotice } from '../../components/test-mode-notice';
 import Page from '../../components/page';
-import { Card, CardBody } from '@wordpress/components';
+import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
 import ErrorBoundary from '../../components/error-boundary';
 import PaymentDetailsSummary from '../summary';
 import PaymentDetailsTimeline from '../timeline';

--- a/client/payment-details/readers/index.js
+++ b/client/payment-details/readers/index.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '@wordpress/components';
+import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
 import { getQuery } from '@woocommerce/navigation';
 import {
 	downloadCSVFile,

--- a/client/payment-details/summary/missing-order-notice/index.tsx
+++ b/client/payment-details/summary/missing-order-notice/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { Button, RadioControl } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
@@ -13,7 +12,6 @@ import interpolateComponents from '@automattic/interpolate-components';
 /**
  * Internal dependencies.
  */
-
 import ConfirmationModal from 'wcpay/components/confirmation-modal';
 import { Charge } from 'wcpay/types/charges';
 import { usePaymentIntentWithChargeFallback } from 'wcpay/data';

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Button, RadioControl } from '@wordpress/components';
+import { Button, RadioControl } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';

--- a/client/payment-details/transaction-breakdown/fees-breakdown/fee-breakdown-components.tsx
+++ b/client/payment-details/transaction-breakdown/fees-breakdown/fee-breakdown-components.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Flex, FlexItem } from '@wordpress/components';
+import { Flex, FlexItem } from 'wcpay/components/wp-components-wrapped';
 
 /** Internal dependencies */
 import { formatCurrency } from 'multi-currency/interface/functions';

--- a/client/payment-details/transaction-breakdown/index.tsx
+++ b/client/payment-details/transaction-breakdown/index.tsx
@@ -18,7 +18,7 @@ import {
 	CardFooter,
 	Flex,
 	FlexItem,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { TimelineItem } from 'wcpay/data/timeline/types';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import { formatCurrency } from 'multi-currency/interface/functions';

--- a/client/plugins-page/deactivation-survey/index.tsx
+++ b/client/plugins-page/deactivation-survey/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/plugins-page/deactivation-survey/index.tsx
+++ b/client/plugins-page/deactivation-survey/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal } from 'wcpay/components/wp-components-wrapped';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 
 /**
  * Internal dependencies

--- a/client/settings/advanced-settings/debug-mode.js
+++ b/client/settings/advanced-settings/debug-mode.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/advanced-settings/index.js
+++ b/client/settings/advanced-settings/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Card } from '@wordpress/components';
+import { Card } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/advanced-settings/multi-currency-toggle.js
+++ b/client/settings/advanced-settings/multi-currency-toggle.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import {
+	CheckboxControl,
+	ExternalLink,
+} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import InlineNotice from 'wcpay/components/inline-notice';
 import { _n, sprintf } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
@@ -4,7 +4,7 @@
 import React, { useContext, useState } from 'react';
 import InlineNotice from 'wcpay/components/inline-notice';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useEffect } from '@wordpress/element';
 

--- a/client/settings/advanced-settings/stripe-billing-section.tsx
+++ b/client/settings/advanced-settings/stripe-billing-section.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**

--- a/client/settings/advanced-settings/stripe-billing-toggle.tsx
+++ b/client/settings/advanced-settings/stripe-billing-toggle.tsx
@@ -3,7 +3,10 @@
  */
 import React, { useContext } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import {
+	CheckboxControl,
+	ExternalLink,
+} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import {
+	CheckboxControl,
+	ExternalLink,
+} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**

--- a/client/settings/buy-now-pay-later-section/index.js
+++ b/client/settings/buy-now-pay-later-section/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Card, ExternalLink } from '@wordpress/components';
+import { Card, ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/card-body/index.tsx
+++ b/client/settings/card-body/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import { CardBody as BundledWordPressComponentsCardBody } from '@wordpress/components';
+import { CardBody as BundledWordPressComponentsCardBody } from 'wcpay/components/wp-components-wrapped';
 import clsx from 'clsx';
 
 /**

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -4,7 +4,11 @@
 import React, { useContext } from 'react';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Card, SelectControl, ExternalLink } from '@wordpress/components';
+import {
+	Card,
+	SelectControl,
+	ExternalLink,
+} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -8,14 +8,14 @@ import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { BaseControl, Button } from '@wordpress/components';
 import TrashIcon from 'gridicons/dist/trash';
 import clsx from 'clsx';
 
 /**
  * Internal dependencies
  */
-import { FileUploadControl } from 'components/file-upload';
+import { BaseControl, Button } from 'wcpay/components/wp-components-wrapped';
+import { FileUploadControl } from 'wcpay/components/file-upload';
 
 interface WooPayFileUploadProps {
 	fieldKey: string;

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -4,13 +4,16 @@
  */
 import React, { useMemo } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-syntax
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
+import {
 	SelectControl,
 	RadioControl,
 	RangeControl,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { useContext } from '@wordpress/element';

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -4,12 +4,12 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CheckboxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import CardBody from '../card-body';
+import { Card, CheckboxControl } from 'wcpay/components/wp-components-wrapped';
 import GeneralPaymentRequestButtonSettings from './general-payment-request-button-settings';
 import {
 	usePaymentRequestEnabledSettings,

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -5,18 +5,18 @@
 import React from 'react';
 import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CheckboxControl,
-	TextareaControl,
-	ExternalLink,
-} from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
+import {
+	Card,
+	CheckboxControl,
+	TextareaControl,
+	ExternalLink,
+} from 'wcpay/components/wp-components-wrapped';
 import CardBody from '../card-body';
 import WooPayFileUpload from './file-upload';
 import WooPayPreview from './woopay-preview';

--- a/client/settings/express-checkout/apple-google-pay-item.tsx
+++ b/client/settings/express-checkout/apple-google-pay-item.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import React, { useContext } from 'react';
 

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Card } from '@wordpress/components';
+import { Card } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/express-checkout/link-item.tsx
+++ b/client/settings/express-checkout/link-item.tsx
@@ -3,7 +3,10 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/express-checkout/woopay-item.tsx
+++ b/client/settings/express-checkout/woopay-item.tsx
@@ -4,7 +4,10 @@
 
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import { getPaymentMethodSettingsUrl } from '../../utils';
 import { useContext } from '@wordpress/element';

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useContext, useMemo, Dispatch, SetStateAction } from 'react';
 import { __ } from '@wordpress/i18n';
-import { TextControl } from '@wordpress/components';
+import { TextControl } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -6,7 +6,7 @@ import { isMatchWith } from 'lodash';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { LoadableBlock } from 'wcpay/components/loadable';
-import { Button, Notice } from '@wordpress/components';
+import { Button, Notice } from 'wcpay/components/wp-components-wrapped';
 import { dispatch } from '@wordpress/data';
 
 /**

--- a/client/settings/fraud-protection/advanced-settings/rule-card.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-card.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Card } from '@wordpress/components';
+import { Card } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
@@ -3,7 +3,10 @@
  */
 import React, { useContext } from 'react';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, RadioControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	RadioControl,
+} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/components/fp-modal/index.tsx
+++ b/client/settings/fraud-protection/components/fp-modal/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/components/protection-level-modal-notice/index.tsx
+++ b/client/settings/fraud-protection/components/protection-level-modal-notice/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Notice } from '@wordpress/components';
+import { Notice } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/components/protection-levels/index.tsx
+++ b/client/settings/fraud-protection/components/protection-levels/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 import { useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/index.tsx
+++ b/client/settings/fraud-protection/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card } from '@wordpress/components';
+import { Card } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/general-settings/enable-woopayments-checkbox.js
+++ b/client/settings/general-settings/enable-woopayments-checkbox.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card, CheckboxControl } from '@wordpress/components';
+import { Card, CheckboxControl } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/general-settings/test-mode-confirm-modal.tsx
+++ b/client/settings/general-settings/test-mode-confirm-modal.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/google-pay-test-mode-compatibility-notice.tsx
+++ b/client/settings/google-pay-test-mode-compatibility-notice.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import React, { useContext } from 'react';
 

--- a/client/settings/payment-methods-list/activation-modal.tsx
+++ b/client/settings/payment-methods-list/activation-modal.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal Dependencies

--- a/client/settings/payment-methods-list/delete-modal.tsx
+++ b/client/settings/payment-methods-list/delete-modal.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -4,7 +4,7 @@
  */
 import clsx from 'clsx';
 import React, { useContext } from 'react';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/payment-methods-list/use-payment-method-availability.tsx
+++ b/client/settings/payment-methods-list/use-payment-method-availability.tsx
@@ -17,7 +17,7 @@ import PAYMENT_METHOD_IDS from 'wcpay/constants/payment-method';
 import { getMissingCurrenciesTooltipMessage } from 'multi-currency/utils/missing-currencies-message';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { ChipType } from 'wcpay/components/chip';
 
 const documentationTypeMap = {

--- a/client/settings/payment-methods-section/index.js
+++ b/client/settings/payment-methods-section/index.js
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card } from '@wordpress/components';
+import { Card } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState, useEffect, useLayoutEffect } from 'react';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { dispatch } from '@wordpress/data';

--- a/client/settings/support-email-input/index.js
+++ b/client/settings/support-email-input/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { TextControl, Notice } from '@wordpress/components';
+import { TextControl, Notice } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { BaseControl, Notice } from '@wordpress/components';
+import { BaseControl, Notice } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from 'react';
 

--- a/client/settings/transactions/index.js
+++ b/client/settings/transactions/index.js
@@ -7,7 +7,7 @@ import {
 	CheckboxControl,
 	Notice,
 	TextControl,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/settings/transactions/manual-capture-control.tsx
+++ b/client/settings/transactions/manual-capture-control.tsx
@@ -4,7 +4,11 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, Button, ExternalLink } from '@wordpress/components';
+import {
+	CheckboxControl,
+	Button,
+	ExternalLink,
+} from 'wcpay/components/wp-components-wrapped';
 import { useState } from '@wordpress/element';
 /**
  * Internal dependencies

--- a/client/settings/woopay-disable-feedback/index.js
+++ b/client/settings/woopay-disable-feedback/index.js
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/subscription-product-onboarding/modal.js
+++ b/client/subscription-product-onboarding/modal.js
@@ -3,7 +3,9 @@
  */
 import React from 'react';
 
-import { Button, Icon, Modal } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import {
 	createInterpolateElement,
 	useEffect,

--- a/client/subscription-product-onboarding/modal.js
+++ b/client/subscription-product-onboarding/modal.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 
-import { Button, Icon, Modal } from '@wordpress/components';
+import { Button, Icon, Modal } from 'wcpay/components/wp-components-wrapped';
 import {
 	createInterpolateElement,
 	useEffect,

--- a/client/subscriptions-empty-state/index.js
+++ b/client/subscriptions-empty-state/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement, render, useState } from '@wordpress/element';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 import { recordEvent } from '../tracks';
 import UnconnectedImage from 'assets/images/subscriptions-empty-state-unconnected.svg?asset';

--- a/client/subscriptions-empty-state/index.js
+++ b/client/subscriptions-empty-state/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement, render, useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 import { recordEvent } from '../tracks';
 import UnconnectedImage from 'assets/images/subscriptions-empty-state-unconnected.svg?asset';

--- a/client/tos/modal/index.js
+++ b/client/tos/modal/index.js
@@ -4,7 +4,9 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Button, Notice, Modal } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { Link } from '@woocommerce/components';
 import { addQueryArgs } from '@wordpress/url';
 

--- a/client/tos/modal/index.js
+++ b/client/tos/modal/index.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Button, Notice, Modal } from '@wordpress/components';
+import { Button, Notice, Modal } from 'wcpay/components/wp-components-wrapped';
 import { Link } from '@woocommerce/components';
 import { addQueryArgs } from '@wordpress/url';
 

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import { TabPanel } from '@wordpress/components';
+import { TabPanel } from 'wcpay/components/wp-components-wrapped';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { __, sprintf } from '@wordpress/i18n';
 

--- a/client/transactions/list/converted-amount.tsx
+++ b/client/transactions/list/converted-amount.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Tooltip as FallbackTooltip } from '@wordpress/components';
+import { Tooltip as FallbackTooltip } from 'wcpay/components/wp-components-wrapped';
 import SyncIcon from 'gridicons/dist/sync';
 import clsx from 'clsx';
 

--- a/client/transactions/list/deposit.tsx
+++ b/client/transactions/list/deposit.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import { Link } from '@woocommerce/components';
 import InfoOutlineIcon from 'gridicons/dist/info-outline';
 

--- a/client/transactions/risk-review/columns.tsx
+++ b/client/transactions/risk-review/columns.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { TableCardColumn, TableCardBodyColumn } from '@woocommerce/components';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/client/transactions/risk-review/test/__snapshots__/columns.test.tsx.snap
+++ b/client/transactions/risk-review/test/__snapshots__/columns.test.tsx.snap
@@ -33,13 +33,13 @@ exports[`Review fraud outcome transactions columns should render the column corr
     "value": "review",
   },
   {
-    "display": <ForwardRef(Button)
+    "display": <ForwardRef
       href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock"
       isSecondary={true}
       onClick={[Function]}
     >
       Review
-    </ForwardRef(Button)>,
+    </ForwardRef>,
   },
 ]
 `;

--- a/client/types/notices.d.ts
+++ b/client/types/notices.d.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line no-restricted-syntax
 import { Notice } from '@wordpress/components';
 
 interface ActionButton extends Notice.ButtonAction {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -15,7 +15,7 @@ import { formatFee } from 'utils/fees';
 import React from 'react';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
 import { createInterpolateElement } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 import PAYMENT_METHOD_IDS from 'constants/payment-method';
 
 const countryFeeStripeDocsBaseLink =

--- a/client/vat/form-modal/index.tsx
+++ b/client/vat/form-modal/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/vat/form/tasks/company-data-task.tsx
+++ b/client/vat/form/tasks/company-data-task.tsx
@@ -8,7 +8,7 @@ import {
 	Notice,
 	TextareaControl,
 	TextControl,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import React, { useContext, useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -8,7 +8,7 @@ import {
 	CheckboxControl,
 	Notice,
 	TextControl,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import React, { useContext, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';

--- a/includes/multi-currency/client/blocks/currency-switcher.js
+++ b/includes/multi-currency/client/blocks/currency-switcher.js
@@ -12,11 +12,9 @@ import {
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	CheckboxControl,
-	PanelBody,
-	RangeControl,
-} from 'wcpay/components/wp-components-wrapped';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { PanelBody } from 'wcpay/components/wp-components-wrapped/components/panel-body';
+import { RangeControl } from 'wcpay/components/wp-components-wrapped/components/range-control';
 import { registerBlockType } from '@wordpress/blocks';
 import {
 	ColorPaletteControl,

--- a/includes/multi-currency/client/blocks/currency-switcher.js
+++ b/includes/multi-currency/client/blocks/currency-switcher.js
@@ -16,7 +16,7 @@ import {
 	CheckboxControl,
 	PanelBody,
 	RangeControl,
-} from '@wordpress/components';
+} from 'wcpay/components/wp-components-wrapped';
 import { registerBlockType } from '@wordpress/blocks';
 import {
 	ColorPaletteControl,

--- a/includes/multi-currency/client/components/preview-modal/index.js
+++ b/includes/multi-currency/client/components/preview-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Modal } from 'wcpay/components/wp-components-wrapped';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { __ } from '@wordpress/i18n';
 import { useStoreSettings } from 'multi-currency/data';
 

--- a/includes/multi-currency/client/components/preview-modal/index.js
+++ b/includes/multi-currency/client/components/preview-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import { useStoreSettings } from 'multi-currency/data';
 

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/delete-button.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/delete-button.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Icon } from '@wordpress/components';
+import { Button, Icon } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useCallback, useState } from '@wordpress/element';
 import {

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/delete-button.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/delete-button.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Icon } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useCallback, useState } from '@wordpress/element';
 import {

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/index.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/index.js
@@ -4,7 +4,11 @@
  */
 import React from 'react';
 import { sprintf, __ } from '@wordpress/i18n';
-import { Card, CardBody, CardDivider } from '@wordpress/components';
+import {
+	Card,
+	CardBody,
+	CardDivider,
+} from 'wcpay/components/wp-components-wrapped';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/index.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/index.js
@@ -4,11 +4,9 @@
  */
 import React from 'react';
 import { sprintf, __ } from '@wordpress/i18n';
-import {
-	Card,
-	CardBody,
-	CardDivider,
-} from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped/components/card-divider';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item.js
@@ -4,7 +4,7 @@
  */
 import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/list-item.js
@@ -4,7 +4,7 @@
  */
 import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal-checkbox.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal-checkbox.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal-checkbox.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal-checkbox.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/modal.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**

--- a/includes/multi-currency/client/settings/multi-currency/store-settings/index.js
+++ b/includes/multi-currency/client/settings/multi-currency/store-settings/index.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { Button, Card, CardBody, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CheckboxControl,
+} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 

--- a/includes/multi-currency/client/settings/multi-currency/store-settings/index.js
+++ b/includes/multi-currency/client/settings/multi-currency/store-settings/index.js
@@ -2,12 +2,10 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import {
-	Button,
-	Card,
-	CardBody,
-	CheckboxControl,
-} from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 

--- a/includes/multi-currency/client/settings/single-currency/currency-preview.js
+++ b/includes/multi-currency/client/settings/single-currency/currency-preview.js
@@ -4,7 +4,8 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 import { TextControlWithAffixes } from '@woocommerce/components';
 import {
 	formatCurrency,

--- a/includes/multi-currency/client/settings/single-currency/currency-preview.js
+++ b/includes/multi-currency/client/settings/single-currency/currency-preview.js
@@ -4,7 +4,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '@wordpress/components';
+import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
 import { TextControlWithAffixes } from '@woocommerce/components';
 import {
 	formatCurrency,

--- a/includes/multi-currency/client/settings/single-currency/index.js
+++ b/includes/multi-currency/client/settings/single-currency/index.js
@@ -12,7 +12,7 @@ import moment from 'moment';
  */
 import CurrencyPreview from './currency-preview';
 import './style.scss';
-import { Button, Card, CardBody } from '@wordpress/components';
+import { Button, Card, CardBody } from 'wcpay/components/wp-components-wrapped';
 import clsx from 'clsx';
 import {
 	decimalCurrencyCharmOptions,

--- a/includes/multi-currency/client/settings/single-currency/index.js
+++ b/includes/multi-currency/client/settings/single-currency/index.js
@@ -12,7 +12,9 @@ import moment from 'moment';
  */
 import CurrencyPreview from './currency-preview';
 import './style.scss';
-import { Button, Card, CardBody } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 import clsx from 'clsx';
 import {
 	decimalCurrencyCharmOptions,

--- a/includes/multi-currency/client/setup/tasks/add-currencies-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/add-currencies-task/index.js
@@ -3,7 +3,7 @@
  */
 import React, { useContext, useEffect, useState } from 'react';
 import { sprintf, __, _n } from '@wordpress/i18n';
-import { Button, Card, CardBody } from '@wordpress/components';
+import { Button, Card, CardBody } from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import _ from 'lodash';
 

--- a/includes/multi-currency/client/setup/tasks/add-currencies-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/add-currencies-task/index.js
@@ -3,7 +3,9 @@
  */
 import React, { useContext, useEffect, useState } from 'react';
 import { sprintf, __, _n } from '@wordpress/i18n';
-import { Button, Card, CardBody } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 import interpolateComponents from '@automattic/interpolate-components';
 import _ from 'lodash';
 

--- a/includes/multi-currency/client/setup/tasks/multi-currency-setup.js
+++ b/includes/multi-currency/client/setup/tasks/multi-currency-setup.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Card, CardBody } from '@wordpress/components';
+import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/includes/multi-currency/client/setup/tasks/multi-currency-setup.js
+++ b/includes/multi-currency/client/setup/tasks/multi-currency-setup.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 
 /**
  * Internal dependencies

--- a/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useEffect, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/setup-complete-task/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useEffect, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies

--- a/includes/multi-currency/client/setup/tasks/store-settings-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/store-settings-task/index.js
@@ -2,12 +2,10 @@
  * External dependencies
  */
 import React, { useContext, useState, useEffect } from 'react';
-import {
-	Button,
-	Card,
-	CardBody,
-	CheckboxControl,
-} from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/includes/multi-currency/client/setup/tasks/store-settings-task/index.js
+++ b/includes/multi-currency/client/setup/tasks/store-settings-task/index.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import React, { useContext, useState, useEffect } from 'react';
-import { Button, Card, CardBody, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CheckboxControl,
+} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
