### PR TITLE
Fix imports for the unbundled components

### DIFF
--- a/changelog/fix-imports
+++ b/changelog/fix-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix imports for the unbundled components.

--- a/client/card-readers/index.tsx
+++ b/client/card-readers/index.tsx
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Page from 'components/page';
 import ReadersList from './list';
-import { TabPanel } from 'wcpay/components/wp-components-wrapped';
+import { TabPanel } from 'wcpay/components/wp-components-wrapped/components/tab-panel';
 
 import './style.scss';
 

--- a/client/card-readers/list/index.tsx
+++ b/client/card-readers/list/index.tsx
@@ -4,15 +4,13 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	Card,
-	CardBody,
-	CardDivider,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped/components/card-divider';
 import SettingsSection from 'wcpay/settings/settings-section';
 import SettingsLayout from 'wcpay/settings/settings-layout';
 import LoadableSettingsSection from 'wcpay/settings/loadable-settings-section';

--- a/client/components/account-status/account-fees/index.js
+++ b/client/components/account-status/account-fees/index.js
@@ -19,7 +19,7 @@ import {
 	getCurrentBaseFee,
 	getTransactionsPaymentMethodName,
 } from 'utils/account-fees';
-import { CardDivider } from 'wcpay/components/wp-components-wrapped';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped/components/card-divider';
 import './styles.scss';
 
 const AccountFee = ( props ) => {

--- a/client/components/active-loan-summary/index.tsx
+++ b/client/components/active-loan-summary/index.tsx
@@ -2,21 +2,19 @@
  * External dependencies
  */
 import React from 'react';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	Flex,
-	FlexBlock,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexBlock } from 'wcpay/components/wp-components-wrapped/components/flex-block';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import { formatExplicitCurrency } from 'multi-currency/interface/functions';
 import Loadable from 'components/loadable';
 import { useActiveLoanSummary } from 'wcpay/data';

