### PR TITLE
Redirect user to dispute detail

### DIFF
--- a/changelog/redirect-user-to-dispute-detail
+++ b/changelog/redirect-user-to-dispute-detail
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Redirect merchant to the dispute detail screen

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -440,7 +440,7 @@ export default ( { query }: { query: { id: string } } ) => {
 		);
 	};
 
-	const doSave = async ( submit: boolean ) => {
+	const doSave = async ( submit: boolean, notify = true ) => {
 		// Prevent submit if upload is in progress
 		if ( isUploadingEvidence() ) {
 			createInfoNotice(
@@ -502,7 +502,9 @@ export default ( { query }: { query: { id: string } } ) => {
 			} );
 
 			setDispute( updatedDispute );
-			handleSaveSuccess( submit );
+			if ( notify ) {
+				handleSaveSuccess( submit );
+			}
 			updateDisputeInStore( updatedDispute as any );
 
 			if ( submit ) {
@@ -523,7 +525,7 @@ export default ( { query }: { query: { id: string } } ) => {
 	const handleStepChange = async ( newStep: number ) => {
 		// Only save if not in readOnly mode
 		if ( ! readOnly ) {
-			await doSave( false );
+			await doSave( false, false );
 		}
 		// Update step
 		setCurrentStep( newStep );

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -414,21 +414,6 @@ export default ( { query }: { query: { id: string } } ) => {
 			id: submit
 				? 'evidence-submitted'
 				: `evidence-saved-${ dispute.id }`,
-			actions: submit
-				? [
-						{
-							label: __(
-								'View submitted evidence',
-								'woocommerce-payments'
-							),
-							url: getAdminUrl( {
-								page: 'wc-admin',
-								path: '/payments/disputes/challenge',
-								id: query.id,
-							} ),
-						},
-				  ]
-				: [],
 		} );
 
 		// Only redirect after submission, not after save
@@ -731,12 +716,12 @@ export default ( { query }: { query: { id: string } } ) => {
 
 			const href = getAdminUrl( {
 				page: 'wc-admin',
-				path: '/payments/disputes',
-				filter: 'awaiting_response',
+				path: '/payments/disputes/details',
+				id: dispute?.id,
 			} );
 			window.location.replace( href );
 		}
-	}, [ redirectAfterSave, navigationCleanup ] );
+	}, [ redirectAfterSave, navigationCleanup, dispute?.id ] );
 
 	// --- Accordion summary content ---
 	const summaryItems = useMemo( () => {


### PR DESCRIPTION
See: p1751674628159679/1751654895.833319-slack-C03LA109BKM
Addresses: WOOPMNT-5148

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Remove the link to the submitted experience of the snackbar.
Redirect the user to the dispute detail screen.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Go through the form and submit it, ensure that you will get redirected to the dispute detail screen.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.