### PR TITLE
Fix Support Phone number input styling to match that of WooPayments

### DIFF
--- a/changelog/fix-fix-phone-input-styling
+++ b/changelog/fix-fix-phone-input-styling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix margins for phone number input and add styling to match other inputs

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -13,6 +13,7 @@ import utils from 'iti/utils';
 
 interface PhoneNumberInputProps {
 	value: string;
+	id: string;
 	onValidationChange: ( isValid: boolean ) => void;
 	onValueChange: ( value: string ) => void;
 	onCountryDropdownClick?: () => void;
@@ -27,6 +28,7 @@ interface PhoneNumberInputProps {
 const PhoneNumberInput = ( {
 	onValueChange,
 	value,
+	id,
 	onValidationChange = ( validation ) => validation,
 	onCountryDropdownClick,
 	inputProps = {
@@ -207,6 +209,7 @@ const PhoneNumberInput = ( {
 			<input
 				type="tel"
 				ref={ inputRef }
+				id={ id }
 				value={ removeInternationalPrefix( value ) }
 				onBlur={ () => {
 					setFocusLost( true );

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -144,7 +144,6 @@
 // override intl-tel-input styles
 .iti {
 	width: 100%;
-	margin-top: $gap-large;
 
 	&--container {
 		margin-top: 0;

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -211,10 +211,3 @@
 		width: auto;
 	}
 }
-
-#account-business-support-phone-input {
-	height: 40px;
-	padding-right: 12px;
-	width: 100%;
-	border-radius: 0;
-}

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -211,3 +211,10 @@
 		width: auto;
 	}
 }
+
+#account-business-support-phone-input {
+	height: 40px;
+	padding-right: 12px;
+	width: 100%;
+	border-radius: 0;
+}

--- a/client/settings/support-phone-input/styles.scss
+++ b/client/settings/support-phone-input/styles.scss
@@ -14,3 +14,10 @@
 		border-radius: 0;
 	}
 }
+
+#account-business-support-phone-input {
+	height: 40px;
+	padding-right: 12px;
+	width: 100%;
+	border-radius: 0;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the styling of the input to match the styling of WooPayments.

Before:

<img width="1316" height="802" alt="CleanShot 2025-08-28 at 16 16 42@2x" src="https://github.com/user-attachments/assets/a693a552-cf74-4959-98ea-4b4290a811a9" />

After:

<img width="1292" height="668" alt="CleanShot 2025-08-28 at 16 10 46@2x" src="https://github.com/user-attachments/assets/29df02fe-5d8f-440e-b9a5-eb5b9e2d1b74" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get this branch locally or on JN
* Onboard a test account
* Go to Payments > Settings and scroll down to the Phone Support input
* Double-check that it looks like other inputs and that it displays correctly on mobile

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
