### PR TITLE
Fix orphan words

### DIFF
--- a/changelog/fix-orphan-words
+++ b/changelog/fix-orphan-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change copy to avoid leaving words alone.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -13,7 +13,6 @@ import HelpOutlineIcon from 'gridicons/dist/help-outline';
 /**
  * Internal dependencies.
  */
-import useConfirmNavigation from 'utils/use-confirm-navigation';
 import { recordEvent } from 'tracks';
 import { TestModeNotice } from 'components/test-mode-notice';
 import ErrorBoundary from 'components/error-boundary';
@@ -38,12 +37,8 @@ import RecommendedDocuments from './recommended-documents';
 import InlineNotice from 'components/inline-notice';
 import ShippingDetails from './shipping-details';
 import CoverLetter from './cover-letter';
-import {
-	Button,
-	HorizontalRule,
-	Icon,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { HorizontalRule } from 'wcpay/components/wp-components-wrapped/components/horizontal-rule';
 import { getAdminUrl } from 'wcpay/utils';
 import { StepperPanel } from 'wcpay/components/stepper';
 import {
@@ -694,25 +689,6 @@ export default ( { query }: { query: { id: string } } ) => {
 		// Remove the file name from the uploaded files.
 		setUploadedFiles( ( prev ) => ( { ...prev, [ key ]: '' } ) );
 	};
-
-	// --- Navigation warning ---
-	const confirmationNavigationCallback = useConfirmNavigation( () => {
-		if ( showConfirmation || readOnly ) return;
-		return __(
-			'There are unsaved changes on this page. Are you sure you want to leave and discard the unsaved changes?',
-			'woocommerce-payments'
-		);
-	} );
-
-	// Store the cleanup function from the navigation confirmation
-	const [ navigationCleanup, setNavigationCleanup ] = useState<
-		( () => void ) | null
-	>( null );
-
-	useEffect( () => {
-		const cleanup = confirmationNavigationCallback();
-		setNavigationCleanup( cleanup );
-	}, [ confirmationNavigationCallback, readOnly ] );
 
 	// --- Accordion summary content ---
 	const summaryItems = useMemo( () => {

--- a/client/disputes/new-evidence/product-details.tsx
+++ b/client/disputes/new-evidence/product-details.tsx
@@ -34,7 +34,7 @@ const ProductDetails: React.FC< ProductDetailsProps > = ( {
 			</h3>
 			<div className="wcpay-dispute-evidence-product-details__subheading">
 				{ __(
-					'Please check the correct product type has been selected and the description is accurate.',
+					'Please ensure the product type and description have been entered accurately.',
 					'woocommerce-payments'
 				) }
 			</div>

--- a/client/disputes/new-evidence/shipping-details.tsx
+++ b/client/disputes/new-evidence/shipping-details.tsx
@@ -39,7 +39,7 @@ const ShippingDetails: React.FC< ShippingDetailsProps > = ( {
 			</h3>
 			<div className="wcpay-dispute-evidence-shipping-details__subheading">
 				{ __(
-					'Please check that all of the prefilled information is accurate and complete any empty fields.',
+					'Please ensure all prefilled information is correct and complete any missing details.',
 					'woocommerce-payments'
 				) }
 			</div>


### PR DESCRIPTION
Fixes WOOPMNT-5150

#### Changes proposed in this Pull Request

This PR adds new copy, avoiding leaving a single word alone. Also removed some unused code.

Before
<img width="1146" height="190" alt="image" src="https://github.com/user-attachments/assets/fb2256a6-4a86-4ee5-bd24-333742849457" />
After
<img width="1566" height="212" alt="image" src="https://github.com/user-attachments/assets/a5818e0b-2916-47a7-b0cf-e2aa4a817639" />
Before
<img width="1120" height="238" alt="image" src="https://github.com/user-attachments/assets/e3aaa3fc-b2ae-4a1d-85bc-930c6edff1a7" />
After
<img width="1742" height="248" alt="image" src="https://github.com/user-attachments/assets/6e46871f-5f4e-437f-8d72-e5c126f88162" />

#### Testing instructions

* Create a new dispute, you can do this making a purchase with the following CC `4000000000000259`
* Go to Payments > Disputes, select one dispute
* On the dispute page, hit Challenge dispute
* Ensure the new copy was introduced

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
