### PR TITLE
Checkout optimization: Avoid multiple calls for payment method details

### DIFF
--- a/changelog/woopmnt-5248-checkout-optimization-avoid-multiple-payment-method-details
+++ b/changelog/woopmnt-5248-checkout-optimization-avoid-multiple-payment-method-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Generate payment method details in WooPayments instead of Woo core, cache them for performance improvements.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -596,7 +596,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			add_action( 'woocommerce_update_order', [ $this, 'schedule_order_tracking' ], 10, 2 );
 			add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'setup_payment_error_handler' ], 10, 2 );
-			add_filter( 'wc_order_payment_card_info', [ $this, 'get_card_info' ], 10, 2 );
 
 			add_filter( 'rest_request_before_callbacks', [ $this, 'remove_all_actions_on_preflight_check' ], 10, 3 );
 
@@ -4555,67 +4554,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return $this->account->get_recommended_payment_methods( $country_code );
-	}
-
-	/**
-	 * Prepare card info for an order.
-	 *
-	 * @param array    $card_info The card info.
-	 * @param WC_Order $order The order.
-	 * @return array The card info.
-	 */
-	public function get_card_info( $card_info, WC_Order $order ) {
-		if ( self::GATEWAY_ID !== $order->get_payment_method() ) {
-			return $card_info;
-		}
-
-		$payment_method_details = $this->order_service->get_payment_method_details( $order );
-		if ( ! $payment_method_details ) {
-			$payment_method_id = $order->get_meta( '_payment_method_id' );
-			if ( ! $payment_method_id ) {
-				return $card_info;
-			}
-
-			try {
-				$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
-			} catch ( API_Exception $ex ) {
-				Logger::error(
-					sprintf(
-						'Retrieving info for payment method for order %s: %s',
-						$order->get_id(),
-						$ex->getMessage()
-					)
-				);
-
-				return $card_info;
-			}
-
-			// Cache payment method details.
-			$this->order_service->store_payment_method_details( $order, $payment_method_details );
-		}
-
-		$card_info = [];
-
-		if ( isset( $payment_method_details['type'], $payment_method_details[ $payment_method_details['type'] ] ) ) {
-			$details = $payment_method_details[ $payment_method_details['type'] ];
-			switch ( $payment_method_details['type'] ) {
-				case 'card':
-				default:
-					$card_info['brand'] = $details['brand'] ?? '';
-					$card_info['last4'] = $details['last4'] ?? '';
-					break;
-				case 'card_present':
-				case 'interac_present':
-					$card_info['brand']        = $details['brand'] ?? '';
-					$card_info['last4']        = $details['last4'] ?? '';
-					$card_info['account_type'] = $details['receipt']['account_type'] ?? '';
-					$card_info['aid']          = $details['receipt']['dedicated_file_name'] ?? '';
-					$card_info['app_name']     = $details['receipt']['application_preferred_name'] ?? '';
-					break;
-			}
-		}
-
-		return array_map( 'sanitize_text_field', $card_info );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4569,7 +4569,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return $card_info;
 		}
 
