### PR TITLE
Fix subscription PM change notes

### DIFF
--- a/changelog/woopmnt-4836-non-specific-card-details-notice-when-updating-payment
+++ b/changelog/woopmnt-4836-non-specific-card-details-notice-when-updating-payment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order notes after subscriptions' payment method gets changed.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1757,7 +1757,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// Only attempt to use WC_Subscriptions_Change_Payment_Gateway if it exists.
 				if ( class_exists( 'WC_Subscriptions_Change_Payment_Gateway' ) ) {
 					// Update the payment method for subscription if the payment intent is not requiring action.
-					WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $order, $payment_information->get_payment_method() );
+					WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $order, $this->id );
 				}
 
 				// Because this new payment does not require action/confirmation, remove this filter so that WC_Subscriptions_Change_Payment_Gateway proceeds to update all subscriptions if flagged.

--- a/includes/payment-methods/class-cc-payment-method.php
+++ b/includes/payment-methods/class-cc-payment-method.php
@@ -39,7 +39,7 @@ class CC_Payment_Method extends UPE_Payment_Method {
 	 */
 	public function get_title( ?string $account_country = null, $payment_details = false ) {
 		if ( ! $payment_details ) {
-			return __( 'Cards', 'woocommerce-payments' );
+			return __( 'Card', 'woocommerce-payments' );
 		}
 
 		$details       = $payment_details[ $this->stripe_id ];

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
@@ -94,7 +94,7 @@ describeif( shouldRunSubscriptionsTests )(
 				.replace( '#', '' );
 
 			const transactionPageLink = await merchantPage
-				.getByText( 'Payment via Cards', { exact: false } )
+				.getByText( 'Payment via Card', { exact: false } )
 				.getByRole( 'link', { name: /pi_.+/ } )
 				.getAttribute( 'href' );
 

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -336,9 +336,9 @@ export const addToCartFromShopPage = async (
 
 export const selectPaymentMethod = async (
 	page: Page,
-	paymentMethod = 'Cards'
+	paymentMethod = 'Card'
 ) => {
-	await page.getByText( paymentMethod ).click();
+	await page.getByText( paymentMethod, { exact: true } ).click();
 };
 
 /**
@@ -542,7 +542,7 @@ export const addSavedCard = async (
 ) => {
 	await page.getByRole( 'link', { name: 'Add payment method' } ).click();
 	await page.waitForLoadState( 'networkidle' );
-	await page.getByText( 'Cards', { exact: true } ).click();
+	await page.getByText( 'Card', { exact: true } ).click();
 	const frameHandle = page.getByTitle( 'Secure payment input frame' );
 	const stripeFrame = frameHandle.contentFrame();
 

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -698,7 +698,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$afterpay_method   = $this->mock_payment_methods['afterpay_clearpay'];
 
 		$this->assertEquals( 'card', $card_method->get_id() );
-		$this->assertEquals( 'Cards', $card_method->get_title( 'US' ) );
+		$this->assertEquals( 'Card', $card_method->get_title( 'US' ) );
 		$this->assertEquals( 'Visa debit card', $card_method->get_title( 'US', $mock_visa_details ) );
 		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( 'US', $mock_mastercard_details ) );
 		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -1011,7 +1011,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$becs_method       = $this->mock_payment_methods['au_becs_debit'];
 
 		$this->assertEquals( 'card', $card_method->get_id() );
-		$this->assertEquals( 'Cards', $card_method->get_title( 'US' ) );
+		$this->assertEquals( 'Card', $card_method->get_title( 'US' ) );
 		$this->assertEquals( 'Visa debit card', $card_method->get_title( 'US', $mock_visa_details ) );
 		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( 'US', $mock_mastercard_details ) );
 		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -625,7 +625,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$afterpay_method   = $this->payment_methods['afterpay_clearpay'];
 		$grabpay_method    = $this->payment_methods['grabpay'];
 		$this->assertEquals( 'card', $card_method->get_id() );
-		$this->assertEquals( 'Cards', $card_method->get_title() );
+		$this->assertEquals( 'Card', $card_method->get_title() );
 		$this->assertEquals( 'Visa debit card', $card_method->get_title( 'US', $mock_visa_details ) );
 		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( 'US', $mock_mastercard_details ) );
 		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );

--- a/tests/unit/test-class-wc-payments-checkout.php
+++ b/tests/unit/test-class-wc-payments-checkout.php
@@ -389,7 +389,7 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 				'card' => [
 					'isReusable'             => true,
 					'isBnpl'                 => false,
-					'title'                  => 'Cards',
+					'title'                  => 'Card',
 					'icon'                   => $icon_url,
 					'darkIcon'               => $dark_icon_url,
 					'showSaveOption'         => true,


### PR DESCRIPTION
Fixes WOOPMNT-4836

#### Changes proposed in this Pull Request

1. Provide the gateway ID to subscriptions, rather than a payment method ID, avoiding PM IDs in order notes. https://github.com/Automattic/woocommerce-payments/commit/a8eec328b10814f515719bf906fdc4d3e9f7b156
2. While attempting to address https://github.com/Automattic/woocommerce-payments/issues/9660, https://github.com/Automattic/woocommerce-payments/pull/10005 changed the name of the default payment method. The change is now partially reverted, so that `Card` appears in the front-end and subscription PM change messages. The plural still remains in the back-end where it says `Credit / Debit Cards`:

<img width="1206" height="131" alt="image" src="https://github.com/user-attachments/assets/b2be5531-3b9b-4ea7-ac78-197e4199e535" />

This makes more sense, as shoppers would never pay with "Cards", they would just pay with a card.

#### Testing instructions

1. Sign up for a subscription, and change the payment method a few times, with new cards. There is a bug when switching to another stored payment instrument, especially if it was already used for the same subscription. There will be a separate issue for that.
2. Check the order notes, and make sure that everything looks alright. There should be no `Cards ending in XXXX` or `pm_XYZ` there.
3. Follow the critical flow testing instructions for [Subscription checkout with Link & payment method change](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#subscription-checkout-with-link--payment-method-change). The notes should look meaningful:

<img width="272" height="386" alt="image" src="https://github.com/user-attachments/assets/105420b7-fbe5-4025-8422-5c43ffa232a4" />

Note: Sometimes `Card` is used instead of `Link`, as that is the default name of the main gateway, and there are no details for the card at the moment. Not ideal, still better.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or **does not apply**)