### PR TITLE
Card readers page to use the wp.components available in the WordPress installation

### DIFF
--- a/changelog/card-readers-page-wp-components
+++ b/changelog/card-readers-page-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make the card reaaders page use the wp.components available in the WordPress installation.

--- a/client/index.js
+++ b/client/index.js
@@ -250,7 +250,11 @@ addFilter(
 			capability: 'manage_woocommerce',
 		} );
 		pages.push( {
-			container: CardReadersPage,
+			container: () => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<CardReadersPage />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/card-readers',
 			wpOpenMenu: menuID,
 			breadcrumbs: [


### PR DESCRIPTION
See WOOPMNT-5171

#### Changes proposed in this Pull Request

Make the card readers page to use the wp.components available in the WordPress installation.

Before
<img width="1423" height="389" alt="image" src="https://github.com/user-attachments/assets/a130cd7a-7862-464b-a561-4c76eb6d1f03" />
After
<img width="1327" height="444" alt="image" src="https://github.com/user-attachments/assets/5ed1ab4c-336f-4579-8a61-acde96aad94b" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You have to enable card readers on the Stripe page: https://docs.stripe.com/terminal/payments/connect-reader?terminal-sdk-platform=server-driven&reader-type=smart#register-reader
* Once enabled, go to WCPay Dev and clear cache for that account
* Go to Payments > Card Readers

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
