### PR TITLE
Revert "Amend changelog entries for release 9.9.0"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,21 +1,12 @@
 *** WooPayments Changelog ***
 
-= 9.9.0 - 2025-09-03 =
+= 9.8.0 - 2025-08-13 =
 * Add - Add address autocomplete to Checkout
 * Add - Add support for small screens on the evidence submission form.
-* Fix - fix: adding some missing i18n wrappers
-* Fix - fix: prevent Stripe Link to be shown on the checkout form
-* Fix - Fix checks for the billing details for the BNPL methods on the Pay for Order page.
 * Fix - Fix customer details section when name and/or email are very big.
-* Fix - Fixed WooPay terms and conditions text for merchants using blocks checkout.
 * Fix - Fix Google/Apple Pay "State / County is required" error during checkout for Croatia
-* Fix - Fix margins for phone number input and add styling to match other inputs
 * Fix - Fix the icon border of the Steps component for a dispute.
-* Fix - Fix VAT setup modal for unsupported merchants
-* Fix - Generate payment method details in WooPayments instead of Woo core, cache them for performance improvements.
-* Fix - Ignore webhooks whenever the order key in their body does not match the local order.
 * Fix - Reset the enabled payment methods to default value on account reset.
-* Fix - Show Activate payments notice in WooPayments Settings only for test accounts.
 * Fix - Suppress sending completed-renewal-order email after dispute resolution
 * Update - As of this change, we stop bundling WordPress Components in favor of using the wp.components available in the WordPress installation.
 * Update - Make onboading pages use the pw.components available in the WordPress installation.
@@ -23,20 +14,14 @@
 * Update - Make the KYC onboarding use the WP components available in the installation.
 * Update - update: ensure Google Pay/Apple Pay can check out w/ LT addresses
 * Update - update: fraud protection rules to use WP components bundled within the WP installation
-* Update - update: label text on the support phone number in test mode
-* Update - update: settings page design audit.
 * Update - Update documents page to use WP components available in the WordPress installation.
 * Update - Update loan page to use the installation WordPress components.
 * Update - Update the "Learn more about disputes" link in the confirmation screen of the disputes documentation.
-* Update - Update WP components for development and tests.
-* Update - Update “Finish setting up WooPayments” task to redirect to NOX flow.
 * Dev - Fix: enhances the robustness of the selectPaymentMethod method in end-to-end tests
 * Dev - Fix: Respond to a dispute e2e tests
 * Dev - Fix: select payment method shopper util
-* Dev - Fix E2E subcription shopper test failures because the core changes text from "Sign up now" to "Add to cart"
 * Dev - Removed all the Progressive Onboarding (PO) code.
 * Dev - update: use React 18
-* Dev - Update JS packages mini-css-extract-plugin and shelljs
 * Dev - Update tested WooCommerce version to 10.1.0
 
 = 9.7.0 - 2025-07-24 =

--- a/changelog/dev-fix-e2e-due-to-woosub-7-8-1
+++ b/changelog/dev-fix-e2e-due-to-woosub-7-8-1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix E2E test failures as the follow-up of PR 11013
+
+

--- a/changelog/dev-update-js-packages
+++ b/changelog/dev-update-js-packages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update JS packages mini-css-extract-plugin and shelljs

--- a/changelog/fix-WOOPMNT-5223-activate-payments-notice-on-live-account
+++ b/changelog/fix-WOOPMNT-5223-activate-payments-notice-on-live-account
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show Activate payments notice in WooPayments Settings only for test accounts.

--- a/changelog/fix-afterpay-affirm-order-pay-flow
+++ b/changelog/fix-afterpay-affirm-order-pay-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix checks for the billing details for the BNPL methods on the Pay for Order page.

--- a/changelog/fix-e2e-test-subscriptions-shopper
+++ b/changelog/fix-e2e-test-subscriptions-shopper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix E2E subcription shopper test failures because the core changes text from "Sign up now" to "Add to cart"

--- a/changelog/fix-fix-phone-input-styling
+++ b/changelog/fix-fix-phone-input-styling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix margins for phone number input and add styling to match other inputs

--- a/changelog/fix-prevent-link-on-card-form
+++ b/changelog/fix-prevent-link-on-card-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: prevent Stripe Link to be shown on the checkout form

--- a/changelog/fix-run-id-for-github-action
+++ b/changelog/fix-run-id-for-github-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix GITHUB_RUN_ID env variable
+
+

--- a/changelog/fix-some-missing-i18n-wrappers
+++ b/changelog/fix-some-missing-i18n-wrappers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: adding some missing i18n wrappers

--- a/changelog/fix-woopay-terms-and-conditions-blocks-default-texts
+++ b/changelog/fix-woopay-terms-and-conditions-blocks-default-texts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed WooPay terms and conditions text for merchants using blocks checkout.

