### PR TITLE
Show helper link to the recommended documents section

### DIFF
--- a/changelog/add-external-link-to-documents-section
+++ b/changelog/add-external-link-to-documents-section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add external help link to the recomended documents section.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -927,6 +927,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedDocumentsFields }
 						readOnly={ readOnly }
+						showHelperLink={ true }
 					/>
 					{ inlineNotice( bankName ) }
 				</>

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -927,7 +927,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedDocumentsFields }
 						readOnly={ readOnly }
-						showHelperLink={ true }
+						hasHelperLink={ true }
 					/>
 					{ inlineNotice( bankName ) }
 				</>

--- a/client/disputes/new-evidence/recommended-documents.tsx
+++ b/client/disputes/new-evidence/recommended-documents.tsx
@@ -9,12 +9,14 @@ import { __ } from '@wordpress/i18n';
  */
 import FileUploadControl from './file-upload-control';
 import { DocumentField, RecommendedDocumentsProps } from './types';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 
 const RecommendedDocuments: React.FC< RecommendedDocumentsProps > = ( {
 	fields,
 	readOnly = false,
 	customHeading,
 	customSubheading,
+	showHelperLink = false,
 } ) => {
 	return (
 		<section className="wcpay-dispute-evidence-recommended-documents">
@@ -29,6 +31,16 @@ const RecommendedDocuments: React.FC< RecommendedDocumentsProps > = ( {
 						'woocommerce-payments'
 					) }
 			</div>
+			{ showHelperLink && (
+				<div className="wcpay-dispute-evidence-recommended-documents__helper-link">
+					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept">
+						{ __(
+							'Learn more about documents',
+							'woocommerce-payments'
+						) }
+					</ExternalLink>
+				</div>
+			) }
 			<ul className="wcpay-dispute-evidence-recommended-documents__list">
 				{ fields.map( ( field: DocumentField ) => (
 					<li

--- a/client/disputes/new-evidence/recommended-documents.tsx
+++ b/client/disputes/new-evidence/recommended-documents.tsx
@@ -16,7 +16,7 @@ const RecommendedDocuments: React.FC< RecommendedDocumentsProps > = ( {
 	readOnly = false,
 	customHeading,
 	customSubheading,
-	showHelperLink = false,
+	hasHelperLink = false,
 } ) => {
 	return (
 		<section className="wcpay-dispute-evidence-recommended-documents">
@@ -31,7 +31,7 @@ const RecommendedDocuments: React.FC< RecommendedDocumentsProps > = ( {
 						'woocommerce-payments'
 					) }
 			</div>
-			{ showHelperLink && (
+			{ hasHelperLink && (
 				<div className="wcpay-dispute-evidence-recommended-documents__helper-link">
 					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept">
 						{ __(

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -250,6 +250,10 @@
 		margin-top: 16px;
 		margin-bottom: 0;
 	}
+
+	&__helper-link {
+		margin-top: 8px;
+	}
 }
 
 // Recommended documents section

--- a/client/disputes/new-evidence/test/recommended-documents.test.tsx
+++ b/client/disputes/new-evidence/test/recommended-documents.test.tsx
@@ -31,20 +31,6 @@ jest.mock( 'wcpay/components/wp-components-wrapped', () => {
 	};
 } );
 
-// Mock the specific ExternalLink component
-jest.mock(
-	'wcpay/components/wp-components-wrapped/components/external-link',
-	() => {
-		return {
-			ExternalLink: ( { href, children }: any ) => (
-				<a href={ href } data-testid="external-link">
-					{ children }
-				</a>
-			),
-		};
-	}
-);
-
 describe( 'RecommendedDocuments', () => {
 	const fields = [
 		{
@@ -103,10 +89,9 @@ describe( 'RecommendedDocuments', () => {
 		it( 'does not show helper link by default', () => {
 			render( <RecommendedDocuments fields={ fields } /> );
 			expect(
-				screen.queryByTestId( 'external-link' )
-			).not.toBeInTheDocument();
-			expect(
-				screen.queryByText( 'Learn more about documents' )
+				screen.queryByRole( 'link', {
+					name: /Learn more about documents/i,
+				} )
 			).not.toBeInTheDocument();
 		} );
 
@@ -117,11 +102,10 @@ describe( 'RecommendedDocuments', () => {
 					showHelperLink={ true }
 				/>
 			);
-			const helperLink = screen.getByTestId( 'external-link' );
+			const helperLink = screen.getByRole( 'link', {
+				name: /Learn more about documents/i,
+			} );
 			expect( helperLink ).toBeInTheDocument();
-			expect( helperLink ).toHaveTextContent(
-				'Learn more about documents'
-			);
 		} );
 
 		it( 'hides helper link when showHelperLink is false', () => {
@@ -132,10 +116,9 @@ describe( 'RecommendedDocuments', () => {
 				/>
 			);
 			expect(
-				screen.queryByTestId( 'external-link' )
-			).not.toBeInTheDocument();
-			expect(
-				screen.queryByText( 'Learn more about documents' )
+				screen.queryByRole( 'link', {
+					name: /Learn more about documents/i,
+				} )
 			).not.toBeInTheDocument();
 		} );
 
@@ -146,7 +129,9 @@ describe( 'RecommendedDocuments', () => {
 					showHelperLink={ true }
 				/>
 			);
-			const helperLink = screen.getByTestId( 'external-link' );
+			const helperLink = screen.getByRole( 'link', {
+				name: /Learn more about documents/i,
+			} );
 			expect( helperLink ).toHaveAttribute(
 				'href',
 				'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
@@ -172,11 +157,12 @@ describe( 'RecommendedDocuments', () => {
 					showHelperLink={ true }
 				/>
 			);
-			const helperLinkContainer = screen
-				.getByTestId( 'external-link' )
-				.closest(
-					'.wcpay-dispute-evidence-recommended-documents__helper-link'
-				);
+			const helperLink = screen.getByRole( 'link', {
+				name: /Learn more about documents/i,
+			} );
+			const helperLinkContainer = helperLink.closest(
+				'.wcpay-dispute-evidence-recommended-documents__helper-link'
+			);
 			expect( helperLinkContainer ).toBeInTheDocument();
 		} );
 	} );

--- a/client/disputes/new-evidence/test/recommended-documents.test.tsx
+++ b/client/disputes/new-evidence/test/recommended-documents.test.tsx
@@ -95,11 +95,11 @@ describe( 'RecommendedDocuments', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'shows helper link when showHelperLink is true', () => {
+		it( 'shows helper link when hasHelperLink is true', () => {
 			render(
 				<RecommendedDocuments
 					fields={ fields }
-					showHelperLink={ true }
+					hasHelperLink={ true }
 				/>
 			);
 			const helperLink = screen.getByRole( 'link', {
@@ -108,11 +108,11 @@ describe( 'RecommendedDocuments', () => {
 			expect( helperLink ).toBeInTheDocument();
 		} );
 
-		it( 'hides helper link when showHelperLink is false', () => {
+		it( 'hides helper link when hasHelperLink is false', () => {
 			render(
 				<RecommendedDocuments
 					fields={ fields }
-					showHelperLink={ false }
+					hasHelperLink={ false }
 				/>
 			);
 			expect(
@@ -126,7 +126,7 @@ describe( 'RecommendedDocuments', () => {
 			render(
 				<RecommendedDocuments
 					fields={ fields }
-					showHelperLink={ true }
+					hasHelperLink={ true }
 				/>
 			);
 			const helperLink = screen.getByRole( 'link', {
@@ -142,7 +142,7 @@ describe( 'RecommendedDocuments', () => {
 			render(
 				<RecommendedDocuments
 					fields={ fields }
-					showHelperLink={ true }
+					hasHelperLink={ true }
 				/>
 			);
 			expect(
@@ -154,7 +154,7 @@ describe( 'RecommendedDocuments', () => {
 			render(
 				<RecommendedDocuments
 					fields={ fields }
-					showHelperLink={ true }
+					hasHelperLink={ true }
 				/>
 			);
 			const helperLink = screen.getByRole( 'link', {

--- a/client/disputes/new-evidence/test/recommended-documents.test.tsx
+++ b/client/disputes/new-evidence/test/recommended-documents.test.tsx
@@ -31,6 +31,20 @@ jest.mock( 'wcpay/components/wp-components-wrapped', () => {
 	};
 } );
 
+// Mock the specific ExternalLink component
+jest.mock(
+	'wcpay/components/wp-components-wrapped/components/external-link',
+	() => {
+		return {
+			ExternalLink: ( { href, children }: any ) => (
+				<a href={ href } data-testid="external-link">
+					{ children }
+				</a>
+			),
+		};
+	}
+);
+
 describe( 'RecommendedDocuments', () => {
 	const fields = [
 		{
@@ -83,5 +97,87 @@ describe( 'RecommendedDocuments', () => {
 		const removeButtons = screen.getAllByLabelText( /Remove file/i );
 		fireEvent.click( removeButtons[ 0 ] );
 		expect( fields[ 1 ].onFileRemove ).toHaveBeenCalled();
+	} );
+
+	describe( 'helper link functionality', () => {
+		it( 'does not show helper link by default', () => {
+			render( <RecommendedDocuments fields={ fields } /> );
+			expect(
+				screen.queryByTestId( 'external-link' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Learn more about documents' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'shows helper link when showHelperLink is true', () => {
+			render(
+				<RecommendedDocuments
+					fields={ fields }
+					showHelperLink={ true }
+				/>
+			);
+			const helperLink = screen.getByTestId( 'external-link' );
+			expect( helperLink ).toBeInTheDocument();
+			expect( helperLink ).toHaveTextContent(
+				'Learn more about documents'
+			);
+		} );
+
+		it( 'hides helper link when showHelperLink is false', () => {
+			render(
+				<RecommendedDocuments
+					fields={ fields }
+					showHelperLink={ false }
+				/>
+			);
+			expect(
+				screen.queryByTestId( 'external-link' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Learn more about documents' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders helper link with correct href', () => {
+			render(
+				<RecommendedDocuments
+					fields={ fields }
+					showHelperLink={ true }
+				/>
+			);
+			const helperLink = screen.getByTestId( 'external-link' );
+			expect( helperLink ).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
+			);
+		} );
+
+		it( 'renders helper link with correct text content', () => {
+			render(
+				<RecommendedDocuments
+					fields={ fields }
+					showHelperLink={ true }
+				/>
+			);
+			expect(
+				screen.getByText( 'Learn more about documents' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders helper link in the correct container', () => {
+			render(
+				<RecommendedDocuments
+					fields={ fields }
+					showHelperLink={ true }
+				/>
+			);
+			const helperLinkContainer = screen
+				.getByTestId( 'external-link' )
+				.closest(
+					'.wcpay-dispute-evidence-recommended-documents__helper-link'
+				);
+			expect( helperLinkContainer ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/disputes/new-evidence/types.ts
+++ b/client/disputes/new-evidence/types.ts
@@ -95,4 +95,5 @@ export interface RecommendedDocumentsProps {
 	readOnly?: boolean;
 	customHeading?: string;
 	customSubheading?: string;
+	showHelperLink?: boolean;
 }

--- a/client/disputes/new-evidence/types.ts
+++ b/client/disputes/new-evidence/types.ts
@@ -95,5 +95,5 @@ export interface RecommendedDocumentsProps {
 	readOnly?: boolean;
 	customHeading?: string;
 	customSubheading?: string;
-	showHelperLink?: boolean;
+	hasHelperLink?: boolean;
 }


### PR DESCRIPTION
See WOOPMNT-5149

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Add helper link (https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept) to the recommended documents section 

<img width="647" alt="image" src="https://github.com/user-attachments/assets/d437c19c-fbbf-4701-8c0a-48bc976351da" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge dispute and ensure the link is appearing on the recomended documents section.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
