### PR TITLE
Fix step back behavior

### DIFF
--- a/changelog/click-back-should-also-change-scroll-position-to-the-top
+++ b/changelog/click-back-should-also-change-scroll-position-to-the-top
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Step back should also scroll the page to the top

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
@@ -140,6 +140,11 @@ export default ( { query }: { query: { id: string } } ) => {
 	const [ refundStatus, setRefundStatus ] = useState(
 		'refund_has_been_issued'
 	);
+
+	// Refs for heading elements to focus on step navigation
+	const stepHeadingRefs = useRef< {
+		[ key: number ]: HTMLHeadingElement | null;
+	} >( {} );
 
 	// --- Data loading ---
 	useEffect( () => {
@@ -440,6 +445,19 @@ export default ( { query }: { query: { id: string } } ) => {
 		// Scroll to top of page
 		window.scrollTo( { top: 0, behavior: 'smooth' } );
 	};
+
+	// Focus on heading when step changes
+	useEffect( () => {
+		// Use setTimeout to ensure the DOM has updated with the new step content
+		const timeoutId = setTimeout( () => {
+			const headingRef = stepHeadingRefs.current[ currentStep ];
+			if ( headingRef ) {
+				headingRef.focus();
+			}
+		}, 100 );
+
+		return () => clearTimeout( timeoutId );
+	}, [ currentStep ] );
 
 	const updateProductType = ( newType: string ) => {
 		recordEvent( 'wcpay_dispute_product_selected', { selection: newType } );
@@ -758,7 +776,11 @@ export default ( { query }: { query: { id: string } } ) => {
 		if ( currentStep === 0 ) {
 			return (
 				<>
-					<h2 className="wcpay-dispute-evidence-new__stepper-title">
+					<h2
+						className="wcpay-dispute-evidence-new__stepper-title"
+						ref={ ( el ) => ( stepHeadingRefs.current[ 0 ] = el ) }
+						tabIndex={ -1 }
+					>
 						{ steps[ 0 ].heading }
 					</h2>
 					<p className="wcpay-dispute-evidence-new__stepper-subheading">
@@ -793,7 +815,11 @@ export default ( { query }: { query: { id: string } } ) => {
 		if ( hasShipping && currentStep === 1 ) {
 			return (
 				<>
-					<h2 className="wcpay-dispute-evidence-new__stepper-title">
+					<h2
+						className="wcpay-dispute-evidence-new__stepper-title"
+						ref={ ( el ) => ( stepHeadingRefs.current[ 1 ] = el ) }
+						tabIndex={ -1 }
+					>
 						{ steps[ 1 ].heading }
 					</h2>
 					<p className="wcpay-dispute-evidence-new__stepper-subheading">
@@ -825,7 +851,13 @@ export default ( { query }: { query: { id: string } } ) => {
 		if ( currentStep === reviewStep ) {
 			return (
 				<>
-					<h2 className="wcpay-dispute-evidence-new__stepper-title">
+					<h2
+						className="wcpay-dispute-evidence-new__stepper-title"
+						ref={ ( el ) =>
+							( stepHeadingRefs.current[ reviewStep ] = el )
+						}
+						tabIndex={ -1 }
+					>
 						{ steps[ reviewStep ].heading }
 					</h2>
 					<p className="wcpay-dispute-evidence-new__stepper-subheading">

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -435,6 +435,12 @@ export default ( { query }: { query: { id: string } } ) => {
 		window.scrollTo( { top: 0, behavior: 'smooth' } );
 	};
 
+	const handleStepBack = ( step: number ) => {
+		setCurrentStep( step );
+		// Scroll to top of page
+		window.scrollTo( { top: 0, behavior: 'smooth' } );
+	};
+
 	const updateProductType = ( newType: string ) => {
 		recordEvent( 'wcpay_dispute_product_selected', { selection: newType } );
 		setProductType( newType );
@@ -930,7 +936,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				<div className="wcpay-dispute-evidence-new__button-row">
 					<Button
 						variant="secondary"
-						onClick={ () => setCurrentStep( ( s ) => s - 1 ) }
+						onClick={ () => handleStepBack( currentStep - 1 ) }
 						icon={ chevronLeft }
 						iconPosition="left"
 					>
@@ -968,7 +974,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					variant="secondary"
 					icon={ chevronLeft }
 					iconPosition="left"
-					onClick={ () => setCurrentStep( ( s ) => s - 1 ) }
+					onClick={ () => handleStepBack( currentStep - 1 ) }
 				>
 					{ __( 'Back', 'woocommerce-payments' ) }
 				</Button>


### PR DESCRIPTION
Fixes WOOPMNT-5106

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When clicking on the navigation Back button it should scroll the page to the top.

Related to https://github.com/Automattic/woocommerce-payments/pull/10863

![2025-07-01 18 21 50](https://github.com/user-attachments/assets/2cc6334e-d876-4729-bbd1-e663b2bc5425)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge Dispute.
* Ensure when you click on Next button the page scrolls to the top.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
