### PR TITLE
Fix E2E shopper subscription failure due to change in the checkout button

### DIFF
--- a/changelog/dev-fix-e2e-due-to-woosub-7-8-1
+++ b/changelog/dev-fix-e2e-due-to-woosub-7-8-1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix E2E test failures as the follow-up of PR 11013
+
+

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -417,6 +417,12 @@ echo
 echo "WooCommerce version:"
 cli_debug wp plugin get woocommerce --field=version
 
+if [[ ! ${SKIP_WC_SUBSCRIPTIONS_TESTS} ]]; then
+	echo
+    echo "WooCommerce Subscriptions version:"
+	cli_debug wp plugin get woocommerce-subscriptions --field=version
+fi
+
 echo
 echo "Docker environment:"
 cli_debug wp cli info

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-free-trial.spec.ts
@@ -130,7 +130,7 @@ describeif( shouldRunSubscriptionsTests )(
 				const card = config.cards[ '3dsOTP' ];
 				await fillCardDetails( shopperPage, card );
 				await shopperPage
-					.getByRole( 'button', { name: 'Add to cart', exact: true } )
+					.getByRole( 'button', { name: 'Place order', exact: true } )
 					.click();
 				await shopperPage.frames()[ 0 ].waitForLoadState( 'load' );
 				await confirmCardAuthentication( shopperPage, true );


### PR DESCRIPTION
Fixes E2E failures for shopper-subscription tests due to the recent release of Woo Subscription https://github.com/Automattic/woocommerce-payments/actions/runs/17224118145/job/48865352789

See: 

- https://github.com/Automattic/woocommerce-payments/pull/11013#discussion_r2293038791
- https://github.com/woocommerce/woocommerce-subscriptions/releases/tag/7.8.1 and https://github.com/woocommerce/woocommerce-subscriptions/pull/5046

#### Changes proposed in this Pull Request

- Change the `Add to card` button in the checkout page to the proper one `Place order` following the latest version of WooCommerce Subscriptions 7.8.1.
- Echo WooCommerce Subscriptions when it's installed.  

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all tests passed.
