### PR TITLE
update: RedirectToTransactionDetails to use unbundled wp components

### DIFF
--- a/changelog/update-redirect-to-transaction-details-wp-components
+++ b/changelog/update-redirect-to-transaction-details-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: RedirectToTransactionDetails to use Gutenberg components that come with the WP installation

--- a/client/index.js
+++ b/client/index.js
@@ -178,7 +178,11 @@ addFilter(
 		} );
 
 		pages.push( {
-			container: RedirectToTransactionDetails,
+			container: ( { query } ) => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<RedirectToTransactionDetails query={ query } />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/disputes/details',
 			wpOpenMenu: menuID,
 			breadcrumbs: [


### PR DESCRIPTION
Fixes WOOPMNT-5169

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<img width="978" height="588" alt="Screenshot 2025-07-16 at 11 35 04 AM" src="https://github.com/user-attachments/assets/ad307df0-3dbc-4b6c-b3db-d27c774e3515" />
<img width="1020" height="648" alt="Screenshot 2025-07-16 at 11 34 49 AM" src="https://github.com/user-attachments/assets/c55678f8-6193-4d6c-aba9-74383c1a226c" />

- Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails`
- The page should render (but the redirect won't work)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
