### PR TITLE
Fix VAT setup modal for unsupported merchants

### DIFF
--- a/changelog/woopmnt-5274-tax-setup-modal-should-not-display-for-unsupported-merchants
+++ b/changelog/woopmnt-5274-tax-setup-modal-should-not-display-for-unsupported-merchants
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix VAT setup modal for unsupported merchants

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -69,6 +69,7 @@ declare global {
 			pastDue?: boolean;
 			accountLink: string;
 			hasSubmittedVatData?: boolean;
+			isDocumentsEnabled?: boolean;
 			requirements?: {
 				errors?: {
 					code: string;

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -192,7 +192,14 @@ const SettingsManager = () => {
 	useEffect( () => {
 		const urlParams = new URLSearchParams( window.location.search );
 		if ( urlParams.get( 'woopayments-vat-details-modal' ) === 'true' ) {
-			if ( ! wcpaySettings.accountStatus.hasSubmittedVatData ) {
+			if ( ! wcpaySettings.accountStatus.isDocumentsEnabled ) {
+				dispatch( 'core/notices' ).createErrorNotice(
+					__(
+						'Tax details collection is not available for your account.',
+						'woocommerce-payments'
+					)
+				);
+			} else if ( ! wcpaySettings.accountStatus.hasSubmittedVatData ) {
 				setVatFormModalOpen( true );
 			} else {
 				dispatch( 'core/notices' ).createInfoNotice(

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -362,6 +362,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			// Test-drive accounts don't have access to the Stripe dashboard.
 			'accountLink'         => empty( $account['is_test_drive'] ) ? $this->get_login_url() : false,
 			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
+			'isDocumentsEnabled'  => $account['is_documents_enabled'] ?? false,
 			'requirements'        => [
 				'errors' => $account['requirements']['errors'] ?? [],
 			],


### PR DESCRIPTION
Fixes WOOPMNT-5274
Related commit 8e411ffb79d6549ca3c7f31c45fc29c1d15a9d8f

#### Changes proposed in this Pull Request

- Pass `isDocumentsEnabled` (`is_documents_enabled` from the server) to the front-end settings.
- If it's not enabled, dispatch a notice `Tax details collection is not available for your account` like this:

<img width="2860" height="1024" alt="Screen Shot on 2025-08-21 at 12:43:12" src="https://github.com/user-attachments/assets/76065de7-76cb-4c77-ab10-85df68e03fc7" />

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a merchant with country `US` or any country not supporting tax.
* Try https://www.your-site.com/?woopayments-vat-details-redirect link.
* Confirm that it's still redirect to: https://your-site.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&woopayments-vat-details-modal=true
* Confirm: there is a message like the screenshot above. 
* If testing with a merchant in the supported country such as EU countries like `ES`, `DE`, `IT`, etc, it should display the tax info collection modal.
