### PR TITLE
Improve the Payments Overview test account notice

### DIFF
--- a/changelog/update-WOOPMNT-5291-overview-test-account-notice
+++ b/changelog/update-WOOPMNT-5291-overview-test-account-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve messaging around test accounts and development mode on the Payments Overview page.

--- a/client/components/sandbox-mode-switch-to-live-notice/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/index.tsx
@@ -17,6 +17,7 @@ import { ClickTooltip } from 'wcpay/components/tooltip';
 import ErrorBoundary from 'wcpay/components/error-boundary';
 import SetupLivePaymentsModal from './modal';
 import './style.scss';
+import { hasSandboxAccount, hasTestAccount, isInDevMode } from 'wcpay/utils';
 
 interface Props {
 	from: string;
@@ -47,72 +48,310 @@ const SandboxModeSwitchToLiveNotice: React.FC< Props > = ( {
 				className="sandbox-mode-notice"
 				isDismissible={ false }
 			>
-				{ interpolateComponents( {
-					mixedString: sprintf(
-						/* translators: %1$s: WooPayments */
-						__(
-							// eslint-disable-next-line max-len
-							"{{div}}{{strong}}You're using a test account.{{/strong}} To accept payments from shoppers, {{switchToLiveLink}}activate your %1$s account.{{/switchToLiveLink}}{{/div}}{{learnMoreIcon/}}",
-							'woocommerce-payments'
+				{ hasTestAccount() &&
+					! isInDevMode() &&
+					interpolateComponents( {
+						mixedString: sprintf(
+							/* translators: %1$s: WooPayments */
+							__(
+								// eslint-disable-next-line max-len
+								"{{div}}{{strong}}You're using a test account.{{/strong}} To accept payments from shoppers, {{switchToLiveLink}}activate your %1$s account.{{/switchToLiveLink}}{{/div}}{{learnMoreIcon/}}",
+								'woocommerce-payments'
+							),
+							'WooPayments'
 						),
-						'WooPayments'
-					),
-					components: {
-						div: <div />,
-						strong: <strong />,
-						learnMoreIcon: (
-							<ClickTooltip
-								buttonIcon={ <HelpOutlineIcon /> }
-								buttonLabel={ __(
-									'Learn more about test accounts',
-									'woocommerce-payments'
-								) }
-								maxWidth={ '250px' }
-								content={
-									<>
-										{ interpolateComponents( {
-											mixedString: sprintf(
-												/* translators: 1: WooPayments */
-												__(
-													// eslint-disable-next-line max-len
-													'A test account gives you access to all %1$s features while checkout transactions are simulated. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-													'woocommerce-payments'
+						components: {
+							div: <div />,
+							strong: <strong />,
+							learnMoreIcon: (
+								<ClickTooltip
+									buttonIcon={ <HelpOutlineIcon /> }
+									buttonLabel={ __(
+										'Learn more about test accounts',
+										'woocommerce-payments'
+									) }
+									maxWidth={ '250px' }
+									content={
+										<>
+											{ interpolateComponents( {
+												mixedString: sprintf(
+													/* translators: 1: WooPayments */
+													__(
+														// eslint-disable-next-line max-len
+														'A test account gives you access to all %1$s features while checkout transactions are simulated. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+														'woocommerce-payments'
+													),
+													'WooPayments'
 												),
-												'WooPayments'
-											),
-											components: {
-												learnMoreLink: (
-													// eslint-disable-next-line jsx-a11y/anchor-has-content
-													<Link
-														href={
-															// eslint-disable-next-line max-len
-															'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/'
-														}
-														target="_blank"
-														rel="noreferrer"
-														type="external"
-														onClick={ () =>
-															recordEvent(
-																'wcpay_overview_sandbox_mode_learn_more_clicked'
-															)
-														}
-													/>
+												components: {
+													learnMoreLink: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<Link
+															href={
+																// eslint-disable-next-line max-len
+																'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/'
+															}
+															target="_blank"
+															rel="noreferrer"
+															type="external"
+															onClick={ () =>
+																recordEvent(
+																	'wcpay_overview_sandbox_mode_learn_more_clicked',
+																	{
+																		account_type:
+																			'test',
+																		is_dev_mode: false,
+																	}
+																)
+															}
+														/>
+													),
+												},
+											} ) }
+										</>
+									}
+								/>
+							),
+							switchToLiveLink: (
+								<Button
+									variant="link"
+									onClick={ handleCtaClick }
+									__next40pxDefaultSize
+								/>
+							),
+						},
+					} ) }
+				{ hasTestAccount() &&
+					isInDevMode() &&
+					interpolateComponents( {
+						mixedString: sprintf(
+							/* translators: %1$s: WooPayments */
+							__(
+								// eslint-disable-next-line max-len
+								"{{div}}{{strong}}You're using a test account.{{/strong}} ⚠️ Development mode is enabled for the store! There can be no live onboarding process while using development, testing, or staging WordPress environments!{{/div}}{{learnMoreIcon/}}",
+								'woocommerce-payments'
+							),
+							'WooPayments'
+						),
+						components: {
+							div: <div />,
+							strong: <strong />,
+							learnMoreIcon: (
+								<ClickTooltip
+									buttonIcon={ <HelpOutlineIcon /> }
+									buttonLabel={ __(
+										'Learn more about development mode',
+										'woocommerce-payments'
+									) }
+									maxWidth={ '250px' }
+									content={
+										<>
+											{ interpolateComponents( {
+												mixedString: sprintf(
+													/* translators: 1: WooPayments */
+													__(
+														// eslint-disable-next-line max-len
+														'To begin accepting real payments, please go to the live store or change your {{wpEnvLink}}WordPress environment{{/wpEnvLink}} to a production one. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+														'woocommerce-payments'
+													),
+													'WooPayments'
 												),
-											},
-										} ) }
-									</>
-								}
-							/>
+												components: {
+													wpEnvLink: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<Link
+															type="external"
+															target="_blank"
+															rel="noreferrer"
+															href={
+																'https://make.wordpress.org/core/2020/08/27/wordpress-environment-types/'
+															}
+														/>
+													),
+													learnMoreLink: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<Link
+															href={
+																// eslint-disable-next-line max-len
+																'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/#developer-notes'
+															}
+															target="_blank"
+															rel="noreferrer"
+															type="external"
+															onClick={ () =>
+																recordEvent(
+																	'wcpay_overview_sandbox_mode_learn_more_clicked',
+																	{
+																		account_type:
+																			'test',
+																		is_dev_mode: true,
+																	}
+																)
+															}
+														/>
+													),
+												},
+											} ) }
+										</>
+									}
+								/>
+							),
+						},
+					} ) }
+				{ hasSandboxAccount() &&
+					! isInDevMode() &&
+					interpolateComponents( {
+						mixedString: sprintf(
+							/* translators: %1$s: WooPayments */
+							__(
+								// eslint-disable-next-line max-len
+								"{{div}}{{strong}}You're using a sandbox test account.{{/strong}} To accept real payments from shoppers, you will need to first {{resetAccountLink}}reset your account{{/resetAccountLink}} and, then, provide additional details about your business.{{/div}}{{learnMoreIcon/}}",
+								'woocommerce-payments'
+							),
+							'WooPayments'
 						),
-						switchToLiveLink: (
-							<Button
-								variant="link"
-								onClick={ handleCtaClick }
-								__next40pxDefaultSize
-							/>
+						components: {
+							div: <div />,
+							strong: <strong />,
+							resetAccountLink: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<Link
+									href={
+										'https://woocommerce.com/document/woopayments/startup-guide/#resetting'
+									}
+									target="_blank"
+									rel="noreferrer"
+									type="external"
+								/>
+							),
+							learnMoreIcon: (
+								<ClickTooltip
+									buttonIcon={ <HelpOutlineIcon /> }
+									buttonLabel={ __(
+										'Learn more about sandbox accounts',
+										'woocommerce-payments'
+									) }
+									maxWidth={ '250px' }
+									content={
+										<>
+											{ interpolateComponents( {
+												mixedString: sprintf(
+													/* translators: 1: WooPayments */
+													__(
+														// eslint-disable-next-line max-len
+														'A sandbox account gives you access to all %1$s features while checkout transactions are simulated. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+														'woocommerce-payments'
+													),
+													'WooPayments'
+												),
+												components: {
+													learnMoreLink: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<Link
+															href={
+																// eslint-disable-next-line max-len
+																'https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process'
+															}
+															target="_blank"
+															rel="noreferrer"
+															type="external"
+															onClick={ () =>
+																recordEvent(
+																	'wcpay_overview_sandbox_mode_learn_more_clicked',
+																	{
+																		account_type:
+																			'sandbox',
+																		is_dev_mode: false,
+																	}
+																)
+															}
+														/>
+													),
+												},
+											} ) }
+										</>
+									}
+								/>
+							),
+						},
+					} ) }
+				{ hasSandboxAccount() &&
+					isInDevMode() &&
+					interpolateComponents( {
+						mixedString: sprintf(
+							/* translators: %1$s: WooPayments */
+							__(
+								// eslint-disable-next-line max-len
+								'{{div}}{{strong}}You are using a sandbox test account.{{/strong}} ⚠️ Development mode is enabled for the store! There can be no live onboarding process while using development, testing, or staging WordPress environments!{{/div}}{{learnMoreIcon/}}',
+								'woocommerce-payments'
+							),
+							'WooPayments'
 						),
-					},
-				} ) }
+						components: {
+							div: <div />,
+							strong: <strong />,
+							learnMoreIcon: (
+								<ClickTooltip
+									buttonIcon={ <HelpOutlineIcon /> }
+									buttonLabel={ __(
+										'Learn more about development mode',
+										'woocommerce-payments'
+									) }
+									maxWidth={ '250px' }
+									content={
+										<>
+											{ interpolateComponents( {
+												mixedString: sprintf(
+													/* translators: 1: WooPayments */
+													__(
+														// eslint-disable-next-line max-len
+														'To begin accepting real payments, please go to the live store or change your {{wpEnvLink}}WordPress environment{{/wpEnvLink}} to a production one. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+														'woocommerce-payments'
+													),
+													'WooPayments'
+												),
+												components: {
+													wpEnvLink: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<Link
+															type="external"
+															target="_blank"
+															rel="noreferrer"
+															href={
+																'https://make.wordpress.org/core/2020/08/27/wordpress-environment-types/'
+															}
+														/>
+													),
+													learnMoreLink: (
+														// eslint-disable-next-line jsx-a11y/anchor-has-content
+														<Link
+															href={
+																// eslint-disable-next-line max-len
+																'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/#developer-notes'
+															}
+															target="_blank"
+															rel="noreferrer"
+															type="external"
+															onClick={ () =>
+																recordEvent(
+																	'wcpay_overview_sandbox_mode_learn_more_clicked',
+																	{
+																		account_type:
+																			'sandbox',
+																		is_dev_mode: true,
+																	}
+																)
+															}
+														/>
+													),
+												},
+											} ) }
+										</>
+									}
+								/>
+							),
+						},
+					} ) }
 			</BannerNotice>
 			{ livePaymentsModalVisible && (
 				<ErrorBoundary>

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -46,6 +46,7 @@ declare global {
 			email?: string;
 			created: string;
 			isLive?: boolean;
+			testDrive?: boolean;
 			error?: boolean;
 			status?: string;
 			country?: string;

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -33,7 +33,7 @@ import BannerNotice from 'wcpay/components/banner-notice';
 import { MaybeShowMerchantFeedbackPrompt } from 'wcpay/merchant-feedback-prompt';
 import { recordEvent } from 'wcpay/tracks';
 import StripeSpinner from 'wcpay/components/stripe-spinner';
-import { getAdminUrl } from 'wcpay/utils';
+import { getAdminUrl, isInTestModeOnboarding } from 'wcpay/utils';
 import { EmbeddedConnectNotificationBanner } from 'wcpay/embedded-components';
 
 const OverviewPageError = () => {
@@ -92,7 +92,7 @@ const OverviewPage = () => {
 		setStripeNotificationsCountToAddressMemo,
 	] = useState( 0 );
 
-	const isTestModeOnboarding = wcpaySettings.testModeOnboarding;
+	const isTestModeOnboarding = isInTestModeOnboarding();
 	const { isLoading: settingsIsLoading } = useSettings();
 	const [
 		isTestDriveSuccessDisplayed,

--- a/client/utils/__tests__/index.test.js
+++ b/client/utils/__tests__/index.test.js
@@ -6,6 +6,8 @@
 import {
 	getDocumentUrl,
 	getPaymentMethodSettingsUrl,
+	hasTestAccount,
+	hasSandboxAccount,
 	isVersionGreaterOrEqual,
 } from '..';
 
@@ -47,5 +49,153 @@ describe( 'isVersionGreaterOrEqual', () => {
 	it( 'handles versions with missing patch/minor', () => {
 		expect( isVersionGreaterOrEqual( '9.4', '9.4.0' ) ).toBe( true );
 		expect( isVersionGreaterOrEqual( '9', '9.0.0' ) ).toBe( true );
+	} );
+} );
+
+describe( 'hasTestAccount', () => {
+	const originalWcpaySettings = global.wcpaySettings;
+
+	afterEach( () => {
+		global.wcpaySettings = originalWcpaySettings;
+	} );
+
+	it( 'returns false when wcpaySettings is undefined', () => {
+		global.wcpaySettings = undefined;
+		expect( hasTestAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when wcpaySettings is null', () => {
+		global.wcpaySettings = null;
+		expect( hasTestAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when account is not connected', () => {
+		global.wcpaySettings = {
+			isAccountConnected: false,
+			accountStatus: { isLive: false, testDrive: true },
+		};
+		expect( hasTestAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when accountStatus is not an object', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: null,
+		};
+		expect( hasTestAccount() ).toBe( false );
+	} );
+
+	it( 'returns true when account is not live and testDrive is true', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: false, testDrive: true },
+		};
+		expect( hasTestAccount() ).toBe( true );
+	} );
+
+	it( 'returns true when isLive is undefined and testDrive is true', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { testDrive: true },
+		};
+		expect( hasTestAccount() ).toBe( true );
+	} );
+
+	it( 'returns false when account is live', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: true, testDrive: true },
+		};
+		expect( hasTestAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when testDrive is false', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: false, testDrive: false },
+		};
+		expect( hasTestAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when testDrive is undefined', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: false },
+		};
+		expect( hasTestAccount() ).toBe( false );
+	} );
+} );
+
+describe( 'hasSandboxAccount', () => {
+	const originalWcpaySettings = global.wcpaySettings;
+
+	afterEach( () => {
+		global.wcpaySettings = originalWcpaySettings;
+	} );
+
+	it( 'returns false when wcpaySettings is undefined', () => {
+		global.wcpaySettings = undefined;
+		expect( hasSandboxAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when wcpaySettings is null', () => {
+		global.wcpaySettings = null;
+		expect( hasSandboxAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when account is not connected', () => {
+		global.wcpaySettings = {
+			isAccountConnected: false,
+			accountStatus: { isLive: false, testDrive: false },
+		};
+		expect( hasSandboxAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when accountStatus is not an object', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: null,
+		};
+		expect( hasSandboxAccount() ).toBe( false );
+	} );
+
+	it( 'returns true when account is not live and testDrive is false', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: false, testDrive: false },
+		};
+		expect( hasSandboxAccount() ).toBe( true );
+	} );
+
+	it( 'returns true when isLive is undefined and testDrive is false', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { testDrive: false },
+		};
+		expect( hasSandboxAccount() ).toBe( true );
+	} );
+
+	it( 'returns true when isLive is undefined and testDrive is undefined', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: {},
+		};
+		expect( hasSandboxAccount() ).toBe( true );
+	} );
+
+	it( 'returns false when account is live', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: true, testDrive: false },
+		};
+		expect( hasSandboxAccount() ).toBe( false );
+	} );
+
+	it( 'returns false when testDrive is true', () => {
+		global.wcpaySettings = {
+			isAccountConnected: true,
+			accountStatus: { isLive: false, testDrive: true },
+		};
+		expect( hasSandboxAccount() ).toBe( false );
 	} );
 } );

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -42,13 +42,13 @@ export const isInTestMode = ( fallback = false ) => {
 };
 
 /**
- * Returns true if WooPayments is in test/sandbox mode onboarding, false otherwise.
+ * Returns true if WooPayments is in test mode onboarding, false otherwise.
  *
- * @param {boolean} fallback Fallback in case test/sandbox mode onboarding value can't be found
+ * @param {boolean} fallback Fallback in case test mode onboarding value can't be found
  * 							 (for example if the wcpaySettings are undefined).
  *
- * @return {boolean} True if in test/sandbox mode onboarding, false otherwise.
- * 					 Fallback value if test/sandbox mode onboarding value can't be found.
+ * @return {boolean} True if in test mode onboarding, false otherwise.
+ * 					 Fallback value if test mode onboarding value can't be found.
  */
 export const isInTestModeOnboarding = ( fallback = false ) => {
 	if (
@@ -62,11 +62,11 @@ export const isInTestModeOnboarding = ( fallback = false ) => {
 };
 
 /**
- * Returns true if WooPayments is in dev/sandbox mode, false otherwise.
+ * Returns true if WooPayments is in dev mode, false otherwise.
  *
- * @param {boolean} fallback Fallback in case dev/sandbox mode value can't be found (for example if the wcpaySettings are undefined).
+ * @param {boolean} fallback Fallback in case dev mode value can't be found (for example if the wcpaySettings are undefined).
  *
- * @return {boolean} True if in dev/sandbox mode, false otherwise. Fallback value if dev/sandbox mode value can't be found.
+ * @return {boolean} True if in dev mode, false otherwise. Fallback value if dev mode value can't be found.
  */
 export const isInDevMode = ( fallback = false ) => {
 	if (

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -24,6 +24,38 @@ export const isObject = ( value ) => {
 };
 
 /**
+ * Returns true if WooPayments uses a test [drive] account, false otherwise.
+ *
+ * @return {boolean} True if a test [drive] account is connected, false otherwise.
+ */
+export const hasTestAccount = () => {
+	const accountStatus = wcpaySettings?.accountStatus;
+
+	if ( ! wcpaySettings?.isAccountConnected || ! isObject( accountStatus ) ) {
+		return false;
+	}
+
+	// A test [drive] account is one that is not live and is marked as such.
+	return ! accountStatus?.isLive && !! accountStatus?.testDrive;
+};
+
+/**
+ * Returns true if WooPayments uses a sandbox [test] account, false otherwise.
+ *
+ * @return {boolean} True if a sandbox [test] account is connected, false otherwise.
+ */
+export const hasSandboxAccount = () => {
+	const accountStatus = wcpaySettings?.accountStatus;
+
+	if ( ! wcpaySettings?.isAccountConnected || ! isObject( accountStatus ) ) {
+		return false;
+	}
+
+	// A sandbox [test] account is one that is not live and is not a test [drive] account.
+	return ! accountStatus?.isLive && ! accountStatus?.testDrive;
+};
+
+/**
  * Returns true if WooPayments is in test mode, false otherwise.
  *
  * @param {boolean} fallback Test mode fallback value in case test mode value can't be found.


### PR DESCRIPTION
Closes WOOPMNT-5291

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We provide dedicated messaging on the Payments > Overview page activate payments notice for the four combinations:
- test [drive] account not in dev mode
- test [drive] account in dev mode
- sandbox account not in dev mode
- sandbox account in dev mode

This way users are properly informed about the next steps they can take to activate payments.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR's branch on your local installation and build the client assets by running `npm run build`
* Reset/delete any accounts connected.
* Make sure dev mode is not enabled.
* Go to WooCommerce > Settings > Payments and onboard a test account by choosing "Test payments" on the Activate payments NOX step.
* Go to Payments > Overview and you should see the following notice at the top:
<img width="1036" height="782" alt="Screenshot 2025-09-01 at 19 08 59" src="https://github.com/user-attachments/assets/528cdf6a-6285-4f4a-a756-62c7c9bb639b" />

* Go to WCPay Dev Tools and enable dev mode.
* Go back to Payments > Overview and you should see the following notice at the top:
<img width="1035" height="802" alt="Screenshot 2025-09-01 at 19 09 42" src="https://github.com/user-attachments/assets/7178316e-34ba-4e1d-96e2-208028d2998e" />

* Go to WooCommerce > Settings > Payments, reset the current account and onboard a new account, but this time choose "Start accepting payments" on the Activate payments step.
* Complete the KYC in test mode (since dev mode is enabled)
* Go to Payments > Overview and you should see the following notice at the top:
<img width="992" height="989" alt="Screenshot 2025-09-01 at 19 14 36" src="https://github.com/user-attachments/assets/04b312be-37cd-4133-b262-baaef1f9c34c" />

* Go to WCPay Dev Tools and disable dev mode.
* Go back to Payments > Overview and you should see the following notice at the top:
<img width="1058" height="971" alt="Screenshot 2025-09-01 at 19 15 33" src="https://github.com/user-attachments/assets/f2006f7c-78c6-408c-a9cb-78035006321b" />


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
