### PR TITLE
Support more Hong Kong starting phone numbers (4, 7, 8)

### DIFF
--- a/changelog/fix-WOOPMNT-5128-expand-support-of-hong-kong-phone-numbers
+++ b/changelog/fix-WOOPMNT-5128-expand-support-of-hong-kong-phone-numbers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support numbers starting from 4, 7, 8 for Hong Kong phones.

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -63,6 +63,25 @@ const PhoneNumberInput = ( {
 				return true;
 			}
 		}
+
+		// Special case for Hong Kong: the latest HK Telecom numbers have adopted new numbers starting with 4.
+		// Numbers starting from 7 and 8 also can be mobile numbers (as well as pager numbers and forwarding service).
+		if (
+			'852' === instance.getSelectedCountryData().dialCode &&
+			! instance.isValidNumber()
+		) {
+			if ( 12 !== instance.getNumber().length ) {
+				return false;
+			}
+
+			if (
+				[ '4', '7', '8' ].includes(
+					instance.getNumber().substr( 4, 1 )
+				)
+			) {
+				return true;
+			}
+		}
 		return instance.isValidNumber();
 	};
 

--- a/client/settings/support-phone-input/test/support-phone-input.test.js
+++ b/client/settings/support-phone-input/test/support-phone-input.test.js
@@ -167,6 +167,55 @@ describe( 'SupportPhoneInput', () => {
 		).toBeNull();
 	} );
 
+	it( 'Hong Kong phone number validation special cases - starting with 4, 7, 8', async () => {
+		useAccountBusinessSupportPhone.mockReturnValue( [
+			'+85221234567', // test phone number.
+			jest.fn(),
+		] );
+		useTestModeOnboarding.mockReturnValue( true );
+
+		const { container } = render( <SupportPhoneInput /> );
+		expect(
+			container.querySelector( '.components-notice.is-error' )
+		).toBeNull();
+
+		fireEvent.change(
+			screen.getByLabelText(
+				'Support phone number (+1 0000000000 can be used in sandbox mode)'
+			),
+			{
+				target: { value: '+85241234567' },
+			}
+		);
+		expect(
+			container.querySelector( '.components-notice.is-error' )
+		).toBeNull();
+
+		fireEvent.change(
+			screen.getByLabelText(
+				'Support phone number (+1 0000000000 can be used in sandbox mode)'
+			),
+			{
+				target: { value: '+85271234567' },
+			}
+		);
+		expect(
+			container.querySelector( '.components-notice.is-error' )
+		).toBeNull();
+
+		fireEvent.change(
+			screen.getByLabelText(
+				'Support phone number (+1 0000000000 can be used in sandbox mode)'
+			),
+			{
+				target: { value: '+85281234567' },
+			}
+		);
+		expect(
+			container.querySelector( '.components-notice.is-error' )
+		).toBeNull();
+	} );
+
 	it( 'in sandbox mode, allow all 0s number', async () => {
 		useAccountBusinessSupportPhone.mockReturnValue( [
 			'+10000000000', // test phone number.


### PR DESCRIPTION
Fixes WOOPMNT-5128

#### Changes proposed in this Pull Request

This PR adds special-case logic to handle the latest Hong Kong phone number rules. Specifically, it supports new mobile number prefixes starting with 4 as adopted by HK Telecom and requested by the merchant.
Additionally, I added 7 and 8 which are also part of the Linear issue request. Wikipedia says next:
> Fixed land line numbers start with 2 or 3, [mobile](https://en.wikipedia.org/wiki/Mobile_phone) (cellular) phone numbers with 4, 5, 6, 7, 8, or 9, pager numbers with 7 and forwarding service with 8.

This update ensures that users can enter Hong Kong mobile numbers using all supported prefixes, aligning validation with current HK Telecom requirements.

#### Testing instructions

* Check out to `develop` branch
* Access Payments > Settings
* Update the support phone number to Hong Kong and enter a number started with 4, 7 or 8.
* It's not possible to save
* Check out this branch
* Build the client locally
* Update the support phone number to Hong Kong and enter a number started with 4, 7 or 8.
* It should be possible to save

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-9.7.0/_compare/f8c5ac3cb278d6cc17b349db1c20001b549fdf62...d37c7ada1c463ad36d12bbec46005a0379375849_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