--- a/client/components/cancel-authorization-button/index.tsx
+++ b/client/components/cancel-authorization-button/index.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/client/components/capture-authorization-button/index.tsx
+++ b/client/components/capture-authorization-button/index.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/client/components/card-notice/index.tsx
+++ b/client/components/card-notice/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import './styles.scss';
-import { CardFooter } from 'wcpay/components/wp-components-wrapped';
+import { CardFooter } from 'wcpay/components/wp-components-wrapped/components/card-footer';
 
 interface CardNoticeProps {
 	children: React.ReactNode;

--- a/client/components/card-notice/test/index.tsx
+++ b/client/components/card-notice/test/index.tsx
@@ -9,7 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CardNotice from '../';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 describe( 'CardNotice component', () => {
 	test( 'should render child', () => {

--- a/client/components/custom-select-control/index.tsx
+++ b/client/components/custom-select-control/index.tsx
@@ -10,7 +10,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import clsx from 'clsx';

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/client/components/deposits-overview/recent-deposits-list.tsx
+++ b/client/components/deposits-overview/recent-deposits-list.tsx
@@ -2,13 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import {
-	CardBody,
-	CardDivider,
-	Flex,
-	FlexItem,
-	Icon,
-} from 'wcpay/components/wp-components-wrapped';
 import { calendar } from '@wordpress/icons';
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
@@ -16,6 +9,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardDivider } from 'wcpay/components/wp-components-wrapped/components/card-divider';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
 import './style.scss';
 import DepositStatusChip from 'components/deposit-status-chip';
 import { getDepositDate } from 'deposits/utils';

--- a/client/components/download-button/index.tsx
+++ b/client/components/download-button/index.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/client/components/file-upload/index.tsx
+++ b/client/components/file-upload/index.tsx
@@ -3,12 +3,6 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	BaseControl,
-	Button,
-	DropZone,
-	FormFileUpload,
-} from 'wcpay/components/wp-components-wrapped';
 import CheckmarkIcon from 'gridicons/dist/checkmark';
 import ImageIcon from 'gridicons/dist/image';
 import AddOutlineIcon from 'gridicons/dist/add-outline';
@@ -17,6 +11,10 @@ import TrashIcon from 'gridicons/dist/trash';
 /**
  * Internal dependencies.
  */
+import { BaseControl } from 'wcpay/components/wp-components-wrapped/components/base-control';
+import { DropZone } from 'wcpay/components/wp-components-wrapped/components/drop-zone';
+import { FormFileUpload } from 'wcpay/components/wp-components-wrapped/components/form-file-upload';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import type { FileUploadControlProps } from 'wcpay/types/disputes';
 import FileUploadError from './upload-error';
 import FileUploadPreview from './preview';

--- a/client/components/form/fields.tsx
+++ b/client/components/form/fields.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ComponentProps, forwardRef } from 'react';
-import { TextControl } from 'wcpay/components/wp-components-wrapped';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
 import clsx from 'clsx';
 
 /**

--- a/client/components/inline-label-select/index.tsx
+++ b/client/components/inline-label-select/index.tsx
@@ -10,7 +10,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import clsx from 'clsx';

--- a/client/components/jetpack-idc-notice/index.tsx
+++ b/client/components/jetpack-idc-notice/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Notice } from 'wcpay/components/wp-components-wrapped';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 
 /**
  * Internal dependencies

--- a/client/components/payment-method-logos/index.tsx
+++ b/client/components/payment-method-logos/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState, useEffect, useRef } from 'react';
-import { Popover } from 'wcpay/components/wp-components-wrapped';
+import { Popover } from 'wcpay/components/wp-components-wrapped/components/popover';
 
 /**
  * Internal dependencies

--- a/client/components/phone-number-control/index.tsx
+++ b/client/components/phone-number-control/index.tsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState, useRef, useLayoutEffect } from 'react';
-import { BaseControl } from 'wcpay/components/wp-components-wrapped';
+import { BaseControl } from 'wcpay/components/wp-components-wrapped/components/base-control';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import 'intl-tel-input';

--- a/client/components/sandbox-mode-switch-to-live-notice/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { __, sprintf } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 

--- a/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/modal/index.tsx
@@ -4,7 +4,8 @@
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { Icon, currencyDollar } from '@wordpress/icons';
 
 /**

--- a/client/components/stepper/stepper-panel.tsx
+++ b/client/components/stepper/stepper-panel.tsx
@@ -7,7 +7,7 @@ import { check } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { Icon } from 'wcpay/components/wp-components-wrapped';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
 import './style.scss';
 import clsx from 'clsx';
 

--- a/client/components/stepper/test/stepper-panel.test.tsx
+++ b/client/components/stepper/test/stepper-panel.test.tsx
@@ -10,7 +10,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { StepperPanel } from '../stepper-panel';
 
 // Mock the Icon component to avoid dependency on WordPress icons
-jest.mock( 'wcpay/components/wp-components-wrapped', () => ( {
+jest.mock( 'wcpay/components/wp-components-wrapped/components/icon', () => ( {
 	Icon: ( { size }: { size: number } ) => (
 		<span data-testid="mock-icon">icon-{ size }</span>
 	),

--- a/client/components/wp-components-wrapped/components/number-control.tsx
+++ b/client/components/wp-components-wrapped/components/number-control.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+// @ts-expect-error: Suppressing Module '"@wordpress/components"' has no exported member '__experimentalText'.
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis, no-restricted-syntax
+import { __experimentalNumberControl as BundledExperimentalNumberControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { makeWrappedComponent } from '../make-wrapped-component';
+
+export const NumberControl = makeWrappedComponent(
+	BundledExperimentalNumberControl,
+	'__experimentalNumberControl'
+);

--- a/client/components/wp-components-wrapped/index.tsx
+++ b/client/components/wp-components-wrapped/index.tsx
@@ -20,6 +20,7 @@ export { MenuGroup } from './components/menu-group';
 export { MenuItem } from './components/menu-item';
 export { Modal } from './components/modal';
 export { Notice } from './components/notice';
+export { NumberControl } from './components/number-control';
 export { Panel } from './components/panel';
 export { PanelBody } from './components/panel-body';
 export { Popover } from './components/popover';

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -5,13 +5,6 @@
  */
 import React, { useEffect, useState, useRef } from 'react';
 import { render } from '@wordpress/element';
-import {
-	Button,
-	Card,
-	CardBody,
-	Panel,
-	PanelBody,
-} from 'wcpay/components/wp-components-wrapped';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Loader } from '@woocommerce/onboarding';
@@ -20,6 +13,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { Panel } from 'wcpay/components/wp-components-wrapped/components/panel';
+import { PanelBody } from 'wcpay/components/wp-components-wrapped/components/panel-body';
 import { recordEvent } from 'tracks';
 import Page from 'components/page';
 import BannerNotice from 'components/banner-notice';

--- a/client/connect-account-page/info-notice-modal.tsx
+++ b/client/connect-account-page/info-notice-modal.tsx
@@ -4,7 +4,9 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, Modal, Notice } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/connect-account-page/modal/index.js
+++ b/client/connect-account-page/modal/index.js
@@ -6,7 +6,8 @@ import interpolateComponents from '@automattic/interpolate-components';
 /**
  * Internal dependencies
  */
