### PR TITLE
[WIP] Add polling for Won status of a dispute

### DIFF
--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -303,14 +303,25 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			await test.step(
 				'Navigate back to payment details and confirm the dispute status is Won',
 				async () => {
-					// Navigate back to the payment details page
-					await merchantPage.goto( paymentDetailsLink );
+					// Poll for the final status, refreshing the page if needed
+					await expect( async () => {
+						await merchantPage.goto( paymentDetailsLink );
+						await merchantPage.waitForLoadState( 'networkidle' );
 
-					await expect(
-						merchantPage
-							.locator( '.payment-details-summary__status' )
-							.filter( { hasText: 'Disputed: Won' } )
-					).toBeVisible();
+						// Check that we're no longer "Under Review"
+						await expect(
+							merchantPage
+								.locator( '.payment-details-summary__status' )
+								.filter( { hasText: 'Disputed: Under Review' } )
+						).not.toBeVisible( { timeout: 2000 } );
+
+						// Confirm we have the "Won" status
+						await expect(
+							merchantPage
+								.locator( '.payment-details-summary__status' )
+								.filter( { hasText: 'Disputed: Won' } )
+						).toBeVisible( { timeout: 2000 } );
+					} ).toPass( { timeout: 60000, intervals: [ 3000 ] } );
 
 					await expect(
 						merchantPage.getByText(


### PR DESCRIPTION
Fixes #



#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
