### PR TITLE
Do not ask for shipping info for digital products

### DIFF
--- a/changelog/dispute-evidence-for-digital-products-has-no-shipping-info
+++ b/changelog/dispute-evidence-for-digital-products-has-no-shipping-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not ask for shipping info for digital products dispute.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -92,7 +92,11 @@ const steps = [
 	},
 ];
 
-function needsShipping( reason: string | undefined ) {
+function needsShipping( reason: string | undefined, productType = '' ) {
+	// If product type is digital, no shipping is needed
+	if ( productType === 'digital_product_or_service' ) return false;
+
+	// Check dispute reason logic
 	if ( ! reason ) return true;
 	if ( ReasonsNoShipping.includes( reason ) ) return false;
 	if ( ReasonsNeedShipping.includes( reason ) ) return true;
@@ -385,7 +389,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	// --- Step logic ---
 	const disputeReason = dispute?.reason;
-	const hasShipping = needsShipping( disputeReason );
+	const hasShipping = needsShipping( disputeReason, productType );
 	const panelHeadings = hasShipping
 		? [ 'Purchase info', 'Shipping details', 'Review' ]
 		: [ 'Purchase info', 'Review' ];
@@ -942,10 +946,10 @@ export default ( { query }: { query: { id: string } } ) => {
 						}
 						tabIndex={ -1 }
 					>
-						{ steps[ reviewStep ].heading }
+						{ steps[ 2 ].heading }
 					</h2>
 					<p className="wcpay-dispute-evidence-new__stepper-subheading">
-						{ steps[ reviewStep ].subheading }
+						{ steps[ 2 ].subheading }
 					</p>
 					{ isCoverLetterManuallyEdited && (
 						<InlineNotice

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -59,14 +59,6 @@ import RefundStatus from './refund-status';
 import DuplicateStatus from './duplicate-status';
 import ConfirmationScreen from './confirmation-screen';
 
-// --- Utility: Determine if shipping is required for a given reason ---
-const ReasonsNeedShipping = [
-	'product_unacceptable',
-	'product_not_received',
-	'general',
-	'fraudulent',
-];
-
 const ReasonsNoShipping = [
 	'duplicate',
 	'subscription_canceled',
@@ -95,11 +87,8 @@ const steps = [
 function needsShipping( reason: string | undefined, productType = '' ) {
 	// If product type is digital, no shipping is needed
 	if ( productType === 'digital_product_or_service' ) return false;
-
 	// Check dispute reason logic
-	if ( ! reason ) return true;
-	if ( ReasonsNoShipping.includes( reason ) ) return false;
-	if ( ReasonsNeedShipping.includes( reason ) ) return true;
+	if ( ReasonsNoShipping.includes( reason || '' ) ) return false;
 	return true;
 }
 


### PR DESCRIPTION
Fixes WOOPMNT-5277

#### Changes proposed in this Pull Request

We should not request shipping details from the merchant when challenging a dispute on a digital product.

#### Testing instructions

* Use a test card to dispute a digital product (Eg card: 4000000000002685) as product not received
* Challenge the dispute as merchant
* Select Digital product
* Notice that shipping details tab is gone

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
