### PR TITLE
Fix WooPay Direct Checkout on mini-cart

### DIFF
--- a/changelog/fix-woopay-direct-checkout-mini-cart
+++ b/changelog/fix-woopay-direct-checkout-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enable WooPay Direct Checkout on mini-cart.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -199,7 +199,7 @@ class WC_Payments_Checkout {
 			'isPreview'                         => is_preview(),
 			'isSavedCardsEnabled'               => $this->gateway->is_saved_cards_enabled(),
 			'isPaymentRequestEnabled'           => $this->gateway->is_payment_request_enabled(),
-			'isWooPayEnabled'                   => $this->woopay_util->should_enable_woopay( $this->gateway ) && $this->woopay_util->should_enable_woopay_on_cart_or_checkout(),
+			'isWooPayEnabled'                   => $this->woopay_util->should_enable_woopay( $this->gateway ) && $this->woopay_util->should_enable_woopay_on_guest_checkout(),
 			'isWoopayExpressCheckoutEnabled'    => $this->woopay_util->is_woopay_express_checkout_enabled(),
 			'isWoopayFirstPartyAuthEnabled'     => $this->woopay_util->is_woopay_first_party_auth_enabled(),
 			'isWooPayEmailInputEnabled'         => $this->woopay_util->is_woopay_email_input_enabled(),

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -89,7 +89,7 @@ class WC_Payments_WooPay_Direct_Checkout {
 			return;
 		}
 
-		if ( ! $this->woopay_utilities->should_enable_woopay_on_cart_or_checkout() ) {
+		if ( ! $this->woopay_utilities->should_enable_woopay_on_guest_checkout() ) {
 			return;
 		}
 

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -52,6 +52,15 @@ class WooPay_Utilities {
 			return false;
 		}
 
+		return $this->should_enable_woopay_on_guest_checkout();
+	}
+
+	/**
+	 * Check conditions to determine if WooPay should be enabled for guest checkout.
+	 *
+	 * @return bool  True if WooPay should be enabled, false otherwise.
+	 */
+	public function should_enable_woopay_on_guest_checkout(): bool {
 		if ( ! is_user_logged_in() ) {
 			// If there's a subscription product in the cart and the customer isn't logged in we
 			// should not enable WooPay since that situation is currently not supported.

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -39,23 +39,6 @@ class WooPay_Utilities {
 	}
 
 	/**
-	 * Checks various conditions to determine if WooPay should be enabled on the checkout page.
-	 *
-	 * This function should only be called when evaluating something for the checkout or cart page. The
-	 * function will return false if you're on any other page.
-	 *
-	 * @return bool  True if WooPay should be enabled, false otherwise.
-	 */
-	public function should_enable_woopay_on_cart_or_checkout(): bool {
-		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) && ! is_cart() && ! has_block( 'woocommerce/cart' ) ) {
-			// Wrong usage, this should only be called for the checkout or cart page.
-			return false;
-		}
-
-		return $this->should_enable_woopay_on_guest_checkout();
-	}
-
-	/**
 	 * Check conditions to determine if WooPay should be enabled for guest checkout.
 	 *
 	 * @return bool  True if WooPay should be enabled, false otherwise.

--- a/tests/unit/test-class-wc-payments-checkout.php
+++ b/tests/unit/test-class-wc-payments-checkout.php
@@ -110,7 +110,7 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 
 		$this->mock_woopay_utilities = $this->createMock( WooPay_Utilities::class );
 		$this->mock_woopay_utilities = $this->getMockBuilder( WooPay_Utilities::class )
-			->onlyMethods( [ 'should_enable_woopay', 'should_enable_woopay_on_cart_or_checkout' ] )
+			->onlyMethods( [ 'should_enable_woopay', 'should_enable_woopay_on_guest_checkout' ] )
 			->disableOriginalConstructor()
 			->getMock();
 		$this->mock_wcpay_account    = $this->createMock( WC_Payments_Account::class );
@@ -240,7 +240,7 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 			->willReturn( [] );
 
 		$this->mock_woopay_utilities->method( 'should_enable_woopay' )->willReturn( true );
-		$this->mock_woopay_utilities->method( 'should_enable_woopay_on_cart_or_checkout' )->willReturn( true );
+		$this->mock_woopay_utilities->method( 'should_enable_woopay_on_guest_checkout' )->willReturn( true );
 
 		$is_woopay_enabled = $this->system_under_test->get_payment_fields_js_config()['isWooPayEnabled'];
 		$this->assertTrue( $is_woopay_enabled );
@@ -253,7 +253,7 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 			->willReturn( [] );
 
 		$this->mock_woopay_utilities->method( 'should_enable_woopay' )->willReturn( false );
-		$this->mock_woopay_utilities->method( 'should_enable_woopay_on_cart_or_checkout' )->willReturn( true );
+		$this->mock_woopay_utilities->method( 'should_enable_woopay_on_guest_checkout' )->willReturn( true );
 
 		$is_woopay_enabled = $this->system_under_test->get_payment_fields_js_config()['isWooPayEnabled'];
 		$this->assertFalse( $is_woopay_enabled );
@@ -266,7 +266,7 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 			->willReturn( [] );
 
 		$this->mock_woopay_utilities->method( 'should_enable_woopay' )->willReturn( true );
-		$this->mock_woopay_utilities->method( 'should_enable_woopay_on_cart_or_checkout' )->willReturn( false );
+		$this->mock_woopay_utilities->method( 'should_enable_woopay_on_guest_checkout' )->willReturn( false );
 
 		$is_woopay_enabled = $this->system_under_test->get_payment_fields_js_config()['isWooPayEnabled'];
 		$this->assertFalse( $is_woopay_enabled );

--- a/tests/unit/woopay/test-class-woopay-utilities.php
+++ b/tests/unit/woopay/test-class-woopay-utilities.php
@@ -191,6 +191,62 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 		unset( $_POST['save_user_in_woopay'] );
 	}
 
+	/**
+	 * WooPay should be enabled for guest checkout when user is logged in.
+	 *
+	 * @return void
+	 */
+	public function test_should_enable_woopay_on_guest_checkout_logged_in() {
+		wp_set_current_user( 1 );
+
+		$woopay_utilities = new WooPay_Utilities();
+
+		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+	}
+
+	/**
+	 * WooPay should be enabled for guest checkout when user is not logged in and guest checkout is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_should_enable_woopay_on_guest_checkout_logged_out_guest_enabled() {
+		wp_set_current_user( 0 );
+		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+
+		$woopay_utilities = new WooPay_Utilities();
+
+		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+	}
+
+	/**
+	 * WooPay should be disabled for guest checkout when user is not logged in and guest checkout is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_should_enable_woopay_on_guest_checkout_logged_out_guest_disabled() {
+		wp_set_current_user( 0 );
+		update_option( 'woocommerce_enable_guest_checkout', 'no' );
+
+		$woopay_utilities = new WooPay_Utilities();
+
+		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+	}
+
+	/**
+	 * WooPay should be disabled for guest checkout when user is not logged in and cart contains subscription.
+	 *
+	 * @return void
+	 */
+	public function test_should_enable_woopay_on_guest_checkout_logged_out_has_subscription() {
+		wp_set_current_user( 0 );
+		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$woopay_utilities = new WooPay_Utilities();
+
+		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+	}
+
 	private function clean_up_should_enable_woopay_tests() {
 		remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 0 );

--- a/tests/unit/woopay/test-class-woopay-utilities.php
+++ b/tests/unit/woopay/test-class-woopay-utilities.php
@@ -105,13 +105,13 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_should_enable_woopay_on_cart_or_checkout_logged_out() {
+	public function test_should_enable_woopay_on_guest_checkout_logged_out() {
 		add_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 0 );
 
 		$woopay_utilities = new WooPay_Utilities();
 
-		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_cart_or_checkout() );
+		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
 		$this->clean_up_should_enable_woopay_tests();
 	}
 
