### PR TITLE
Extract redirect URL from payment details if not provided.

### DIFF
--- a/changelog/fix-woopmnt-5191-3d-secure-verification-dialog-fails-to-appear-when-using
+++ b/changelog/fix-woopmnt-5191-3d-secure-verification-dialog-fails-to-appear-when-using
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Google Pay 3D Secure authentication being bypassed due to redirect URL extraction issue

--- a/client/express-checkout/cart-api.js
+++ b/client/express-checkout/cart-api.js
@@ -68,7 +68,8 @@ export default class ExpressCheckoutCartApi {
 
 	/**
 	 * Creates an order from the cart object.
-	 * See https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/docs/checkout.md#process-order-and-payment
+	 * See https://github.com/woocommerce/woocommerce/blob/trunk/docs/apis/store-api/
+	 * resources-endpoints/checkout.md#process-order-and-payment
 	 *
 	 * @param {{
 	 *          billing_address: Object,


### PR DESCRIPTION
Fixes #WOOPMNT-5191

Express Checkout was looking for the 3DS redirect URL in `payment_result.redirect_url`, but the backend was storing it in `payment_result.payment_details[]` with key `'redirect'`. When `redirect_url` was empty, the `confirmIntent()` method would return early and skip 3DS authentication entirely. 

#### Changes proposed in this Pull Request

* Updated `onConfirmHandler` in `client/express-checkout/event-handlers.js` to extract the redirect URL from `payment_details` when `redirect_url` is empty

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_I tested locally with WooCommerce Core 9.8.0-beta.1 and tried to checkout with Google Pay and 3DS card in the shortcode based checkout and the block based checkout._

* Check https://linear.app/a8c/issue/STRIPE-624/globalstep-3d-secure-verification-dialog-fails-to-appear-when-paying for the steps to reproduce the issue that this PR solves. Note: Originally reported for the Stripe plugin, but the issue is also present on the WooPayments Plugin.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
