### PR TITLE
Do not allow to challenge Visa compliance disputes

### DIFF
--- a/changelog/woopmnt-5112-visa-compelling-evidence-30-disputes-are-not-supported
+++ b/changelog/woopmnt-5112-visa-compelling-evidence-30-disputes-are-not-supported
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove options to challenge Visa compliance and Visa compelling evidence disputes, as both flows are not supported by the plugin.

--- a/changelog/woopmnt-5112-visa-compelling-evidence-30-disputes-are-not-supported
+++ b/changelog/woopmnt-5112-visa-compelling-evidence-30-disputes-are-not-supported
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove options to challenge Visa compliance and Visa compelling evidence disputes, as both flows are not supported by the plugin.

--- a/changelog/woopmnt-5113-visa-compliance-dispute-requires-attention-to-a-specific-fee
+++ b/changelog/woopmnt-5113-visa-compliance-dispute-requires-attention-to-a-specific-fee
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disallow challenging the Visa compliance disputes.

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -239,9 +239,21 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		isDisputeAcceptRequestPending,
 	} );
 
+	/**
+	 * The following cases cannot be defended:
+	 * - Klarna inquiries
+	 * - Visa Compliance disputes (require confirmation of a specific fee)
+	 * - Visa Compelling Evidence 3 disputes (require a specific evidence flow)
+	 */
 	const isDefendable = ! (
-		paymentMethod === 'klarna' && isInquiry( dispute.status )
-	); // Only Klarna inquires are not defendable
+		( paymentMethod === 'klarna' && isInquiry( dispute.status ) ) ||
+		( dispute?.enhanced_eligibility_types || [] ).includes(
+			'visa_compliance'
+		) ||
+		( dispute?.enhanced_eligibility_types || [] ).includes(
+			'visa_compelling_evidence_3'
+		)
+	);
 
 	const challengeButtonDefaultText = isInquiry( dispute.status )
 		? __( 'Submit evidence', 'woocommerce-payments' )

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -243,15 +243,11 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 	 * The following cases cannot be defended:
 	 * - Klarna inquiries
 	 * - Visa Compliance disputes (require confirmation of a specific fee)
-	 * - Visa Compelling Evidence 3 disputes (require a specific evidence flow)
 	 */
 	const isDefendable = ! (
 		( paymentMethod === 'klarna' && isInquiry( dispute.status ) ) ||
 		( dispute?.enhanced_eligibility_types || [] ).includes(
 			'visa_compliance'
-		) ||
-		( dispute?.enhanced_eligibility_types || [] ).includes(
-			'visa_compelling_evidence_3'
 		)
 	);
 

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -110,6 +110,7 @@ export interface Dispute {
 	 */
 	balance_transactions: BalanceTransaction[];
 	payment_intent: string;
+	enhanced_eligibility_types?: string[];
 }
 
 export interface CachedDispute {


### PR DESCRIPTION
 - Fixes WOOPMNT-5113

#### Changes proposed in this Pull Request

Remove an option to challenge Visa compliance disputes:

 - Challenging Visa compliance dispute is an extremely rare case and is subject to a special dispute fee, to discourage merchants from doing so. It is most likely to be lost anyway.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Set up a store and checkout by using a card `4000008400000779` to create a Visa compliance dispute.
 * Navigate to the "Disputes" screen and click "Respond" on the new dispute.
 * Check that the "Challenge dispute" option is not present:

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/7013fe29-62fa-4cee-9540-53112f84ddc7" />

 * Create a different dispute, with any other type, e.g. using a card `4000000000001976` for an inquiry.
 * Open the dispute response page and see that the "Challenge dispute" option is present:

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/4ad41ef6-8faf-47c7-98fa-41a765fdd3c7" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
