### PR TITLE
Update the overview page to use the components available in the WordPress installation

### DIFF
--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -131,6 +131,14 @@
 	background-image: url( '../images/payment-methods/afterpay-icon.svg' );
 }
 
+.payment-method__brand--afterpay_clearpay.account-country--gb {
+	background-image: url( '../images/payment-methods/clearpay.svg' );
+}
+
+.payment-method__brand--afterpay_clearpay.account-country--us {
+	background-image: url( '../images/payment-methods/afterpay-cashapp-icon.svg' );
+}
+
 .payment-method__brand--affirm {
 	background-image: url( '../images/payment-methods/affirm-icon.svg' );
 }

--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -131,14 +131,6 @@
 	background-image: url( '../images/payment-methods/afterpay-icon.svg' );
 }
 
-.payment-method__brand--afterpay_clearpay.account-country--gb {
-	background-image: url( '../images/payment-methods/clearpay.svg' );
-}
-
-.payment-method__brand--afterpay_clearpay.account-country--us {
-	background-image: url( '../images/payment-methods/afterpay-cashapp-icon.svg' );
-}
-
 .payment-method__brand--affirm {
 	background-image: url( '../images/payment-methods/affirm-icon.svg' );
 }

--- a/changelog/update-wp-components-overview
+++ b/changelog/update-wp-components-overview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the payments overview page to use the components available in the WP installation.

