### PR TITLE
Update Dispute copy

### DIFF
--- a/changelog/update-disputes-copy
+++ b/changelog/update-disputes-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update copy for disputes

--- a/client/components/dispute-status-chip/mappings.ts
+++ b/client/components/dispute-status-chip/mappings.ts
@@ -14,7 +14,7 @@ const status: {
 } = {
 	warning_needs_response: {
 		type: 'warning',
-		message: __( 'Inquiry: Needs response', 'woocommerce-payments' ),
+		message: __( 'Inquiry: Response needed', 'woocommerce-payments' ),
 	},
 	warning_under_review: {
 		type: 'primary',
@@ -26,7 +26,7 @@ const status: {
 	},
 	needs_response: {
 		type: 'warning',
-		message: __( 'Needs response', 'woocommerce-payments' ),
+		message: __( 'Response needed', 'woocommerce-payments' ),
 	},
 	under_review: {
 		type: 'primary',

--- a/client/components/dispute-status-chip/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/dispute-status-chip/test/__snapshots__/index.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`DisputeStatusChip renders needs_response status 1`] = `
   <span
     class="chip chip-alert"
   >
-    Needs response
+    Response needed
   </span>
 </div>
 `;
@@ -65,7 +65,7 @@ exports[`DisputeStatusChip renders warning_needs_response status 1`] = `
   <span
     class="chip chip-alert"
   >
-    Inquiry: Needs response
+    Inquiry: Response needed
   </span>
 </div>
 `;

--- a/client/components/payment-status-chip/__tests__/__snapshots__/index.js.snap
+++ b/client/components/payment-status-chip/__tests__/__snapshots__/index.js.snap
@@ -45,7 +45,7 @@ exports[`PaymentStatusChip renders disputed_needs_response status 1`] = `
   <span
     class="chip chip-warning"
   >
-    Disputed: Needs response
+    Disputed: Response needed
   </span>
 </div>
 `;
@@ -75,7 +75,7 @@ exports[`PaymentStatusChip renders disputed_warning_needs_response status 1`] = 
   <span
     class="chip chip-warning"
   >
-    Inquiry: Needs response
+    Inquiry: Response needed
   </span>
 </div>
 `;

--- a/client/disputes/filters/test/__snapshots__/index.tsx.snap
+++ b/client/disputes/filters/test/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ HTMLOptionsCollection [
   <option
     value="warning_needs_response"
   >
-    Inquiry: Needs response
+    Inquiry: Response needed
   </option>,
   <option
     value="warning_under_review"
@@ -20,7 +20,7 @@ HTMLOptionsCollection [
   <option
     value="needs_response"
   >
-    Needs response
+    Response needed
   </option>,
   <option
     value="under_review"

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -754,7 +754,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				content: dispute.created
 					? formatDateTimeFromTimestamp( dispute.created, {
 							separator: ', ',
-							includeTime: true,
+							includeTime: false,
 					  } )
 					: '–',
 			},
@@ -972,6 +972,10 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedShippingDocumentsFields }
 						readOnly={ readOnly }
+						customSubheading={ __(
+							'We recommend adding the following document(s) to support your case.',
+							'woocommerce-payments'
+						) }
 					/>
 					{ inlineNotice( bankName ) }
 				</>

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -8,6 +8,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import HelpOutlineIcon from 'gridicons/dist/help-outline';
 
 /**
  * Internal dependencies.
@@ -765,6 +766,7 @@ export default ( { query }: { query: { id: string } } ) => {
 						{ reasons[ disputeReason ]?.display || disputeReason }
 						{ disputeReasonSummary.length > 0 && (
 							<ClickTooltip
+								buttonIcon={ <HelpOutlineIcon /> }
 								buttonLabel={ __(
 									'Learn more',
 									'woocommerce-payments'

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -373,7 +373,7 @@ const getRecommendedShippingDocumentFields = (): Array<
 			key: DOCUMENT_FIELD_KEYS.SHIPPING_DOCUMENTATION,
 			label: __( 'Proof of shipping', 'woocommerce-payments' ),
 			description: __(
-				'A copy of the shipment receipt or label.',
+				'A receipt from the shipping carrier or a tracking number, for example.',
 				'woocommerce-payments'
 			),
 			order: 0,

--- a/client/disputes/new-evidence/recommended-documents.tsx
+++ b/client/disputes/new-evidence/recommended-documents.tsx
@@ -13,17 +13,21 @@ import { DocumentField, RecommendedDocumentsProps } from './types';
 const RecommendedDocuments: React.FC< RecommendedDocumentsProps > = ( {
 	fields,
 	readOnly = false,
+	customHeading,
+	customSubheading,
 } ) => {
 	return (
 		<section className="wcpay-dispute-evidence-recommended-documents">
 			<h3 className="wcpay-dispute-evidence-recommended-documents__heading">
-				{ __( 'Recommended documents', 'woocommerce-payments' ) }
+				{ customHeading ||
+					__( 'Recommended documents', 'woocommerce-payments' ) }
 			</h3>
 			<div className="wcpay-dispute-evidence-recommended-documents__subheading">
-				{ __(
-					'While optional, we strongly recommend providing as many of these documents as possible. The following file types are supported: PDF, JPEG, and PNG.',
-					'woocommerce-payments'
-				) }
+				{ customSubheading ||
+					__(
+						'While optional, we strongly recommend providing as many of these documents as possible. The following file types are supported: PDF, JPEG, and PNG.',
+						'woocommerce-payments'
+					) }
 			</div>
 			<ul className="wcpay-dispute-evidence-recommended-documents__list">
 				{ fields.map( ( field: DocumentField ) => (

--- a/client/disputes/new-evidence/types.ts
+++ b/client/disputes/new-evidence/types.ts
@@ -93,4 +93,6 @@ export interface FileUploadControlProps {
 export interface RecommendedDocumentsProps {
 	fields: DocumentField[];
 	readOnly?: boolean;
+	customHeading?: string;
+	customSubheading?: string;
 }

--- a/client/disputes/strings.ts
+++ b/client/disputes/strings.ts
@@ -216,7 +216,7 @@ export const reasons: Record<
 			),
 		],
 		claim: __(
-			'The cardholder claims the product was not received.',
+			'The cardholder claims they did not receive the product.',
 			'woocommerce-payments'
 		),
 	},
@@ -354,12 +354,12 @@ export const reasons: Record<
 // Mapping of disputes status to display string.
 export const displayStatus = {
 	warning_needs_response: __(
-		'Inquiry: Needs response',
+		'Inquiry: Response needed',
 		'woocommerce-payments'
 	),
 	warning_under_review: __( 'Inquiry: Under review', 'woocommerce-payments' ),
 	warning_closed: __( 'Inquiry: Closed', 'woocommerce-payments' ),
-	needs_response: __( 'Needs response', 'woocommerce-payments' ),
+	needs_response: __( 'Response needed', 'woocommerce-payments' ),
 	under_review: __( 'Under review', 'woocommerce-payments' ),
 	charge_refunded: __( 'Charge refunded', 'woocommerce-payments' ),
 	won: __( 'Won', 'woocommerce-payments' ),

--- a/client/disputes/test/__snapshots__/index.tsx.snap
+++ b/client/disputes/test/__snapshots__/index.tsx.snap
@@ -539,7 +539,7 @@ exports[`Disputes list renders correctly 1`] = `
                       <span
                         class="chip chip-alert"
                       >
-                        Needs response
+                        Response needed
                       </span>
                     </a>
                   </td>
@@ -793,7 +793,7 @@ exports[`Disputes list renders correctly 1`] = `
                       <span
                         class="chip chip-alert"
                       >
-                        Needs response
+                        Response needed
                       </span>
                     </a>
                   </td>

--- a/client/payment-details/dispute-details/dispute-due-by-date.tsx
+++ b/client/payment-details/dispute-details/dispute-due-by-date.tsx
@@ -15,8 +15,7 @@ const DisputeDueByDate: React.FC< {
 		moment.unix( dueBy ).utc().diff( moment().utc(), 'days', true )
 	);
 	const respondByDate = formatDateTimeFromTimestamp( dueBy, {
-		separator: ', ',
-		includeTime: true,
+		customFormat: 'F j, Y g:i A',
 	} );
 	return (
 		<span className="dispute-steps__steps__response-date">
@@ -32,8 +31,8 @@ const DisputeDueByDate: React.FC< {
 						sprintf(
 							// Translators: %d is the number of days left to respond to the dispute.
 							_n(
-								'(%d day left to respond)',
-								'(%d days left to respond)',
+								' (%d day left to respond)',
+								' (%d days left to respond)',
 								daysRemaining,
 								'woocommerce-payments'
 							),
@@ -41,9 +40,9 @@ const DisputeDueByDate: React.FC< {
 						) }
 
 					{ daysRemaining === 0 &&
-						__( '(Last day today)', 'woocommerce-payments' ) }
+						__( ' (Last day today)', 'woocommerce-payments' ) }
 					{ daysRemaining < 0 &&
-						__( '(Past due)', 'woocommerce-payments' ) }
+						__( ' (Past due)', 'woocommerce-payments' ) }
 				</span>
 			) }
 		</span>

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -41,8 +41,7 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 	const dueByDate = formatDateTimeFromTimestamp(
 		dispute.evidence_details?.due_by ?? 0,
 		{
-			separator: ' ',
-			includeTime: true,
+			customFormat: 'g:i A \\o\\n F j, Y',
 		}
 	);
 
@@ -62,16 +61,16 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 		noticeText = bankName
 			? sprintf(
 					__(
-						'<strong>%1$s</strong> Submit the evidence to <strong>%2$s</strong> by <strong>%3$s</strong> if you believe the claim to be invalid, or issue a refund.',
+						"<strong>%1$s</strong> If you believe this is incorrect, you have until <strong>%2$s to submit evidence to your customer's bank, %3$s.</strong> Alternatively, you can issue a refund.",
 						'woocommerce-payments'
 					),
 					shopperDisputeReason,
-					bankName,
-					dueByDate
+					dueByDate,
+					bankName
 			  )
 			: sprintf(
 					__(
-						"<strong>%1$s</strong> Submit the evidence to <strong>Cardholder's bank</strong> by <strong>%2$s</strong> if you believe the claim to be invalid, or issue a refund.",
+						"<strong>%1$s</strong> If you believe this is incorrect, you have until <strong>%2$s to submit evidence to your customer's bank.</strong> Alternatively, you can issue a refund.",
 						'woocommerce-payments'
 					),
 					shopperDisputeReason,
@@ -84,16 +83,16 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 		noticeText = bankName
 			? sprintf(
 					__(
-						'<strong>%1$s</strong> Challenge the dispute with <strong>%2$s</strong> by <strong>%3$s</strong> if you believe the claim to be invalid, or accept to forfeit the funds and pay the dispute fee.',
+						"<strong>%1$s</strong> If you believe this is incorrect, you have until <strong>%2$s to challenge the dispute with your customer's bank, %3$s.</strong> If you accept the dispute, you will forfeit the funds and pay the dispute fee.",
 						'woocommerce-payments'
 					),
 					shopperDisputeReason,
-					bankName,
-					dueByDate
+					dueByDate,
+					bankName
 			  )
 			: sprintf(
 					__(
-						"<strong>%1$s</strong> Challenge the dispute with <strong>Cardholder's bank</strong> by <strong>%2$s</strong> if you believe the claim to be invalid, or accept to forfeit the funds and pay the dispute fee.",
+						"<strong>%1$s</strong> If you believe this is incorrect, you have until <strong>%2$s to challenge the dispute with your customer's bank.</strong> If you accept the dispute, you will forfeit the funds and pay the dispute fee.",
 						'woocommerce-payments'
 					),
 					shopperDisputeReason,

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -41,16 +41,16 @@ const DisputeUnderReviewFooter: React.FC< {
 							? sprintf(
 									/* Translators: %1$s - bank name, %2$s - formatted date, <a> - link to documentation page */
 									__(
-										'You submitted evidence for this dispute on %1$s. <strong>%2$s</strong> is reviewing the case, which can take 60 days or more. You will be alerted when they make their final decision. <a>Learn more about the dispute process</a>.',
+										"<strong>The customer's bank, %1$s, is currently reviewing the evidence you submitted on %2$s.</strong> This process can sometimes take more than 60 days — we'll let you know once a decision has been made. <a>Learn more about the dispute process.</a>",
 										'woocommerce-payments'
 									),
-									submissionDateFormatted,
-									bankName
+									bankName,
+									submissionDateFormatted
 							  )
 							: sprintf(
 									/* Translators: %s - formatted date, <a> - link to documentation page */
 									__(
-										'You submitted evidence for this dispute on %s. The <strong>cardholder’s bank</strong> is reviewing the case, which can take 60 days or more. You will be alerted when they make their final decision. <a>Learn more about the dispute process</a>.',
+										"<strong>The customer's bank is currently reviewing the evidence you submitted on %1$s.</strong> This process can sometimes take more than 60 days — we'll let you know once a decision has been made. <a>Learn more about the dispute process.</a>",
 										'woocommerce-payments'
 									),
 									submissionDateFormatted
@@ -119,7 +119,7 @@ const DisputeWonFooter: React.FC< {
 							? sprintf(
 									/* Translators: %1$s - bank name, %2$s - formatted date, <a> - link to documentation page */
 									__(
-										'Good news! <strong>%1$s</strong> decided that you won the dispute on %2$s. The disputed amount and the dispute fee have been credited back to your account. <a>Learn more about preventing disputes</a>.',
+										"<strong>Good news — you've won this dispute! The customer's bank, %1$s, reached this decision on %2$s.</strong> Your account has been credited with the disputed amount and fee. <a>Learn more about preventing disputes.</a>",
 										'woocommerce-payments'
 									),
 									bankName,
@@ -128,7 +128,7 @@ const DisputeWonFooter: React.FC< {
 							: sprintf(
 									/* Translators: %s - formatted date, <a> - link to documentation page */
 									__(
-										'Good news! The <strong>cardholder’s bank</strong> decided that you won the dispute on %s. The disputed amount and the dispute fee have been credited back to your account. <a>Learn more about preventing disputes</a>.',
+										"<strong>Good news — you've won this dispute! The customer's bank reached this decision on %1$s.</strong> Your account has been credited with the disputed amount and fee. <a>Learn more about preventing disputes.</a>",
 										'woocommerce-payments'
 									),
 									closedDateFormatted
@@ -208,7 +208,7 @@ const DisputeLostFooter: React.FC< {
 		messagePrefix = sprintf(
 			/* Translators: %1$s - formatted date */
 			__(
-				'This dispute was accepted and lost on %1$s.',
+				'<strong>You accepted this dispute on %1$s.</strong>',
 				'woocommerce-payments'
 			),
 			closedDateFormatted
@@ -228,7 +228,7 @@ const DisputeLostFooter: React.FC< {
 			messagePrefix = sprintf(
 				/* Translators: %1$s - bank name, %2$s - formatted date */
 				__(
-					'<strong>%1$s</strong> decided that you lost the dispute on %2$s.',
+					"<strong>Unfortunately, you've lost this dispute. The customer's bank, %1$s, reached this decision on %2$s.</strong>",
 					'woocommerce-payments'
 				),
 				bankName,
@@ -238,7 +238,7 @@ const DisputeLostFooter: React.FC< {
 			messagePrefix = sprintf(
 				/* Translators: %s - formatted date */
 				__(
-					'The <strong>cardholder’s bank</strong> decided that you lost the dispute on %s',
+					"<strong>Unfortunately, you've lost this dispute. The customer's bank reached this decision on %1$s.</strong>",
 					'woocommerce-payments'
 				),
 				closedDateFormatted
@@ -257,7 +257,7 @@ const DisputeLostFooter: React.FC< {
 						sprintf(
 							/* Translators: %1$s – the formatted dispute fee amount, <a> - link to documentation page */
 							__(
-								'The %1$s fee has been deducted from your account, and the disputed amount returned to the cardholder. <a>Learn more about preventing disputes</a>.',
+								'The %1$s fee has been deducted from your account, and the disputed amount has been returned to your customer. <a>Learn more about preventing disputes</a>.',
 								'woocommerce-payments'
 							),
 							disputeFeeFormatted

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -74,12 +74,12 @@ export const DisputeSteps: React.FC< Props > = ( {
 				<AccordionBody
 					lg
 					title="Steps you can take"
-					subtitle="Review these steps you can take to respond to disputes effectively"
+					subtitle="We recommend reviewing your options before responding by the deadline. "
 				>
 					<AccordionRow>
 						<div className="dispute-steps__content">
 							<div className="dispute-steps__items">
-								{ /* Step 1: Reach out to your customer */ }
+								{ /* Step 1: Contact your customer */ }
 								<div className="dispute-steps__item">
 									<div className="dispute-steps__item-icon">
 										<Icon icon={ envelope } />
@@ -87,7 +87,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 									<div className="dispute-steps__item-content">
 										<div className="dispute-steps__item-name">
 											{ __(
-												'Reach out to your customer',
+												'Contact your customer',
 												'woocommerce-payments'
 											) }
 										</div>
@@ -115,7 +115,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 									</div>
 								</div>
 
-								{ /* Step 2: Pursue a dispute withdrawal */ }
+								{ /* Step 2: Ask for the dispute to be withdrawn */ }
 								<div className="dispute-steps__item">
 									<div className="dispute-steps__item-icon">
 										<Icon icon={ comment } />
@@ -123,13 +123,13 @@ export const DisputeSteps: React.FC< Props > = ( {
 									<div className="dispute-steps__item-content">
 										<div className="dispute-steps__item-name">
 											{ __(
-												'Pursue a dispute withdrawal',
+												'Ask for the dispute to be withdrawn',
 												'woocommerce-payments'
 											) }
 										</div>
 										<div className="dispute-steps__item-description">
 											{ __(
-												'See if the customer will withdraw their dispute.',
+												"If you've managed to resolve the issue with your customer, help them with the withdrawal of their dispute.",
 												'woocommerce-payments'
 											) }
 										</div>
@@ -163,7 +163,7 @@ export const DisputeSteps: React.FC< Props > = ( {
 										</div>
 										<div className="dispute-steps__item-description">
 											{ __(
-												'Challenge the dispute if you consider the claim to be invalid. Accepting the dispute will automatically close it and the order amount and the dispute fee will not be returned to you.',
+												"Disagree with the dispute? You can challenge it with the customer's bank. Otherwise, accept it to close the case — the order amount and dispute fee won't be refunded.",
 												'woocommerce-payments'
 											) }
 										</div>
@@ -183,13 +183,13 @@ export const DisputeSteps: React.FC< Props > = ( {
 										bankName
 											? sprintf(
 													__(
-														'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
+														'<strong>The outcome of this dispute will be determined by %1$s.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.',
 														'woocommerce-payments'
 													),
 													bankName
 											  )
 											: __(
-													"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
+													"<strong>The outcome of this dispute will be determined by the cardholder's bank.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.",
 													'woocommerce-payments'
 											  ),
 										{
@@ -254,12 +254,12 @@ export const InquirySteps: React.FC< Props > = ( {
 				<AccordionBody
 					lg
 					title="Steps you can take"
-					subtitle="Review these steps you can take to respond to disputes effectively"
+					subtitle="We recommend reviewing your options before responding by the deadline. "
 				>
 					<AccordionRow>
 						<div className="dispute-steps__content">
 							<div className="dispute-steps__items">
-								{ /* Step 1: Reach out to your customer */ }
+								{ /* Step 1: Contact your customer */ }
 								<div className="dispute-steps__item">
 									<div className="dispute-steps__item-icon">
 										<Icon icon={ envelope } />
@@ -267,7 +267,7 @@ export const InquirySteps: React.FC< Props > = ( {
 									<div className="dispute-steps__item-content">
 										<div className="dispute-steps__item-name">
 											{ __(
-												'Reach out to your customer',
+												'Contact your customer',
 												'woocommerce-payments'
 											) }
 										</div>
@@ -309,7 +309,7 @@ export const InquirySteps: React.FC< Props > = ( {
 										</div>
 										<div className="dispute-steps__item-description">
 											{ __(
-												'Submit the evidence by providing the requested information.',
+												"Disagree with the claim? You can challenge it by submitting evidence to the customer's bank. Otherwise, you can settle the inquiry by issuing a refund.",
 												'woocommerce-payments'
 											) }
 										</div>
@@ -342,13 +342,13 @@ export const InquirySteps: React.FC< Props > = ( {
 										bankName
 											? sprintf(
 													__(
-														'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
+														'<strong>The outcome of this dispute will be determined by %1$s.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.',
 														'woocommerce-payments'
 													),
 													bankName
 											  )
 											: __(
-													"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
+													"<strong>The outcome of this dispute will be determined by the cardholder's bank.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.",
 													'woocommerce-payments'
 											  ),
 										{
@@ -413,12 +413,12 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 				<AccordionBody
 					lg
 					title="Steps you can take"
-					subtitle="Review these steps you can take to respond to disputes effectively"
+					subtitle="We recommend reviewing your options before responding by the deadline. "
 				>
 					<AccordionRow>
 						<div className="dispute-steps__content">
 							<div className="dispute-steps__items">
-								{ /* Step 1: Reach out to your customer */ }
+								{ /* Step 1: Contact your customer */ }
 								<div className="dispute-steps__item">
 									<div className="dispute-steps__item-icon">
 										<Icon icon={ envelope } />
@@ -426,13 +426,13 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 									<div className="dispute-steps__item-content">
 										<div className="dispute-steps__item-name">
 											{ __(
-												'Reach out to your customer',
+												'Contact your customer',
 												'woocommerce-payments'
 											) }
 										</div>
 										<div className="dispute-steps__item-description">
 											{ __(
-												'Identify the issue and work towards a resolution where possible.',
+												"Reach out to the customer to check if they're returning the item(s).",
 												'woocommerce-payments'
 											) }
 										</div>
@@ -468,7 +468,7 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 										</div>
 										<div className="dispute-steps__item-description">
 											{ __(
-												'Issue a refund if the item is returned.',
+												"Once you've received the item(s), refund the customer before the deadline to prevent this escalating to a dispute.",
 												'woocommerce-payments'
 											) }
 										</div>
@@ -483,13 +483,13 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 									<div className="dispute-steps__item-content">
 										<div className="dispute-steps__item-name">
 											{ __(
-												'Challenge the dispute if the item is not returned',
+												'Challenge the dispute',
 												'woocommerce-payments'
 											) }
 										</div>
 										<div className="dispute-steps__item-description">
 											{ __(
-												'Allow this inquiry to become a dispute in 21 days if you don’t receive the item.',
+												"Didn't receive the returned item(s)? Once the inquiry has automatically escalated to a dispute after 21 days, you can submit evidence and challenge the dispute.",
 												'woocommerce-payments'
 											) }
 										</div>
@@ -522,13 +522,13 @@ export const NotDefendableInquirySteps: React.FC< Props > = ( {
 										bankName
 											? sprintf(
 													__(
-														'<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. <strong>%1$s</strong> makes the decision in this process.',
+														'<strong>The outcome of this dispute will be determined by %1$s.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.',
 														'woocommerce-payments'
 													),
 													bankName
 											  )
 											: __(
-													"<strong>WooPayments does not determine the outcome of the dispute process</strong> and is not liable for any chargebacks. The cardholder's bank makes the decision in this process.",
+													"<strong>The outcome of this dispute will be determined by the cardholder's bank.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.",
 													'woocommerce-payments'
 											  ),
 										{

--- a/client/payment-details/dispute-details/dispute-summary-row.tsx
+++ b/client/payment-details/dispute-details/dispute-summary-row.tsx
@@ -40,7 +40,7 @@ const DisputeSummaryRow: React.FC< Props > = ( { dispute } ) => {
 			content: dispute.created
 				? formatDateTimeFromTimestamp( dispute.created, {
 						separator: ', ',
-						includeTime: true,
+						includeTime: false,
 				  } )
 				: '–',
 		},

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -38,25 +38,13 @@
 		}
 
 		.dispute-summary-row {
+			font-size: 13px;
+			font-weight: 400;
+
 			margin-top: 40px;
 
 			@media screen and ( max-width: $break-small ) {
 				margin-top: 24px;
-			}
-
-			&__response-date {
-				display: flex;
-				align-items: center;
-				gap: var( --grid-unit-05, 4px );
-				flex-wrap: wrap;
-				&--warning {
-					color: $alert-red;
-					font-weight: 700;
-				}
-				&--urgent {
-					font-weight: 700;
-					color: $alert-red;
-				}
 			}
 		}
 
@@ -224,7 +212,8 @@
 		&__response-date {
 			&--urgent {
 				color: var( --Gutenberg-Alert-Red, #cc1818 );
-				font-weight: 700;
+				font-weight: 600;
+				font-size: 13px;
 			}
 		}
 	}

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -267,6 +267,7 @@
 }
 
 .transaction-details-dispute-footer {
+	color: $gray-700;
 	background-color: #f2f4f5;
 
 	&__actions {

--- a/client/payment-details/summary/__tests__/__snapshots__/index.test.js.snap
+++ b/client/payment-details/summary/__tests__/__snapshots__/index.test.js.snap
@@ -5029,31 +5029,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
                 <span
                   class="woocommerce-list__item-content"
                 >
-                  Sep 19, 2019, 5:24pm
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="woocommerce-list__item"
-          >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Sales channel
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  <span>
-                    Online store
-                  </span>
+                  September 19, 2019 5:24 PM
                 </span>
               </div>
             </div>
@@ -5191,19 +5167,17 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
             data-wp-c16t="true"
             data-wp-component="FlexItem"
           >
-            Good news! The 
             <strong>
-              cardholder’s bank
+              Good news — you've won this dispute! The customer's bank reached this decision on -.
             </strong>
-             decided that you won the dispute on -. The disputed amount and the dispute fee have been credited back to your account. 
+             Your account has been credited with the disputed amount and fee. 
             <a
               href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
               rel="noopener noreferrer"
               target="_blank"
             >
-              Learn more about preventing disputes
+              Learn more about preventing disputes.
             </a>
-            .
           </div>
           <div
             class="components-flex-item transaction-details-dispute-footer__actions emotion-16 emotion-1"

--- a/client/payment-details/summary/__tests__/index.test.js
+++ b/client/payment-details/summary/__tests__/index.test.js
@@ -404,10 +404,10 @@ describe( 'PaymentDetailsSummary', () => {
 			selector: '.wcpay-accordion__title-content',
 		} );
 
-		screen.getByText( /Reach out to your customer/i, {
+		screen.getByText( /Contact your customer/i, {
 			selector: '.dispute-steps__item-name',
 		} );
-		screen.getByText( /Pursue a dispute withdrawal/i, {
+		screen.getByText( /Ask for the dispute to be withdrawn/i, {
 			selector: '.dispute-steps__item-name',
 		} );
 		screen.getByText( /Challenge or accept the dispute/i, {
@@ -419,11 +419,12 @@ describe( 'PaymentDetailsSummary', () => {
 			{ selector: '.dispute-steps__item-description' }
 		);
 		screen.getByText(
-			/See if the customer will withdraw their dispute\./i,
+			/If you've managed to resolve the issue with your customer, help them with the withdrawal of their dispute\./i,
 			{ selector: '.dispute-steps__item-description' }
 		);
 		screen.getByText(
-			/Challenge the dispute if you consider the claim to be invalid\./i,
+			// eslint-disable-next-line max-len
+			/Disagree with the dispute\? You can challenge it with the customer's bank\. Otherwise, accept it to close the case — the order amount and dispute fee won't be refunded\./i,
 			{ selector: '.dispute-steps__item-description' }
 		);
 		screen.getByRole( 'link', { name: /Email customer/i } );
@@ -685,7 +686,7 @@ describe( 'PaymentDetailsSummary', () => {
 		charge.dispute.metadata.__evidence_submitted_at = '1693400000';
 		renderCharge( charge );
 
-		screen.getByText( /decided that you won the dispute/i, {
+		screen.getByText( /Good news — you've won this dispute/i, {
 			ignore: '.a11y-speak-region',
 		} );
 		screen.getByRole( 'button', { name: /View dispute details/i } );
@@ -718,9 +719,12 @@ describe( 'PaymentDetailsSummary', () => {
 
 		renderCharge( charge );
 
-		screen.getByText( /You submitted evidence for this dispute/i, {
-			ignore: '.a11y-speak-region',
-		} );
+		screen.getByText(
+			/The customer's bank is currently reviewing the evidence you submitted/i,
+			{
+				ignore: '.a11y-speak-region',
+			}
+		);
 		screen.getByRole( 'button', { name: /View submitted evidence/i } );
 
 		// No actions or steps rendered
@@ -754,7 +758,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 		renderCharge( charge );
 
-		screen.getByText( /This dispute was accepted/i, {
+		screen.getByText( /You accepted this dispute/i, {
 			ignore: '.a11y-speak-region',
 		} );
 		// Check for the correct fee amount
@@ -793,7 +797,7 @@ describe( 'PaymentDetailsSummary', () => {
 
 		renderCharge( charge );
 
-		screen.getByText( /decided that you lost the dispute/i, {
+		screen.getByText( /Unfortunately, you've lost this dispute/i, {
 			ignore: '.a11y-speak-region',
 		} );
 		// Check for the correct fee amount
@@ -847,7 +851,7 @@ describe( 'PaymentDetailsSummary', () => {
 		screen.getByRole( 'link', {
 			name: /Email customer/i,
 		} );
-		screen.getByText( /Submit evidence /i );
+		screen.getByText( /Submit evidence or issue a refund/i );
 
 		// Actions
 		screen.getByRole( 'button', {

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -173,6 +173,60 @@ const composePaymentSummaryItems = ( {
 		},
 	].filter( isValueTruthy );
 
+const composePaymentSummaryItemsForDispute = ( {
+	charge = {} as Charge,
+}: {
+	charge: Charge;
+} ): HorizontalListItem[] =>
+	[
+		{
+			title: __( 'Date', 'woocommerce-payments' ),
+			content: charge.created
+				? formatDateTimeFromTimestamp( charge.created, {
+						customFormat: 'F j, Y g:i A',
+				  } )
+				: '–',
+		},
+		{
+			title: __( 'Customer', 'woocommerce-payments' ),
+			content: (
+				<CustomerLink
+					billing_details={ charge.billing_details }
+					order_details={ charge.order }
+				/>
+			),
+		},
+		{
+			title: __( 'Order', 'woocommerce-payments' ),
+			content: <OrderLink order={ charge.order } />,
+		},
+		wcpaySettings.isSubscriptionsActive && {
+			title: __( 'Subscription', 'woocommerce-payments' ),
+			content: charge.order?.subscriptions?.length ? (
+				charge.order.subscriptions.map( ( subscription, i, all ) => [
+					<OrderLink key={ i } order={ subscription } />,
+					i !== all.length - 1 && ', ',
+				] )
+			) : (
+				<OrderLink order={ null } />
+			),
+		},
+		{
+			title: __( 'Payment method', 'woocommerce-payments' ),
+			content: (
+				<PaymentMethodDetails
+					payment={ charge.payment_method_details }
+				/>
+			),
+		},
+		{
+			title: __( 'Risk evaluation', 'woocommerce-payments' ),
+			content: charge.outcome?.risk_level
+				? riskMappings[ charge.outcome.risk_level ]
+				: '–',
+		},
+	].filter( isValueTruthy );
+
 const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 	charge = {} as Charge,
 	metadata = {},
@@ -642,10 +696,16 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 			<CardBody useBundledComponent={ shouldUseBundledComponents }>
 				<LoadableBlock isLoading={ isLoading } numLines={ 4 }>
 					<HorizontalList
-						items={ composePaymentSummaryItems( {
-							charge,
-							metadata,
-						} ) }
+						items={
+							charge.dispute
+								? composePaymentSummaryItemsForDispute( {
+										charge,
+								  } )
+								: composePaymentSummaryItems( {
+										charge,
+										metadata,
+								  } )
+						}
 					/>
 				</LoadableBlock>
 			</CardBody>

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -1024,13 +1024,15 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 						bankName
 							? sprintf(
 									__(
-										'<strong>Dispute lost.</strong> <strong>%s</strong> decided that you lost the dispute.',
+										// eslint-disable-next-line max-len
+										"<strong>Dispute lost.</strong> Your customer's bank, <strong>%s</strong>, reviewed the evidence and decided in the customer's favor.",
 										'woocommerce-payments'
 									),
 									bankName
 							  )
 							: __(
-									'<strong>Dispute lost.</strong> <strong>The bank</strong> decided that you lost the dispute.',
+									// eslint-disable-next-line max-len
+									"<strong>Dispute lost.</strong> Your customer's bank reviewed the evidence and decided in the customer's favor.",
 									'woocommerce-payments'
 							  ),
 						{

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -206,11 +206,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                         <strong>
                           Dispute lost.
                         </strong>
-                         
-                        <strong>
-                          The bank
-                        </strong>
-                         decided that you lost the dispute.
+                         Your customer's bank reviewed the evidence and decided in the customer's favor.
                       </span>
                     </div>
                     <span

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -740,11 +740,7 @@ exports[`mapTimelineEvents single currency events formats dispute_lost events 1`
       <strong>
         Dispute lost.
       </strong>
-       
-      <strong>
-        The bank
-      </strong>
-       decided that you lost the dispute.
+       Your customer's bank reviewed the evidence and decided in the customer's favor.
     </React.Fragment>,
     "icon": <CrossIcon
       className="is-error"

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -123,9 +123,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 
 					// Check the dispute details footer
 					expect(
-						merchantPage.getByText(
-							'This dispute was accepted and lost'
-						)
+						merchantPage.getByText( 'You accepted this dispute on' )
 					).toBeVisible();
 				}
 			);
@@ -247,7 +245,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 
 					await expect(
 						merchantPage.getByText(
-							'decided that you won the dispute on'
+							"Good news — you've won this dispute!"
 						)
 					).toBeVisible();
 				}
@@ -347,7 +345,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 
 					await expect(
 						merchantPage.getByText(
-							'decided that you lost the dispute'
+							"Unfortunately, you've lost this dispute"
 						)
 					).toBeVisible();
 				}


### PR DESCRIPTION
See WOOPMNT-5069

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Update copy for the new Disputes screens. See MFTBqaIP0YmS1luyVWmZfW-fi-442_20538

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Ensure the copy matches the figma file

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.