### PR TITLE
[E2E] Re-enable Woocommerce Blocks e2e tests

### DIFF
--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -67,6 +67,7 @@ jobs:
           PHP_STABLE="8.3"
           TEST_GROUPS_WCPAY="wcpay"
           TEST_GROUPS_SUBSCRIPTIONS="subscriptions"
+          TEST_GROUPS_BLOCKS="blocks"
           TEST_BRANCHES_MERCHANT="merchant"
           TEST_BRANCHES_SHOPPER="shopper"
 
@@ -78,12 +79,14 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
           # Add latest with PHP 8.3
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
           # Convert array to JSON
           MATRIX_INCLUDE=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s . -c)
@@ -105,6 +108,8 @@ jobs:
       E2E_PHP_VERSION: ${{ matrix.php }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
+      SKIP_WC_SUBSCRIPTIONS_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
+      SKIP_WC_ACTION_SCHEDULER_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
 
     steps:
       - name: Checkout WCPay repository

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -130,7 +130,6 @@ jobs:
       E2E_PHP_VERSION: ${{ matrix.php }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
-      SKIP_WC_BLOCKS_TESTS: 1 # skip running blocks tests
 
     steps:
       - name: Checkout WCPay repository
@@ -147,28 +146,31 @@ jobs:
         uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WC Checkout blocks & WC latest
-  # [TODO] Unskip blocks tests after investigating constant failures.
-  # blocks-tests:
-  #   runs-on: ubuntu-latest
-  #   name: WC - latest | blocks - shopper
+  blocks-tests:
+    runs-on: ubuntu-latest
+    name: WC - latest | blocks - shopper
 
-  #   env:
-  #     E2E_WP_VERSION: 'latest'
-  #     E2E_WC_VERSION: 'latest'
-  #     E2E_GROUP:  'blocks'
-  #     E2E_BRANCH: 'shopper'
-  #     SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
-  #     SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
+    env:
+      E2E_WP_VERSION: 'latest'
+      E2E_WC_VERSION: 'latest'
+      E2E_GROUP:  'blocks'
+      E2E_BRANCH: 'shopper'
+      SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
+      SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
 
-  #   steps:
-  #     - name: Checkout WCPay repository
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout WCPay repository
+        uses: actions/checkout@v4
 
-  #     - name: Setup E2E environment
-  #       uses: ./.github/actions/e2e/env-setup
+      - name: Setup E2E environment
+        uses: ./.github/actions/e2e/env-setup
 
-  #     - name: Run tests, upload screenshots & logs
-  #       uses: ./.github/actions/e2e/run-log-tests
+      - name: Install Playwright
+        shell: bash
+        run: npx playwright install chromium
+
+      - name: Run tests, upload screenshots & logs
+        uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WP Nightly & WC latest
   wp-nightly-tests:
@@ -177,7 +179,7 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
+        test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
         test_branches: [ 'merchant', 'shopper' ]
 
     name: WP - nightly | WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -62,6 +62,14 @@ jobs:
 
           # Create optimized matrix with selective PHP version testing
           # Build matrix dynamically based on WC versions
+          #
+          # BLOCKS TESTS STRATEGY:
+          # - Run blocks tests on current stable and newer WC versions where blocks support is mature
+          # - WC 7.7.0: NO blocks tests (too old, limited support)
+          # - WC L-1: NO blocks tests (previous major, potential compatibility issues)
+          # - WC latest: YES blocks tests (current stable, full support)
+          # - WC beta: YES blocks tests (newer version, test latest features)
+          # - WC RC: YES blocks tests (newest version, test upcoming release)
 
           # Define common values to reduce repetition
           PHP_LEGACY="7.3"
@@ -82,21 +90,20 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
-          # Add L-1 version with PHP 8.3 only
+          # Add L-1 version with PHP 8.3 only (NO blocks tests - older version)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
-          # Add latest with PHP 8.3 only
+          # Add latest with PHP 8.3 (INCLUDE blocks tests - current stable, full support)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
-          # Add beta with PHP 8.3 only (only if beta version is available)
+          # Add beta with PHP 8.3 (INCLUDE blocks tests - newer version)
           if [[ -n "$BETA_VERSION" ]]; then
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -63,12 +63,12 @@ jobs:
           # Create optimized matrix with selective PHP version testing
           # Build matrix dynamically based on WC versions
           #
-          # BLOCKS TESTS STRATEGY:
-          # - Run blocks tests on current stable and newer WC versions where blocks support is mature
-          # - WC 7.7.0: NO blocks tests (too old, limited support) - uses skip_blocks=1
-          # - WC L-1: NO blocks tests (previous major, potential compatibility issues) - uses skip_blocks=1
-          # - WC latest: YES blocks tests (current stable, full support)
-          # - WC beta: YES blocks tests (newer version, test latest features)
+          # BLOCK-BASED CHECKOUT TESTS STRATEGY:
+          # - Run block-based checkout tests on current stable and newer WC versions where blocks support is mature
+          # - WC 7.7.0: NO block-based checkout tests (too old, limited support) - uses skip_blocks=1
+          # - WC L-1: NO block-based checkout tests (previous major, potential compatibility issues) - uses skip_blocks=1
+          # - WC latest: YES block-based checkout tests (current stable, full support)
+          # - WC beta: YES block-based checkout tests (newer version, test latest features)
           # - WC RC: YES blocks tests (newest version, test upcoming release)
 
           # Define common values to reduce repetition
@@ -162,7 +162,7 @@ jobs:
 
 
   # Run tests against WP Nightly & WC latest
-  # This section tests cutting-edge WordPress features with latest WC
+  # This section tests new WordPress features with latest WC
   # Blocks tests are included here since we're testing against WP nightly + WC latest
   wp-nightly-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -69,6 +69,7 @@ jobs:
           PHP_LATEST="8.4"
           TEST_GROUPS_WCPAY="wcpay"
           TEST_GROUPS_SUBSCRIPTIONS="subscriptions"
+          TEST_GROUPS_BLOCKS="blocks"
           TEST_BRANCHES_MERCHANT="merchant"
           TEST_BRANCHES_SHOPPER="shopper"
 
@@ -86,12 +87,14 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
           # Add latest with PHP 8.3 only
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
           # Add beta with PHP 8.3 only (only if beta version is available)
           if [[ -n "$BETA_VERSION" ]]; then
@@ -99,6 +102,7 @@ jobs:
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           fi
 
           # Add rc with PHP 8.4 only (only if RC version is available)
@@ -130,6 +134,8 @@ jobs:
       E2E_PHP_VERSION: ${{ matrix.php }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
+      SKIP_WC_SUBSCRIPTIONS_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
+      SKIP_WC_ACTION_SCHEDULER_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
 
     steps:
       - name: Checkout WCPay repository
@@ -145,32 +151,7 @@ jobs:
       - name: Run tests, upload screenshots & logs
         uses: ./.github/actions/e2e/run-log-tests
 
-  # Run tests against WC Checkout blocks & WC latest
-  blocks-tests:
-    runs-on: ubuntu-latest
-    name: WC - latest | blocks - shopper
 
-    env:
-      E2E_WP_VERSION: 'latest'
-      E2E_WC_VERSION: 'latest'
-      E2E_GROUP:  'blocks'
-      E2E_BRANCH: 'shopper'
-      SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
-      SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
-
-    steps:
-      - name: Checkout WCPay repository
-        uses: actions/checkout@v4
-
-      - name: Setup E2E environment
-        uses: ./.github/actions/e2e/env-setup
-
-      - name: Install Playwright
-        shell: bash
-        run: npx playwright install chromium
-
-      - name: Run tests, upload screenshots & logs
-        uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WP Nightly & WC latest
   wp-nightly-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -66,7 +66,7 @@ jobs:
           # BLOCK-BASED CHECKOUT TESTS STRATEGY:
           # - Run block-based checkout tests on current stable and newer WC versions where blocks support is mature
           # - WC 7.7.0: NO block-based checkout tests (too old, limited support) - uses skip_blocks=1
-          # - WC L-1: NO block-based checkout tests (previous major, potential compatibility issues) - uses skip_blocks=1
+          # - WC L-1: YES block-based checkout tests (recent version with full block support)
           # - WC latest: YES block-based checkout tests (current stable, full support)
           # - WC beta: YES block-based checkout tests (newer version, test latest features)
           # - WC RC: YES blocks tests (newest version, test upcoming release)
@@ -90,11 +90,12 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
 
-          # Add L-1 version with PHP 8.3 only (NO blocks tests - older version)
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
+          # Add L-1 version with PHP 8.3 only (INCLUDE blocks tests - recent version with full support)
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_BLOCKS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
           # Add latest with PHP 8.3 (INCLUDE blocks tests - current stable, full support)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -173,6 +173,10 @@ jobs:
       matrix:
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
         test_branches: [ 'merchant', 'shopper' ]
+        exclude:
+          # Exclude blocks-merchant combination - no merchant blocks tests exist
+          - test_groups: 'blocks'
+            test_branches: 'merchant'
 
     name: WP - nightly | WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,8 +65,8 @@ jobs:
           #
           # BLOCKS TESTS STRATEGY:
           # - Run blocks tests on current stable and newer WC versions where blocks support is mature
-          # - WC 7.7.0: NO blocks tests (too old, limited support)
-          # - WC L-1: NO blocks tests (previous major, potential compatibility issues)
+          # - WC 7.7.0: NO blocks tests (too old, limited support) - uses skip_blocks=1
+          # - WC L-1: NO blocks tests (previous major, potential compatibility issues) - uses skip_blocks=1
           # - WC latest: YES blocks tests (current stable, full support)
           # - WC beta: YES blocks tests (newer version, test latest features)
           # - WC RC: YES blocks tests (newest version, test upcoming release)
@@ -84,17 +84,17 @@ jobs:
           # Initialize empty matrix array
           MATRIX_ENTRIES=()
 
-          # Add WC 7.7.0 with PHP 7.3 only (legacy)
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          # Add WC 7.7.0 with PHP 7.3 only (legacy - NO blocks tests)
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
 
           # Add L-1 version with PHP 8.3 only (NO blocks tests - older version)
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
 
           # Add latest with PHP 8.3 (INCLUDE blocks tests - current stable, full support)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
@@ -143,6 +143,7 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
       SKIP_WC_SUBSCRIPTIONS_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
       SKIP_WC_ACTION_SCHEDULER_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
+      SKIP_WC_BLOCKS_TESTS: ${{ matrix.skip_blocks == '1' && '1' || '' }}
 
     steps:
       - name: Checkout WCPay repository
@@ -161,6 +162,8 @@ jobs:
 
 
   # Run tests against WP Nightly & WC latest
+  # This section tests cutting-edge WordPress features with latest WC
+  # Blocks tests are included here since we're testing against WP nightly + WC latest
   wp-nightly-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -144,7 +144,7 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
       SKIP_WC_SUBSCRIPTIONS_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
       SKIP_WC_ACTION_SCHEDULER_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
-      SKIP_WC_BLOCKS_TESTS: ${{ matrix.skip_blocks == '1' && '1' || '' }}
+      SKIP_WC_BLOCKS_TESTS: ${{ matrix.skip_blocks }}
 
     steps:
       - name: Checkout WCPay repository

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,7 +65,7 @@ jobs:
           #
           # BLOCK-BASED CHECKOUT TESTS STRATEGY:
           # - Run block-based checkout tests on current stable and newer WC versions where blocks support is mature
-          # - WC 7.7.0: NO block-based checkout tests (too old, limited support) - uses skip_blocks=1
+          # - WC 7.7.0: NO block-based checkout tests (too old, limited support)
           # - WC L-1: YES block-based checkout tests (recent version with full block support)
           # - WC latest: YES block-based checkout tests (current stable, full support)
           # - WC beta: YES block-based checkout tests (newer version, test latest features)
@@ -85,10 +85,10 @@ jobs:
           MATRIX_ENTRIES=()
 
           # Add WC 7.7.0 with PHP 7.3 only (legacy - NO blocks tests)
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\",\"skip_blocks\":\"1\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\",\"skip_blocks\":\"1\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_SUBSCRIPTIONS\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
 
           # Add L-1 version with PHP 8.3 only (INCLUDE blocks tests - recent version with full support)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
@@ -144,7 +144,7 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
       SKIP_WC_SUBSCRIPTIONS_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
       SKIP_WC_ACTION_SCHEDULER_TESTS: ${{ matrix.test_groups == 'blocks' && '1' || '' }}
-      SKIP_WC_BLOCKS_TESTS: ${{ matrix.skip_blocks }}
+      SKIP_WC_BLOCKS_TESTS: ${{ matrix.test_groups != 'blocks' && '1' || '' }}
 
     steps:
       - name: Checkout WCPay repository

--- a/changelog/dev-woopmnt-5251-e2e-investigate-and-re-enable-woocommerce-blocks-e2e-tests
+++ b/changelog/dev-woopmnt-5251-e2e-investigate-and-re-enable-woocommerce-blocks-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Re-enable Blocks E2E tests
+
+

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -156,8 +156,23 @@ By adding additional env variables to your `local.env` file, it is possible to r
 - Adding `E2E_GROUP='wcpay'` and `E2E_BRANCH='merchant'` to your `local.env` file, then running `npm run test:e2e-ui` runs the WooPayments merchant tests for WCPay in UI mode.
 - Adding `E2E_GROUP='wcpay'` and `E2E_BRANCH='shopper'` to your `local.env` file, then running `npm run test:e2e-ui` runs WooPayments shopper tests for WCPay in UI mode.
 - Adding just `E2E_GROUP='wcpay'` to your `local.env` file, then running `npm run test:e2e-ui` runs WooPayments merchant & shopper tests for WCPay in UI mode.
-- Available groups are `wcpay` and `subscriptions`.
+- Available groups are `wcpay`, `subscriptions`, and `blocks`.
 - Available branches are `merchant` and `shopper`.
+
+#### Running tests by tags
+
+You can also run tests using Playwright's tag filtering:
+
+```bash
+# Run only WooCommerce Blocks tests
+npm run test:e2e -- --grep @blocks
+
+# Run WCPay tests excluding blocks tests
+npm run test:e2e wcpay/ -- --grep-invert @blocks
+
+# Run all critical tests (includes blocks tests)
+npm run test:e2e -- --grep @critical
+```
 
 It is also possible to run the groups using the relative path to the tests. e.g.
 
@@ -183,7 +198,7 @@ Place new spec files in the appropriate directory under `tests/e2e/specs`. The d
 - **Subscriptions Merchant**: `tests/e2e/specs/subscriptions/merchant` - Subscription related tests for the merchant role.
 - **Subscriptions Shopper**: `tests/e2e/specs/subscriptions/shopper` - Subscription related tests for the shopper role.
 - **WooPayments Merchant**: `tests/e2e/specs/wcpay/merchant` - Tests for the merchant role in WooPayments.
-- **WooPayments Shopper**: `tests/e2e/specs/wcpay/shopper` - Tests for the shopper role in WooPayments, including Blocks E2E tests.
+- **WooPayments Shopper**: `tests/e2e/specs/wcpay/shopper` - Tests for the shopper role in WooPayments (includes WooCommerce Blocks tests tagged with `@blocks`).
 
 ## Debugging tests
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -11,7 +11,7 @@ config( { path: path.resolve( __dirname, '../e2e/config', 'local.env' ) } );
 
 const { BASE_URL, NODE_ENV, E2E_GROUP, E2E_BRANCH } = process.env;
 
-const validGroups = [ 'wcpay', 'subscriptions' ];
+const validGroups = [ 'wcpay', 'subscriptions', 'blocks' ];
 const validBranches = [ 'merchant', 'shopper' ];
 
 const buildTestDir = ( group: string, branch: string ) => {
@@ -19,6 +19,14 @@ const buildTestDir = ( group: string, branch: string ) => {
 
 	if ( ! group || ! validGroups.includes( group ) ) {
 		return baseDir;
+	}
+
+	// Special handling for blocks tests - they are located in wcpay/shopper directory
+	if ( group === 'blocks' ) {
+		if ( ! branch || ! validBranches.includes( branch ) ) {
+			return `${ baseDir }\/wcpay`;
+		}
+		return `${ baseDir }\/wcpay\/${ branch }`;
 	}
 
 	if ( ! branch || ! validBranches.includes( branch ) ) {
@@ -30,6 +38,11 @@ const buildTestDir = ( group: string, branch: string ) => {
 
 const getTestMatch = ( group: string, branch: string ) => {
 	const testDir = buildTestDir( group, branch );
+
+	// Special handling for blocks tests - filter for wc-blocks test files
+	if ( group === 'blocks' ) {
+		return new RegExp( `${ testDir }\/.*wc-blocks.*\.spec\.ts` );
+	}
 
 	return new RegExp( `${ testDir }\/.*\.spec\.ts` );
 };

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -21,14 +21,6 @@ const buildTestDir = ( group: string, branch: string ) => {
 		return baseDir;
 	}
 
-	// Special handling for blocks tests - they are located in wcpay/shopper directory
-	if ( group === 'blocks' ) {
-		if ( ! branch || ! validBranches.includes( branch ) ) {
-			return `${ baseDir }\/wcpay`;
-		}
-		return `${ baseDir }\/wcpay\/${ branch }`;
-	}
-
 	if ( ! branch || ! validBranches.includes( branch ) ) {
 		return `${ baseDir }\/${ group }`;
 	}
@@ -39,9 +31,11 @@ const buildTestDir = ( group: string, branch: string ) => {
 const getTestMatch = ( group: string, branch: string ) => {
 	const testDir = buildTestDir( group, branch );
 
-	// Special handling for blocks tests - filter for wc-blocks test files
+	// Special handling for blocks tests - use tag filtering.
 	if ( group === 'blocks' ) {
-		return new RegExp( `${ testDir }\/.*wc-blocks.*\.spec\.ts` );
+		// For blocks group, look in wcpay directory but filter by @blocks tag
+		const wcpayTestDir = buildTestDir( 'wcpay', branch );
+		return new RegExp( `${ wcpayTestDir }\/.*\.spec\.ts` );
 	}
 
 	return new RegExp( `${ testDir }\/.*\.spec\.ts` );
@@ -99,6 +93,9 @@ export default defineConfig( {
 
 	testMatch: getTestMatch( E2E_GROUP, E2E_BRANCH ),
 	testIgnore: /specs\/performance/,
+
+	// When running blocks tests, filter by @blocks tag
+	grep: E2E_GROUP === 'blocks' ? /@blocks/ : undefined,
 
 	/* Configure projects for major browsers */
 	projects: [

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -31,9 +31,8 @@ const buildTestDir = ( group: string, branch: string ) => {
 const getTestMatch = ( group: string, branch: string ) => {
 	const testDir = buildTestDir( group, branch );
 
-	// Special handling for blocks tests - use tag filtering.
 	if ( group === 'blocks' ) {
-		// For blocks group, look in wcpay directory but filter by @blocks tag
+		// For blocks group, look in wcpay directory - actual @blocks tag filtering happens via grep config
 		const wcpayTestDir = buildTestDir( 'wcpay', branch );
 		return new RegExp( `${ wcpayTestDir }\/.*\.spec\.ts` );
 	}

--- a/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-checkout-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-checkout-failures.spec.ts
@@ -60,7 +60,7 @@ const errorsInsideStripeFrame = [
 
 describeif( shouldRunWCBlocksTests )(
 	'WooCommerce Blocks > Checkout failures',
-	{ tag: '@critical' },
+	{ tag: [ '@critical', '@blocks' ] },
 	() => {
 		let shopperPage: Page;
 

--- a/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-checkout-purchase.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-checkout-purchase.spec.ts
@@ -20,7 +20,7 @@ import { config } from '../../../config/default';
 
 describeif( shouldRunWCBlocksTests )(
 	'WooCommerce Blocks > Successful purchase',
-	{ tag: '@critical' },
+	{ tag: [ '@critical', '@blocks' ] },
 	() => {
 		let shopperPage: Page;
 

--- a/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-saved-card-checkout-and-usage.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-saved-card-checkout-and-usage.spec.ts
@@ -30,7 +30,7 @@ import { config } from '../../../config/default';
 
 describeif( shouldRunWCBlocksTests )(
 	'WooCommerce Blocks > Saved cards',
-	{ tag: '@critical' },
+	{ tag: [ '@critical', '@blocks' ] },
 	() => {
 		let shopperPage: Page;
 		const card = config.cards.basic;


### PR DESCRIPTION
Fixes #WOOPMNT-5251

Re-enables WooCommerce blocks e2e tests that were previously disabled.

#### Changes proposed in this Pull Request

- **Tag-based approach**: WooCommerce Blocks tests now use `@blocks` tags for selective execution
- **Preserved directory structure**: Blocks tests remain in `wcpay/shopper/` where they logically belong
- **Playwright config**: Added support for `E2E_GROUP=blocks` with automatic `@blocks` tag filtering
- **Test tagging**: All blocks tests now tagged with `{ tag: [ '@critical', '@blocks' ] }`
- **Backward compatibility**: Existing CI workflows continue to work without changes

#### Test Strategy
- **WC 7.7.0**: Blocks tests skipped (legacy version, limited blocks support)
- **WC L-1 and newer**: Blocks tests enabled (full blocks support available)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E tests should pass: https://github.com/Automattic/woocommerce-payments/actions/runs/16883606803

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
