### PR TITLE
Add logic for the subscription cancelled (subscription_canceled)

### DIFF
--- a/changelog/evidence-submission-form-subscription-cancelled
+++ b/changelog/evidence-submission-form-subscription-cancelled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add logic for subscription cancelled for the new evidence form.

--- a/client/disputes/new-evidence/cover-letter-generator.ts
+++ b/client/disputes/new-evidence/cover-letter-generator.ts
@@ -286,6 +286,38 @@ ${ __(
 ) }`;
 	}
 
+	if ( dispute.reason === 'subscription_canceled' ) {
+		return `${ __(
+			'We are submitting evidence in response to chargeback',
+			'woocommerce-payments'
+		) } #${ data.caseNumber } ${ __(
+			'for transaction',
+			'woocommerce-payments'
+		) } #${ data.transactionId } ${ __( 'on', 'woocommerce-payments' ) } ${
+			data.transactionDate
+		}.
+
+${ __( 'Our records indicate that the customer,', 'woocommerce-payments' ) } ${
+			data.customerName
+		}, ${ __( 'subscribed to', 'woocommerce-payments' ) } ${
+			data.product
+		} ${ __(
+			"and was billed according to the terms accepted at the time of signup. The customer's account remained active and no cancellation was recorded prior to the billing date.",
+			'woocommerce-payments'
+		) }
+
+${ __(
+	'To support our case, we are providing the following documentation:',
+	'woocommerce-payments'
+) }
+${ attachmentsList }
+
+${ __(
+	'Based on this information, we respectfully request that the chargeback be reversed. Please let us know if any further details are required.',
+	'woocommerce-payments'
+) }`;
+	}
+
 	return `${ __(
 		'We are submitting evidence in response to chargeback',
 		'woocommerce-payments'

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -56,15 +56,6 @@ const getRecommendedDocumentFields = (
 			order: 20,
 		},
 		{
-			key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
-			label: __( "Customer's signature", 'woocommerce-payments' ),
-			description: __(
-				"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
-				'woocommerce-payments'
-			),
-			order: 30,
-		},
-		{
 			key: DOCUMENT_FIELD_KEYS.UNCATEGORIZED_FILE,
 			label: __( 'Other documents', 'woocommerce-payments' ),
 			description: __(
@@ -81,6 +72,15 @@ const getRecommendedDocumentFields = (
 		Array< RecommendedDocument >
 	> = {
 		credit_not_processed: [
+			{
+				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
+				label: __( "Customer's signature", 'woocommerce-payments' ),
+				description: __(
+					"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
 			{
 				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
 				label: __( 'Store refund policy', 'woocommerce-payments' ),
@@ -102,6 +102,15 @@ const getRecommendedDocumentFields = (
 		],
 		duplicate: [
 			{
+				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
+				label: __( "Customer's signature", 'woocommerce-payments' ),
+				description: __(
+					"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
+			{
 				key: DOCUMENT_FIELD_KEYS.DUPLICATE_CHARGE_DOCUMENTATION,
 				label: __(
 					'Documentation for the duplicate charge',
@@ -116,28 +125,46 @@ const getRecommendedDocumentFields = (
 		],
 		subscription_canceled: [
 			{
-				key: DOCUMENT_FIELD_KEYS.CANCELLATION_POLICY,
-				label: __( 'Cancellation policy', 'woocommerce-payments' ),
-				description: __(
-					"A screenshot of your store's cancellation policy.",
-					'woocommerce-payments'
-				),
-				order: 40,
-			},
-			{
 				key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
 				label: __(
 					'Proof of active subscription',
 					'woocommerce-payments'
 				),
 				description: __(
-					'Such as billing history, subscription status, or cancellation logs.',
+					'Any documents showing the billing history, subscription status, or cancellation logs, for example.',
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
+			{
+				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
+				label: __( 'Store refund policy', 'woocommerce-payments' ),
+				description: __(
+					"A screenshot of your store's refund policy.",
+					'woocommerce-payments'
+				),
+				order: 40,
+			},
+			{
+				key: DOCUMENT_FIELD_KEYS.CANCELLATION_POLICY,
+				label: __( 'Terms of service', 'woocommerce-payments' ),
+				description: __(
+					"A screenshot of your store's terms of service.",
 					'woocommerce-payments'
 				),
 				order: 50,
 			},
 		],
 		fraudulent: [
+			{
+				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
+				label: __( "Customer's signature", 'woocommerce-payments' ),
+				description: __(
+					"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
 			{
 				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
 				label: __( 'Store refund policy', 'woocommerce-payments' ),
@@ -150,6 +177,15 @@ const getRecommendedDocumentFields = (
 		],
 		product_not_received: [
 			{
+				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
+				label: __( "Customer's signature", 'woocommerce-payments' ),
+				description: __(
+					"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
+			{
 				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
 				label: __( 'Store refund policy', 'woocommerce-payments' ),
 				description: __(
@@ -160,6 +196,15 @@ const getRecommendedDocumentFields = (
 			},
 		],
 		product_unacceptable: [
+			{
+				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
+				label: __( "Customer's signature", 'woocommerce-payments' ),
+				description: __(
+					"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
 			{
 				key: DOCUMENT_FIELD_KEYS.SERVICE_DOCUMENTATION,
 				label: __( 'Item condition', 'woocommerce-payments' ),
@@ -180,6 +225,15 @@ const getRecommendedDocumentFields = (
 			},
 		],
 		unrecognized: [
+			{
+				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,
+				label: __( "Customer's signature", 'woocommerce-payments' ),
+				description: __(
+					"Any relevant documents showing the customer's signature, such as signed proof of delivery.",
+					'woocommerce-payments'
+				),
+				order: 30,
+			},
 			{
 				key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
 				label: __(

--- a/client/disputes/new-evidence/test/cover-letter-generator.test.ts
+++ b/client/disputes/new-evidence/test/cover-letter-generator.test.ts
@@ -404,6 +404,27 @@ describe( 'Cover Letter Generator', () => {
 			);
 			expect( result ).toContain( '<Customer Name>' );
 		} );
+
+		it( 'should generate body for subscription canceled dispute', () => {
+			const attachmentsList = '• Test Attachment';
+			const subscriptionCanceledDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'subscription_canceled' as DisputeReason,
+			};
+			const result = generateBody(
+				mockCoverLetterData,
+				subscriptionCanceledDispute,
+				attachmentsList
+			);
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain( 'John Doe' );
+			expect( result ).toContain( 'Test Product' );
+			expect( result ).toContain( 'subscribed to' );
+			expect( result ).toContain(
+				"and was billed according to the terms accepted at the time of signup. The customer's account remained active and no cancellation was recorded prior to the billing date."
+			);
+		} );
 	} );
 
 	describe( 'generateClosing', () => {
@@ -554,6 +575,29 @@ describe( 'Cover Letter Generator', () => {
 			expect( result ).toContain( 'ch_123' );
 			expect( result ).toContain(
 				'The customer requested a refund outside of the eligible window outlined in our refund policy, which was clearly presented on the website and on the order confirmation.'
+			);
+		} );
+
+		it( 'should generate cover letter for subscription canceled dispute', () => {
+			const subscriptionCanceledDispute: ExtendedDispute = {
+				...mockDispute,
+				reason: 'subscription_canceled' as DisputeReason,
+			};
+			const result = generateCoverLetter(
+				subscriptionCanceledDispute,
+				mockAccountDetails,
+				mockSettings,
+				'Test Bank'
+			);
+			expect( result ).toContain( 'Test Store' );
+			expect( result ).toContain( 'Test Bank' );
+			expect( result ).toContain( 'dp_123' );
+			expect( result ).toContain( 'ch_123' );
+			expect( result ).toContain( 'John Doe' );
+			expect( result ).toContain( 'Test Product' );
+			expect( result ).toContain( 'subscribed to' );
+			expect( result ).toContain(
+				"and was billed according to the terms accepted at the time of signup. The customer's account remained active and no cancellation was recorded prior to the billing date."
 			);
 		} );
 	} );

--- a/client/disputes/new-evidence/test/recommended-document-fields.test.ts
+++ b/client/disputes/new-evidence/test/recommended-document-fields.test.ts
@@ -12,11 +12,10 @@ describe( 'Recommended Documents', () => {
 	describe( 'getRecommendedDocumentFields', () => {
 		it( 'should return default fields when no specific reason is provided', () => {
 			const result = getRecommendedDocumentFields( '' );
-			expect( result ).toHaveLength( 4 ); // Default fields
+			expect( result ).toHaveLength( 3 ); // Default fields
 			expect( result[ 0 ].key ).toBe( 'receipt' );
 			expect( result[ 1 ].key ).toBe( 'customer_communication' );
-			expect( result[ 2 ].key ).toBe( 'customer_signature' );
-			expect( result[ 3 ].key ).toBe( 'uncategorized_file' );
+			expect( result[ 2 ].key ).toBe( 'uncategorized_file' );
 		} );
 
 		it( 'should return fields for product_unacceptable reason', () => {
@@ -51,9 +50,9 @@ describe( 'Recommended Documents', () => {
 			expect( result ).toHaveLength( 6 ); // Default fields + 2 specific fields
 			expect( result[ 0 ].key ).toBe( 'receipt' );
 			expect( result[ 1 ].key ).toBe( 'customer_communication' );
-			expect( result[ 2 ].key ).toBe( 'customer_signature' );
-			expect( result[ 3 ].key ).toBe( 'cancellation_policy' );
-			expect( result[ 4 ].key ).toBe( 'access_activity_log' );
+			expect( result[ 2 ].key ).toBe( 'access_activity_log' );
+			expect( result[ 3 ].key ).toBe( 'refund_policy' );
+			expect( result[ 4 ].key ).toBe( 'cancellation_policy' );
 			expect( result[ 5 ].key ).toBe( 'uncategorized_file' );
 		} );
 


### PR DESCRIPTION
See WOOPMNT-4997

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Ensure the evidence submission form generates the correct cover letter
- Add support for subscription_canceled on the cover letter generation
- Add the correct recommended documents for subscription_canceled

Template

```
[Your Business Name] [Your Address] [Your Email] [Your Phone Number] [Date]

To: [Acquiring Bank or Payment Processor Name]  
Subject: Chargeback Dispute – Case # [Chargeback Case Number]

Dear Dispute Resolution Team,

We are submitting evidence in response to chargeback # [Chargeback Case Number] for transaction # [Transaction ID] on [Transaction Date].

Our records indicate that the customer, [Customer Name], subscribed to [Product or Service] and was billed according to the terms accepted at the time of signup. The customer’s account remained active and no cancellation was recorded prior to the billing date.

To support our case, we are providing the following documentation:
• <Attachment description> (Attachment A)
• <Attachment description> (Attachment B)

Based on this information, we respectfully request that the chargeback be reversed. Please let us know if any further details are required.

Thank you,  
[Your Name]  
[Your Business Name]
```

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute in test mode.
* Since Stripe doesn't have a specific cards for testing this case you SHOULD hardcode the chargeback reason (subscription_canceled) in two different places: [here](https://github.com/Automattic/woocommerce-payments/blob/85ec6420dfb7574962cc081fa7c7e71a1504d35b/client/disputes/new-evidence/index.tsx#L287) and [here](https://github.com/Automattic/woocommerce-payments/blob/85ec6420dfb7574962cc081fa7c7e71a1504d35b/client/disputes/new-evidence/cover-letter-generator.ts#L325)
* Go to Payments > Disputes, select any dispute (since you hardcoded the reason) listed.
* Hit Challenge Dispute
* Fill out the form and on the final step check the cover letter follows the template on the description.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
