### PR TITLE
Remove `convert_to_server_locale` as it has to be done on the server

### DIFF
--- a/changelog/chore-remove-convert-to-server-locale
+++ b/changelog/chore-remove-convert-to-server-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove conversion to the server locale, as it is done on the server.

--- a/includes/admin/class-wc-rest-payments-deposits-controller.php
+++ b/includes/admin/class-wc-rest-payments-deposits-controller.php
@@ -142,9 +142,7 @@ class WC_REST_Payments_Deposits_Controller extends WC_Payments_REST_Controller {
 	 */
 	public function get_deposits_export( $request ) {
 		$user_email   = $request->get_param( 'user_email' );
-		$wpcom_locale = WC_Payments_Utils::convert_to_server_locale(
-			$request->get_param( 'locale' )
-		);
+		$wpcom_locale = $request->get_param( 'locale' );
 		$filters      = $this->get_deposits_filters( $request );
 
 		return $this->forward_request( 'get_deposits_export', [ $filters, $user_email, $wpcom_locale ] );

--- a/includes/admin/class-wc-rest-payments-deposits-controller.php
+++ b/includes/admin/class-wc-rest-payments-deposits-controller.php
@@ -141,11 +141,11 @@ class WC_REST_Payments_Deposits_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_deposits_export( $request ) {
-		$user_email   = $request->get_param( 'user_email' );
-		$wpcom_locale = $request->get_param( 'locale' );
-		$filters      = $this->get_deposits_filters( $request );
+		$user_email = $request->get_param( 'user_email' );
+		$locale     = $request->get_param( 'locale' );
+		$filters    = $this->get_deposits_filters( $request );
 
-		return $this->forward_request( 'get_deposits_export', [ $filters, $user_email, $wpcom_locale ] );
+		return $this->forward_request( 'get_deposits_export', [ $filters, $user_email, $locale ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-disputes-controller.php
+++ b/includes/admin/class-wc-rest-payments-disputes-controller.php
@@ -167,9 +167,7 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 	 */
 	public function get_disputes_export( $request ) {
 		$user_email   = $request->get_param( 'user_email' );
-		$wpcom_locale = WC_Payments_Utils::convert_to_server_locale(
-			$request->get_param( 'locale' )
-		);
+		$wpcom_locale = $request->get_param( 'locale' );
 		$filters      = $this->get_disputes_filters( $request );
 
 		return $this->forward_request( 'get_disputes_export', [ $filters, $user_email, $wpcom_locale ] );

--- a/includes/admin/class-wc-rest-payments-disputes-controller.php
+++ b/includes/admin/class-wc-rest-payments-disputes-controller.php
@@ -166,11 +166,11 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_disputes_export( $request ) {
-		$user_email   = $request->get_param( 'user_email' );
-		$wpcom_locale = $request->get_param( 'locale' );
-		$filters      = $this->get_disputes_filters( $request );
+		$user_email = $request->get_param( 'user_email' );
+		$locale     = $request->get_param( 'locale' );
+		$filters    = $this->get_disputes_filters( $request );
 
-		return $this->forward_request( 'get_disputes_export', [ $filters, $user_email, $wpcom_locale ] );
+		return $this->forward_request( 'get_disputes_export', [ $filters, $user_email, $locale ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -173,9 +173,7 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 	public function get_transactions_export( $request ) {
 		$user_email   = $request->get_param( 'user_email' );
 		$deposit_id   = $request->get_param( 'deposit_id' );
-		$wpcom_locale = WC_Payments_Utils::convert_to_server_locale(
-			$request->get_param( 'locale' )
-		);
+		$wpcom_locale = $request->get_param( 'locale' );
 		$filters      = $this->get_transactions_filters( $request );
 
 		return $this->forward_request( 'get_transactions_export', [ $filters, $user_email, $deposit_id, $wpcom_locale ] );

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -171,12 +171,12 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_transactions_export( $request ) {
-		$user_email   = $request->get_param( 'user_email' );
-		$deposit_id   = $request->get_param( 'deposit_id' );
-		$wpcom_locale = $request->get_param( 'locale' );
-		$filters      = $this->get_transactions_filters( $request );
+		$user_email = $request->get_param( 'user_email' );
+		$deposit_id = $request->get_param( 'deposit_id' );
+		$locale     = $request->get_param( 'locale' );
+		$filters    = $this->get_transactions_filters( $request );
 
-		return $this->forward_request( 'get_transactions_export', [ $filters, $user_email, $deposit_id, $wpcom_locale ] );
+		return $this->forward_request( 'get_transactions_export', [ $filters, $user_email, $deposit_id, $locale ] );
 	}
 
 	/**

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1277,34 +1277,6 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Converts a WP locale to a wpcom-compatible language code.
-	 *
-	 * @see Automattic\Jetpack\Jetpack_Mu_Wpcom\Common::get_iso_639_locale() for similar logic.
-	 * @see https://translate.wordpress.com/projects/wpcom/ for the current state of wpcom translations.
-	 *
-	 * @param string $wp_locale a WordPress locale code to be converted e.g. "en_US", "pt_BR".
-	 * @return string language code compatible with wpcom e.g. "en", "pt-br".
-	 */
-	public static function convert_to_server_locale( string $wp_locale ): string {
-		$wp_locale_lowercase                    = strtolower( $wp_locale );
-		$region_specific_wpcom_language_codes   = [ 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ];
-		$is_region_specific_wpcom_language_code = in_array( $wp_locale_lowercase, $region_specific_wpcom_language_codes, true );
-
-		$language_code = $is_region_specific_wpcom_language_code ?
-			// If it is a region-specific language code, we replace the underscore with a dash, e.g. 'pt_br' => 'pt-br'.
-			str_replace( '_', '-', $wp_locale_lowercase ) :
-			// Otherwise, we remove the country code and return only the language code, e.g. 'nl_NL' => 'nl'.
-			preg_replace( '/([-_].*)$/i', '', $wp_locale_lowercase );
-
-		if ( empty( $language_code ) ) {
-			// If the language code is empty, we return 'en' as a fallback.
-			return 'en';
-		}
-
-		return $language_code;
-	}
-
-	/**
 	 * Check if the current page is the cart page.
 	 *
 	 * @return bool True if the current page is the cart page, false otherwise.

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -891,37 +891,6 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'es', $result );
 	}
 
-	/**
-	 * @dataProvider provider_convert_to_server_locale
-	 */
-	public function test_convert_to_server_locale( string $input_locale, string $expected_locale ) {
-		$result = WC_Payments_Utils::convert_to_server_locale( $input_locale );
-		$this->assertEquals( $expected_locale, $result );
-	}
-
-	public function provider_convert_to_server_locale(): array {
-		// Label => [ WordPress locale, transact-platform-server locale ].
-		return [
-			'Supported locale (Arabic)'                => [ 'ar_AR', 'ar' ],
-			'Supported locale (German)'                => [ 'de_DE', 'de' ],
-			'Supported locale (Spanish)'               => [ 'es_ES', 'es' ],
-			'Supported locale (French)'                => [ 'fr_FR', 'fr' ],
-			'Supported locale (Hebrew)'                => [ 'he_IL', 'he' ],
-			'Supported locale (Indonesian)'            => [ 'id_ID', 'id' ],
-			'Supported locale (Italian)'               => [ 'it_IT', 'it' ],
-			'Supported locale (Japanese)'              => [ 'ja_JP', 'ja' ],
-			'Supported locale (Korean)'                => [ 'ko_KR', 'ko' ],
-			'Supported locale (Dutch)'                 => [ 'nl_NL', 'nl' ],
-			'Supported locale (Portuguese (Brazil))'   => [ 'pt_BR', 'pt-br' ],
-			'Supported locale (Russian)'               => [ 'ru_RU', 'ru' ],
-			'Supported locale (Swedish)'               => [ 'sv_SE', 'sv' ],
-			'Supported locale (Turkish)'               => [ 'tr_TR', 'tr' ],
-			'Supported locale (Chinese (Simplified))'  => [ 'zh_CN', 'zh-cn' ],
-			'Supported locale (Chinese (Traditional))' => [ 'zh_TW', 'zh-tw' ],
-			'Empty locale fallback to en'              => [ '', 'en' ],
-		];
-	}
-
 	public function not_payment_settings_page_conditions_provider(): array {
 		return [
 			'is_admin() is false'                 => [ false, 'woocommerce_payments_foo', 'checkout' ],


### PR DESCRIPTION
Fixes [WOOPMNT-5135](https://linear.app/a8c/issue/WOOPMNT-5135/remove-client-side-locale-conversion-for-csv-exports)

#### Changes proposed in this Pull Request

In #10197 a new utility function `convert_to_server_locale` was introduced to provide an expected locale value for specific dialects when exporting transactions, disputes and deposits.

However, this conversion doesn't belong to the client code, as it can be done on the server level and apply to merchants independently of the version of the plugin they have. Therefore it can be removed, once server change is ready.


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> I'm pasting testing instructions from the #10197 verbatim. The only pre-requisite is that related server changes is already deployed.

> [!IMPORTANT]
> You must use production or sandbox transact-platform-server for email/CSV translations to work correctly. E.g. with Jurassic Ninja. Build a release with `npm run build:release` and use the created .zip file for the testing.
> Alternatively, if you've figured out how to get these email/CSV translations working on your local transact-platform-server, please let me know how!

1. Browse to `WP Admin -> Users -> Profile`
2. Change the profile language to a wpcom-supported region-specific language:
	* `pt_BR` Portugese (Brazil)
	* `zh_CN` Chinese (Simplified)
	* `zh_TW` Chinese (Traditional)
4. Run a CSV export of transactions, payouts or disputes, making sure you have more than a single pagination to trigger a server export
5. Ensure the email and CSV are provided in the user language.
8. Repeat steps above with other wpcom-supported languages
	* E.g. for French, the following WP locales will all fall back to `fr` on wpcom.
		* Français `fr_FR` ([translate.wordpress.com link](https://translate.wordpress.com/projects/wpcom/fr/default/?filters%5Bterm%5D=wcpay&filters%5Bterm_scope%5D=scope_references&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filters%5Bview%5D=&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc))
		* Français du Canada `fr_CA` ([translate.wordpress.com link](https://translate.wordpress.com/projects/wpcom/fr-ca/default/?filters%5Bterm%5D=wcpay&filters%5Bterm_scope%5D=scope_references&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filters%5Bview%5D=&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc))
		* Français de Belgique `fr_BE` ([translate.wordpress.com link](https://translate.wordpress.com/projects/wpcom/fr-be/default/?filters%5Bterm%5D=wcpay&filters%5Bterm_scope%5D=scope_references&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filters%5Bview%5D=&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc))
10. Repeat steps above with a language **unsupported by wpcom**, e.g. Polish `pl_PL`
	* The email and CSV language should be provided in English.

**WPCOM-compatible languages**
| WPCOM language code | WP locale code | Language                       |
|---------------------|----------------|--------------------------------|
| **ar**              | ar             | Arabic                         |
| **de**              | de_*           | German                         |
| **es**              | es_*           | Spanish                        |
| **fr**              | fr_*           | French                         |
| **he**              | he_*           | Hebrew                         |
| **id**              | id_*           | Indonesian                     |
| **it**              | it_*           | Italian                        |
| **ja**              | ja             | Japanese                       |
| **ko**              | ko_*           | Korean                         |
| **nl**              | nl_*           | Dutch (Netherlands)            |
| **pt-br**           | pt_BR          | Portuguese (Brazil)            |
| **ru**              | ru_*           | Russian (Russia)               |
| **sv**              | sv_*           | Swedish (Sweden)               |
| **tr**              | tr_*           | Turkish (Turkey)               |
| **zh-cn**           | zh_CN          | Simplified Chinese (Singapore) |
| **zh-tw**           | zh_TW          | Traditional Chinese (Taiwan)   |

------------------


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
