### PR TITLE
Fix spinner misaligned in Proceed to Checkout button

### DIFF
--- a/changelog/fix-woopmnt-5198-spinner-in-the-proceed-to-checkout-button-is-misaligned
+++ b/changelog/fix-woopmnt-5198-spinner-in-the-proceed-to-checkout-button-is-misaligned
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Spinner alignment in the "Proceed to Checkout" button of the cart page.

--- a/changelog/fix-woopmnt-5198-spinner-in-the-proceed-to-checkout-button-is-misaligned
+++ b/changelog/fix-woopmnt-5198-spinner-in-the-proceed-to-checkout-button-is-misaligned
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix: Spinner alignment in the "Proceed to Checkout" button of the cart page.
+Fix: Spinner alignment issues in cart checkout button and checkout address form email field.

--- a/client/cart/blocks/index.js
+++ b/client/cart/blocks/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { renderBNPLCartMessaging } from './product-details';
+import './style.scss';
 
 const { registerPlugin } = window.wp.plugins;
 

--- a/client/cart/blocks/style.scss
+++ b/client/cart/blocks/style.scss
@@ -7,7 +7,6 @@
 
 /**
  * Fix for cart submit button spinner alignment
- *
  */
 .wc-block-cart__submit-button .wc-block-components-button__text {
 	position: relative;
@@ -16,13 +15,5 @@
 		/* Override the base style's top/left: initial */
 		top: 0;
 		left: 0;
-
-		&::after {
-			/* Ensure proper centering - this should match the base style */
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			margin: -0.5em 0 0 -0.5em;
-		}
 	}
 }

--- a/client/cart/blocks/style.scss
+++ b/client/cart/blocks/style.scss
@@ -1,0 +1,28 @@
+/**
+ * Cart Blocks Styles
+ *
+ * This file contains styles specific to WooCommerce cart blocks
+ * and WCPay integrations within the cart context.
+ */
+
+/**
+ * Fix for cart submit button spinner alignment
+ *
+ */
+.wc-block-cart__submit-button .wc-block-components-button__text {
+	position: relative;
+
+	.wc-block-components-spinner {
+		/* Override the base style's top/left: initial */
+		top: 0;
+		left: 0;
+
+		&::after {
+			/* Ensure proper centering - this should match the base style */
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			margin: -0.5em 0 0 -0.5em;
+		}
+	}
+}

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -1,18 +1,3 @@
-/* Cart button spinner fix - temporary location */
-.wc-block-cart__submit-button {
-	.wc-block-components-button__text {
-		position: relative !important;
-
-		.wc-block-components-spinner::after {
-			/* Fix spinner positioning - center it properly */
-			position: absolute !important;
-			top: 50% !important;
-			left: 50% !important;
-			margin: -0.5em 0 0 -0.5em !important;
-		}
-	}
-}
-
 .wcpay-express-checkout-wrapper {
 	width: 100%;
 	clear: both;

--- a/client/checkout/express-checkout-buttons.scss
+++ b/client/checkout/express-checkout-buttons.scss
@@ -1,3 +1,18 @@
+/* Cart button spinner fix - temporary location */
+.wc-block-cart__submit-button {
+	.wc-block-components-button__text {
+		position: relative !important;
+
+		.wc-block-components-spinner::after {
+			/* Fix spinner positioning - center it properly */
+			position: absolute !important;
+			top: 50% !important;
+			left: 50% !important;
+			margin: -0.5em 0 0 -0.5em !important;
+		}
+	}
+}
+
 .wcpay-express-checkout-wrapper {
 	width: 100%;
 	clear: both;

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -24,6 +24,21 @@
 	}
 }
 
+/* Fix for address form email field spinner alignment */
+.wc-block-components-address-form__email {
+	position: relative;
+
+	.wc-block-components-spinner {
+		/* Override the base style's top/left: initial */
+		top: 50%;
+		left: auto;
+		right: 10px;
+		width: 24px;
+		height: 24px;
+		transform: translateY( -50% );
+	}
+}
+
 .woopay-login-session-iframe {
 	width: 100%;
 	height: 100vh;

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1885,6 +1885,15 @@ class WC_Payments {
 		if ( WC_Payments_Utils::is_cart_block() ) {
 			self::register_script_with_dependencies( 'WCPAY_CART_BLOCK', 'dist/cart-block', [ 'wc-cart-block-frontend' ] );
 			wp_enqueue_script( 'WCPAY_CART_BLOCK' );
+
+			// Enqueue cart block styles.
+			WC_Payments_Utils::enqueue_style(
+				'WCPAY_CART_BLOCK',
+				plugins_url( 'dist/cart-block.css', WCPAY_PLUGIN_FILE ),
+				[],
+				self::get_file_version( 'dist/cart-block.css' ),
+				'all'
+			);
 		}
 	}
 


### PR DESCRIPTION
Fixes #WOOPMNT-5198

The spinner in the "Proceed to Checkout" button on the cart page (block based) was misaligned. Possibly due to conflicts with[ newer container query styles introduced in WooCommerce 10.0](https://developer.woocommerce.com/2025/07/03/cart-and-checkout-block-container-query-support-in-woocommerce-10-0/).

<img width="3112" height="1676" alt="image" src="https://github.com/user-attachments/assets/1205cd79-c8ce-4b6b-b8e6-6bdd4ae8eed6" />


#### Changes proposed in this Pull Request
* Created a new cart-specific stylesheet
* Added CSS rules to override the problematic styles

Tested on WooCommerce v9.9.5 [JN](https://night-of-roundworms.jurassic.ninja/) and v10.0.3 [JN](https://casually-surrounding-haddock.jurassic.ninja)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a merchant, go to Payments > Settings and make sure that WooPay, Apple Pay and Google Pay are enabled
* As a merchant, make sure that you have a block based Cart page available
* As a shopper navigate to the Shop page
* Click Add to Cart button of a product
* In the Cart page, click Proceed to Checkout
* Confirm that the spinner that appears inside the button is centered



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