@@ -120,13 +120,13 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_should_enable_woopay_on_cart_or_checkout_logged_in() {
+	public function test_should_enable_woopay_on_guest_checkout_logged_in_on_cart_or_checkout() {
 		add_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 1 );
 
 		$woopay_utilities = new WooPay_Utilities();
 
-		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_cart_or_checkout() );
+		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
 		$this->clean_up_should_enable_woopay_tests();
 	}
 
@@ -135,14 +135,14 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_should_enable_woopay_on_cart_or_checkout_logged_out_has_subscription() {
+	public function test_should_enable_woopay_on_guest_checkout_logged_out_has_subscription() {
 		add_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 0 );
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
 		$woopay_utilities = new WooPay_Utilities();
 
-		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_cart_or_checkout() );
+		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
 		$this->clean_up_should_enable_woopay_tests();
 	}
 
@@ -151,14 +151,14 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_should_enable_woopay_on_cart_or_checkout_logged_in_has_subscription() {
+	public function test_should_enable_woopay_on_guest_checkout_logged_in_has_subscription() {
 		add_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 1 );
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
 		$woopay_utilities = new WooPay_Utilities();
 
-		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_cart_or_checkout() );
+		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
 		$this->clean_up_should_enable_woopay_tests();
 	}
 
@@ -167,14 +167,14 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_should_enable_woopay_on_cart_or_checkout_logged_out_guest_checkout_disabled() {
+	public function test_should_enable_woopay_on_guest_checkout_logged_out_guest_checkout_disabled() {
 		add_filter( 'woocommerce_is_checkout', '__return_true' );
 		wp_set_current_user( 0 );
 		update_option( 'woocommerce_enable_guest_checkout', 'no' );
 
 		$woopay_utilities = new WooPay_Utilities();
 
-		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_cart_or_checkout() );
+		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
 		$this->clean_up_should_enable_woopay_tests();
 	}
 
