### PR TITLE
Unbundle payouts and payout details

### DIFF
--- a/changelog/update-wp-components-payouts
+++ b/changelog/update-wp-components-payouts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the payout list and payout details pages to use the WP components available on the WP installation.

--- a/client/components/wp-components-wrapped/components/text.tsx
+++ b/client/components/wp-components-wrapped/components/text.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+// @ts-expect-error: Suppressing Module '"@wordpress/components"' has no exported member '__experimentalText'.
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis, no-restricted-syntax
+import { __experimentalText as BundledText } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const Text = makeWrappedComponent( BundledText, 'Text' );

--- a/client/components/wp-components-wrapped/components/text.tsx
+++ b/client/components/wp-components-wrapped/components/text.tsx
@@ -3,11 +3,14 @@
  */
 // @ts-expect-error: Suppressing Module '"@wordpress/components"' has no exported member '__experimentalText'.
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis, no-restricted-syntax
-import { __experimentalText as BundledText } from '@wordpress/components';
+import { __experimentalText as BundledExperimentalText } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { makeWrappedComponent } from '../make-wrapped-component';
 
-export const Text = makeWrappedComponent( BundledText, 'Text' );
+export const Text = makeWrappedComponent(
+	BundledExperimentalText,
+	'__experimentalText'
+);

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -33,3 +33,4 @@ export { TextControl } from './components/text-control';
 export { TextareaControl } from './components/textarea-control';
 export { ToggleControl } from './components/toggle-control';
 export { Tooltip } from './components/tooltip';
+export { Text } from './components/text';

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -5,18 +5,6 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-// eslint-disable-next-line no-restricted-syntax
-import {
-	// @ts-expect-error: Suppressing Module '"@wordpress/components"' has no exported member '__experimentalText'.
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- used by TableCard component which we replicate here.
-	__experimentalText as Text,
-} from '@wordpress/components';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
 import {
 	SummaryListPlaceholder,
 	SummaryList,
@@ -28,6 +16,11 @@ import clsx from 'clsx';
 /**
  * Internal dependencies.
  */
+import { Text } from 'wcpay/components/wp-components-wrapped/components/text';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import type { CachedDeposit } from 'types/deposits';
 import { useDeposit } from 'data';
 import TransactionsList from 'transactions/list';

--- a/client/index.js
+++ b/client/index.js
@@ -96,7 +96,11 @@ addFilter(
 		} );
 
 		pages.push( {
-			container: DepositsPage,
+			container: ( { query } ) => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<DepositsPage query={ query } />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/payouts',
 			wpOpenMenu: menuID,
 			breadcrumbs: [ rootLink, __( 'Payouts', 'woocommerce-payments' ) ],
@@ -106,7 +110,11 @@ addFilter(
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
-			container: DepositDetailsPage,
+			container: ( { query } ) => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<DepositDetailsPage query={ query } />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/payouts/details',
 			wpOpenMenu: menuID,
 			breadcrumbs: [


### PR DESCRIPTION
See WOOPMNT-5166
See WOOPMNT-5167

#### Changes proposed in this Pull Request

Updating the components on the payouts list and payout details pages to use the WP components that come with the WP installation.

Payout details page use the Card component, this component changed, the newer Card has its border rounded. The same page uses a Woocommerce component [SummaryList](https://woocommerce.github.io/woocommerce/?path=/docs/components-summarylist--docs) which is not rounded, making it look a bit odd but unless we rethink this page it is what it is.

Before

<img width="1695" height="597" alt="image" src="https://github.com/user-attachments/assets/aea6ef7d-4346-4e81-a329-d44fef32e8bd" />

After

<img width="1709" height="610" alt="image" src="https://github.com/user-attachments/assets/37d6becf-bfc9-47e1-9c7f-b8fa03e9b1d8" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To generate a manual payout, follow the steps below:
* Open the WCPay Dev menu and click the Stripe link in the top-right corner under Store details.
* In the Stripe view, click the three dots menu in the top-right corner and select View Dashboard as <Store Account>.
* In the left-hand menu, go to Balance.
* If your store doesn't have sufficient funds, click the [+ Top up] button to add funds.
* Once you have funds, click the [→ Pay out] button and choose an amount to pay out.
* On your test store, navigate to Payments > Payouts and verify that the changes described in this PR are reflected correctly.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
