### PR TITLE
Make the connect account components to use wp.components from the WP installation

### DIFF
--- a/changelog/make-connect-account-use-wp-components-from-installation
+++ b/changelog/make-connect-account-use-wp-components-from-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make the connect acctount components use the wp.components from the installation.

--- a/client/components/banner-notice/index.tsx
+++ b/client/components/banner-notice/index.tsx
@@ -7,7 +7,6 @@
  * External dependencies
  */
 import React, { ComponentProps } from 'react';
-
 import { __ } from '@wordpress/i18n';
 import { useEffect, renderToString } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -577,6 +577,7 @@ const ConnectAccountPage: React.FC = () => {
 									isSubmitted || isAccountSetupSessionError
 								}
 								onClick={ handleSetup }
+								__next40pxDefaultSize
 							>
 								{ ctaLabel }
 							</Button>
@@ -591,6 +592,7 @@ const ConnectAccountPage: React.FC = () => {
 											onClick={ () =>
 												setModalVisible( true )
 											}
+											__next40pxDefaultSize
 										>
 											{ strings.button.reset }
 										</Button>
@@ -624,6 +626,7 @@ const ConnectAccountPage: React.FC = () => {
 										isBusy={ isTestDriveModeSubmitted }
 										disabled={ isTestDriveModeSubmitted }
 										onClick={ handleSetupTestDriveMode }
+										__next40pxDefaultSize
 									>
 										{ strings.button.sandbox }
 									</Button>

--- a/client/connect-account-page/info-notice-modal.tsx
+++ b/client/connect-account-page/info-notice-modal.tsx
@@ -4,14 +4,14 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
-import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
-import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
+import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { Notice } from 'wcpay/components/wp-components-wrapped/components/notice';
 import { recordEvent } from 'tracks';
 import TipBox from 'components/tip-box';
 import strings from './strings';
@@ -42,6 +42,7 @@ const InfoNoticeModal: React.FC = () => {
 							);
 							setModalOpen( true );
 						} }
+						__next40pxDefaultSize
 					>
 						{ strings.infoNotice.button }
 					</Button>
