### PR TITLE
E2E - Fix failures for Shopper: Subscription

### DIFF
--- a/changelog/fix-e2e-test-subscriptions-shopper
+++ b/changelog/fix-e2e-test-subscriptions-shopper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix E2E subcription shopper test failures because the core changes text from "Sign up now" to "Add to cart"

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
@@ -86,7 +86,7 @@ describeif( shouldRunSubscriptionsTests )(
 
 				// Add it to the cart and verify that the cart page shows the free trial details
 				await shopperPage
-					.getByRole( 'button', { name: 'Sign up now' } )
+					.getByRole( 'button', { name: 'Add to cart' } )
 					.click();
 				await goToCart( shopperPage );
 				await expect(

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
@@ -130,7 +130,7 @@ describeif( shouldRunSubscriptionsTests )(
 				const card = config.cards[ '3dsOTP' ];
 				await fillCardDetails( shopperPage, card );
 				await shopperPage
-					.getByRole( 'button', { name: 'Sign up now' } )
+					.getByRole( 'button', { name: 'Add to cart', exact: true } )
 					.click();
 				await shopperPage.frames()[ 0 ].waitForLoadState( 'load' );
 				await confirmCardAuthentication( shopperPage, true );

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
@@ -86,7 +86,7 @@ describeif( shouldRunSubscriptionsTests )(
 
 				// Add it to the cart and verify that the cart page shows the free trial details
 				await shopperPage
-					.getByRole( 'button', { name: 'Add to cart' } )
+					.getByRole( 'button', { name: 'Add to cart', exact: true } )
 					.click();
 				await goToCart( shopperPage );
 				await expect(

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
@@ -45,7 +45,7 @@ describeif( shouldRunSubscriptionsTests )(
 				);
 				await goToProductPageBySlug( shopperPage, productSlug );
 				await shopperPage
-					.getByRole( 'button', { name: 'Add to cart' } )
+					.getByRole( 'button', { name: 'Add to cart', exact: true } )
 					.click();
 				await shopperPage.waitForLoadState( 'networkidle' );
 				await expect(

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
@@ -45,7 +45,7 @@ describeif( shouldRunSubscriptionsTests )(
 				);
 				await goToProductPageBySlug( shopperPage, productSlug );
 				await shopperPage
-					.getByRole( 'button', { name: 'Sign up now' } )
+					.getByRole( 'button', { name: 'Add to cart' } )
 					.click();
 				await shopperPage.waitForLoadState( 'networkidle' );
 				await expect(


### PR DESCRIPTION
Fixes [WOOPMNT-5278](https://linear.app/a8c/issue/WOOPMNT-5278/e2e-test-failures-for-shopper-subscriptions-due-to-button-text-change)

Errors from multiple branches recently in `WC - latest | subscriptions - shopper`
For example, PR https://github.com/Automattic/woocommerce-payments/pull/11009 with this job log https://github.com/Automattic/woocommerce-payments/actions/runs/17140352651/job/48626327524

```
  4 failed
    [chromium] › tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts:70:7 › Shopper: Subscriptions - Purchase Free Trial › Shopper should be able to purchase a free trial @critical 
    [chromium] › tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts:163:7 › Shopper: Subscriptions - Purchase Free Trial › Merchant should be able to create an order with "Setup Intent" 
    [chromium] › tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts:37:7 › Shopper Subscriptions Purchase No Signup Fee › It should be able to purchase a subscription without a signup fee @critical 
    [chromium] › tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts:71:7 › Shopper Subscriptions Purchase No Signup Fee › It should have a charge for subscription cost without fee & an active subscription
``` 

```
Error: locator.click: Test ended.
Call log:
  - waiting for getByRole('button', { name: 'Sign up now' })


  47 | 				await shopperPage
  48 | 					.getByRole( 'button', { name: 'Sign up now' } )
> 49 | 					.click();
     | 					 ^
  50 | 				await shopperPage.waitForLoadState( 'networkidle' );
  51 | 				await expect(
  52 | 					shopperPage.getByText( /has been added to your cart\./ )
    at /home/runner/work/woocommerce-payments/woocommerce-payments/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts:49:7
```

#### Root cause 

From screenshots in the artifact, it seems all `Sign up now` texts have been changed to the default Woo button text `Add to cart` 

<img width="1280" height="720" alt="test-failed-1" src="https://github.com/user-attachments/assets/2e9a0546-38be-4a42-8d65-a8574b47732d" />

This matches with the latest release of WooCommerce Subscriptions 7.8.0 on Aug 20 with this PR https://github.com/woocommerce/woocommerce-subscriptions/pull/4970

#### Changes proposed in this Pull Request

- Just updated the text to match it.

#### Testing instructions

* Verify that all E2E tests are working well. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Irrerlevant - Covered with tests (or have a good reason not to test in description ☝️)
- [x] Irrerlevant - Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
