### PR TITLE
Fix WooPay button spinner on some themes

### DIFF
--- a/changelog/fix-woopay-snipper-button-on-some-themes
+++ b/changelog/fix-woopay-snipper-button-on-some-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay button spinner on some themes.

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -150,6 +150,8 @@
 	box-sizing: content-box;
 	text-align: center;
 	font-size: 1.25em;
+	top: initial;
+	left: initial;
 
 	&::after {
 		content: ' ';


### PR DESCRIPTION
Fixes [WOOPAY-360](https://linear.app/a8c/issue/WOOPAY-360/button-spinner-is-missing)

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes the spinner in the WooPay express checkout button not being shown on some themes during the redirect.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install the Tsubaki theme.
* On the product, cart or checkout page, click the WooPay express checkout button.
* The inner spinner should be shown and redirect to WooPay as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
