### PR TITLE
Fixed which terms should show up in WooPay when the merchant uses the default text, custom blocks text, custom WooPay and checkbox enabled or not.

### DIFF
--- a/changelog/fix-woopay-terms-and-conditions-blocks-default-texts
+++ b/changelog/fix-woopay-terms-and-conditions-blocks-default-texts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed WooPay terms and conditions text for merchants using blocks checkout.


### PR DESCRIPTION
Closes WOOPAY-370

#### Changes proposed in this Pull Request
This PR fixes the terms text shown in WooPay. Previously we didn't take into account the difference between the text with and without the blocks checkout terms checkbox.

When the checkbox is displayed the following message should show up:

```
You must accept our **Terms and Conditions** and **Privacy Policy** to continue with your purchase.
```

When the checkbox is not displayed the following message should show up:
```
By proceeding with your purchase you agree to our **Terms and Conditions** and **Privacy Policy**
```

#### Testing instructions
**Setup**
- Checkout to this branch
- Go to wp-admin > Payments > WooPay > Customize > Checkout policies > Remove the text
- Save
- Edit the blocks checkout page 
- Remove the complete checkout block
- Add it back again

**Checkbox disabled, default text**

- Make sure the `Terms and Conditions` checkbox is **disabled**
- As a shopper buy something via WooPay
- Make sure the checkbox **does not** show up under the place order button
- Make sure the text shown is `By proceeding with your purchase you agree to our **Terms and Conditions** and **Privacy Policy**`

**Checkbox enabled, default text**
- Make sure the `Terms and Conditions` checkbox is **enabled**
- As a shopper buy something via WooPay
- Make sure the checkbox **does** show up under the place order button
- Make sure the text shown is `You must accept our **Terms and Conditions** and **Privacy Policy** to continue with your purchase.`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