--- a/client/components/account-balances/balance-tooltip.tsx
+++ b/client/components/account-balances/balance-tooltip.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { ClickTooltip } from 'components/tooltip';
 import { documentationUrls, fundLabelStrings } from './strings';
 import InlineNotice from 'components/inline-notice';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 
 type TotalBalanceTooltipProps = {
 	balance: number;
@@ -132,10 +133,7 @@ export const AvailableBalanceTooltip: React.FC< AvailableBalanceTooltipProps > =
 								),
 								components: {
 									discoverWhyLink: (
-										// eslint-disable-next-line jsx-a11y/anchor-has-content
-										<a
-											rel="external noopener noreferrer"
-											target="_blank"
+										<ExternalLink
 											href={
 												documentationUrls.negativeBalance
 											}

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -4,7 +4,6 @@
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -13,6 +12,7 @@ import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
 import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
 import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import type * as AccountOverview from 'wcpay/types/account-overview';
 import BalanceBlock from './balance-block';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
@@ -207,11 +207,10 @@ const AccountBalances: React.FC = () => {
 											components: {
 												strong: <strong />,
 												learnMoreLink: (
-													<Link
-														href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/"
-														target="_blank"
-														rel="noreferrer"
-														type="external"
+													<ExternalLink
+														href={
+															'https://woocommerce.com/document/woopayments/payouts/instant-payouts/'
+														}
 													/>
 												),
 											},

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -2,12 +2,6 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	Flex,
-} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
@@ -15,6 +9,10 @@ import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
 import type * as AccountOverview from 'wcpay/types/account-overview';
 import BalanceBlock from './balance-block';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';

--- a/client/components/account-status/account-status-item.js
+++ b/client/components/account-status/account-status-item.js
@@ -1,17 +1,11 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import {
-	Flex,
-	FlexBlock,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
-
-/**
  * Internal dependencies
  */
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexBlock } from 'wcpay/components/wp-components-wrapped/components/flex-block';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 
 const AccountStatusItem = ( { label, align, value, children } ) => {
 	return (

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, CardDivider } from 'wcpay/components/wp-components-wrapped';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -12,6 +11,8 @@ import strings from './strings';
 import './styles.scss';
 import ResetAccountModal from 'wcpay/overview/modal/reset-account';
 import { isInTestModeOnboarding } from 'wcpay/utils';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped/components/card-divider';
 
 const handleReset = () => {
 	window.location.href = addQueryArgs( wcpaySettings.connectUrl, {

--- a/client/components/account-status/account-tools/index.tsx
+++ b/client/components/account-status/account-tools/index.tsx
@@ -40,6 +40,7 @@ export const AccountTools = () => {
 					<Button
 						variant={ 'secondary' }
 						onClick={ () => setModalVisible( true ) }
+						__next40pxDefaultSize
 					>
 						{ strings.reset }
 					</Button>

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -90,6 +90,7 @@ const AccountStatusDetails = ( props ) => {
 						}
 						href={ accountLink }
 						target={ '_blank' }
+						__next40pxDefaultSize
 					>
 						{ __( 'Edit details', 'woocommerce-payments' ) }
 					</Button>

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -3,19 +3,18 @@
 /**
  * External dependencies
  */
-import {
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	FlexBlock,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
+import { FlexBlock } from 'wcpay/components/wp-components-wrapped/components/flex-block';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import AccountFees from './account-fees';
 import AccountStatusItem from './account-status-item';
 import DepositsStatus from 'components/deposits-status';
@@ -25,7 +24,6 @@ import './style.scss';
 import './shared.scss';
 import { AccountTools } from './account-tools';
 import { recordEvent } from 'wcpay/tracks';
-import { addQueryArgs } from '@wordpress/url';
 
 const AccountStatusCard = ( props ) => {
 	const { title, children, value } = props;

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -12,7 +12,8 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, renderToString } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
 import clsx from 'clsx';
-import { Icon, Button } from 'wcpay/components/wp-components-wrapped';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { check, info } from '@wordpress/icons';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import NoticeIcon from 'gridicons/dist/notice';
@@ -171,6 +172,7 @@ const BannerNotice: React.FC< React.PropsWithChildren< Props > > = ( {
 										onClick={ url ? undefined : onClick }
 										className={ buttonCustomClasses }
 										target={ urlTarget }
+										__next40pxDefaultSize
 									>
 										{ label }
 									</Button>
@@ -190,6 +192,7 @@ const BannerNotice: React.FC< React.PropsWithChildren< Props > > = ( {
 					) }
 					onClick={ handleRemove }
 					showTooltip={ false }
+					__next40pxDefaultSize
 				/>
 			) }
 		</div>

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -12,8 +12,6 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, renderToString } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
 import clsx from 'clsx';
-import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
-import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { check, info } from '@wordpress/icons';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import NoticeIcon from 'gridicons/dist/notice';
@@ -22,6 +20,8 @@ import CloseIcon from 'gridicons/dist/cross-small';
 /**
  * Internal dependencies.
  */
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import './style.scss';
 
 const statusIconMap = {

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -2,13 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardFooter,
-	CardHeader,
-} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import { getHistory } from '@woocommerce/navigation';
 
@@ -32,6 +25,11 @@ import {
 } from './deposit-notices';
 import { hasAutomaticScheduledDeposits } from 'wcpay/deposits/utils';
 import useRecentDeposits from './hooks';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardFooter } from 'wcpay/components/wp-components-wrapped/components/card-footer';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
 import './style.scss';
 
 const DepositsOverview: React.FC = () => {
@@ -195,6 +193,7 @@ const DepositsOverview: React.FC = () => {
 						<Button
 							variant="secondary"
 							onClick={ navigateToDepositsHistory }
+							__next40pxDefaultSize
 						>
 							{ __(
 								'View full payout history',
@@ -218,6 +217,7 @@ const DepositsOverview: React.FC = () => {
 									'wcpay_overview_deposits_change_schedule_click'
 								)
 							}
+							__next40pxDefaultSize
 						>
 							{ __(
 								'Change payout schedule',

--- a/client/components/tooltip/index.tsx
+++ b/client/components/tooltip/index.tsx
@@ -4,13 +4,13 @@
 import React, { useState, useRef } from 'react';
 import clsx from 'clsx';
 import { noop } from 'lodash';
-import { Icon } from 'wcpay/components/wp-components-wrapped';
 // eslint-disable-next-line no-restricted-syntax
-import { Icon as IconType } from '@wordpress/components';
+import type { Icon as IconType } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
 import TooltipBase, { TooltipBaseProps } from './tooltip-base';
 
 type TooltipProps = TooltipBaseProps & {

--- a/client/components/welcome/index.tsx
+++ b/client/components/welcome/index.tsx
@@ -2,11 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import {
-	CardHeader,
-	Flex,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -15,6 +10,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useAllDepositsOverviews } from 'data';
 import { useCurrentWpUser } from './hooks';
 import { CurrencySelect } from './currency-select';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import './style.scss';
 
 type TimeOfDay = 'morning' | 'afternoon' | 'evening';

--- a/client/components/wp-components-wrapped/make-wrapped-component.tsx
+++ b/client/components/wp-components-wrapped/make-wrapped-component.tsx
@@ -49,12 +49,17 @@ export const makeWrappedComponent = <
 			componentName as keyof typeof context
 		] as React.ComponentType< any >;
 
+		// Conditionally pass special props only if they have defined values to prevent React warnings about unknown DOM props
 		return (
 			<ContextComponent
 				{ ...rest }
 				ref={ ref }
-				__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
-				__next40pxDefaultSize={ __next40pxDefaultSize }
+				{ ...( __nextHasNoMarginBottom !== undefined && {
+					__nextHasNoMarginBottom,
+				} ) }
+				{ ...( __next40pxDefaultSize !== undefined && {
+					__next40pxDefaultSize,
+				} ) }
 			/>
 		);
 	} );

--- a/client/deposits/instant-payouts/index.tsx
+++ b/client/deposits/instant-payouts/index.tsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
@@ -12,6 +11,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import { Button } from 'wcpay/components/wp-components-wrapped';
 import { formatCurrency } from 'multi-currency/interface/functions';
 import InstantPayoutModal from './modal';
 import { useInstantDeposit } from 'wcpay/data';
@@ -49,6 +49,7 @@ const InstantPayoutButton: React.FC< InstantPayoutButtonProps > = ( {
 				isPrimary
 				disabled={ buttonDisabled }
 				onClick={ () => setModalOpen( true ) }
+				__next40pxDefaultSize
 			>
 				{ sprintf(
 					__(

--- a/client/index.js
+++ b/client/index.js
@@ -85,7 +85,11 @@ addFilter(
 		} );
 
 		pages.push( {
-			container: OverviewPage,
+			container: () => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<OverviewPage />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/overview',
 			wpOpenMenu: menuID,
 			breadcrumbs: [ rootLink, __( 'Overview', 'woocommerce-payments' ) ],

--- a/client/merchant-feedback-prompt/index.tsx
+++ b/client/merchant-feedback-prompt/index.tsx
@@ -3,21 +3,19 @@
  */
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-import {
-	Button,
-	Flex,
-	FlexItem,
-	SnackbarList,
-} from 'wcpay/components/wp-components-wrapped';
-// eslint-disable-next-line no-restricted-syntax
-import { NoticeList } from '@wordpress/components';
 import { Icon, thumbsUp, thumbsDown } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line no-restricted-syntax
+import type { NoticeList } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
+import { SnackbarList } from 'wcpay/components/wp-components-wrapped/components/snackbar-list';
 import { recordEvent } from 'wcpay/tracks';
 import { PositiveFeedbackModal } from './positive-modal';
 import { NegativeFeedbackModal } from './negative-modal';
@@ -126,6 +124,7 @@ const MerchantFeedbackPrompt: React.FC< MerchantFeedbackPromptProps > = ( {
 											showPositiveFeedbackModal();
 											dismissPrompt();
 										} }
+										__next40pxDefaultSize
 									>
 										<Icon
 											icon={ thumbsUp }
@@ -153,6 +152,7 @@ const MerchantFeedbackPrompt: React.FC< MerchantFeedbackPromptProps > = ( {
 											showNegativeFeedbackModal();
 											dismissPrompt();
 										} }
+										__next40pxDefaultSize
 									>
 										<Icon
 											icon={ thumbsDown }

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -4,16 +4,17 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { Card, Notice } from 'wcpay/components/wp-components-wrapped';
 import { getQuery } from '@woocommerce/navigation';
 import { __, sprintf } from '@wordpress/i18n';
 import { dispatch } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies.
  */
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import AccountBalances from 'components/account-balances';
 import AccountStatus from 'components/account-status';
 import ActiveLoanSummary from 'components/active-loan-summary';
@@ -317,14 +318,10 @@ const OverviewPage = () => {
 							components: {
 								seeDetailsLink: (
 									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									<Link
+									<ExternalLink
 										href={
-											// eslint-disable-next-line max-len
 											'https://woocommerce.com/document/woopayments/startup-guide/#requirements'
 										}
-										target="_blank"
-										rel="noreferrer"
-										type="external"
 									/>
 								),
 							},

--- a/client/overview/modal/connection-success/index.tsx
+++ b/client/overview/modal/connection-success/index.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { Modal, Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import './style.scss';
 import strings from './strings';
 import { saveOption } from 'wcpay/data/settings/actions';
@@ -44,6 +45,7 @@ export const ConnectionSuccessModal = () => {
 							isBusy={ false }
 							disabled={ false }
 							onClick={ onDismiss }
+							__next40pxDefaultSize
 						>
 							{ strings.button }
 						</Button>

--- a/client/overview/modal/progressive-onboarding-eligibility/index.tsx
+++ b/client/overview/modal/progressive-onboarding-eligibility/index.tsx
@@ -4,13 +4,14 @@
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
 import { Icon, store, currencyDollar } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
  */
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { trackEligibilityModalClosed } from 'onboarding/tracking';
 import ConfettiAnimation from 'components/confetti-animation';
 import { saveOption } from 'wcpay/data/settings/actions';
@@ -122,10 +123,18 @@ const ProgressiveOnboardingEligibilityModal: React.FC = () => {
 				</div>
 			</div>
 			<div className="wcpay-progressive-onboarding-eligibility-modal__footer">
-				<Button variant="secondary" onClick={ handleSetup }>
+				<Button
+					variant="secondary"
+					onClick={ handleSetup }
+					__next40pxDefaultSize
+				>
 					{ __( 'Set up payouts', 'woocommerce-payments' ) }
 				</Button>
-				<Button variant="primary" onClick={ handlePaymentsOnly }>
+				<Button
+					variant="primary"
+					onClick={ handlePaymentsOnly }
+					__next40pxDefaultSize
+				>
 					{ __( 'Start selling', 'woocommerce-payments' ) }
 				</Button>
 			</div>

--- a/client/overview/modal/reset-account/index.tsx
+++ b/client/overview/modal/reset-account/index.tsx
@@ -2,15 +2,13 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import {
-	Button,
-	CardDivider,
-	Modal,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped/components/card-divider';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import './style.scss';
 import strings from './strings';
 import { isInTestModeOnboarding } from 'utils';
@@ -62,6 +60,7 @@ const ResetAccountModal: React.FC< Props > = ( props: Props ) => {
 						setSubmitted( false );
 						onDismiss();
 					} }
+					__next40pxDefaultSize
 				>
 					{ strings.cancel }
 				</Button>
@@ -74,6 +73,7 @@ const ResetAccountModal: React.FC< Props > = ( props: Props ) => {
 						setSubmitted( true );
 						onSubmit();
 					} }
+					__next40pxDefaultSize
 				>
 					{ strings.reset }
 				</Button>

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, Modal, Notice } from 'wcpay/components/wp-components-wrapped';
 import { sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import strings from './strings';
 import './index.scss';
 import { recordEvent } from 'wcpay/tracks';
@@ -79,13 +81,18 @@ const UpdateBusinessDetailsModal = ( {
 					</div>
 					<hr />
 					<div className="wcpay-update-business-details-modal__footer">
-						<Button variant={ 'secondary' } onClick={ closeModal }>
+						<Button
+							variant={ 'secondary' }
+							onClick={ closeModal }
+							__next40pxDefaultSize
+						>
 							{ strings.cancel }
 						</Button>
 
 						<Button
 							variant={ 'primary' }
 							onClick={ openAccountLink }
+							__next40pxDefaultSize
 						>
 							{ strings.updateBusinessDetails }
 						</Button>


### PR DESCRIPTION
See WOOPMNT-5165

#### Changes proposed in this Pull Request

Updating the components of the overview page to use the WP components that come with the WP installation.



Overview page use the Card component, this component changed, the newer Card has its border rounded.

Before
<img width="786" height="1313" alt="image" src="https://github.com/user-attachments/assets/7b099cd3-5310-4ea2-ad6d-bd8d3a396e8e" />
After
<img width="745" height="888" alt="image" src="https://github.com/user-attachments/assets/164ca620-e61b-4b5b-978a-9487858033cb" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Payments > Overview and ensure the visual differences apply

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
