### PR TITLE
Fix: Set `link` wallets option for Stripe Payment Element based on isLinkEnabled

### DIFF
--- a/changelog/fix-conditionally-link-options-in-checkout-form
+++ b/changelog/fix-conditionally-link-options-in-checkout-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Conditionally set Stripe Link wallet option based on payment method configuration

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -290,6 +290,9 @@ async function createStripePaymentElement(
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
+			link: isLinkEnabled( getUPEConfig( 'paymentMethodsConfig' ) )
+				? 'auto'
+				: 'never',
 		},
 	} );
 

--- a/client/checkout/utils/__tests__/upe.test.js
+++ b/client/checkout/utils/__tests__/upe.test.js
@@ -639,7 +639,7 @@ describe( 'getStripeElementOptions', () => {
 				},
 			},
 			terms: { bancontact: 'always', card: 'always', eps: 'always' },
-			wallets: { applePay: 'never', googlePay: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never', link: 'never' },
 		} );
 	} );
 
@@ -687,7 +687,7 @@ describe( 'getStripeElementOptions', () => {
 				},
 			},
 			terms: { bancontact: 'always', card: 'always', eps: 'always' },
-			wallets: { applePay: 'never', googlePay: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never', link: 'never' },
 		} );
 	} );
 
@@ -727,7 +727,50 @@ describe( 'getStripeElementOptions', () => {
 				},
 			},
 			terms: { card: 'never' },
-			wallets: { applePay: 'never', googlePay: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never', link: 'never' },
+		} );
+	} );
+
+	test( 'should return options with link: "auto" when both card and link are available', () => {
+		const shouldSavePayment = false;
+		const paymentMethodsConfig = {
+			card: {
+				isReusable: true,
+			},
+			link: {
+				isReusable: false,
+			},
+		};
+
+		getUPEConfig.mockImplementation( ( argument ) => {
+			if ( argument === 'cartContainsSubscription' ) {
+				return false;
+			}
+		} );
+
+		const options = getStripeElementOptions(
+			shouldSavePayment,
+			paymentMethodsConfig
+		);
+
+		expect( options ).toEqual( {
+			fields: {
+				billingDetails: {
+					address: {
+						city: 'never',
+						country: 'never',
+						line1: 'never',
+						line2: 'never',
+						postalCode: 'never',
+						state: 'never',
+					},
+					email: 'never',
+					name: 'never',
+					phone: 'never',
+				},
+			},
+			terms: { card: 'never' },
+			wallets: { applePay: 'never', googlePay: 'never', link: 'auto' },
 		} );
 	} );
 } );

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -225,6 +225,19 @@ export function dispatchChangeEventFor( element ) {
 }
 
 /**
+ * Check whether Stripe Link is enabled.
+ *
+ * @param {Object} paymentMethodsConfig Checkout payment methods configuration settings object.
+ * @return {boolean} True, if enabled; false otherwise.
+ */
+export const isLinkEnabled = ( paymentMethodsConfig ) => {
+	return (
+		paymentMethodsConfig.link !== undefined &&
+		paymentMethodsConfig.card !== undefined
+	);
+};
+
+/**
  * Returns the prepared set of options needed to initialize the Stripe elements for UPE in Block Checkout.
  * The initial options have all the fields set to 'never' to hide them from the UPE, because all the
  * information is already collected in the checkout form. Additionally, the options are updated with
@@ -258,6 +271,7 @@ export const getStripeElementOptions = (
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
+			link: isLinkEnabled( paymentMethodsConfig ) ? 'auto' : 'never',
 		},
 	};
 
@@ -269,19 +283,6 @@ export const getStripeElementOptions = (
 	options.terms = getTerms( paymentMethodsConfig, showTerms );
 
 	return options;
-};
-
-/**
- * Check whether Stripe Link is enabled.
- *
- * @param {Object} paymentMethodsConfig Checkout payment methods configuration settings object.
- * @return {boolean} True, if enabled; false otherwise.
- */
-export const isLinkEnabled = ( paymentMethodsConfig ) => {
-	return (
-		paymentMethodsConfig.link !== undefined &&
-		paymentMethodsConfig.card !== undefined
-	);
 };
 
 /**


### PR DESCRIPTION
Fixes [WOOPMNT-5299](https://linear.app/a8c/issue/WOOPMNT-5299/add-conditional-handling-for-stripe-link-wallet-option) 

Relevant PRs: 
- #11028 
- #10973

#### Changes proposed in this Pull Request

This PR implements a flexible approach for handling Stripe Link wallet configuration instead of completely removing the link option as in PR #11028 

**What changed:**
- Instead of removing `link: 'never'` completely (as in the reverted commit), the code now conditionally sets the link wallet option based on payment method configuration
- When Link is enabled: sets `link: 'auto'` - this is to fix #11026
- When Link is not enabled: sets `link: 'never'` - this is to fix #10976
- Updated corresponding tests to reflect the conditional behavior

This provides better flexibility and follows the existing `isLinkEnabled()` logic used throughout the codebase, ensuring consistent behavior across different checkout scenarios.

#### Testing instructions

Basically, follow the testing instruction in #11028. However, it's a bit tricky as Stripe is not always enabling `Stripe Link` in the card form, i.e. test 1. 


#### Test 1 - Card form should not show Stripe Link

- Ensure you have a US Stripe account
- In the settings page, ensure that Stripe Link is **disabled**. 
- As a logged-in customer, add a product to the cart
- Go to the checkout page
- Set your billing address to US
- **Confirm: The Card form should not show Stripe Link**

#### Test 2 - Stripe Link is working when it's enabled in Settings for this own issue. 

- Ensure you have a US Stripe account
- In the settings page, ensure that Stripe Link is **enabled**. 
- As a logged-in customer, add a product to the cart
- Go to the checkout page
- Set your billing address to US

Next steps to test Stripe Link: 

1. Wait until the `Link` logo is displayed next to the email. 
<img width="1952" height="448" alt="Screen Shot on 2025-08-30 at 15:13:21" src="https://github.com/user-attachments/assets/6ababb5e-ffb8-4dd8-a82d-aab4e76643b6" />

2. Click on `Link` logo.
3. Fill out the `Card` form
4. After adding all fields: card number, exp, ccv, the section for adding phone number and email for Stripe Link display like this 
<img width="2372" height="2240" alt="Screen Shot on 2025-08-29 at 21:01:27" src="https://github.com/user-attachments/assets/3e3f35cc-1633-41f0-ab73-af53a63054e8" />

5. Choose this option and it will work. 
 
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
