### PR TITLE
Revert "fix: stripe link on card form"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,6 @@
 
 = 9.9.0 - 2025-09-03 =
 * Fix - fix: adding some missing i18n wrappers
-* Fix - fix: prevent Stripe Link to be shown on the checkout form
 * Fix - Fix checks for the billing details for the BNPL methods on the Pay for Order page.
 * Fix - Fixed WooPay terms and conditions text for merchants using blocks checkout.
 * Fix - Fix margins for phone number input and add styling to match other inputs

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -290,7 +290,6 @@ async function createStripePaymentElement(
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
-			link: 'never',
 		},
 	} );
 

--- a/client/checkout/utils/__tests__/upe.test.js
+++ b/client/checkout/utils/__tests__/upe.test.js
@@ -639,7 +639,7 @@ describe( 'getStripeElementOptions', () => {
 				},
 			},
 			terms: { bancontact: 'always', card: 'always', eps: 'always' },
-			wallets: { applePay: 'never', googlePay: 'never', link: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never' },
 		} );
 	} );
 
@@ -687,7 +687,7 @@ describe( 'getStripeElementOptions', () => {
 				},
 			},
 			terms: { bancontact: 'always', card: 'always', eps: 'always' },
-			wallets: { applePay: 'never', googlePay: 'never', link: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never' },
 		} );
 	} );
 
@@ -727,7 +727,7 @@ describe( 'getStripeElementOptions', () => {
 				},
 			},
 			terms: { card: 'never' },
-			wallets: { applePay: 'never', googlePay: 'never', link: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never' },
 		} );
 	} );
 } );

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -258,7 +258,6 @@ export const getStripeElementOptions = (
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
-			link: 'never',
 		},
 	};
 

--- a/readme.txt
+++ b/readme.txt
@@ -89,7 +89,6 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 
 = 9.9.0 - 2025-09-03 =
 * Fix - fix: adding some missing i18n wrappers
-* Fix - fix: prevent Stripe Link to be shown on the checkout form
 * Fix - Fix checks for the billing details for the BNPL methods on the Pay for Order page.
 * Fix - Fixed WooPay terms and conditions text for merchants using blocks checkout.
 * Fix - Fix margins for phone number input and add styling to match other inputs


### PR DESCRIPTION
Fixes #11026
Fixes WOOPMNT-5287

## Changes proposed in this Pull Request

- The fix in the original commit https://github.com/Automattic/woocommerce-payments/pull/10973 is no longer needed.
- I reverted it because it causes the regression [#11026](https://github.com/Automattic/woocommerce-payments/issues/11026). 
   - I found it out because the stable version 9.8.0 is still working with Stripe Like, but the [release candidate 9.9.0](https://github.com/Automattic/woocommerce-payments/actions/runs/17263594323) is not. 
   - In the list of issues/commits for 9.9.0, [#11026](https://github.com/Automattic/woocommerce-payments/issues/11026) is the only one related to Stripe Link. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Test 1 - https://github.com/Automattic/woocommerce-payments/pull/10973 is no longer needed. 

- Ensure you have a US Stripe account
- In the settings page, ensure that Stripe Link is **disabled**. 
- As a logged-in customer, add a product to the cart
- Go to the checkout page
- Set your billing address to US
- **Confirm: The Card form should not show Stripe Link**

#### Test 2 - Stripe Link is working when it's enabled in Settings for this own issue. 

- Ensure you have a US Stripe account
- In the settings page, ensure that Stripe Link is **enabled**. 
- As a logged-in customer, add a product to the cart
- Go to the checkout page
- Set your billing address to US

**Next step is a bit different from the testing step mentioned here https://woocommerce.com/document/woopayments/payment-methods/link-by-stripe/#new-user-experience** - I think that's because Stripe Link has changed the UX. 

1. Wait until the `Link` logo is displayed next to the email. 
<img width="1952" height="448" alt="Screen Shot on 2025-08-30 at 15:13:21" src="https://github.com/user-attachments/assets/6ababb5e-ffb8-4dd8-a82d-aab4e76643b6" />

2. Click on `Link` logo.
3. Fill out the `Card` form
4. After adding all fields: card number, exp, ccv, the section for adding phone number and email for Stripe Link display like this 
<img width="2372" height="2240" alt="Screen Shot on 2025-08-29 at 21:01:27" src="https://github.com/user-attachments/assets/3e3f35cc-1633-41f0-ab73-af53a63054e8" />

5. Choose this option and it will work. 

-------------------

- [x] I removed the relevant changelog entry instead, because we're aiming to merge to the release branch `release/9.9.0`. ~Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.~ 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

> [!IMPORTANT]
> Update the critical flow as mentioned below because the Stripe Link flow has been changed.
> - ✅ [Done](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows/_compare/c3fba39ff8b35c51dcea8585fce066a29bb2db67...bfb4ddd15d233757ee1c7db97eb5ebea579028c2).
 