### PR TITLE
Fix icon border color

### DIFF
--- a/changelog/fix-icon-border-gray-200
+++ b/changelog/fix-icon-border-gray-200
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the icon border of the Steps component for a dispute.

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -134,7 +134,7 @@
 			height: 44px;
 			border-radius: var( --radius-s, 2px );
 			padding: 10px;
-			border: 1px solid rgba( 0, 0, 0, 0.1 );
+			border: 1px solid $gray-200;
 			margin-right: 12px;
 
 			@media screen and ( max-width: $break-small ) {


### PR DESCRIPTION
Fixes WOOPMNT-5194

#### Changes proposed in this Pull Request

Fix the icon border color to gray-200

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a dispute (make a purchase using this card (4000000000000259)
* Payments > Disputes
* Select a dispute and ensure the icon border is gray-200 (`#e0e0e0`). https://wordpress.github.io/gutenberg/?path=/docs/tokens-color--page

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
