### PR TITLE
Fix Google/Apple Pay State / County is required error during checkout for HR customers

### DIFF
--- a/changelog/fix-woopmnt-5240-google-pay-giving-state-county-is-required-error-for-certain
+++ b/changelog/fix-woopmnt-5240-google-pay-giving-state-county-is-required-error-for-certain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Google/Apple Pay "State / County is required" error during checkout for Croatia

--- a/includes/constants/class-express-checkout-element-states.php
+++ b/includes/constants/class-express-checkout-element-states.php
@@ -1173,13 +1173,14 @@ class Express_Checkout_Element_States {
 	 * @see https://github.com/google/libaddressinput/wiki/AddressValidationMetadata
 	 */
 	const COUNTRIES_WITHOUT_STATES = [
+		Country_Code::ALGERIA,
 		Country_Code::ANGOLA,
 		Country_Code::BANGLADESH,
-		Country_Code::BULGARIA,
 		Country_Code::BENIN,
 		Country_Code::BOLIVIA,
+		Country_Code::BULGARIA,
+		Country_Code::CROATIA,
 		Country_Code::DOMINICAN_REPUBLIC,
-		Country_Code::ALGERIA,
 		Country_Code::GHANA,
 		Country_Code::GUATEMALA,
 		Country_Code::HUNGARY,
@@ -1193,9 +1194,9 @@ class Express_Checkout_Element_States {
 		Country_Code::PAKISTAN,
 		Country_Code::PARAGUAY,
 		Country_Code::ROMANIA,
+		Country_Code::SOUTH_AFRICA,
 		Country_Code::TANZANIA,
 		Country_Code::UGANDA,
-		Country_Code::SOUTH_AFRICA,
 		Country_Code::ZAMBIA,
 	];
 }


### PR DESCRIPTION
Fixes #WOOPMNT-5240

#### Changes proposed in this Pull Request

* Add HR to the list of countries where the state field is not mandatory for Express Checkout buttons


#### Screenshots

**Before**

<img width="1566" height="981" alt="Screenshot 2025-08-05 at 11 19 59" src="https://github.com/user-attachments/assets/c7d62d72-8998-40db-b9f3-d1a9b4760376" />

**After**

<img width="1601" height="904" alt="Screenshot 2025-08-05 at 11 21 41" src="https://github.com/user-attachments/assets/947249d7-74d4-4960-8bbc-b6e96bbba157" />


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Pre-requisites**

1. Enable Apple Pay / Google Pay in Payments > Settings
2. npm run tube:start so the Express Checkout buttons are available

**Testing with Google Pay**

1. With Google Chrome, Go to a page where the Express Checkout is available: product, cart or checkout.
2. Click the Google Pay button
3. In the Google Pay modal, select the Croatian user
4. Click the Pay now button to proceed with the payment.
5. Check that the order is correctly processed and there are no state/county related errors.

**Testing with Apple Pay**
On top of the other requirements you'll need:

1. Use Safari browser for testing.
2. You'll need an Apple ID from an affected country or you can use an Apple Sandbox account. There are instructions available here pcrvl0-1yh-p2.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.