@@ -94,7 +95,11 @@ const InfoNoticeModal: React.FC = () => {
 					</div>
 					<hr />
 					<div className="connect-account-page__info-modal__footer">
-						<Button variant="primary" onClick={ handleModalClose }>
+						<Button
+							variant="primary"
+							onClick={ handleModalClose }
+							__next40pxDefaultSize
+						>
 							{ __( 'Got it', 'woocommerce-payments' ) }
 						</Button>
 					</div>

--- a/client/connect-account-page/modal/index.js
+++ b/client/connect-account-page/modal/index.js
@@ -8,20 +8,11 @@ import interpolateComponents from '@automattic/interpolate-components';
  */
 import { Button } from 'wcpay/components/wp-components-wrapped/components/button';
 import { Modal } from 'wcpay/components/wp-components-wrapped/components/modal';
+import { ExternalLink } from 'wcpay/components/wp-components-wrapped/components/external-link';
 import { __, sprintf } from '@wordpress/i18n';
-import { Link, List } from '@woocommerce/components';
+import { List } from '@woocommerce/components';
 import { useState } from '@wordpress/element';
 import './style.scss';
-
-const LearnMoreLink = ( props ) => (
-	<Link
-		{ ...props }
-		href="https://woocommerce.com/document/woopayments/compatibility/countries/"
-		target="_blank"
-		rel="noopener noreferrer"
-		type="external"
-	/>
-);
 
 const OnboardingLocationCheckModal = ( {
 	countries,
@@ -60,7 +51,9 @@ const OnboardingLocationCheckModal = ( {
 			'WooPayments'
 		),
 		components: {
-			link: <LearnMoreLink />,
+			link: (
+				<ExternalLink href="https://woocommerce.com/document/woopayments/compatibility/countries/" />
+			),
 			list: <List items={ countries } />,
 		},
 	} );
@@ -80,17 +73,19 @@ const OnboardingLocationCheckModal = ( {
 				</div>
 				<div className="woocommerce-payments__onboarding_location_check-footer">
 					<Button
-						isSecondary
+						variant="secondary"
 						onClick={ handleConfirmedRequest }
 						isBusy={ isProcessingContinue }
+						__next40pxDefaultSize
 					>
 						{ __( 'Continue', 'woocommerce-payments' ) }
 					</Button>
 
 					<Button
-						isPrimary
+						variant="primary"
 						onClick={ handleDeclinedRequest }
 						disabled={ isProcessingContinue }
+						__next40pxDefaultSize
 					>
 						{ __( 'Cancel', 'woocommerce-payments' ) }
 					</Button>

--- a/client/connect-account-page/modal/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/modal/test/__snapshots__/index.js.snap
@@ -3,6 +3,14 @@
 exports[`Onboarding: location check dialog renders correctly when cancel button is clicked 1`] = `null`;
 
 exports[`Onboarding: location check dialog renders correctly when continue button is clicked 1`] = `
+.emotion-2 {
+  width: 1em;
+  height: 1em;
+  margin: 0;
+  vertical-align: middle;
+  fill: currentColor;
+}
+
 <div
   aria-labelledby="components-modal-header-1"
   class="components-modal__frame woocommerce-payments__onboarding_location_check-modal"
@@ -93,12 +101,33 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
         </ul>
          
         <a
-          data-link-type="external"
+          class="components-external-link"
           href="https://woocommerce.com/document/woopayments/compatibility/countries/"
-          rel="noopener noreferrer"
+          rel="external noreferrer noopener"
           target="_blank"
         >
           Learn more
+          <span
+            class="components-visually-hidden emotion-0 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="VisuallyHidden"
+            style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+          >
+            (opens in a new tab)
+          </span>
+          <svg
+            aria-hidden="true"
+            class="components-external-link__icon emotion-2 emotion-3"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+            />
+          </svg>
         </a>
          about setting up business entities in foreign countries.
       </div>
@@ -125,6 +154,14 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
 `;
 
 exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
+.emotion-2 {
+  width: 1em;
+  height: 1em;
+  margin: 0;
+  vertical-align: middle;
+  fill: currentColor;
+}
+
 <div
   aria-labelledby="components-modal-header-0"
   class="components-modal__frame woocommerce-payments__onboarding_location_check-modal"
@@ -215,12 +252,33 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
         </ul>
          
         <a
-          data-link-type="external"
+          class="components-external-link"
           href="https://woocommerce.com/document/woopayments/compatibility/countries/"
-          rel="noopener noreferrer"
+          rel="external noreferrer noopener"
           target="_blank"
         >
           Learn more
+          <span
+            class="components-visually-hidden emotion-0 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="VisuallyHidden"
+            style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+          >
+            (opens in a new tab)
+          </span>
+          <svg
+            aria-hidden="true"
+            class="components-external-link__icon emotion-2 emotion-3"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+            />
+          </svg>
         </a>
          about setting up business entities in foreign countries.
       </div>

--- a/client/index.js
+++ b/client/index.js
@@ -46,7 +46,11 @@ addFilter(
 			: __( 'Connect', 'woocommerce-payments' );
 
 		pages.push( {
-			container: ConnectAccountPage,
+			container: () => (
+				<WordPressComponentsContext.Provider value={ wp.components }>
+					<ConnectAccountPage />
+				</WordPressComponentsContext.Provider>
+			),
 			path: '/payments/connect',
 			wpOpenMenu: menuID,
 			breadcrumbs: [ rootLink, connectionPageTitle ],


### PR DESCRIPTION
See WOOPMNT-5162

#### Changes proposed in this Pull Request

Make onboarding use wp.components from the WP installation.

before

<img width="833" height="485" alt="image" src="https://github.com/user-attachments/assets/537760c3-911b-41be-bf3b-57f17d325d7d" />

<img width="613" height="302" alt="image" src="https://github.com/user-attachments/assets/f3170b15-8b0c-40ef-b935-ee2b1d5d862d" />


after

<img width="722" height="453" alt="image" src="https://github.com/user-attachments/assets/946449d5-8525-4b18-85b3-200984138c77" />

<img width="607" height="319" alt="image" src="https://github.com/user-attachments/assets/8796c68b-dc4d-434a-850e-0db04a867a7a" />


#### Testing instructions

* Reset your account (also the jetpack connection)
  * It can be done using this plugin https://github.com/Automattic/jetpack-debug-helper or on WCPay Dev check "Force the WCPay plugin to act as disconnected from the Transact Platform Server"
* Redo the connection and ensure everything is working

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
