### PR TITLE
Remove 4px gap between the title and description

### DIFF
--- a/changelog/remove-4px-gap-between-the-title-and-descrition
+++ b/changelog/remove-4px-gap-between-the-title-and-descrition
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove unecessary gap
+Remove unnecessary gap

--- a/changelog/remove-4px-gap-between-the-title-and-descrition
+++ b/changelog/remove-4px-gap-between-the-title-and-descrition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unecessary gap

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -322,7 +322,6 @@
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
-		gap: 4px;
 	}
 	&__info-header {
 		height: 32px;


### PR DESCRIPTION
Fixes WOOPMNT-5152

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

There was a specific request from design to remove 4px gap between the title and description.

![2025-07-08 13 22 18](https://github.com/user-attachments/assets/4f208fc6-95e8-42c0-8580-662e5d6c892a)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* code review is fine
* or...
* Using WP-CLI, run: `wp option update _wcpay_feature_new_evidence_submission_form 1 --allow-root`.
* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge dispute and ensure the gap is not present anymore.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
