### PR TITLE
Make onboarding KYC use wp.components from the WP installation

### DIFF
--- a/changelog/make-kyc-onboarding-use-wp-components-from-wp-installation
+++ b/changelog/make-kyc-onboarding-use-wp-components-from-wp-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make the KYC onboarding use the WP components available in the installation.

--- a/client/index.js
+++ b/client/index.js
@@ -71,7 +71,11 @@ addFilter(
 		} );
 
 		pages.push( {
-			container: OnboardingKycPage,
+			container: () => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<OnboardingKycPage />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/onboarding/kyc',
 			wpOpenMenu: menuID,
 			breadcrumbs: [


### PR DESCRIPTION
See WOOPMNT-5164

#### Changes proposed in this Pull Request

Make onboarding KYC use `wp.components` from the WP installation. I haven't found any visual change on the screen since most of them come from Stripe's SDK.

#### Testing instructions

* For me the fastest way to see the components was commenting the if statement in:`includes/admin/class-wc-payments-admin.php`:
```diff
-- if ( $this->account->is_stripe_connected() && ! $this->account->is_details_submitted() ) {
++ // if ( $this->account->is_stripe_connected() && ! $this->account->is_details_submitted() ) {
	wc_admin_register_page(
		[
			'id'         => 'wc-payments-onboarding-kyc',
			'title'      => __( 'Continue onboarding', 'woocommerce-payments' ),
			'parent'     => 'wc-payments',
			'path'       => '/payments/onboarding/kyc',
			'capability' => 'manage_woocommerce',
			'nav_args'   => [
				'parent' => 'wc-payments',
				'order'  => 50,
			],
		]
	);
	remove_submenu_page( 'wc-admin&path=/payments/connect', 'wc-admin&path=/payments/onboarding/kyc' );
-- }
++ // }
```
* Then go to Payments > Continue onboarding
* Ensure everything is still working

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