-import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link, List } from '@woocommerce/components';
 import { useState } from '@wordpress/element';

--- a/client/deposits/index.tsx
+++ b/client/deposits/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { addQueryArgs } from '@wordpress/url';
 
 /**

--- a/client/deposits/instant-payouts/index.tsx
+++ b/client/deposits/instant-payouts/index.tsx
@@ -11,7 +11,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { formatCurrency } from 'multi-currency/interface/functions';
 import InstantPayoutModal from './modal';
 import { useInstantDeposit } from 'wcpay/data';

--- a/client/deposits/instant-payouts/modal.tsx
+++ b/client/deposits/instant-payouts/modal.tsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { recordEvent } from 'tracks';
 import { _n, __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery, getHistory } from '@woocommerce/navigation';
 import clsx from 'clsx';

--- a/client/disputes/new-evidence/confirmation-screen.tsx
+++ b/client/disputes/new-evidence/confirmation-screen.tsx
@@ -10,7 +10,8 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button, ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { getAdminUrl } from 'wcpay/utils';
 import InlineNotice from 'components/inline-notice';
 import DisputeEvidenceSubmittedIllustration from 'assets/images/dispute-evidence-submitted.svg?asset';

--- a/client/disputes/new-evidence/cover-letter.tsx
+++ b/client/disputes/new-evidence/cover-letter.tsx
@@ -8,10 +8,8 @@ import { external } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import {
-	TextareaControl,
-	Button,
-} from 'wcpay/components/wp-components-wrapped';
+import { TextareaControl } from 'wcpay/components/wp-components-wrapped/components/textarea-control';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import type { CoverLetterProps } from './types';
 
 const CoverLetter: React.FC< CoverLetterProps > = ( {

--- a/client/disputes/new-evidence/duplicate-status.tsx
+++ b/client/disputes/new-evidence/duplicate-status.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { RadioControl } from 'wcpay/components/wp-components-wrapped';
+import { RadioControl } from 'wcpay/components/wp-components-wrapped/components/radio-control';
 
 interface DuplicateStatusProps {
 	duplicateStatus: string;

--- a/client/disputes/new-evidence/file-upload-control.tsx
+++ b/client/disputes/new-evidence/file-upload-control.tsx
@@ -8,7 +8,8 @@ import { closeSmall, cloudUpload } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { Button, FormFileUpload } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { FormFileUpload } from 'wcpay/components/wp-components-wrapped/components/form-file-upload';
 import { FileUploadControlProps } from './types';
 import { formatFileNameWithSize } from './utils';
 

--- a/client/disputes/new-evidence/product-details.tsx
+++ b/client/disputes/new-evidence/product-details.tsx
@@ -7,10 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	SelectControl,
-	TextareaControl,
-} from 'wcpay/components/wp-components-wrapped';
+import { SelectControl } from 'wcpay/components/wp-components-wrapped/components/select-control';
+import { TextareaControl } from 'wcpay/components/wp-components-wrapped/components/textarea-control';
 
 interface ProductDetailsProps {
 	productType: string;

--- a/client/disputes/new-evidence/refund-status.tsx
+++ b/client/disputes/new-evidence/refund-status.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { RadioControl } from 'wcpay/components/wp-components-wrapped';
+import { RadioControl } from 'wcpay/components/wp-components-wrapped/components/radio-control';
 
 interface RefundStatusProps {
 	refundStatus: string;

--- a/client/disputes/new-evidence/shipping-details.tsx
+++ b/client/disputes/new-evidence/shipping-details.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { TextControl } from 'wcpay/components/wp-components-wrapped';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
 
 interface ShippingDetailsProps {
 	shippingCarrier: string;

--- a/client/disputes/new-evidence/test/file-upload-control.test.tsx
+++ b/client/disputes/new-evidence/test/file-upload-control.test.tsx
@@ -10,26 +10,29 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import FileUploadControl from '../file-upload-control';
 
 // Mock FormFileUpload to directly render an input for testing
-jest.mock( 'wcpay/components/wp-components-wrapped', () => {
-	const original = jest.requireActual(
-		'wcpay/components/wp-components-wrapped'
-	);
-	return {
-		...original,
-		FormFileUpload: ( { onChange, render: renderProp }: any ) => (
-			<>
-				<input
-					aria-label="Upload file"
-					type="file"
-					onChange={ onChange }
-					data-testid="mock-upload-input"
-				/>
-				{ /* eslint-disable-next-line @typescript-eslint/no-empty-function */ }
-				{ renderProp( { openFileDialog: () => {} } ) }
-			</>
-		),
-	};
-} );
+jest.mock(
+	'wcpay/components/wp-components-wrapped/components/form-file-upload',
+	() => {
+		const original = jest.requireActual(
+			'wcpay/components/wp-components-wrapped/components/form-file-upload'
+		);
+		return {
+			...original,
+			FormFileUpload: ( { onChange, render: renderProp }: any ) => (
+				<>
+					<input
+						aria-label="Upload file"
+						type="file"
+						onChange={ onChange }
+						data-testid="mock-upload-input"
+					/>
+					{ /* eslint-disable-next-line @typescript-eslint/no-empty-function */ }
+					{ renderProp( { openFileDialog: () => {} } ) }
+				</>
+			),
+		};
+	}
+);
 
 describe( 'FileUploadControl', () => {
 	const baseProps = {

--- a/client/disputes/new-evidence/test/recommended-documents.test.tsx
+++ b/client/disputes/new-evidence/test/recommended-documents.test.tsx
@@ -10,26 +10,29 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import RecommendedDocuments from '../recommended-documents';
 
 // Mock FormFileUpload to directly render an input for testing
-jest.mock( 'wcpay/components/wp-components-wrapped', () => {
-	const original = jest.requireActual(
-		'wcpay/components/wp-components-wrapped'
-	);
-	return {
-		...original,
-		FormFileUpload: ( { onChange, render: renderProp }: any ) => (
-			<>
-				<input
-					aria-label="Upload file"
-					type="file"
-					onChange={ onChange }
-					data-testid="mock-upload-input"
-				/>
-				{ /* eslint-disable-next-line @typescript-eslint/no-empty-function */ }
-				{ renderProp( { openFileDialog: () => {} } ) }
-			</>
-		),
-	};
-} );
+jest.mock(
+	'wcpay/components/wp-components-wrapped/components/form-file-upload',
+	() => {
+		const original = jest.requireActual(
+			'wcpay/components/wp-components-wrapped/components/form-file-upload'
+		);
+		return {
+			...original,
+			FormFileUpload: ( { onChange, render: renderProp }: any ) => (
+				<>
+					<input
+						aria-label="Upload file"
+						type="file"
+						onChange={ onChange }
+						data-testid="mock-upload-input"
+					/>
+					{ /* eslint-disable-next-line @typescript-eslint/no-empty-function */ }
+					{ renderProp( { openFileDialog: () => {} } ) }
+				</>
+			),
+		};
+	}
+);
 
 describe( 'RecommendedDocuments', () => {
 	const fields = [

--- a/client/disputes/redirect-to-transaction-details/index.tsx
+++ b/client/disputes/redirect-to-transaction-details/index.tsx
@@ -3,16 +3,14 @@
  */
 import React, { useEffect } from 'react';
 import { getHistory } from '@woocommerce/navigation';
-import {
-	Spinner,
-	Icon,
-	Flex,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies.
  */
+import { Spinner } from 'wcpay/components/wp-components-wrapped/components/spinner';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import Page from 'components/page';
 import { useDispute } from 'data/index';
 import { Charge } from 'wcpay/types/charges';

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { TableCard, TableCardColumn } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/client/merchant-feedback-prompt/negative-modal.tsx
+++ b/client/merchant-feedback-prompt/negative-modal.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal } from 'wcpay/components/wp-components-wrapped';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { dispatch } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/merchant-feedback-prompt/positive-modal.tsx
+++ b/client/merchant-feedback-prompt/positive-modal.tsx
@@ -4,12 +4,6 @@
 import React, { useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import {
-	Button,
-	Flex,
-	FlexItem,
-	Modal,
-} from 'wcpay/components/wp-components-wrapped';
-import {
 	Icon,
 	commentContent,
 	people,
@@ -20,6 +14,10 @@ import {
 /**
  * Internal dependencies
  */
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import { recordEvent } from 'wcpay/tracks';
 import './style.scss';
 

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { isEmpty, mapValues } from 'lodash';
 
 /**

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -9,19 +9,17 @@ import { backup, edit, lock, arrowRight } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
-import {
-	Button,
-	ExternalLink,
-	Flex,
-	FlexItem,
-	Icon,
-	Modal,
-	HorizontalRule,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { HorizontalRule } from 'wcpay/components/wp-components-wrapped/components/horizontal-rule';
 import type { Dispute } from 'wcpay/types/disputes';
 import type { ChargeBillingDetails } from 'wcpay/types/charges';
 import { recordEvent } from 'tracks';

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -5,16 +5,14 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { createInterpolateElement } from '@wordpress/element';
-import {
-	Button,
-	CardFooter,
-	Flex,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CardFooter } from 'wcpay/components/wp-components-wrapped/components/card-footer';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import type { Dispute } from 'wcpay/types/disputes';
 import { recordEvent } from 'tracks';
 import { getAdminUrl } from 'wcpay/utils';

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -6,7 +6,8 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import { Icon, Button } from 'wcpay/components/wp-components-wrapped';
+import { Icon } from 'wcpay/components/wp-components-wrapped/components/icon';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { envelope, comment, page } from '@wordpress/icons';
 
 /**

--- a/client/payment-details/dispute-details/evidence-list.tsx
+++ b/client/payment-details/dispute-details/evidence-list.tsx
@@ -7,7 +7,8 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
-import { Button, PanelBody } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { PanelBody } from 'wcpay/components/wp-components-wrapped/components/panel-body';
 import { Icon, page } from '@wordpress/icons';
 
 /**

--- a/client/payment-details/readers/index.js
+++ b/client/payment-details/readers/index.js
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 import { getQuery } from '@woocommerce/navigation';
 import {
 	downloadCSVFile,

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -66,7 +66,7 @@ import {
 	formatDateTimeFromString,
 	formatDateTimeFromTimestamp,
 } from 'wcpay/utils/date-time';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 
 declare const window: any;
 

--- a/client/payment-details/summary/missing-order-notice/index.tsx
+++ b/client/payment-details/summary/missing-order-notice/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, RadioControl } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { RadioControl } from 'wcpay/components/wp-components-wrapped/components/radio-control';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';

--- a/client/payment-details/transaction-breakdown/fees-breakdown/fee-breakdown-components.tsx
+++ b/client/payment-details/transaction-breakdown/fees-breakdown/fee-breakdown-components.tsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Flex, FlexItem } from 'wcpay/components/wp-components-wrapped';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 
 /** Internal dependencies */
 import { formatCurrency } from 'multi-currency/interface/functions';

--- a/client/payment-details/transaction-breakdown/index.tsx
+++ b/client/payment-details/transaction-breakdown/index.tsx
@@ -11,14 +11,12 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import { useTimeline } from 'wcpay/data';
-import {
-	Card,
-	CardBody,
-	CardHeader,
-	CardFooter,
-	Flex,
-	FlexItem,
-} from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
+import { CardHeader } from 'wcpay/components/wp-components-wrapped/components/card-header';
+import { CardFooter } from 'wcpay/components/wp-components-wrapped/components/card-footer';
+import { Flex } from 'wcpay/components/wp-components-wrapped/components/flex';
+import { FlexItem } from 'wcpay/components/wp-components-wrapped/components/flex-item';
 import { TimelineItem } from 'wcpay/data/timeline/types';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import { formatCurrency } from 'multi-currency/interface/functions';

--- a/client/settings/advanced-settings/debug-mode.js
+++ b/client/settings/advanced-settings/debug-mode.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/advanced-settings/index.js
+++ b/client/settings/advanced-settings/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Card } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
 
 /**
  * Internal dependencies

--- a/client/settings/advanced-settings/multi-currency-toggle.js
+++ b/client/settings/advanced-settings/multi-currency-toggle.js
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-import {
-	CheckboxControl,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { useMultiCurrency } from 'wcpay/data';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-automatically-notice.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import InlineNotice from 'wcpay/components/inline-notice';
 import { _n, sprintf } from '@wordpress/i18n';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
+++ b/client/settings/advanced-settings/stripe-billing-notices/migrate-option-notice.tsx
@@ -4,7 +4,7 @@
 import React, { useContext, useState } from 'react';
 import InlineNotice from 'wcpay/components/inline-notice';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useEffect } from '@wordpress/element';
 

--- a/client/settings/advanced-settings/stripe-billing-section.tsx
+++ b/client/settings/advanced-settings/stripe-billing-section.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { createInterpolateElement } from '@wordpress/element';
 
 /**

--- a/client/settings/advanced-settings/stripe-billing-toggle.tsx
+++ b/client/settings/advanced-settings/stripe-billing-toggle.tsx
@@ -3,15 +3,13 @@
  */
 import React, { useContext } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	CheckboxControl,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
  */
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import StripeBillingMigrationNoticeContext from './stripe-billing-notices/context';
 
 interface Props {

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-import {
-	CheckboxControl,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { useWCPaySubscriptions } from 'wcpay/data';
 import interpolateComponents from '@automattic/interpolate-components';
 

--- a/client/settings/buy-now-pay-later-section/index.js
+++ b/client/settings/buy-now-pay-later-section/index.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Card, ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/card-body/index.tsx
+++ b/client/settings/card-body/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useContext } from 'react';
-import { CardBody as BundledWordPressComponentsCardBody } from 'wcpay/components/wp-components-wrapped';
+import { CardBody as BundledWordPressComponentsCardBody } from 'wcpay/components/wp-components-wrapped/components/card-body';
 import clsx from 'clsx';
 
 /**

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -4,16 +4,14 @@
 import React, { useContext } from 'react';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	SelectControl,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
  */
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { SelectControl } from 'wcpay/components/wp-components-wrapped/components/select-control';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { STORE_NAME } from 'wcpay/data/constants';
 import { getDepositMonthlyAnchorLabel } from 'wcpay/deposits/utils';
 import WCPaySettingsContext from '../wcpay-settings-context';

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -14,7 +14,8 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import { BaseControl, Button } from 'wcpay/components/wp-components-wrapped';
+import { BaseControl } from 'wcpay/components/wp-components-wrapped/components/base-control';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { FileUploadControl } from 'wcpay/components/file-upload';
 
 interface WooPayFileUploadProps {

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -4,16 +4,6 @@
  */
 import React, { useMemo } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-// eslint-disable-next-line no-restricted-syntax
-import {
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalNumberControl as NumberControl,
-} from '@wordpress/components';
-import {
-	SelectControl,
-	RadioControl,
-	RangeControl,
-} from 'wcpay/components/wp-components-wrapped';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { useContext } from '@wordpress/element';
@@ -21,6 +11,10 @@ import { useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { SelectControl } from 'wcpay/components/wp-components-wrapped/components/select-control';
+import { RadioControl } from 'wcpay/components/wp-components-wrapped/components/radio-control';
+import { RangeControl } from 'wcpay/components/wp-components-wrapped/components/range-control';
+import { NumberControl } from 'wcpay/components/wp-components-wrapped/components/number-control';
 import CardBody from '../card-body';
 import PaymentRequestButtonPreview from './payment-request-button-preview';
 import interpolateComponents from '@automattic/interpolate-components';

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -9,7 +9,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import CardBody from '../card-body';
-import { Card, CheckboxControl } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import GeneralPaymentRequestButtonSettings from './general-payment-request-button-settings';
 import {
 	usePaymentRequestEnabledSettings,

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -11,12 +11,10 @@ import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import {
-	Card,
-	CheckboxControl,
-	TextareaControl,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { TextareaControl } from 'wcpay/components/wp-components-wrapped/components/textarea-control';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import CardBody from '../card-body';
 import WooPayFileUpload from './file-upload';
 import WooPayPreview from './woopay-preview';

--- a/client/settings/express-checkout/apple-google-pay-item.tsx
+++ b/client/settings/express-checkout/apple-google-pay-item.tsx
@@ -2,16 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	CheckboxControl,
-} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import React, { useContext } from 'react';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import { getPaymentMethodSettingsUrl } from '../../utils';
 import { usePaymentRequestEnabledSettings } from 'wcpay/data';
 import { ApplePayIcon, GooglePayIcon } from 'wcpay/payment-methods-icons';

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Card } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
 
 /**
  * Internal dependencies

--- a/client/settings/express-checkout/link-item.tsx
+++ b/client/settings/express-checkout/link-item.tsx
@@ -3,15 +3,13 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	CheckboxControl,
-} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import {
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,

--- a/client/settings/express-checkout/woopay-item.tsx
+++ b/client/settings/express-checkout/woopay-item.tsx
@@ -4,10 +4,6 @@
 
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	CheckboxControl,
-} from 'wcpay/components/wp-components-wrapped';
 import interpolateComponents from '@automattic/interpolate-components';
 import { getPaymentMethodSettingsUrl } from '../../utils';
 import { useContext } from '@wordpress/element';
@@ -15,6 +11,8 @@ import { useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import {
 	useEnabledPaymentMethodIds,
 	useWooPayEnabledSettings,

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useContext, useMemo, Dispatch, SetStateAction } from 'react';
 import { __ } from '@wordpress/i18n';
-import { TextControl } from 'wcpay/components/wp-components-wrapped';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -6,7 +6,8 @@ import { isMatchWith } from 'lodash';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { LoadableBlock } from 'wcpay/components/loadable';
-import { Button, Notice } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import { dispatch } from '@wordpress/data';
 
 /**

--- a/client/settings/fraud-protection/advanced-settings/rule-card.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-card.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Card } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
+++ b/client/settings/fraud-protection/advanced-settings/rule-toggle.tsx
@@ -3,14 +3,12 @@
  */
 import React, { useContext } from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	ToggleControl,
-	RadioControl,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { ToggleControl } from 'wcpay/components/wp-components-wrapped/components/toggle-control';
+import { RadioControl } from 'wcpay/components/wp-components-wrapped/components/radio-control';
 import './../style.scss';
 import FraudPreventionSettingsContext from './context';
 import { FraudPreventionSettings } from '../interfaces';

--- a/client/settings/fraud-protection/components/fp-modal/index.tsx
+++ b/client/settings/fraud-protection/components/fp-modal/index.tsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, Modal } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/components/protection-level-modal-notice/index.tsx
+++ b/client/settings/fraud-protection/components/protection-level-modal-notice/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Notice } from 'wcpay/components/wp-components-wrapped';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/components/protection-levels/index.tsx
+++ b/client/settings/fraud-protection/components/protection-levels/index.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import HelpOutlineIcon from 'gridicons/dist/help-outline';
 import { useState } from '@wordpress/element';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal dependencies

--- a/client/settings/fraud-protection/index.tsx
+++ b/client/settings/fraud-protection/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
 
 /**
  * Internal dependencies

--- a/client/settings/general-settings/enable-woopayments-checkbox.js
+++ b/client/settings/general-settings/enable-woopayments-checkbox.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 
 /**
  * Internal dependencies

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -3,7 +3,8 @@
  */
 import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card, CheckboxControl } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/general-settings/test-mode-confirm-modal.tsx
+++ b/client/settings/general-settings/test-mode-confirm-modal.tsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/google-pay-test-mode-compatibility-notice.tsx
+++ b/client/settings/google-pay-test-mode-compatibility-notice.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import interpolateComponents from '@automattic/interpolate-components';
 import React, { useContext } from 'react';
 

--- a/client/settings/payment-methods-list/activation-modal.tsx
+++ b/client/settings/payment-methods-list/activation-modal.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 
 /**
  * Internal Dependencies

--- a/client/settings/payment-methods-list/delete-modal.tsx
+++ b/client/settings/payment-methods-list/delete-modal.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import interpolateComponents from '@automattic/interpolate-components';
 
 /**

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -4,7 +4,7 @@
  */
 import clsx from 'clsx';
 import React, { useContext } from 'react';
-import { CheckboxControl } from 'wcpay/components/wp-components-wrapped';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
 
 /**
  * Internal dependencies

--- a/client/settings/payment-methods-list/use-payment-method-availability.tsx
+++ b/client/settings/payment-methods-list/use-payment-method-availability.tsx
@@ -17,7 +17,7 @@ import PAYMENT_METHOD_IDS from 'wcpay/constants/payment-method';
 import { getMissingCurrenciesTooltipMessage } from 'multi-currency/utils/missing-currencies-message';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { ChipType } from 'wcpay/components/chip';
 
 const documentationTypeMap = {

--- a/client/settings/payment-methods-section/index.js
+++ b/client/settings/payment-methods-section/index.js
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card } from 'wcpay/components/wp-components-wrapped';
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
 
 /**
  * Internal dependencies

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState, useEffect, useLayoutEffect } from 'react';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { dispatch } from '@wordpress/data';

--- a/client/settings/support-email-input/index.js
+++ b/client/settings/support-email-input/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { TextControl, Notice } from 'wcpay/components/wp-components-wrapped';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { BaseControl, Notice } from 'wcpay/components/wp-components-wrapped';
+import { BaseControl } from 'wcpay/components/wp-components-wrapped/components/base-control';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from 'react';
 

--- a/client/settings/transactions/index.js
+++ b/client/settings/transactions/index.js
@@ -2,16 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Card,
-	CheckboxControl,
-	Notice,
-	TextControl,
-} from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Card } from 'wcpay/components/wp-components-wrapped/components/card';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
 import CardBody from '../card-body';
 import {
 	useAccountStatementDescriptor,

--- a/client/settings/transactions/manual-capture-control.tsx
+++ b/client/settings/transactions/manual-capture-control.tsx
@@ -4,15 +4,13 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	CheckboxControl,
-	Button,
-	ExternalLink,
-} from 'wcpay/components/wp-components-wrapped';
 import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import {
 	useManualCapture,
 	useCardPresentEligible,

--- a/client/settings/woopay-disable-feedback/index.js
+++ b/client/settings/woopay-disable-feedback/index.js
@@ -3,7 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Modal } from 'wcpay/components/wp-components-wrapped';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 
 /**
  * Internal dependencies

--- a/client/transactions/list/converted-amount.tsx
+++ b/client/transactions/list/converted-amount.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { Tooltip as FallbackTooltip } from 'wcpay/components/wp-components-wrapped';
+import { Tooltip as FallbackTooltip } from 'wcpay/components/wp-components-wrapped/components/tooltip';
 import SyncIcon from 'gridicons/dist/sync';
 import clsx from 'clsx';
 

--- a/client/transactions/list/deposit.tsx
+++ b/client/transactions/list/deposit.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { Link } from '@woocommerce/components';
 import InfoOutlineIcon from 'gridicons/dist/info-outline';
 

--- a/client/transactions/risk-review/columns.tsx
+++ b/client/transactions/risk-review/columns.tsx
@@ -4,11 +4,11 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { TableCardColumn, TableCardBodyColumn } from '@woocommerce/components';
-import { Button } from 'wcpay/components/wp-components-wrapped';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 import { formatExplicitCurrency } from 'multi-currency/interface/functions';

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -15,7 +15,7 @@ import { formatFee } from 'utils/fees';
 import React from 'react';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
 import { createInterpolateElement } from '@wordpress/element';
-import { ExternalLink } from 'wcpay/components/wp-components-wrapped';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import PAYMENT_METHOD_IDS from 'constants/payment-method';
 
 const countryFeeStripeDocsBaseLink =

--- a/client/vat/form-modal/index.tsx
+++ b/client/vat/form-modal/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Modal } from 'wcpay/components/wp-components-wrapped';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/client/vat/form/tasks/company-data-task.tsx
+++ b/client/vat/form/tasks/company-data-task.tsx
@@ -3,12 +3,6 @@
 /**
  * External dependencies
  */
-import {
-	Button,
-	Notice,
-	TextareaControl,
-	TextControl,
-} from 'wcpay/components/wp-components-wrapped';
 import { __ } from '@wordpress/i18n';
 import React, { useContext, useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
@@ -16,6 +10,10 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
+import { TextareaControl } from 'wcpay/components/wp-components-wrapped/components/textarea-control';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
 import CollapsibleBody from 'wcpay/components/wizard/collapsible-body';
 import WizardTaskItem from 'wcpay/components/wizard/task-item';
 import WizardTaskContext from 'wcpay/components/wizard/task/context';

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -3,12 +3,6 @@
 /**
  * External dependencies
  */
-import {
-	Button,
-	CheckboxControl,
-	Notice,
-	TextControl,
-} from 'wcpay/components/wp-components-wrapped';
 import { __, sprintf } from '@wordpress/i18n';
 import React, { useContext, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
@@ -16,6 +10,10 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { CheckboxControl } from 'wcpay/components/wp-components-wrapped/components/checkbox-control';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
+import { TextControl } from 'wcpay/components/wp-components-wrapped/components/text-control';
 import CollapsibleBody from 'wcpay/components/wizard/collapsible-body';
 import WizardTaskItem from 'wcpay/components/wizard/task-item';
 import WizardTaskContext from 'wcpay/components/wizard/task/context';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed a lot of places were still using the import from index. Since importing from index increased the bundle size this PR addresses that.

#### Testing instructions

* Code review and smoke test

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
