### PR TITLE
Reset UPE enabled payment methods to default on account reset

### DIFF
--- a/changelog/fix-WOOPMNT-5219-reset-upe-enabled-pms-on-account-reset
+++ b/changelog/fix-WOOPMNT-5219-reset-upe-enabled-pms-on-account-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reset the enabled payment methods to default value on account reset.

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -884,6 +884,7 @@ class WC_Payments_Onboarding_Service {
 		$gateway = WC_Payments::get_gateway();
 		$gateway->update_option( 'enabled', 'no' );
 		$gateway->update_option( 'test_mode', 'no' );
+		$gateway->update_option( 'upe_enabled_payment_method_ids', [ 'card' ] );
 
 		update_option( '_wcpay_onboarding_stripe_connected', [] );
 		update_option( self::TEST_MODE_OPTION, 'no' );


### PR DESCRIPTION
Fixes WOOPMNT-5219

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When resetting an account (and starting onboarding fresh), we also reset the UPE enabled PMs to the default value (just cards) to avoid having miss matches between what users configure in the NOX in-context flow and what they end up with enabled.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this PR's branch on your local installation and build it by running `npm run build`
2. Make sure you are using the latest WooCommerce trunk build
3. Remove any onboarded account
4. Go to WooCommerce > Settings > Payments and set the business location to UK
5. Click on "Complete setup" for WooPayments and, on the "Choose your payment methods" step, enable "Bancontact" and "Multibanco" on top of the default enabled payment methods:
<img width="1928" height="1288" alt="Screenshot 2025-07-29 at 11 49 31" src="https://github.com/user-attachments/assets/1fc9b704-c4a3-4025-af17-08ef4cbe9e27" />

6. Click "Continue" and setup a test account.
7. Once complete, go to Payments > Settings and make sure your chosen payment methods are enabled.
8. Go to WooCommerce > Settings > Payments, reset the account, and set the business location to AU
9. Click on "Complete setup" for WooPayments and use the default enabled payment methods to set up a test account.
10. Once complete, go to Payments > Settings and make sure Bancontact is not enabled:
<img width="1436" height="1285" alt="Screenshot 2025-07-29 at 11 55 23" src="https://github.com/user-attachments/assets/d22c93be-bf3d-426c-805a-5f3816f41c7d" />

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