-		$payment_method_details = $order->get_meta( '_wcpay_payment_method_details' );
+		$payment_method_details = $this->order_service->get_payment_method_details( $order );
 		if ( ! $payment_method_details ) {
 			$payment_method_id = $order->get_meta( '_payment_method_id' );
 			if ( ! $payment_method_id ) {
@@ -4591,8 +4591,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 
 			// Cache payment method details.
-			$order->update_meta_data( '_wcpay_payment_method_details', wp_json_encode( $payment_method_details ) );
-			$order->save_meta_data();
+			$this->order_service->store_payment_method_details( $order, $payment_method_details );
 		}
 
 		$card_info = [];

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use WCPay\Constants\Country_Code;
@@ -4579,7 +4578,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			try {
 				$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
-			} catch ( ApiException $ex ) {
+			} catch ( API_Exception $ex ) {
 				Logger::error(
 					sprintf(
 						'Retrieving info for payment method for order %s: %s',

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use WCPay\Constants\Country_Code;
@@ -596,6 +597,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			add_action( 'woocommerce_update_order', [ $this, 'schedule_order_tracking' ], 10, 2 );
 			add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'setup_payment_error_handler' ], 10, 2 );
+			add_filter( 'wc_order_payment_card_info', [ $this, 'get_card_info' ], 10, 2 );
 
 			add_filter( 'rest_request_before_callbacks', [ $this, 'remove_all_actions_on_preflight_check' ], 10, 3 );
 
@@ -4554,6 +4556,68 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return $this->account->get_recommended_payment_methods( $country_code );
+	}
+
+	/**
+	 * Prepare card info for an order.
+	 *
+	 * @param array    $card_info The card info.
+	 * @param WC_Order $order The order.
+	 * @return array The card info.
+	 */
+	public function get_card_info( $card_info, WC_Order $order ) {
+		if ( self::GATEWAY_ID !== $order->get_payment_method() ) {
+			return $card_info;
+		}
+
+		$payment_method_details = $order->get_meta( '_wcpay_payment_method_details' );
+		if ( ! $payment_method_details ) {
+			$payment_method_id = $order->get_meta( '_payment_method_id' );
+			if ( ! $payment_method_id ) {
+				return $card_info;
+			}
+
+			try {
+				$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
+			} catch ( ApiException $ex ) {
+				Logger::error(
+					sprintf(
+						'Retrieving info for payment method for order %s: %s',
+						$order->get_id(),
+						$ex->getMessage()
+					)
+				);
+
+				return $card_info;
+			}
+
+			// Cache payment method details.
+			$order->update_meta_data( '_wcpay_payment_method_details', wp_json_encode( $payment_method_details ) );
+			$order->save_meta_data();
+		}
+
+		$card_info = [];
+
+		if ( isset( $payment_method_details['type'], $payment_method_details[ $payment_method_details['type'] ] ) ) {
+			$details = $payment_method_details[ $payment_method_details['type'] ];
+			switch ( $payment_method_details['type'] ) {
+				case 'card':
+				default:
+					$card_info['brand'] = $details['brand'] ?? '';
+					$card_info['last4'] = $details['last4'] ?? '';
+					break;
+				case 'card_present':
+				case 'interac_present':
+					$card_info['brand']        = $details['brand'] ?? '';
+					$card_info['last4']        = $details['last4'] ?? '';
+					$card_info['account_type'] = $details['receipt']['account_type'] ?? '';
+					$card_info['aid']          = $details['receipt']['dedicated_file_name'] ?? '';
+					$card_info['app_name']     = $details['receipt']['application_preferred_name'] ?? '';
+					break;
+			}
+		}
+
+		return array_map( 'sanitize_text_field', $card_info );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -162,6 +162,13 @@ class WC_Payments_Order_Service {
 	const WCPAY_MULTIBANCO_URL_META_KEY = '_wcpay_multibanco_url';
 
 	/**
+	 * Meta key for cached payment method details.
+	 *
+	 * @const string
+	 */
+	const PAYMENT_METHOD_DETAILS_META_KEY = '_wcpay_payment_method_details';
+
+	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -2344,6 +2351,32 @@ class WC_Payments_Order_Service {
 			'url'       => $order->get_meta( self::WCPAY_MULTIBANCO_URL_META_KEY ),
 			'expiry'    => $order->get_meta( self::WCPAY_MULTIBANCO_EXPIRY_META_KEY ),
 		];
+	}
+
+	/**
+	 * Store payment method details in the order meta.
+	 *
+	 * @param  WC_Order $order                  The order.
+	 * @param  array    $payment_method_details The payment method details.
+	 * @return void
+	 */
+	public function store_payment_method_details( WC_Order $order, array $payment_method_details ): void {
+		$order->update_meta_data( self::PAYMENT_METHOD_DETAILS_META_KEY, wp_json_encode( $payment_method_details ) );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Get cached payment method details from the order meta.
+	 *
+	 * @param  WC_Order $order The order.
+	 * @return array           The payment method details.
+	 */
+	public function get_payment_method_details( WC_Order $order ): ?array {
+		$json = $order->get_meta( self::PAYMENT_METHOD_DETAILS_META_KEY );
+		if ( '' === $json ) {
+			return null;
+		}
+		return json_decode( $json, true );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -977,8 +977,7 @@ class WC_Payments_Order_Service {
 		if ( null !== $charge ) {
 			$payment_method_details = $charge->get_payment_method_details();
 			if ( $payment_method_details ) {
-				$order->update_meta_data( '_wcpay_payment_details', wp_json_encode( $payment_method_details ) );
-				$order->save_meta_data();
+				$this->store_payment_method_details( $order, $payment_method_details );
 			}
 		}
 	}

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -962,8 +962,18 @@ class WC_Payments_Order_Service {
 		$payment_transaction_id = $payment_transaction['id'] ?? '';
 		$outcome                = $charge ? $charge->get_outcome() : null;
 		$risk_level             = $outcome ? $outcome['risk_level'] : null;
+
 		// next, save it in order meta.
 		$this->attach_intent_info_to_order__legacy( $order, $intent_id, $intent_status, $payment_method, $customer_id, $charge_id, $currency, $payment_transaction_id, $risk_level );
+
+		// Store payment method details when available.
+		if ( null !== $charge ) {
+			$payment_method_details = $charge->get_payment_method_details();
+			if ( $payment_method_details ) {
+				$order->update_meta_data( '_wcpay_payment_details', wp_json_encode( $payment_method_details ) );
+				$order->save_meta_data();
+			}
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-method-service.php
+++ b/includes/class-wc-payments-payment-method-service.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Class WC_Payments_Payment_Method_Service
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use WCPay\Exceptions\API_Exception;
+use WCPay\Logger;
+
+/**
+ * Class handling payment method-related functionality.
+ *
+ * Note that this is regarding Stripe-like PaymentMethod objects, not payment methods (p24, card, etc.).
+ */
+class WC_Payments_Payment_Method_Service {
+	/**
+	 * Client for making requests to the WooCommerce Payments API
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $payments_api_client;
+
+	/**
+	 * Order service.
+	 *
+	 * @var WC_Payments_Order_Service
+	 */
+	private $order_service;
+
+	/**
+	 * Constructor for WC_Payments_Payment_Method_Service.
+	 *
+	 * @param WC_Payments_API_Client    $payments_api_client Client for making requests to the WooCommerce Payments API.
+	 * @param WC_Payments_Order_Service $order_service Order service.
+	 */
+	public function __construct(
+		WC_Payments_API_Client $payments_api_client,
+		WC_Payments_Order_Service $order_service
+	) {
+		$this->payments_api_client = $payments_api_client;
+		$this->order_service       = $order_service;
+	}
+
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_filter( 'wc_order_payment_card_info', [ $this, 'get_card_info' ], 10, 2 );
+	}
+
+
+	/**
+	 * Prepare card info for an order.
+	 *
+	 * @param array    $card_info The card info.
+	 * @param WC_Order $order The order.
+	 * @return array The card info.
+	 */
+	public function get_card_info( $card_info, WC_Order $order ) {
+		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID !== $order->get_payment_method() ) {
+			return $card_info;
+		}
+
+		$payment_method_details = $this->order_service->get_payment_method_details( $order );
+		if ( ! $payment_method_details ) {
+			$payment_method_id = $order->get_meta( '_payment_method_id' );
+			if ( ! $payment_method_id ) {
+				return $card_info;
+			}
+
+			try {
+				$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
+			} catch ( API_Exception $ex ) {
+				Logger::error(
+					sprintf(
+						'Retrieving info for payment method for order %s: %s',
+						$order->get_id(),
+						$ex->getMessage()
+					)
+				);
+
+				return $card_info;
+			}
+
+			// Cache payment method details.
+			$this->order_service->store_payment_method_details( $order, $payment_method_details );
+		}
+
+		$card_info = [];
+
+		if ( isset( $payment_method_details['type'], $payment_method_details[ $payment_method_details['type'] ] ) ) {
+			$details = $payment_method_details[ $payment_method_details['type'] ];
+			switch ( $payment_method_details['type'] ) {
+				case 'card':
+				default:
+					$card_info['brand'] = $details['brand'] ?? '';
+					$card_info['last4'] = $details['last4'] ?? '';
+					break;
+				case 'card_present':
+				case 'interac_present':
+					$card_info['brand']        = $details['brand'] ?? '';
+					$card_info['last4']        = $details['last4'] ?? '';
+					$card_info['account_type'] = $details['receipt']['account_type'] ?? '';
+					$card_info['aid']          = $details['receipt']['dedicated_file_name'] ?? '';
+					$card_info['app_name']     = $details['receipt']['application_preferred_name'] ?? '';
+					break;
+			}
+		}
+
+		return array_map( 'sanitize_text_field', $card_info );
+	}
+}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -318,6 +318,13 @@ class WC_Payments {
 	private static $currency_manager;
 
 	/**
+	 * Instance of WC_Payments_Payment_Method_Service, created in init function
+	 *
+	 * @var WC_Payments_Payment_Method_Service
+	 */
+	private static $payment_method_service;
+
+	/**
 	 * Entry point to the initialization logic.
 	 */
 	public static function init() {
@@ -517,6 +524,7 @@ class WC_Payments {
 		include_once __DIR__ . '/compat/multi-currency/wc-payments-multi-currency.php';
 		include_once __DIR__ . '/compat/multi-currency/class-wc-payments-currency-manager.php';
 		include_once __DIR__ . '/class-duplicates-detection-service.php';
+		include_once __DIR__ . '/class-wc-payments-payment-method-service.php';
 
 		wcpay_get_container()->get( \WCPay\Internal\LoggerContext::class )->init_hooks();
 
@@ -645,6 +653,9 @@ class WC_Payments {
 
 		$express_checkout_helper = new WC_Payments_Express_Checkout_Button_Helper( self::get_gateway(), self::$account );
 		self::set_express_checkout_helper( $express_checkout_helper );
+
+		self::$payment_method_service = new WC_Payments_Payment_Method_Service( self::$api_client, self::$order_service );
+		self::$payment_method_service->init_hooks();
 
 		// Delay registering hooks that could end up in a fatal error due to expired account cache.
 		// The `woocommerce_payments_account_refreshed` action will result in a fatal error if it's fired before the `$wp_rewrite` is defined.

--- a/tests/unit/test-class-wc-payments-payment-method-service.php
+++ b/tests/unit/test-class-wc-payments-payment-method-service.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Class WC_Payments_Payment_Method_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Exceptions\API_Exception;
+use WCPay\Logger;
+
+/**
+ * WC_Payments_Payment_Method_Service unit tests.
+ */
+class WC_Payments_Payment_Method_Service_Test extends WCPAY_UnitTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payments_Payment_Method_Service
+	 */
+	private $payment_method_service;
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Mock WC_Payments_Order_Service.
+	 *
+	 * @var WC_Payments_Order_Service|MockObject
+	 */
+	private $mock_order_service;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client    = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_order_service = $this->createMock( WC_Payments_Order_Service::class );
+
+		$this->payment_method_service = new WC_Payments_Payment_Method_Service(
+			$this->mock_api_client,
+			$this->mock_order_service
+		);
+	}
+
+	/**
+	 * Test get_card_info returns original card_info when order payment method is not WCPay.
+	 */
+	public function test_get_card_info_returns_original_when_not_wcpay_order() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method' )->willReturn( 'some_other_gateway' );
+
+		$original_card_info = [
+			'brand' => 'visa',
+			'last4' => '1234',
+		];
+
+		$result = $this->payment_method_service->get_card_info( $original_card_info, $order );
+
+		$this->assertEquals( $original_card_info, $result );
+	}
+
+	/**
+	 * Test get_card_info returns original card_info when payment method details are not available.
+	 */
+	public function test_get_card_info_returns_original_when_no_payment_method_details() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method' )->willReturn( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+
+		$this->mock_order_service
+			->method( 'get_payment_method_details' )
+			->willReturn( null );
+
+		$order->method( 'get_meta' )
+			->with( '_payment_method_id' )
+			->willReturn( null );
+
+		$original_card_info = [
+			'brand' => 'visa',
+			'last4' => '1234',
+		];
+
+		$result = $this->payment_method_service->get_card_info( $original_card_info, $order );
+
+		$this->assertEquals( $original_card_info, $result );
+	}
+
+	/**
+	 * Test get_card_info handles API exception gracefully.
+	 */
+	public function test_get_card_info_handles_api_exception() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method' )->willReturn( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+		$order->method( 'get_id' )->willReturn( 123 );
+
+		$this->mock_order_service
+			->method( 'get_payment_method_details' )
+			->willReturn( null );
+
+		$order->method( 'get_meta' )
+			->with( '_payment_method_id' )
+			->willReturn( 'pm_test_123' );
+
+		$this->mock_api_client
+			->method( 'get_payment_method' )
+			->willThrowException( new API_Exception( 'API Error', 'api_error', 500 ) );
+
+		$original_card_info = [
+			'brand' => 'visa',
+			'last4' => '1234',
+		];
+
+		$result = $this->payment_method_service->get_card_info( $original_card_info, $order );
+
+		$this->assertEquals( $original_card_info, $result );
+	}
+
+	/**
+	 * Test get_card_info processes card payment method correctly.
+	 */
+	public function test_get_card_info_processes_card_payment_method() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method' )->willReturn( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+
+		$payment_method_details = [
+			'type' => 'card',
+			'card' => [
+				'brand' => 'visa',
+				'last4' => '4242',
+			],
+		];
+
+		$this->mock_order_service
+			->method( 'get_payment_method_details' )
+			->willReturn( $payment_method_details );
+
+		$original_card_info = [];
+
+		$result = $this->payment_method_service->get_card_info( $original_card_info, $order );
+
+		$expected = [
+			'brand' => 'visa',
+			'last4' => '4242',
+		];
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_card_info processes card_present payment method correctly.
+	 *
+	 * Also tests cache.
+	 */
+	public function test_get_card_info_processes_card_present_payment_method() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method' )->willReturn( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+
+		$payment_method_details = [
+			'type'         => 'card_present',
+			'card_present' => [
+				'brand'   => 'visa',
+				'last4'   => '4242',
+				'receipt' => [
+					'account_type'               => 'credit',
+					'dedicated_file_name'        => 'A0000000031010',
+					'application_preferred_name' => 'VISA',
+				],
+			],
+		];
+
+		$this->mock_order_service
+			->method( 'get_payment_method_details' )
+			->willReturn( $payment_method_details );
+
+		$original_card_info = [];
+
+		$result = $this->payment_method_service->get_card_info( $original_card_info, $order );
+
+		$expected = [
+			'brand'        => 'visa',
+			'last4'        => '4242',
+			'account_type' => 'credit',
+			'aid'          => 'A0000000031010',
+			'app_name'     => 'VISA',
+		];
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_card_info caches payment method details when retrieved from API.
+	 */
+	public function test_get_card_info_caches_payment_method_details() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_payment_method' )->willReturn( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+		$order->method( 'get_id' )->willReturn( 123 );
+
+		$this->mock_order_service
+			->method( 'get_payment_method_details' )
+			->willReturn( null );
+
+		$order->method( 'get_meta' )
+			->with( '_payment_method_id' )
+			->willReturn( 'pm_test_123' );
+
+		$payment_method_details = [
+			'type' => 'card',
+			'card' => [
+				'brand' => 'visa',
+				'last4' => '4242',
+			],
+		];
+
+		$this->mock_api_client
+			->method( 'get_payment_method' )
+			->with( 'pm_test_123' )
+			->willReturn( $payment_method_details );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'store_payment_method_details' )
+			->with( $order, $payment_method_details );
+
+		$original_card_info = [];
+
+		$this->payment_method_service->get_card_info( $original_card_info, $order );
+	}
+}


### PR DESCRIPTION
Fixes WOOPMNT-5248

#### Changes proposed in this Pull Request

1. Add a new `WC_Payments_Payment_Method_Service` class, implement Core's `PaymentInfo-> get_wcpay_card_info()` within it. Use the filter from https://github.com/woocommerce/woocommerce/pull/60257 to execute the new method.
2. Update the order service to allow it to manipulate the stored payment method details.
3. Within `attach_intent_info_to_order()`, check for the payment method in the intent response, and store it immediately. This will avoid any later calls to retrieve payment method details.

#### Testing instructions

1. Try Woo Core `trunk` (or .org version) with `develop`.
2. Checkout will trigger multiple requests to GET a payment method.
3. Check out https://github.com/woocommerce/woocommerce/pull/60257's branch without this one.
4. Checkout should only trigger a single GET payment method request.
5. Check out this branch.
6. Checkout should not trigger any GET payment method requests.

~Note: I'm working on unit tests, but manual tests can be performed already.~ Added in https://github.com/Automattic/woocommerce-payments/pull/11001/commits/62c60847334f5e913cd65b821e9cac5006b020f7

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests