### PR TITLE
Disable the scheduled code freeze

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -2,8 +2,8 @@ name: "Release - Code freeze"
 
 # This action will run according to the cron schedule or when triggered manually
 on:
-  schedule:
-    - cron: '0 12 * * 0' # Run at 1200 UTC on Sundays.
+  # schedule:
+    # - cron: '0 18 * * 3' # Run at 1800 UTC on Wednesdays.
   workflow_dispatch:
     inputs:
       skipSlackPing:

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -57,16 +57,16 @@ jobs:
         env:
           NEXT_VERSION: ${{ steps.next-version.outputs.NEXT_RELEASE_VERSION }}
         run: |
-          git fetch --tags origin
-          NEXT_VERSION_TAG_STABLE=$(git tag -l "${{ env.NEXT_VERSION }}" | tail -1)
-          NEXT_VERSION_TAG_FROM_WEEK_2=$(git tag -l "${{ env.NEXT_VERSION }}-test-2" | tail -1)
-          if [[ -z "$NEXT_VERSION_TAG_FROM_WEEK_2" ]]; then
-            echo "Code freeze is not needed :x:" >> $GITHUB_STEP_SUMMARY
-            echo "FREEZE=0" >> $GITHUB_OUTPUT
-          elif [[ -z "$NEXT_VERSION_TAG_STABLE" ]]; then
-            echo "Code freeze is needed :white_check_mark:" >> $GITHUB_STEP_SUMMARY
-            echo "FREEZE=1" >> $GITHUB_OUTPUT
-          fi
+          # git fetch --tags origin
+          # NEXT_VERSION_TAG_STABLE=$(git tag -l "${{ env.NEXT_VERSION }}" | tail -1)
+          # NEXT_VERSION_TAG_FROM_WEEK_2=$(git tag -l "${{ env.NEXT_VERSION }}-test-2" | tail -1)
+          # if [[ -z "$NEXT_VERSION_TAG_FROM_WEEK_2" ]]; then
+          #   echo "Code freeze is not needed :x:" >> $GITHUB_STEP_SUMMARY
+          #   echo "FREEZE=0" >> $GITHUB_OUTPUT
+          # elif [[ -z "$NEXT_VERSION_TAG_STABLE" ]]; then
+          # fi
+          echo "Code freeze is needed :white_check_mark:" >> $GITHUB_STEP_SUMMARY
+          echo "FREEZE=1" >> $GITHUB_OUTPUT
 
   create-release-pr:
     name: "Raise a PR to trunk"


### PR DESCRIPTION
Changes:

1. Disable the scheduled code freeze workflow.
2. Always set `FREEZE` to `1`, so that manually running the workflow will create a new version.

This is temporary, until I figure out how to test GH workflows (locally), so that I can make actually do a code freeze on the wednesday of the second week since the last release.

The current logic is based on the existence of `-test-1` or `-test-2` branches and would require a bit of tweaking before it can be applied.