### PR TITLE
Add webhook processing for account.deleted and improve account reset cleanup

### DIFF
--- a/changelog/update-handle-account-deleted-webhooks
+++ b/changelog/update-handle-account-deleted-webhooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Introduce account.deleted webhook processing for a smoother experience when an account is deleted from the Transact Platform.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -982,7 +982,7 @@ class WC_Payments_Admin {
 			'isNextDepositNoticeDismissed'       => WC_Payments_Features::is_next_deposit_notice_dismissed(),
 			'isInstantDepositNoticeDismissed'    => get_option( 'wcpay_instant_deposit_notice_dismissed', false ),
 			'dismissedDuplicateNotices'          => get_option( 'wcpay_duplicate_payment_method_notices_dismissed', [] ),
-			'isConnectionSuccessModalDismissed'  => get_option( 'wcpay_connection_success_modal_dismissed', false ),
+			'isConnectionSuccessModalDismissed'  => get_option( WC_Payments_Onboarding_Service::ONBOARDING_CONNECTION_SUCCESS_MODAL_OPTION, false ),
 			'isOverviewSurveySubmitted'          => get_option( 'wcpay_survey_payment_overview_submitted', false ),
 			'trackingInfo'                       => $this->account->get_tracking_info(),
 			'lifetimeTPV'                        => $this->account->get_lifetime_total_payment_volume(),

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -245,6 +245,35 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	}
 
 	/**
+	 * Delete all known cache entries.
+	 */
+	public function delete_all() {
+		$keys = [
+			self::ACCOUNT_KEY,
+			self::ONBOARDING_FIELDS_DATA_KEY,
+			self::BUSINESS_TYPES_KEY,
+			self::PAYMENT_PROCESS_FACTORS_KEY,
+			self::FRAUD_SERVICES_KEY,
+			self::RECOMMENDED_PAYMENT_METHODS,
+			self::DISPUTE_STATUS_COUNTS_KEY,
+			self::ACTIVE_DISPUTES_KEY,
+			self::AUTHORIZATION_SUMMARY_KEY,
+			self::AUTHORIZATION_SUMMARY_KEY_TEST_MODE,
+			self::CONNECT_INCENTIVE_KEY,
+			self::TRACKING_INFO_KEY,
+		];
+
+		foreach ( $keys as $key ) {
+			$this->delete( $key );
+		}
+
+		// Delete prefix-based keys.
+		$this->delete_by_prefix( self::PAYMENT_METHODS_KEY_PREFIX );
+		$this->delete_by_prefix( self::ONBOARDING_FIELDS_DATA_KEY ); // It can be prefixed with the locale.
+		$this->delete_by_prefix( self::RECOMMENDED_PAYMENT_METHODS ); // It can be prefixed with the locale.
+	}
+
+	/**
 	 * Hook function allowing the cache refresh to be selectively disabled in certain situations
 	 * (such as while running an Action Scheduler job). While the refresh is disabled, get_or_add
 	 * will only return the cached value and never regenerate it, even if it's expired.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -40,7 +40,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	const TRACKS_EVENT_ACCOUNT_CONNECT_FINISHED                 = 'wcpay_account_connect_finished';
 	const TRACKS_EVENT_KYC_REMINDER_MERCHANT_RETURNED           = 'wcpay_kyc_reminder_merchant_returned';
 	const TRACKS_EVENT_ACCOUNT_REFERRAL                         = 'wcpay_account_referral';
-	const NOX_PROFILE_OPTION_KEY                                = 'woocommerce_woopayments_nox_profile';
+	// NOX-related constants from the WooCommerce core.
+	const NOX_PROFILE_OPTION_KEY    = 'woocommerce_woopayments_nox_profile';
+	const NOX_ONBOARDING_LOCKED_KEY = 'woocommerce_woopayments_nox_onboarding_locked';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -885,15 +885,17 @@ class WC_Payments_Onboarding_Service {
 
 		update_option( '_wcpay_onboarding_stripe_connected', [] );
 		update_option( self::TEST_MODE_OPTION, 'no' );
+		self::clear_account_options();
 
 		// Discard any ongoing onboarding session.
 		delete_transient( WC_Payments_Account::ONBOARDING_STATE_TRANSIENT );
-		delete_option( WC_Payments_Account::EMBEDDED_KYC_IN_PROGRESS_OPTION );
+		$this->clear_embedded_kyc_in_progress();
 		delete_transient( WC_Payments_Account::WOOPAY_ENABLED_BY_DEFAULT_TRANSIENT );
 		$this->clear_onboarding_init_in_progress();
 
-		// Clear the cache to avoid stale data.
-		WC_Payments::get_account_service()->clear_cache();
+		// Clear the entire database cache since everything hinges on the account.
+		// If the account is gone, everything else is too.
+		$this->database_cache->delete_all();
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -636,7 +636,7 @@ class WC_Payments {
 		self::$card_gateway->init_hooks();
 		self::$wc_payments_checkout->init_hooks();
 
-		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::get_gateway(), self::$customer_service, self::$database_cache );
+		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::get_gateway(), self::$customer_service, self::$database_cache, self::$onboarding_service );
 		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 
 		self::$customer_service_api = new WC_Payments_Customer_Service_API( self::$customer_service );

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -443,11 +443,20 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'quantity'                 => 1,
 			'addons_price_before_calc' => 10,
 		];
-		$expected  = [
-			'name'    => 'Customer defined price',
-			'value'   => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'display' => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-		];
+
+		if ( version_compare( WC_VERSION, '10.2.0-dev', '<' ) ) {
+			$expected = [
+				'name'    => 'Customer defined price',
+				'value'   => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+				'display' => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			];
+		} else {
+			$expected = [
+				'name'    => 'Customer defined price',
+				'value'   => ' (<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+				'display' => ' (<span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			];
+		}
 
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
 	}
@@ -467,11 +476,19 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'data'     => WC_Helper_Product::create_simple_product(),
 			'quantity' => 1,
 		];
-		$expected  = [
-			'name'    => 'Multiplier',
-			'value'   => '2 (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'display' => '',
-		];
+		if ( version_compare( WC_VERSION, '10.2.0-dev', '<' ) ) {
+			$expected = [
+				'name'    => 'Multiplier',
+				'value'   => '2 (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+				'display' => '',
+			];
+		} else {
+			$expected = [
+				'name'    => 'Multiplier',
+				'value'   => '2 (+ <span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+				'display' => '',
+			];
+		}
 
 		$this->mock_multi_currency
 			->expects( $this->exactly( 2 ) )
@@ -503,11 +520,20 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'data'     => WC_Helper_Product::create_simple_product(),
 			'quantity' => 1,
 		];
-		$expected  = [
-			'name'    => 'Checkbox',
-			'value'   => 'Flat fee (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'display' => '',
-		];
+
+		if ( version_compare( WC_VERSION, '10.2.0-dev', '<' ) ) {
+			$expected = [
+				'name'    => 'Checkbox',
+				'value'   => 'Flat fee (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+				'display' => '',
+			];
+		} else {
+			$expected = [
+				'name'    => 'Checkbox',
+				'value'   => 'Flat fee (+ <span class="woocommerce-Price-amount amount"><bdi class="woocommerce-Price-bidi"><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+				'display' => '',
+			];
+		}
 
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price );
 		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );


### PR DESCRIPTION
Contributes to WOOPMNT-5301

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We handle `account.deleted` webhooks, alongside the `account.updated` ones, and enforce a much more extensive cleanup when the connected account is deleted:
- the entire onboarding is reset
- the gateway settings are reset
- any account-related options are removed
- and _all_ the database cache known entries are removed since they all depend on the now deleted account - this ensures that when people reset their account (and maybe stop using WooPayments) their database is clean.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The unit tests should pass.
* Follow the testing instructions in [the sister platform PR](https://github.com/Automattic/transact-platform-server/pull/7653)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
