### PR TITLE
Update “Finish setting up WooPayments” task to redirect to NOX flow

### DIFF
--- a/changelog/update-WOOPMNT-5258-business-details-task-link-to-nox
+++ b/changelog/update-WOOPMNT-5258-business-details-task-link-to-nox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update “Finish setting up WooPayments” task to redirect to NOX flow.

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -13,6 +13,7 @@ import type { TaskItemProps } from '../types';
 import UpdateBusinessDetailsModal from 'wcpay/overview/modal/update-business-details';
 import { recordEvent } from 'wcpay/tracks';
 import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
+import { getAdminUrl } from 'utils';
 
 export const getUpdateBusinessDetailsTask = (
 	errorMessages: string[],
@@ -120,12 +121,14 @@ export const getUpdateBusinessDetailsTask = (
 				source,
 			} );
 
-			// If the onboarding isn't complete use the connectUrl instead,
-			// as the accountLink doesn't handle redirecting back to the overview page.
+			// If the onboarding isn't complete redirect to the NOX onboarding page.
 			if ( ! detailsSubmitted ) {
-				window.location.href = addQueryArgs( connectUrl, {
-					from: 'WCPAY_OVERVIEW',
+				window.location.href = getAdminUrl( {
+					page: 'wc-settings',
+					tab: 'checkout',
+					path: '/woopayments/onboarding',
 					source: 'wcpay-finish-setup-task',
+					from: 'WCPAY_OVERVIEW',
 				} );
 			} else {
 				window.open( accountLinkWithSource, '_blank' );

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -27,7 +27,6 @@ export const getUpdateBusinessDetailsTask = (
 	const accountDetailsPastDue = 'restricted' === status && pastDue;
 	const hasMultipleErrors = 1 < errorMessages.length;
 	const hasSingleError = 1 === errorMessages.length;
-	const connectUrl = wcpaySettings.connectUrl;
 	const accountLinkWithSource = accountLink
 		? addQueryArgs( accountLink, {
 				from: 'WCPAY_OVERVIEW',


### PR DESCRIPTION
Fixes WOOPMNT-5258

#### Changes proposed in this Pull Request
This PR updates the redirection so that clicking “Finish setting up WooPayments” sends the user to the NOX flow, shown whenever live onboarding is in progress.

#### Prerequisites
- Activate the WCPay Dev Tools plugin and disable Dev Mode.
- Ensure any previously connected accounts are reset.

#### Testing instructions
1. Navigate to Payments and click the "Complete setup" on WooPayments.
<img width="1550" height="672" alt="Screenshot 2025-08-15 at 13 34 15" src="https://github.com/user-attachments/assets/78bbfb5f-6463-46e1-b94d-115a0bbf406d" />

2. Continue through payment methods and WPCOM connection screens. On the onboarding mode screen, click on the "Start accepting payments" button.
<img width="1644" height="834" alt="Screenshot 2025-08-15 at 15 15 14" src="https://github.com/user-attachments/assets/6f37a612-843c-4ee3-b342-e9c615bf6783" />

3. After finishing two-factor authentication and embedded KYC is loaded, close the modal.
<img width="1643" height="834" alt="Screenshot 2025-08-15 at 15 17 30" src="https://github.com/user-attachments/assets/d0306a47-7682-4b85-84a7-bf361f30533b" />

4. Navigate to WooCommerce > Home, and click on the "Finish setting up WooPayments" task.
<img width="1543" height="716" alt="Screenshot 2025-08-15 at 15 18 06" src="https://github.com/user-attachments/assets/6218764b-df12-45af-bd60-f14fe63bb1df" />

5. Ensure you are redirected to the NOX flow.
<img width="1640" height="830" alt="Screenshot 2025-08-15 at 15 20 01" src="https://github.com/user-attachments/assets/369582a9-c2ed-444d-a9a2-426f0211eaa9" />

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
