### PR TITLE
Update expired card message expectation in E2E tests

### DIFF
--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
@@ -42,7 +42,10 @@ test.describe(
 			);
 			await shopper.placeOrder( page );
 
-			await waitForBanner( page, 'Error: Your card has expired.' );
+			await waitForBanner(
+				page,
+				"Your card's expiration date is in the past."
+			);
 		} );
 
 		test( 'should throw an error that the card CVV number is invalid', async ( {
@@ -93,7 +96,10 @@ test.describe(
 			);
 			await shopper.placeOrder( page );
 
-			await waitForBanner( page, 'Error: Your card has expired.' );
+			await waitForBanner(
+				page,
+				"Your card's expiration date is in the past."
+			);
 		} );
 
 		test( 'should throw an error that the card was declined due to incorrect CVC number', async ( {

--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
@@ -35,7 +35,7 @@ const cards: Array< CardType > = [
 	[
 		'declined-expired',
 		config.cards[ 'declined-expired' ],
-		'Error: Your card has expired.',
+		"Your card's expiration date is in the past.",
 	],
 	[
 		'declined-cvc',


### PR DESCRIPTION
Fixes [WOOPMNT-5126](https://linear.app/a8c/issue/WOOPMNT-5126/update-expired-card-error-message-in-e2e-tests)

#### Changes proposed in this Pull Request

 - Change the expected `Error: Your card has expired.` to the actual `Your card's expiration date is in the past.`
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
