### PR TITLE
Make the Onboarding use wp.components from the WP installation

### DIFF
--- a/changelog/onboading-pages-wp-components
+++ b/changelog/onboading-pages-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make onboading pages use the pw.components available in the WordPress installation.

--- a/client/components/custom-select-control/index.tsx
+++ b/client/components/custom-select-control/index.tsx
@@ -10,7 +10,6 @@
  * External Dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { check, chevronDown, Icon } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import clsx from 'clsx';
@@ -20,6 +19,7 @@ import { useSelect, UseSelectState } from 'downshift';
 /**
  * Internal Dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import './style.scss';
 
 export interface Item {
@@ -172,6 +172,7 @@ function CustomSelectControl< ItemType extends Item >( {
 					),
 					name,
 				} ) }
+				__next40pxDefaultSize
 			>
 				<span className="components-custom-select-control__button-value">
 					{ itemString || placeholder }

--- a/client/index.js
+++ b/client/index.js
@@ -57,7 +57,11 @@ addFilter(
 		} );
 
 		pages.push( {
-			container: OnboardingPage,
+			container: () => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<OnboardingPage />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/onboarding',
 			wpOpenMenu: menuID,
 			breadcrumbs: [

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { isEmpty, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { useStepperContext } from 'components/stepper';
 import { Item as SelectItem } from 'components/custom-select-control';
 import { ListItem as GroupedSelectItem } from 'components/grouped-select-control';
@@ -51,6 +51,7 @@ export const OnboardingForm: React.FC< { children?: React.ReactNode } > = ( {
 				variant={ 'primary' }
 				type="submit"
 				className="stepper__cta"
+				__next40pxDefaultSize
 			>
 				{ strings.continue }
 			</Button>


### PR DESCRIPTION
See WOOPMNT-5163

#### Changes proposed in this Pull Request

Make onboarding use wp.components from the WP installation. I have found only one visual change on the screen.

Before

<img width="717" height="395" alt="image" src="https://github.com/user-attachments/assets/01e3d26d-626b-4861-819b-e5a51b87a5fa" />

After

<img width="761" height="410" alt="image" src="https://github.com/user-attachments/assets/4e4304c0-4000-411e-87b3-e548534be319" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For me the fastest way to see the components was commenting the if statement in:
* `includes/admin/class-wc-payments-admin.php`
```diff
-- if ( ! $this->account->is_stripe_connected() ) {
++ // if ( ! $this->account->is_stripe_connected() ) {
	wc_admin_register_page(
		[
			'id'         => 'wc-payments-onboarding',
			'title'      => __( 'Onboarding', 'woocommerce-payments' ),
			'parent'     => 'wc-payments',
			'path'       => '/payments/onboarding',
			'capability' => 'manage_woocommerce',
			'nav_args'   => [
				'parent' => 'wc-payments',
			],
		]
	);
	remove_submenu_page( 'wc-admin&path=/payments/connect', 'wc-admin&path=/payments/onboarding' );
-- }
++ // }
```
* Then go to Payments > Onboarding
* Ensure everything is still working

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
