### PR TITLE
E2E: Fixed addSavedCard and Rate Limit adding card too soon with 3DS cards 

### DIFF
--- a/changelog/fix-flaky-e2e-addSavedCard
+++ b/changelog/fix-flaky-e2e-addSavedCard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky E2E test in addSavedCard function

--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-saved-cards.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-saved-cards.spec.ts
@@ -171,9 +171,6 @@ test.describe( 'Shopper can save and delete cards', () => {
 							await confirmCardAuthentication( shopperPage );
 						}
 
-						// Take note of the time when we added this card
-						cardTimingHelper.markCardAdded();
-
 						// waiting for the new page to be loaded, since there is a redirect happening after the submission..
 						await shopperPage.waitForLoadState( 'networkidle' );
 
@@ -182,6 +179,9 @@ test.describe( 'Shopper can save and delete cards', () => {
 								'Payment method successfully added.'
 							)
 						).toBeVisible();
+
+						// Take note of the time when we added this card
+						cardTimingHelper.markCardAdded();
 
 						// Verify that the card was added
 						await expect(

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -587,7 +587,13 @@ export const addSavedCard = async (
 	zipCode?: string
 ) => {
 	await page.getByRole( 'link', { name: 'Add payment method' } ).click();
-	await page.waitForLoadState( 'networkidle' );
+
+	// Wait for the page to be stable
+	// Use a more reliable approach than networkidle which can timeout
+	await page.waitForLoadState( 'domcontentloaded' );
+	// Ensure UI is not blocked
+	await isUIUnblocked( page );
+
 	await page.getByText( 'Card', { exact: true } ).click();
 	const frameHandle = page.getByTitle( 'Secure payment input frame' );
 	const stripeFrame = frameHandle.contentFrame();


### PR DESCRIPTION
Fixes [WOOPMNT-5286](https://linear.app/a8c/issue/WOOPMNT-5286/address-flaky-e2e-test-in-addsavedcard-function)

#### Changes proposed in this Pull Request

- Changes in this PR basically following `selectPaymentMethod` improvements in #10994 https://github.com/Automattic/woocommerce-payments/blob/40929bbf5650ae4d99fab8ebfb7b041c701f86e1/tests/e2e/utils/shopper.ts#L337-L346

- Another change is to move `markCardAdded` after confirming that the card is really added to the back-end. This is to fix the issue `You cannot add a new payment method so soon after the previous one. Please try again later.` like this: 

<img width="1280" height="720" alt="736c1008ae017a704d5ba03d16be688b69c1a4f2 (1)" src="https://github.com/user-attachments/assets/7e36025d-1c36-4ecf-8aca-79532fbf4b3e" />

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure E2E tests passed.
* Trigger other E2E test workflows and confirm it works. 

1. `E2E Tests - All` https://github.com/Automattic/woocommerce-payments/actions/runs/17320043970
2. `E2E Tests on Atomic - All` https://github.com/Automattic/woocommerce-payments/actions/runs/17320054976

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)