--- a/changelog/update-WOOPMNT-5258-business-details-task-link-to-nox
+++ b/changelog/update-WOOPMNT-5258-business-details-task-link-to-nox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update “Finish setting up WooPayments” task to redirect to NOX flow.

--- a/changelog/update-settings-page-design-audit
+++ b/changelog/update-settings-page-design-audit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: settings page design audit.

--- a/changelog/update-support-phone-input-label-text-in-test-mode
+++ b/changelog/update-support-phone-input-label-text-in-test-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: label text on the support phone number in test mode

--- a/changelog/update-wp-components-after-react-18
+++ b/changelog/update-wp-components-after-react-18
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WP components for development and tests.

--- a/changelog/woopmnt-5248-checkout-optimization-avoid-multiple-payment-method-details
+++ b/changelog/woopmnt-5248-checkout-optimization-avoid-multiple-payment-method-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Generate payment method details in WooPayments instead of Woo core, cache them for performance improvements.

--- a/changelog/woopmnt-5262-payments-transactions-report-link-to-order-id-if-order
+++ b/changelog/woopmnt-5262-payments-transactions-report-link-to-order-id-if-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ignore webhooks whenever the order key in their body does not match the local order.

--- a/changelog/woopmnt-5274-tax-setup-modal-should-not-display-for-unsupported-merchants
+++ b/changelog/woopmnt-5274-tax-setup-modal-should-not-display-for-unsupported-merchants
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix VAT setup modal for unsupported merchants

--- a/readme.txt
+++ b/readme.txt
@@ -87,45 +87,6 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 
 == Changelog ==
 
-= 9.9.0 - 2025-09-03 =
-* Add - Add address autocomplete to Checkout
-* Add - Add support for small screens on the evidence submission form.
-* Fix - fix: adding some missing i18n wrappers
-* Fix - fix: prevent Stripe Link to be shown on the checkout form
-* Fix - Fix checks for the billing details for the BNPL methods on the Pay for Order page.
-* Fix - Fix customer details section when name and/or email are very big.
-* Fix - Fixed WooPay terms and conditions text for merchants using blocks checkout.
-* Fix - Fix Google/Apple Pay "State / County is required" error during checkout for Croatia
-* Fix - Fix margins for phone number input and add styling to match other inputs
-* Fix - Fix the icon border of the Steps component for a dispute.
-* Fix - Fix VAT setup modal for unsupported merchants
-* Fix - Generate payment method details in WooPayments instead of Woo core, cache them for performance improvements.
-* Fix - Ignore webhooks whenever the order key in their body does not match the local order.
-* Fix - Reset the enabled payment methods to default value on account reset.
-* Fix - Show Activate payments notice in WooPayments Settings only for test accounts.
-* Fix - Suppress sending completed-renewal-order email after dispute resolution
-* Update - As of this change, we stop bundling WordPress Components in favor of using the wp.components available in the WordPress installation.
-* Update - Make onboading pages use the pw.components available in the WordPress installation.
-* Update - Make the connect acctount components use the wp.components from the installation.
-* Update - Make the KYC onboarding use the WP components available in the installation.
-* Update - update: ensure Google Pay/Apple Pay can check out w/ LT addresses
-* Update - update: fraud protection rules to use WP components bundled within the WP installation
-* Update - update: label text on the support phone number in test mode
-* Update - update: settings page design audit.
-* Update - Update documents page to use WP components available in the WordPress installation.
-* Update - Update loan page to use the installation WordPress components.
-* Update - Update the "Learn more about disputes" link in the confirmation screen of the disputes documentation.
-* Update - Update WP components for development and tests.
-* Update - Update “Finish setting up WooPayments” task to redirect to NOX flow.
-* Dev - Fix: enhances the robustness of the selectPaymentMethod method in end-to-end tests
-* Dev - Fix: Respond to a dispute e2e tests
-* Dev - Fix: select payment method shopper util
-* Dev - Fix E2E subcription shopper test failures because the core changes text from "Sign up now" to "Add to cart"
-* Dev - Removed all the Progressive Onboarding (PO) code.
-* Dev - update: use React 18
-* Dev - Update JS packages mini-css-extract-plugin and shelljs
-* Dev - Update tested WooCommerce version to 10.1.0
-
 = 9.8.0 - 2025-08-13 =
 * Add - Add address autocomplete to Checkout
 * Add - Add support for small screens on the evidence submission form.


### PR DESCRIPTION
This reverts commit cbe069e80d3e5830456030da53f3f20447052161 by running the changelog on the wrong branch. It should be `release/9.9.0` but I chose `develope` instead. 

Here is the run https://github.com/Automattic/woocommerce-payments/actions/workflows/release-changelog.yml

#### Changes proposed in this Pull Request

- Just revert the previous commit.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just confirm the revert.