@@ -237,7 +237,7 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_should_enable_woopay_on_guest_checkout_logged_out_has_subscription() {
+	public function test_should_enable_woopay_on_guest_checkout_logged_out_has_subscription_with_enable_guest_checkout_enabled() {
 		wp_set_current_user( 0 );
 		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );

--- a/tests/unit/woopay/test-class-woopay-utilities.php
+++ b/tests/unit/woopay/test-class-woopay-utilities.php
@@ -211,11 +211,18 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_should_enable_woopay_on_guest_checkout_logged_out_guest_enabled() {
 		wp_set_current_user( 0 );
-		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+		add_filter(
+			'pre_option_woocommerce_enable_guest_checkout',
+			function () {
+				return 'yes';
+			}
+		);
 
 		$woopay_utilities = new WooPay_Utilities();
 
 		$this->assertTrue( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+
+		remove_all_filters( 'pre_option_woocommerce_enable_guest_checkout' );
 	}
 
 	/**
@@ -225,11 +232,18 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_should_enable_woopay_on_guest_checkout_logged_out_guest_disabled() {
 		wp_set_current_user( 0 );
-		update_option( 'woocommerce_enable_guest_checkout', 'no' );
+		add_filter(
+			'pre_option_woocommerce_enable_guest_checkout',
+			function () {
+				return 'no';
+			}
+		);
 
 		$woopay_utilities = new WooPay_Utilities();
 
 		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+
+		remove_all_filters( 'pre_option_woocommerce_enable_guest_checkout' );
 	}
 
 	/**
@@ -239,12 +253,20 @@ class WooPay_Utilities_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_should_enable_woopay_on_guest_checkout_logged_out_has_subscription_with_enable_guest_checkout_enabled() {
 		wp_set_current_user( 0 );
-		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+		add_filter(
+			'pre_option_woocommerce_enable_guest_checkout',
+			function () {
+				return 'yes';
+			}
+		);
+
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
 		$woopay_utilities = new WooPay_Utilities();
 
 		$this->assertFalse( $woopay_utilities->should_enable_woopay_on_guest_checkout() );
+
+		remove_all_filters( 'pre_option_woocommerce_enable_guest_checkout' );
 	}
 
 	private function clean_up_should_enable_woopay_tests() {


### PR DESCRIPTION
Fixes [WOOPAY-238](https://linear.app/a8c/issue//woopay-direct-checkout-is-only-available-in-cart-and-checkout-page)

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR makes the WooPay Direct Checkout work again on every page on the mini cart, it stopped working due to changes on https://github.com/Automattic/woocommerce-payments/pull/9792.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The `Hover over the mini-cart` step can also be tested with a theme with a sidebar cart.

### Guest user, without subscriptions.

* Log in on WooPay.
* As a guest user, add a product to the cart.
* Reload the page.
* Hover over the mini-cart at the top of the page and click the Checkout button.
* Click the `Checkout` button.
* You should be redirected to WooPay.

### Guest user, with subscriptions.

* Log in on WooPay.
* As a guest user, add a subscription to the cart.
* Reload the page.
* Hover over the mini-cart at the top of the page and click the Checkout button.
* Click the `Checkout` button.
* You should be redirected to the default checkout page.

### Authenticated user, without subscriptions.

* Log in on WooPay.
* As a guest user, add a product to the cart.
* Reload the page.
* Hover over the mini-cart at the top of the page and click the Checkout button.
* Click the `Checkout` button.
* You should be redirected to WooPay.

### Authenticated user, with subscriptions.

* Log in on WooPay.
* As a guest user, add a subscription to the cart.
* Reload the page.
* Hover over the mini-cart at the top of the page and click the Checkout button.
* Click the `Checkout` button.
* You should be redirected to WooPay.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
