### PR TITLE
Remove isNewEvidenceSubmissionFormEnabled feature flag

### DIFF
--- a/changelog/remove-new-evidence-submission-feature-flag
+++ b/changelog/remove-new-evidence-submission-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Removes the feature flag for the new evidence submission form.

--- a/client/disputes/new-evidence/product-details.tsx
+++ b/client/disputes/new-evidence/product-details.tsx
@@ -43,6 +43,7 @@ const ProductDetails: React.FC< ProductDetailsProps > = ( {
 					label={ __( 'PRODUCT TYPE', 'woocommerce-payments' ) }
 					value={ productType }
 					onChange={ onProductTypeChange }
+					data-testid={ 'dispute-challenge-product-type-selector' }
 					options={ [
 						{
 							label: __(

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -31,7 +31,6 @@ declare global {
 			isAuthAndCaptureEnabled: boolean;
 			paymentTimeline: boolean;
 			isDisputeIssuerEvidenceEnabled: boolean;
-			isNewEvidenceSubmissionFormEnabled: boolean;
 			multiCurrency?: boolean;
 		};
 		accountFees: Record< string, any >;

--- a/client/index.js
+++ b/client/index.js
@@ -21,7 +21,6 @@ import TransactionsPage from 'transactions';
 import PaymentDetailsPage from 'payment-details';
 import DisputesPage from 'disputes';
 import RedirectToTransactionDetails from 'disputes/redirect-to-transaction-details';
-import DisputeEvidencePage from 'wcpay/disputes/evidence';
 import DisputeNewEvidencePage from 'wcpay/disputes/new-evidence';
 import { MultiCurrencySetupPage } from 'multi-currency/interface/components';
 import CardReadersPage from 'card-readers';
@@ -193,57 +192,29 @@ addFilter(
 			capability: 'manage_woocommerce',
 		} );
 
-		if ( wcpaySettings.featureFlags.isNewEvidenceSubmissionFormEnabled ) {
-			pages.push( {
-				container: ( { query } ) => (
-					<WordPressComponentsContext.Provider
-						value={ wp.components }
-					>
-						<DisputeNewEvidencePage query={ query } />
-					</WordPressComponentsContext.Provider>
-				),
-				path: '/payments/disputes/challenge',
-				wpOpenMenu: menuID,
-				breadcrumbs: [
-					rootLink,
-					[
-						'/payments/disputes',
-						__( 'Disputes', 'woocommerce-payments' ),
-					],
-					__( 'Challenge dispute', 'woocommerce-payments' ),
+		pages.push( {
+			container: ( { query } ) => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<DisputeNewEvidencePage query={ query } />
+				</WordPressComponentsContext.Provider>
+			),
+			path: '/payments/disputes/challenge',
+			wpOpenMenu: menuID,
+			breadcrumbs: [
+				rootLink,
+				[
+					'/payments/disputes',
+					__( 'Disputes', 'woocommerce-payments' ),
 				],
-				navArgs: {
-					id: 'wc-payments-disputes-challenge',
-					parentPath: '/payments/disputes',
-				},
-				capability: 'manage_woocommerce',
-			} );
-		} else {
-			pages.push( {
-				container: ( { query } ) => (
-					<WordPressComponentsContext.Provider
-						value={ wp.components }
-					>
-						<DisputeEvidencePage query={ query } />
-					</WordPressComponentsContext.Provider>
-				),
-				path: '/payments/disputes/challenge',
-				wpOpenMenu: menuID,
-				breadcrumbs: [
-					rootLink,
-					[
-						'/payments/disputes',
-						__( 'Disputes', 'woocommerce-payments' ),
-					],
-					__( 'Challenge dispute', 'woocommerce-payments' ),
-				],
-				navArgs: {
-					id: 'wc-payments-disputes-challenge',
-					parentPath: '/payments/disputes',
-				},
-				capability: 'manage_woocommerce',
-			} );
-		}
+				__( 'Challenge dispute', 'woocommerce-payments' ),
+			],
+			navArgs: {
+				id: 'wc-payments-disputes-challenge',
+				parentPath: '/payments/disputes',
+			},
+			capability: 'manage_woocommerce',
+		} );
+
 		pages.push( {
 			container: MultiCurrencySetupPage,
 			path: '/payments/multi-currency-setup',

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -21,15 +21,14 @@ class WC_Payments_Features {
 	 *   - The next version of WooPayments.
 	 *   - The flag to be deleted.
 	 */
-	const WCPAY_SUBSCRIPTIONS_FLAG_NAME          = '_wcpay_feature_subscriptions';
-	const STRIPE_BILLING_FLAG_NAME               = '_wcpay_feature_stripe_billing';
-	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME      = '_wcpay_feature_woopay_express_checkout';
-	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME      = '_wcpay_feature_woopay_first_party_auth';
-	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME       = '_wcpay_feature_woopay_direct_checkout';
-	const AUTH_AND_CAPTURE_FLAG_NAME             = '_wcpay_feature_auth_and_capture';
-	const DISPUTE_ISSUER_EVIDENCE                = '_wcpay_feature_dispute_issuer_evidence';
-	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME  = '_wcpay_feature_woopay_global_theme_support';
-	const NEW_EVIDENCE_SUBMISSION_FORM_FLAG_NAME = '_wcpay_feature_new_evidence_submission_form';
+	const WCPAY_SUBSCRIPTIONS_FLAG_NAME         = '_wcpay_feature_subscriptions';
+	const STRIPE_BILLING_FLAG_NAME              = '_wcpay_feature_stripe_billing';
+	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME     = '_wcpay_feature_woopay_express_checkout';
+	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME     = '_wcpay_feature_woopay_first_party_auth';
+	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME      = '_wcpay_feature_woopay_direct_checkout';
+	const AUTH_AND_CAPTURE_FLAG_NAME            = '_wcpay_feature_auth_and_capture';
+	const DISPUTE_ISSUER_EVIDENCE               = '_wcpay_feature_dispute_issuer_evidence';
+	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME = '_wcpay_feature_woopay_global_theme_support';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -342,15 +341,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether the new evidence submission form feature is enabled.
-	 *
-	 * @return bool
-	 */
-	public static function is_new_evidence_submission_form_enabled(): bool {
-		return '1' === get_option( self::NEW_EVIDENCE_SUBMISSION_FORM_FLAG_NAME, '0' );
-	}
-
-	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -358,13 +348,12 @@ class WC_Payments_Features {
 	public static function to_array() {
 		return array_filter(
 			[
-				'multiCurrency'                      => self::is_customer_multi_currency_enabled(),
-				'woopay'                             => self::is_woopay_eligible(),
-				'documents'                          => self::is_documents_section_enabled(),
-				'woopayExpressCheckout'              => self::is_woopay_express_checkout_enabled(),
-				'isAuthAndCaptureEnabled'            => self::is_auth_and_capture_enabled(),
-				'isDisputeIssuerEvidenceEnabled'     => self::is_dispute_issuer_evidence_enabled(),
-				'isNewEvidenceSubmissionFormEnabled' => self::is_new_evidence_submission_form_enabled(),
+				'multiCurrency'                  => self::is_customer_multi_currency_enabled(),
+				'woopay'                         => self::is_woopay_eligible(),
+				'documents'                      => self::is_documents_section_enabled(),
+				'woopayExpressCheckout'          => self::is_woopay_express_checkout_enabled(),
+				'isAuthAndCaptureEnabled'        => self::is_auth_and_capture_enabled(),
+				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 			]
 		);
 	}

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -491,7 +491,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 					merchantPage.getByTestId(
 						'dispute-challenge-product-type-selector'
 					)
-				).toHaveValue( 'offline_service' );
+				).toHaveValue( 'offline_service', { timeout: 40000 } );
 			}
 		);
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -462,13 +462,9 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 		await test.step(
 			'Verify the previously selected challenge product type is saved',
 			async () => {
-				await expect(
-					merchantPage
-						.getByTestId(
-							'dispute-challenge-product-type-selector'
-						)
-						.waitFor( { state: 'visible' } )
-				);
+				await merchantPage
+					.getByTestId( 'dispute-challenge-product-type-selector' )
+					.waitFor( { timeout: 2000 } );
 
 				await expect(
 					merchantPage.getByTestId(

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -446,9 +446,6 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 					name: 'Save for later',
 				} )
 				.click();
-
-			// Wait for the redirect to the dispute details page.
-			await merchantPage.waitForURL( /\/payments\/disputes\/details/ );
 		} );
 
 		await test.step(

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -463,6 +463,14 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			'Verify the previously selected challenge product type is saved',
 			async () => {
 				await expect(
+					merchantPage
+						.getByTestId(
+							'dispute-challenge-product-type-selector'
+						)
+						.waitFor( { state: 'visible' } )
+				);
+
+				await expect(
 					merchantPage.getByTestId(
 						'dispute-challenge-product-type-selector'
 					)

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -175,67 +175,87 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			} );
 
 			await test.step(
-				'Confirm the expected challenge form sections are visible',
+				'Confirm the expected stepper steps are visible',
 				async () => {
 					await expect(
-						merchantPage.getByText( 'General evidence', {
+						merchantPage.getByText( 'Purchase info', {
 							exact: true,
 						} )
 					).toBeVisible();
 
 					await expect(
-						merchantPage.getByText( 'Shipping information', {
+						merchantPage.getByText( 'Shipping details', {
 							exact: true,
 						} )
 					).toBeVisible();
 
 					await expect(
-						merchantPage
-							.getByText( 'Additional details', {
-								exact: true,
-							} )
-							.first()
+						merchantPage.getByText( 'Review', {
+							exact: true,
+						} )
 					).toBeVisible();
 				}
 			);
 
 			await test.step(
-				'Fill in the additional details field with the `winning_evidence` text',
+				'Navigate to the next step (Shipping details)',
 				async () => {
 					await merchantPage
-						.getByLabel( 'Additional details' )
-						.fill( 'winning_evidence' );
+						.getByRole( 'button', {
+							name: 'Next',
+						} )
+						.click();
 				}
 			);
 
 			await test.step(
-				'Submit the evidence and accept the dialog',
+				'Confirm we are on the shipping details step',
 				async () => {
-					// Prepare to accept the dialog before clicking the submit button
-					merchantPage.on( 'dialog', ( dialog ) => dialog.accept() );
+					await expect(
+						merchantPage.getByText( 'Add your shipping details', {
+							exact: true,
+						} )
+					).toBeVisible();
+				}
+			);
+
+			await test.step( 'Navigate to the review step', async () => {
+				await merchantPage
+					.getByRole( 'button', {
+						name: 'Next',
+					} )
+					.click();
+			} );
+
+			await test.step(
+				'Confirm we are on the review step and submit the evidence',
+				async () => {
+					await expect(
+						merchantPage.getByText( 'Review your cover letter', {
+							exact: true,
+						} )
+					).toBeVisible();
+
+					await merchantPage
+						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.fill( 'winning_evidence' );
 
 					// Click the submit button
 					await merchantPage
 						.getByRole( 'button', {
-							name: 'Submit evidence',
+							name: 'Submit',
 						} )
 						.click();
-
-					// Wait for the dispute list page to load.
-					await expect(
-						merchantPage
-							.getByRole( 'heading', {
-								name: 'Disputes',
-							} )
-							.first()
-					).toBeVisible();
 				}
 			);
 
 			await test.step(
-				'Navigate to the payment details screen and confirm the dispute status is Won',
+				'Wait for the redirect to the dispute details page and confirm the dispute status is Won',
 				async () => {
-					await merchantPage.goto( paymentDetailsLink );
+					// Wait for the redirect to complete
+					await merchantPage.waitForURL(
+						/\/payments\/disputes\/details/
+					);
 
 					await expect(
 						merchantPage.getByText( 'Disputed: Won', {
@@ -252,7 +272,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			);
 
 			await test.step(
-				'Confirm dispute action buttons are not present anymore since the dispute has been accepted',
+				'Confirm dispute action buttons are not present anymore since the dispute has been submitted',
 				async () => {
 					await expect(
 						merchantPage.getByTestId( 'challenge-dispute-button' )
@@ -298,44 +318,64 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			} );
 
 			await test.step(
-				'Fill in the additional details field with the `losing_evidence` text',
+				'Navigate to the next step (Shipping details)',
 				async () => {
 					await merchantPage
-						.getByLabel( 'Additional details', {
-							exact: true,
+						.getByRole( 'button', {
+							name: 'Next',
 						} )
-						.fill( 'losing_evidence' );
+						.click();
 				}
 			);
 
 			await test.step(
-				'Submit the evidence and accept the dialog',
+				'Confirm we are on the shipping details step',
 				async () => {
-					// Prepare to accept the dialog before clicking the submit button
-					merchantPage.on( 'dialog', ( dialog ) => dialog.accept() );
-
-					// Click the submit button
-					await merchantPage
-						.getByRole( 'button', {
-							name: 'Submit evidence',
-						} )
-						.click();
-
-					// Wait for the dispute list page to load.
 					await expect(
-						merchantPage
-							.getByRole( 'heading', {
-								name: 'Disputes',
-							} )
-							.first()
+						merchantPage.getByText( 'Add your shipping details', {
+							exact: true,
+						} )
 					).toBeVisible();
 				}
 			);
 
+			await test.step( 'Navigate to the review step', async () => {
+				await merchantPage
+					.getByRole( 'button', {
+						name: 'Next',
+					} )
+					.click();
+			} );
+
 			await test.step(
-				'Navigate to the payment details screen and confirm the dispute status is Lost',
+				'Confirm we are on the review step and submit the evidence',
 				async () => {
-					await merchantPage.goto( paymentDetailsLink );
+					await expect(
+						merchantPage.getByText( 'Review your cover letter', {
+							exact: true,
+						} )
+					).toBeVisible();
+
+					await merchantPage
+						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.fill( 'losing_evidence' );
+
+					// Click the submit button
+					await merchantPage
+						.getByRole( 'button', {
+							name: 'Submit',
+						} )
+						.click();
+				}
+			);
+
+			await test.step(
+				'Wait for the redirect to the dispute details page and confirm the dispute status is Lost',
+				async () => {
+					// Wait for the redirect to complete
+					await merchantPage.waitForURL(
+						/\/payments\/disputes\/details/
+					);
 
 					await expect(
 						merchantPage.getByText( 'Disputed: Lost', {
@@ -352,7 +392,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			);
 
 			await test.step(
-				'Confirm dispute action buttons are not present anymore since the dispute has been accepted',
+				'Confirm dispute action buttons are not present anymore since the dispute has been submitted',
 				async () => {
 					await expect(
 						merchantPage.getByTestId( 'challenge-dispute-button' )
@@ -407,14 +447,8 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 				} )
 				.click();
 
-			// Wait for the redirect to the dispute list page.
-			await expect(
-				merchantPage
-					.getByRole( 'heading', {
-						name: 'Disputes',
-					} )
-					.first()
-			).toBeVisible();
+			// Wait for the redirect to the dispute details page.
+			await merchantPage.waitForURL( /\/payments\/disputes\/details/ );
 		} );
 
 		await test.step(

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -446,9 +446,40 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			}
 		);
 
-		await merchantPage
-			.getByTestId( 'dispute-challenge-product-type-selector' )
-			.selectOption( 'offline_service' );
+		// wait for the customer details to be visible
+		await test.step(
+			'Wait for the customer details to be visible',
+			async () => {
+				await expect(
+					merchantPage.getByText( 'Customer details', {
+						exact: true,
+					} )
+				).toBeVisible();
+			}
+		);
+
+		await test.step(
+			'Confirm we are on the challenge dispute page',
+			async () => {
+				await expect(
+					merchantPage.getByText( "Let's gather the basics", {
+						exact: true,
+					} )
+				).toBeVisible();
+			}
+		);
+
+		await test.step(
+			'Fill in the product type and product description',
+			async () => {
+				await merchantPage
+					.getByTestId( 'dispute-challenge-product-type-selector' )
+					.selectOption( 'offline_service' );
+				await merchantPage
+					.getByLabel( 'PRODUCT DESCRIPTION' )
+					.fill( 'my product description' );
+			}
+		);
 
 		await test.step( 'Save the dispute challenge for later', async () => {
 			await merchantPage
@@ -458,11 +489,13 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 				.click();
 		} );
 
+		await test.step( 'Go back to the payment details page', async () => {
+			await merchantPage.goto( paymentDetailsLink );
+		} );
+
 		await test.step(
 			'Navigate to the payment details screen and click the challenge dispute button',
 			async () => {
-				await merchantPage.goto( paymentDetailsLink );
-
 				await merchantPage
 					.getByTestId( 'challenge-dispute-button' )
 					.click();
@@ -491,7 +524,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 					merchantPage.getByTestId(
 						'dispute-challenge-product-type-selector'
 					)
-				).toHaveValue( 'offline_service', { timeout: 40000 } );
+				).toHaveValue( 'offline_service' );
 			}
 		);
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -194,6 +194,10 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 							exact: true,
 						} )
 					).toBeVisible();
+
+					await merchantPage
+						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.fill( 'my product description' );
 				}
 			);
 
@@ -236,6 +240,18 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 						} )
 					).toBeVisible();
 
+					// wait cover letter to load with content and replace with new content
+					await merchantPage
+						.getByLabel( 'COVER LETTER' )
+						.waitFor( { state: 'visible', timeout: 5000 } );
+
+					// Check existing content
+					await expect(
+						merchantPage.getByLabel( 'COVER LETTER' )
+					).toContainText( 'WooPayments', {
+						timeout: 5000,
+					} );
+
 					await merchantPage
 						.getByLabel( 'COVER LETTER' )
 						.fill( 'winning_evidence' );
@@ -252,15 +268,10 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			await test.step(
 				'Wait for the redirect to the dispute details page and confirm the dispute status is Won',
 				async () => {
-					// Wait for the redirect to complete
-					await merchantPage.waitForURL(
-						/\/payments\/disputes\/details/
-					);
-
 					await expect(
-						merchantPage.getByText( 'Disputed: Won', {
-							exact: true,
-						} )
+						merchantPage
+							.locator( '.payment-details-summary__status' )
+							.filter( { hasText: 'Disputed: Won' } )
 					).toBeVisible();
 
 					await expect(
@@ -356,6 +367,18 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 						} )
 					).toBeVisible();
 
+					// wait cover letter to load with content and replace with new content
+					await merchantPage
+						.getByLabel( 'COVER LETTER' )
+						.waitFor( { state: 'visible', timeout: 5000 } );
+
+					// Check existing content
+					await expect(
+						merchantPage.getByLabel( 'COVER LETTER' )
+					).toContainText( 'WooPayments', {
+						timeout: 5000,
+					} );
+
 					await merchantPage
 						.getByLabel( 'COVER LETTER' )
 						.fill( 'losing_evidence' );
@@ -372,15 +395,10 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			await test.step(
 				'Wait for the redirect to the dispute details page and confirm the dispute status is Lost',
 				async () => {
-					// Wait for the redirect to complete
-					await merchantPage.waitForURL(
-						/\/payments\/disputes\/details/
-					);
-
 					await expect(
-						merchantPage.getByText( 'Disputed: Lost', {
-							exact: true,
-						} )
+						merchantPage
+							.locator( '.payment-details-summary__status' )
+							.filter( { hasText: 'Disputed: Lost' } )
 					).toBeVisible();
 
 					await expect(

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -237,7 +237,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 					).toBeVisible();
 
 					await merchantPage
-						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.getByLabel( 'COVER LETTER' )
 						.fill( 'winning_evidence' );
 
 					// Click the submit button
@@ -357,7 +357,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 					).toBeVisible();
 
 					await merchantPage
-						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.getByLabel( 'COVER LETTER' )
 						.fill( 'losing_evidence' );
 
 					// Click the submit button

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -446,17 +446,9 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			}
 		);
 
-		await test.step( 'Select the product type', async () => {
-			await merchantPage
-				.getByTestId( 'dispute-challenge-product-type-selector' )
-				.selectOption( 'offline_service' );
-
-			await expect(
-				merchantPage.getByTestId(
-					'dispute-challenge-product-type-selector'
-				)
-			).toHaveValue( 'offline_service' );
-		} );
+		await merchantPage
+			.getByTestId( 'dispute-challenge-product-type-selector' )
+			.selectOption( 'offline_service' );
 
 		await test.step( 'Save the dispute challenge for later', async () => {
 			await merchantPage
@@ -480,9 +472,20 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 		await test.step(
 			'Verify the previously selected challenge product type is saved',
 			async () => {
+				await test.step(
+					'Confirm we are on the challenge dispute page',
+					async () => {
+						await expect(
+							merchantPage.getByText( "Let's gather the basics", {
+								exact: true,
+							} )
+						).toBeVisible();
+					}
+				);
+
 				await merchantPage
 					.getByTestId( 'dispute-challenge-product-type-selector' )
-					.waitFor( { timeout: 2000 } );
+					.waitFor( { timeout: 5000, state: 'visible' } );
 
 				await expect(
 					merchantPage.getByTestId(


### PR DESCRIPTION
See WOOPMNT-5014

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Removes the feature flag for the new evidence submission form

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge dispute and ensure you're seeing the new form.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
