### PR TITLE
Avoid processing webhooks meant for different sites

### DIFF
--- a/changelog/woopmnt-5262-payments-transactions-report-link-to-order-id-if-order
+++ b/changelog/woopmnt-5262-payments-transactions-report-link-to-order-id-if-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ignore webhooks whenever the order key in their body does not match the local order.

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -63,19 +63,15 @@ class WC_Payments_DB {
 	/**
 	 * Retrieve an order from the DB using a corresponding Stripe intent ID.
 	 *
-	 * @param string      $intent_id Intent ID corresponding to an order ID.
-	 * @param string|null $order_key Order key.
+	 * @param string $intent_id Intent ID corresponding to an order ID.
+	 *
 	 * @return boolean|WC_Order|WC_Order_Refund
 	 */
-	public function order_from_intent_id( $intent_id, ?string $order_key = null ) {
+	public function order_from_intent_id( $intent_id ) {
 		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_INTENT_ID, $intent_id );
 
 		if ( $order_id ) {
-			$order = $this->order_from_order_id( $order_id );
-			if ( ! is_null( $order_key ) && $order->get_order_key() !== $order_key ) {
-				return null;
-			}
-			return $order;
+			return $this->order_from_order_id( $order_id );
 		}
 		return false;
 	}

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -63,15 +63,19 @@ class WC_Payments_DB {
 	/**
 	 * Retrieve an order from the DB using a corresponding Stripe intent ID.
 	 *
-	 * @param string $intent_id Intent ID corresponding to an order ID.
-	 *
+	 * @param string      $intent_id Intent ID corresponding to an order ID.
+	 * @param string|null $order_key Order key.
 	 * @return boolean|WC_Order|WC_Order_Refund
 	 */
-	public function order_from_intent_id( $intent_id ) {
+	public function order_from_intent_id( $intent_id, ?string $order_key = null ) {
 		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_INTENT_ID, $intent_id );
 
 		if ( $order_id ) {
-			return $this->order_from_order_id( $order_id );
+			$order = $this->order_from_order_id( $order_id );
+			if ( ! is_null( $order_key ) && $order->get_order_key() !== $order_key ) {
+				return null;
+			}
+			return $order;
 		}
 		return false;
 	}

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -727,24 +727,6 @@ class WC_Payments_Webhook_Processing_Service {
 		// Look up the order related to this intent.
 		$order = $this->wcpay_db->order_from_intent_id( $intent_id );
 
-		/**
-		 * If the order has been found, but there is an order key mismatch, it
-		 * could be caused by another site creating orders with the same IDs
-		 * while this site remains the primary webhook receiver.
-		 */
-		if ( ! is_null( $order_key ) && $order instanceof WC_Order && $order->get_order_key() !== $order_key ) {
-			Logger::debug(
-				'Mismatching order key found while retrieving an order for webhook processing',
-				[
-					'intent_id'         => $intent_id,
-					'order_id'          => $order->get_id(),
-					'webhook_order_key' => $order_key,
-					'local_order_key'   => $order->get_order_key(),
-				]
-			);
-			return null;
-		}
-
 		if ( ! $order instanceof \WC_Order ) {
 			// Retrieving order with order_id in case intent_id was not properly set.
 			Logger::debug( 'intent_id not found, using order_id to retrieve order' );
@@ -763,6 +745,24 @@ class WC_Payments_Webhook_Processing_Service {
 				// If the payment intent contains an invoice it is a WCPay Subscription-related intent and will be handled by the `invoice.paid` event.
 				return null;
 			}
+		}
+
+		/**
+		 * If the order has been found, but there is an order key mismatch, it
+		 * could be caused by another site creating orders with the same IDs
+		 * while this site remains the primary webhook receiver.
+		 */
+		if ( ! is_null( $order_key ) && $order instanceof WC_Order && $order->get_order_key() !== $order_key ) {
+			Logger::debug(
+				'Mismatching order key found while retrieving an order for webhook processing',
+				[
+					'intent_id'         => $intent_id,
+					'order_id'          => $order->get_id(),
+					'webhook_order_key' => $order_key,
+					'local_order_key'   => $order->get_order_key(),
+				]
+			);
+			return null;
 		}
 
 		if ( ! $order instanceof \WC_Order ) {

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -725,7 +725,25 @@ class WC_Payments_Webhook_Processing_Service {
 		$order_key    = $this->read_webhook_property( $event_object, 'metadata' )['order_key'] ?? null;
 
 		// Look up the order related to this intent.
-		$order = $this->wcpay_db->order_from_intent_id( $intent_id, $order_key );
+		$order = $this->wcpay_db->order_from_intent_id( $intent_id );
+
+		/**
+		 * If the order has been found, but there is an order key mismatch, it
+		 * could be caused by another site creating orders with the same IDs
+		 * while this site remains the primary webhook receiver.
+		 */
+		if ( ! is_null( $order_key ) && $order instanceof WC_Order && $order->get_order_key() !== $order_key ) {
+			Logger::debug(
+				'Mismatching order key found while retrieving an order for webhook processing',
+				[
+					'intent_id'         => $intent_id,
+					'order_id'          => $order->get_id(),
+					'webhook_order_key' => $order_key,
+					'local_order_key'   => $order->get_order_key(),
+				]
+			);
+			return null;
+		}
 
 		if ( ! $order instanceof \WC_Order ) {
 			// Retrieving order with order_id in case intent_id was not properly set.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -752,7 +752,7 @@ class WC_Payments_Webhook_Processing_Service {
 		 * could be caused by another site creating orders with the same IDs
 		 * while this site remains the primary webhook receiver.
 		 */
-		if ( ! is_null( $order_key ) && $order instanceof WC_Order && $order->get_order_key() !== $order_key ) {
+		if ( null !== $order_key && $order instanceof WC_Order && $order->get_order_key() !== $order_key ) {
 			Logger::debug(
 				'Mismatching order key found while retrieving an order for webhook processing',
 				[

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -722,9 +722,10 @@ class WC_Payments_Webhook_Processing_Service {
 		$event_data   = $this->read_webhook_property( $event_body, 'data' );
 		$event_object = $this->read_webhook_property( $event_data, 'object' );
 		$intent_id    = $this->read_webhook_property( $event_object, 'id' );
+		$order_key    = $this->read_webhook_property( $event_object, 'metadata' )['order_key'] ?? null;
 
 		// Look up the order related to this intent.
-		$order = $this->wcpay_db->order_from_intent_id( $intent_id );
+		$order = $this->wcpay_db->order_from_intent_id( $intent_id, $order_key );
 
 		if ( ! $order instanceof \WC_Order ) {
 			// Retrieving order with order_id in case intent_id was not properly set.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2760,9 +2760,12 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	 * @return array
 	 */
 	private function get_order_info_from_intention_object( $intention_id, $order_key = null ) {
-		$order  = $this->wcpay_db->order_from_intent_id( $intention_id, $order_key );
-		$object = $this->add_order_info_to_object( $order, [] );
+		$order = $this->wcpay_db->order_from_intent_id( $intention_id );
+		if ( $order instanceof WC_Order && ! is_null( $order_key ) && $order_key !== $order->get_order_key() ) {
+			return [];
+		}
 
+		$object = $this->add_order_info_to_object( $order, [] );
 		return $object['order'];
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2761,7 +2761,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	 */
 	private function get_order_info_from_intention_object( $intention_id, $order_key = null ) {
 		$order = $this->wcpay_db->order_from_intent_id( $intention_id );
-		if ( $order instanceof WC_Order && ! is_null( $order_key ) && $order_key !== $order->get_order_key() ) {
+		if ( $order instanceof WC_Order && null !== $order_key && $order_key !== $order->get_order_key() ) {
 			return [];
 		}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2289,7 +2289,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		$payment_method_options = $intention_array['payment_method_options'] ?? [];
 
 		$charge = ! empty( $charge_array ) ? self::deserialize_charge_object_from_array( $charge_array ) : null;
-		$order  = $this->get_order_info_from_intention_object( $intention_array['id'] );
+		$order  = $this->get_order_info_from_intention_object( $intention_array['id'], $intention_array['metadata']['order_key'] ?? null );
 
 		$intent = new WC_Payments_API_Payment_Intention(
 			$intention_array['id'],
@@ -2756,11 +2756,11 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	 * Adds additional info to intention object.
 	 *
 	 * @param string $intention_id Intention ID.
-	 *
+	 * @param string $order_key    Order key.
 	 * @return array
 	 */
-	private function get_order_info_from_intention_object( $intention_id ) {
-		$order  = $this->wcpay_db->order_from_intent_id( $intention_id );
+	private function get_order_info_from_intention_object( $intention_id, $order_key = null ) {
+		$order  = $this->wcpay_db->order_from_intent_id( $intention_id, $order_key );
 		$object = $this->add_order_info_to_object( $order, [] );
 
 		return $object['order'];

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1275,6 +1275,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 					],
 				],
 			],
+			'metadata'           => [],
 			'last_payment_error' => [
 				'message'        => 'error message',
 				'payment_method' => [
@@ -1345,6 +1346,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'object'             => 'payment_intent',
 			'amount'             => 1500,
 			'charges'            => [],
+			'metadata'           => [],
 			'last_payment_error' => [
 				'code'           => 'card_declined',
 				'decline_code'   => 'debit_notification_undelivered',
@@ -1988,6 +1990,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 							],
 						],
 					],
+					'metadata'           => [],
 					'last_payment_error' => [
 						'message'        => 'Card declined',
 						'payment_method' => [

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -749,6 +749,46 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a payment_intent.succeeded event will ignore the order due to key mismatch.
+	 */
+	public function test_payment_intent_successful_ignores_order_due_to_key_mismatch() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'pi_123123123123123', // payment_intent's ID.
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [
+					[
+						'id' => 'py_123123123123123',
+					],
+				],
+			],
+			'currency' => 'eur',
+			'metadata' => [
+				'order_key' => 'abcd',
+			],
+		];
+
+		$this->mock_order->expects( $this->any() )
+			->method( 'get_order_key' )
+			->willReturn( 'xyz' );
+
+		$this->mock_order->expects( $this->never() )->method( 'update_meta_data' );
+		$this->mock_order->expects( $this->never() )->method( 'save' );
+		$this->mock_order->expects( $this->never() )->method( 'payment_complete' );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
 	 * Tests that a payment_intent.succeeded event will add relevant metadata.
 	 */
 	public function test_payment_intent_successful_adds_relevant_metadata() {


### PR DESCRIPTION
Fixes WOOPMNT-5262

#### Changes proposed in this Pull Request

The initial plan was to follow the Linear issue and not link to orders from the Transactions screen in case there are mismatched order keys, but that failed. Within the transactions (as queried from the server), we don't have access to the order key, so there is no opportunity to check against it.

Digging further in to find the root cause in pcreKM-3AY-p2#comment-4544 with @kaushikasomaiya, we realized that the orders are queried by charge IDs and there should be no need to filter things if the order is not updated with an incorrect charge ID in the first place. Therefore, this PR adds verification to order loading while processing a webhook. If there is a mismatch in the order key (compared to the one in the intent meta), the webhook is essentially ignored.

#### Testing instructions

This would be easy to test if you have two sites connected to the same account and triggering subscription renewals. However, that is not a feasible testing scenario.

Instead, I recommend hacking the code a bit.

1. Add a breakpoint around [here](https://github.com/Automattic/woocommerce-payments/blob/a4159c93e7a3371f21e67a1f9385006268ead519/includes/class-wc-payments-webhook-processing-service.php#L755).
2. Start listening for webhooks if you are using a local server.
3. Go through checkout and make sure that the condition is never entered.
4. Before that line, add `$order_key .= 'something'`.
5. Go through checkout again.
6. This time the condition should be entered.
7. Verify that there is a similar entry in the WooCommerce logs:

<img width="856" height="479" alt="image" src="https://github.com/user-attachments/assets/72bbb432-3e1b-4550-97b9-11f561426b68" />
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)