### PR TITLE
Attempt to fix the cover letter save behavior

### DIFF
--- a/changelog/attempt-to-improve-the-cover-letter-save-behavior
+++ b/changelog/attempt-to-improve-the-cover-letter-save-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve the cover letter save behavior.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -195,9 +195,44 @@ export default ( { query }: { query: { id: string } } ) => {
 				const savedCoverLetter = d.evidence?.uncategorized_text;
 				if ( savedCoverLetter ) {
 					setCoverLetter( savedCoverLetter );
+					// Create a dispute object with current evidence state for comparison
+					const disputeWithCurrentEvidence = {
+						...d,
+						evidence: {
+							...d.evidence,
+							product_description:
+								d.evidence?.product_description || '',
+							receipt: d.evidence?.receipt || '',
+							customer_communication:
+								d.evidence?.customer_communication || '',
+							customer_signature:
+								d.evidence?.customer_signature || '',
+							refund_policy: d.evidence?.refund_policy || '',
+							duplicate_charge_documentation:
+								d.evidence?.duplicate_charge_documentation ||
+								'',
+							shipping_documentation:
+								d.evidence?.shipping_documentation || '',
+							service_documentation:
+								d.evidence?.service_documentation || '',
+							cancellation_policy:
+								d.evidence?.cancellation_policy || '',
+							access_activity_log:
+								d.evidence?.access_activity_log || '',
+							uncategorized_file:
+								d.evidence?.uncategorized_file || '',
+							shipping_carrier:
+								d.evidence?.shipping_carrier || '',
+							shipping_date: d.evidence?.shipping_date || '',
+							shipping_tracking_number:
+								d.evidence?.shipping_tracking_number || '',
+							shipping_address:
+								d.evidence?.shipping_address || '',
+						},
+					};
 					// Only mark as manually edited if it differs from what would be auto-generated
 					const generatedContent = generateCoverLetter(
-						d,
+						disputeWithCurrentEvidence,
 						getBusinessDetails(),
 						settings,
 						bankName,
@@ -276,17 +311,49 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	// Update cover letter when evidence changes
 	useEffect( () => {
-		if ( ! dispute || ! settings || isCoverLetterManuallyEdited ) return;
+		if ( ! dispute || ! settings ) return;
+
+		// Create a dispute object with current evidence state for generation
+		const disputeWithCurrentEvidence = {
+			...dispute,
+			evidence: {
+				...dispute.evidence,
+				product_description: productDescription,
+				receipt: evidence.receipt,
+				customer_communication: evidence.customer_communication,
+				customer_signature: evidence.customer_signature,
+				refund_policy: evidence.refund_policy,
+				duplicate_charge_documentation:
+					evidence.duplicate_charge_documentation,
+				shipping_documentation: evidence.shipping_documentation,
+				service_documentation: evidence.service_documentation,
+				cancellation_policy: evidence.cancellation_policy,
+				access_activity_log: evidence.access_activity_log,
+				uncategorized_file: evidence.uncategorized_file,
+				shipping_carrier: shippingCarrier,
+				shipping_date: shippingDate,
+				shipping_tracking_number: shippingTrackingNumber,
+				shipping_address: shippingAddress,
+			},
+		};
 
 		const generatedCoverLetter = generateCoverLetter(
-			dispute,
+			disputeWithCurrentEvidence,
 			getBusinessDetails(),
 			settings,
 			bankName,
 			refundStatus,
 			duplicateStatus
 		);
-		setCoverLetter( generatedCoverLetter );
+
+		// Only auto-update if not manually edited, or if the current content matches what was previously generated
+		if (
+			! isCoverLetterManuallyEdited ||
+			coverLetter === generatedCoverLetter
+		) {
+			setCoverLetter( generatedCoverLetter );
+			setIsCoverLetterManuallyEdited( false );
+		}
 	}, [
 		dispute,
 		settings,
@@ -300,6 +367,7 @@ export default ( { query }: { query: { id: string } } ) => {
 		shippingAddress,
 		refundStatus,
 		duplicateStatus,
+		coverLetter,
 	] );
 
 	// --- Step logic ---
@@ -909,10 +977,41 @@ export default ( { query }: { query: { id: string } } ) => {
 								return;
 							}
 
+							// Create a dispute object with current evidence state for generation
+							const disputeWithCurrentEvidence = {
+								...dispute,
+								evidence: {
+									...dispute.evidence,
+									product_description: productDescription,
+									receipt: evidence.receipt,
+									customer_communication:
+										evidence.customer_communication,
+									customer_signature:
+										evidence.customer_signature,
+									refund_policy: evidence.refund_policy,
+									duplicate_charge_documentation:
+										evidence.duplicate_charge_documentation,
+									shipping_documentation:
+										evidence.shipping_documentation,
+									service_documentation:
+										evidence.service_documentation,
+									cancellation_policy:
+										evidence.cancellation_policy,
+									access_activity_log:
+										evidence.access_activity_log,
+									uncategorized_file:
+										evidence.uncategorized_file,
+									shipping_carrier: shippingCarrier,
+									shipping_date: shippingDate,
+									shipping_tracking_number: shippingTrackingNumber,
+									shipping_address: shippingAddress,
+								},
+							};
+
 							// If the value is empty, regenerate the content
 							if ( newValue.trim() === '' ) {
 								const generatedContent = generateCoverLetter(
-									dispute,
+									disputeWithCurrentEvidence,
 									getBusinessDetails(),
 									settings,
 									bankName,
@@ -926,7 +1025,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 							// Compare with what would be auto-generated
 							const generatedContent = generateCoverLetter(
-								dispute,
+								disputeWithCurrentEvidence,
 								getBusinessDetails(),
 								settings,
 								bankName,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The cover letter currently shows a notice when changes made on it are saved and they don't match what the generation process would have produced.

The problem is that after passing each step the evidence is saved and changes made on the next step are not reflected in the cover letter making the notice misleading and also the cover letter doesn't get the changes.

This PR attempts to fix the following problem scenario:
* on the first step the user adds information to the fields, also containing files;
* the user goes to the next step (the cover letter is generated and saved);
* on the second step the user adds more information to the fields, also containing files;
* the user goes to the next step (the cover letter is not generated because it thinks the cover letter was customized);
* the user goes to the third step and see the notice about the changes not matching the generation process and the cover letter is not updated with the changes from the second step.

@dmvrtx since you highlighted this issue to me, I'll be adding you to test this.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge Dispute.
* Follow the scenario description...

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
