### PR TITLE
E2E - fix pulling non-latest WC versions, set up tests with rc

### DIFF
--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -51,7 +51,7 @@ jobs:
         test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
         test_branches: [ 'merchant', 'shopper' ]
 
-    name: WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
+    name: WC - ${{ matrix.wc_version }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
     env:
       E2E_WP_VERSION: 'latest'

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        wc_version:   [ 'latest', 'rc' ]
+        wc_version:   [ 'latest' ]
         test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
         test_branches: [ 'merchant', 'shopper' ]
 

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -47,6 +47,7 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
+        wc_version:   [ 'latest', 'rc' ]
         test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
         test_branches: [ 'merchant', 'shopper' ]
 
@@ -54,7 +55,7 @@ jobs:
 
     env:
       E2E_WP_VERSION: 'latest'
-      E2E_WC_VERSION: 'latest'
+      E2E_WC_VERSION: ${{ matrix.wc_version }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          WC_VERSIONS=$( echo "[\"7.7.0\", \"latest\", \"beta\"]" )
+          WC_VERSIONS=$( echo "[\"7.7.0\", \"latest\", \"beta\", \"rc\"]" )
           echo "matrix={\"woocommerce\":$WC_VERSIONS,\"test_groups\":[\"wcpay\", \"subscriptions\"],\"test_branches\":[\"merchant\", \"shopper\"]}" >> $GITHUB_OUTPUT
 
   # Run WCPay & subscriptions tests against specific WC versions

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -193,7 +193,7 @@ install_woocommerce() {
 
 	if [[ $WC_VERSION == 'beta' ]]; then
 		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
-		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys[-1]' --sort-keys)
+		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last'' --sort-keys)
 	fi
 
 	if [[ -n $INSTALLED_WC_VERSION ]] && [[ $WC_VERSION == 'latest' ]]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -191,7 +191,7 @@ install_woocommerce() {
 	WC_INSTALL_EXTRA=''
 	INSTALLED_WC_VERSION=$(wp plugin get woocommerce --field=version)
 
-	if [[ $WC_VERSION == 'beta' || $WC_VERSION == 'rc' ]]; then
+	if [[ $WC_VERSION == 'beta' ]] || [[ $WC_VERSION == 'rc' ]]; then
 		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
 		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("'$WC_VERSION'";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last' --sort-keys)
 	fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -193,7 +193,7 @@ install_woocommerce() {
 
 	if [[ $WC_VERSION == 'beta' ]]; then
 		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
-		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last'' --sort-keys)
+		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last' --sort-keys)
 	fi
 
 	if [[ -n $INSTALLED_WC_VERSION ]] && [[ $WC_VERSION == 'latest' ]]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -191,9 +191,9 @@ install_woocommerce() {
 	WC_INSTALL_EXTRA=''
 	INSTALLED_WC_VERSION=$(wp plugin get woocommerce --field=version)
 
-	if [[ $WC_VERSION == 'beta' ]]; then
+	if [[ $WC_VERSION == 'beta' || $WC_VERSION == 'rc' ]]; then
 		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
-		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last' --sort-keys)
+		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("'$WC_VERSION'";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last' --sort-keys)
 	fi
 
 	if [[ -n $INSTALLED_WC_VERSION ]] && [[ $WC_VERSION == 'latest' ]]; then

--- a/changelog/fix-e2e-beta-pull
+++ b/changelog/fix-e2e-beta-pull
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E setup fix
+
+

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -208,9 +208,10 @@ cli wp plugin install wordpress-importer --activate
 
 # Install WooCommerce
 if [[ -n "$E2E_WC_VERSION" && $E2E_WC_VERSION != 'latest' ]]; then
-	# If specified version is 'beta', fetch the latest beta version from WordPress.org API
-	if [[ $E2E_WC_VERSION == 'beta' ]]; then
-		E2E_WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys[-1]' --sort-keys)
+	# If specified version is 'beta' or 'rc', fetch the latest beta version from WordPress.org API
+	if [[ $E2E_WC_VERSION == 'beta' ]] || [[ $E2E_WC_VERSION == 'rc' ]]; then
+		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
+		E2E_WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("'$E2E_WC_VERSION'";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last' --sort-keys)
 	fi
 
 	echo "Installing and activating specified WooCommerce version..."


### PR DESCRIPTION
Our script has been pulling Woo 9.9-beta as a beta version. This is partially because there have been no beta versions after that, but we're also at Woo 10+ and we're sorting the versions wrong: by string, not by number.

#### Changes proposed in this Pull Request

- Fixed the `curl | jq` command to sort the versions properly.
- Add `rc` to the WC version matrix for `E2E Tests - All` runs

#### Testing instructions

Compare the output of the old command:
`curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("rc";"i"))) | keys[-1]' --sort-keys`
to the new one:
`curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("rc";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last' --sort-keys`