### PR TITLE
Documents section should have subtitle copy and font size of the according content should be 14px

### DIFF
--- a/changelog/copy-and-font-size-of-envidence-form
+++ b/changelog/copy-and-font-size-of-envidence-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix copy for the documents section and fix the font size of the content inside the accordion on top.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -927,7 +927,6 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedDocumentsFields }
 						readOnly={ readOnly }
-						hasHelperLink
 					/>
 					{ inlineNotice( bankName ) }
 				</>
@@ -962,7 +961,6 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedShippingDocumentsFields }
 						readOnly={ readOnly }
-						hasHelperLink
 					/>
 					{ inlineNotice( bankName ) }
 				</>

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -927,7 +927,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedDocumentsFields }
 						readOnly={ readOnly }
-						hasHelperLink={ true }
+						hasHelperLink
 					/>
 					{ inlineNotice( bankName ) }
 				</>
@@ -962,10 +962,7 @@ export default ( { query }: { query: { id: string } } ) => {
 					<RecommendedDocuments
 						fields={ recommendedShippingDocumentsFields }
 						readOnly={ readOnly }
-						customSubheading={ __(
-							'We recommend adding the following document(s) to support your case.',
-							'woocommerce-payments'
-						) }
+						hasHelperLink
 					/>
 					{ inlineNotice( bankName ) }
 				</>

--- a/client/disputes/new-evidence/recommended-documents.tsx
+++ b/client/disputes/new-evidence/recommended-documents.tsx
@@ -14,33 +14,26 @@ import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/
 const RecommendedDocuments: React.FC< RecommendedDocumentsProps > = ( {
 	fields,
 	readOnly = false,
-	customHeading,
-	customSubheading,
-	hasHelperLink = false,
 } ) => {
 	return (
 		<section className="wcpay-dispute-evidence-recommended-documents">
 			<h3 className="wcpay-dispute-evidence-recommended-documents__heading">
-				{ customHeading ||
-					__( 'Recommended documents', 'woocommerce-payments' ) }
+				{ __( 'Recommended documents', 'woocommerce-payments' ) }
 			</h3>
 			<div className="wcpay-dispute-evidence-recommended-documents__subheading">
-				{ customSubheading ||
-					__(
-						'While optional, we strongly recommend providing as many of these documents as possible. The following file types are supported: PDF, JPEG, and PNG.',
+				{ __(
+					'While optional, we strongly recommend providing as many of these documents as possible. The following file types are supported: PDF, JPEG, and PNG.',
+					'woocommerce-payments'
+				) }
+			</div>
+			<div className="wcpay-dispute-evidence-recommended-documents__helper-link">
+				<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept">
+					{ __(
+						'Learn more about documents',
 						'woocommerce-payments'
 					) }
+				</ExternalLink>
 			</div>
-			{ hasHelperLink && (
-				<div className="wcpay-dispute-evidence-recommended-documents__helper-link">
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept">
-						{ __(
-							'Learn more about documents',
-							'woocommerce-payments'
-						) }
-					</ExternalLink>
-				</div>
-			) }
 			<ul className="wcpay-dispute-evidence-recommended-documents__list">
 				{ fields.map( ( field: DocumentField ) => (
 					<li

--- a/client/disputes/new-evidence/style.scss
+++ b/client/disputes/new-evidence/style.scss
@@ -378,6 +378,14 @@
 	}
 }
 
+.wcpay-accordion {
+	.wcpay-inline-notice.components-notice {
+		.components-notice__content {
+			font-size: 14px;
+		}
+	}
+}
+
 @media print {
 	.wcpay-dispute-evidence-cover-letter {
 		max-width: 700px;

--- a/client/disputes/new-evidence/test/recommended-documents.test.tsx
+++ b/client/disputes/new-evidence/test/recommended-documents.test.tsx
@@ -95,40 +95,8 @@ describe( 'RecommendedDocuments', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'shows helper link when hasHelperLink is true', () => {
-			render(
-				<RecommendedDocuments
-					fields={ fields }
-					hasHelperLink={ true }
-				/>
-			);
-			const helperLink = screen.getByRole( 'link', {
-				name: /Learn more about documents/i,
-			} );
-			expect( helperLink ).toBeInTheDocument();
-		} );
-
-		it( 'hides helper link when hasHelperLink is false', () => {
-			render(
-				<RecommendedDocuments
-					fields={ fields }
-					hasHelperLink={ false }
-				/>
-			);
-			expect(
-				screen.queryByRole( 'link', {
-					name: /Learn more about documents/i,
-				} )
-			).not.toBeInTheDocument();
-		} );
-
-		it( 'renders helper link with correct href', () => {
-			render(
-				<RecommendedDocuments
-					fields={ fields }
-					hasHelperLink={ true }
-				/>
-			);
+		it( 'renders helper link with correct href and text', () => {
+			render( <RecommendedDocuments fields={ fields } /> );
 			const helperLink = screen.getByRole( 'link', {
 				name: /Learn more about documents/i,
 			} );
@@ -136,27 +104,14 @@ describe( 'RecommendedDocuments', () => {
 				'href',
 				'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
 			);
-		} );
 
-		it( 'renders helper link with correct text content', () => {
-			render(
-				<RecommendedDocuments
-					fields={ fields }
-					hasHelperLink={ true }
-				/>
-			);
 			expect(
 				screen.getByText( 'Learn more about documents' )
 			).toBeInTheDocument();
 		} );
 
 		it( 'renders helper link in the correct container', () => {
-			render(
-				<RecommendedDocuments
-					fields={ fields }
-					hasHelperLink={ true }
-				/>
-			);
+			render( <RecommendedDocuments fields={ fields } /> );
 			const helperLink = screen.getByRole( 'link', {
 				name: /Learn more about documents/i,
 			} );

--- a/client/disputes/new-evidence/test/recommended-documents.test.tsx
+++ b/client/disputes/new-evidence/test/recommended-documents.test.tsx
@@ -86,15 +86,6 @@ describe( 'RecommendedDocuments', () => {
 	} );
 
 	describe( 'helper link functionality', () => {
-		it( 'does not show helper link by default', () => {
-			render( <RecommendedDocuments fields={ fields } /> );
-			expect(
-				screen.queryByRole( 'link', {
-					name: /Learn more about documents/i,
-				} )
-			).not.toBeInTheDocument();
-		} );
-
 		it( 'renders helper link with correct href and text', () => {
 			render( <RecommendedDocuments fields={ fields } /> );
 			const helperLink = screen.getByRole( 'link', {

--- a/client/disputes/new-evidence/types.ts
+++ b/client/disputes/new-evidence/types.ts
@@ -93,7 +93,4 @@ export interface FileUploadControlProps {
 export interface RecommendedDocumentsProps {
 	fields: DocumentField[];
 	readOnly?: boolean;
-	customHeading?: string;
-	customSubheading?: string;
-	hasHelperLink?: boolean;
 }

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -150,6 +150,10 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 		async ( { browser } ) => {
 			const { merchantPage } = await getMerchant( browser );
 
+			const orderId = await createDisputedOrder( browser );
+
+			await goToPaymentDetailsForOrder( merchantPage, orderId );
+
 			await test.step(
 				'Click the challenge dispute button to navigate to the challenge dispute page',
 				async () => {
@@ -296,6 +300,10 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 		},
 		async ( { browser } ) => {
 			const { merchantPage } = await getMerchant( browser );
+
+			const orderId = await createDisputedOrder( browser );
+
+			await goToPaymentDetailsForOrder( merchantPage, orderId );
 
 			await test.step(
 				'Click the challenge dispute button to navigate to the challenge dispute page',

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -150,13 +150,6 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 		async ( { browser } ) => {
 			const { merchantPage } = await getMerchant( browser );
 
-			const orderId = await createDisputedOrder( browser );
-
-			const paymentDetailsLink = await goToPaymentDetailsForOrder(
-				merchantPage,
-				orderId
-			);
-
 			await test.step(
 				'Click the challenge dispute button to navigate to the challenge dispute page',
 				async () => {
@@ -303,13 +296,6 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 		},
 		async ( { browser } ) => {
 			const { merchantPage } = await getMerchant( browser );
-
-			const orderId = await createDisputedOrder( browser );
-
-			const paymentDetailsLink = await goToPaymentDetailsForOrder(
-				merchantPage,
-				orderId
-			);
 
 			await test.step(
 				'Click the challenge dispute button to navigate to the challenge dispute page',


### PR DESCRIPTION
Fixes WOOPMNT-5159
Fixes WOOPMNT-5160

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fix copy for the documents section and fix the font size of the content inside the accordion on top.

<img width="2326" height="670" alt="image" src="https://github.com/user-attachments/assets/159478ad-9319-4eb2-b19c-595f4063ec56" />
<img width="1324" height="444" alt="image" src="https://github.com/user-attachments/assets/ffa16a8c-baa5-4144-987f-9ab318edfd85" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you don't have any test disputes, please follow [the critical flows document](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#dispute-created-notifications) for creating a dispute (card `4000000000002685`) in test mode.
* Go to Payments > Disputes, select the dispute listed.
* Hit Challenge dispute.
* Ensure the notice test inside the Accordion is 14px;
* Eensure the documents section on the Shipping details step has a subheading and also the helper link

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
