### PR TITLE
[E2E Tests - All] Fix WC - 7.7.0 | wcpay - shopper failing

### DIFF
--- a/changelog/dev-woopmnt-5242-e2e-tests-all-wc-770-wcpay-shopper-failing
+++ b/changelog/dev-woopmnt-5242-e2e-tests-all-wc-770-wcpay-shopper-failing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix E2E test failure due to Bancontact payment method selection during checkout
+
+

--- a/changelog/dev-woopmnt-5242-e2e-tests-all-wc-770-wcpay-shopper-failing
+++ b/changelog/dev-woopmnt-5242-e2e-tests-all-wc-770-wcpay-shopper-failing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix E2E test failured due to Bancontact payment method selection during checkout

--- a/changelog/dev-woopmnt-5242-e2e-tests-all-wc-770-wcpay-shopper-failing
+++ b/changelog/dev-woopmnt-5242-e2e-tests-all-wc-770-wcpay-shopper-failing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix E2E test failured due to Bancontact payment method selection during checkout

--- a/tests/e2e/specs/wcpay/shopper/multi-currency-checkout.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/multi-currency-checkout.spec.ts
@@ -156,6 +156,13 @@ test.describe( 'Multi-currency checkout', () => {
 
 			// Shopper checkout with Bancontact.
 			await shopperPage.getByText( 'Bancontact' ).click();
+
+			// Wait for the Bancontact payment method to be actually selected
+			await shopperPage.waitForSelector(
+				'#payment_method_woocommerce_payments_bancontact:checked',
+				{ timeout: 10000 }
+			);
+
 			await shopper.focusPlaceOrderButton( shopperPage );
 			await shopper.placeOrder( shopperPage );
 			await shopperPage

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-purchase-with-upe-methods.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-purchase-with-upe-methods.spec.ts
@@ -98,6 +98,13 @@ test.describe(
 							ctpEnabled
 						);
 						await shopperPage.getByText( 'Bancontact' ).click();
+
+						// Wait for the Bancontact payment method to be actually selected
+						await shopperPage.waitForSelector(
+							'#payment_method_woocommerce_payments_bancontact:checked',
+							{ timeout: 10000 }
+						);
+
 						await focusPlaceOrderButton( shopperPage );
 						await placeOrder( shopperPage );
 						await shopperPage


### PR DESCRIPTION
Fixes #WOOPMNT-5242

Some test runs are failing due to not having the Bancontact payment method actually selected when placing the order. Looking at the screenshots, the credit card is the one selected but placing the order fails due to validation errors because the card details are missing.

#### Changes proposed in this Pull Request
* Ensure Bancontact is selected before placing the order
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull request E2E tests should pass
* E2E All tests should pass with the present branch: https://github.com/Automattic/woocommerce-payments/actions/runs/16719290307

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
