### PR TITLE
update: order page to use unbundled WP components

### DIFF
--- a/changelog/update-order-page-wp-components
+++ b/changelog/update-order-page-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: order page assets with wp components

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -12,6 +12,7 @@ import { isAwaitingResponse, isUnderReview } from 'wcpay/disputes/utils';
 import TestModeNotice from './test-mode-notice';
 import DisputedOrderNoticeHandler from 'wcpay/components/disputed-order-notice';
 import getStatusChangeStrategy from './order-status-change-strategies';
+import { WordPressComponentsContext } from 'wcpay/wordpress-components-context/context';
 
 function disableWooOrderRefundButton( disputeStatus ) {
 	const refundButton = document.querySelector( 'button.refund-items' );
@@ -112,13 +113,23 @@ jQuery( function ( $ ) {
 
 		ReactDOM.render(
 			<>
-				{ testMode && <TestModeNotice /> }
+				{ testMode && (
+					<WordPressComponentsContext.Provider
+						value={ wp.components }
+					>
+						<TestModeNotice />
+					</WordPressComponentsContext.Provider>
+				) }
 
 				{ chargeId && orderTestModeMatch && (
-					<DisputedOrderNoticeHandler
-						chargeId={ chargeId }
-						onDisableOrderRefund={ disableWooOrderRefundButton }
-					/>
+					<WordPressComponentsContext.Provider
+						value={ wp.components }
+					>
+						<DisputedOrderNoticeHandler
+							chargeId={ chargeId }
+							onDisableOrderRefund={ disableWooOrderRefundButton }
+						/>
+					</WordPressComponentsContext.Provider>
 				) }
 			</>,
 			container

--- a/client/order/test-mode-notice/index.tsx
+++ b/client/order/test-mode-notice/index.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 
 /**
  * Internal dependencies

--- a/client/order/test-mode-notice/index.tsx
+++ b/client/order/test-mode-notice/index.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
@@ -20,16 +21,12 @@ const TestModeNotice = (): JSX.Element => {
 				),
 				components: {
 					learnMoreLink: (
-						<a
-							target="_blank"
-							href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/"
-							rel="noopener noreferrer"
-						>
+						<ExternalLink href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/">
 							{ __(
 								'Learn more about test mode',
 								'woocommerce-payments'
 							) }
-						</a>
+						</ExternalLink>
 					),
 				},
 			} ) }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -634,7 +634,7 @@ class WC_Payments_Admin {
 			'all'
 		);
 
-		WC_Payments::register_script_with_dependencies( 'WCPAY_ADMIN_ORDER_ACTIONS', 'dist/order', [ 'jquery-tiptip' ] );
+		WC_Payments::register_script_with_dependencies( 'WCPAY_ADMIN_ORDER_ACTIONS', 'dist/order', [ 'jquery-tiptip', 'wp-components' ] );
 
 		WC_Payments_Utils::register_style(
 			'WCPAY_ADMIN_ORDER_ACTIONS',


### PR DESCRIPTION
Fixes WOOPMNT-5122

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Updating the `order` bundle (which is used on WC "order details" pages in the admin) to use the WP components that come with the WordPress installation.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a customer, place an order with the card `4000000000001976`
- As a merchant, navigate to `wp-admin` > WooCommerce > Orders
- Open the order details for the order that was placed
- The UI should still work

See the differences, below:
![2025-07-02 16 23 50](https://github.com/user-attachments/assets/25ef43c1-dc38-4453-a024-2fbdb84b32d8)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
