### PR TITLE
Fix item data assertions in WooCommerce Product Add-Ons tests

### DIFF
--- a/changelog/fix-wc-compat-beta-product-addons-test
+++ b/changelog/fix-wc-compat-beta-product-addons-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixes Compatibility tests failing in CI
+
+

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -405,12 +405,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 
 		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
-		// Compare user-facing values.
-		$this->assertSame( $expected['name'], $actual['name'] );
-		// Only check label for zero price case.
-		$this->assertSame( $expected['name'], $actual['name'] );
-		$this->assertSame( $expected['value'], strip_tags( $actual['value'] ) );
-		$this->assertSame( $expected['display'], strip_tags( $actual['display'] ) );
+		$this->assertSame( $expected, $this->array_strip_tags( $actual ) );
 	}
 
 	public function test_get_item_data_returns_zero_percentage_price_data_correctly() {
@@ -434,11 +429,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 
 		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
-		$this->assertSame( $expected['name'], $actual['name'] );
-		// Only check label for zero percentage price case.
-		$this->assertSame( $expected['name'], $actual['name'] );
-		$this->assertSame( $expected['value'], strip_tags( $actual['value'] ) );
-		$this->assertSame( $expected['display'], strip_tags( $actual['display'] ) );
+		$this->assertSame( $expected, $this->array_strip_tags( $actual ) );
 	}
 
 	public function test_get_item_data_returns_custom_price_data_correctly() {

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -457,14 +457,12 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 		$expected  = [
 			'name'    => 'Customer defined price',
-			'value'   => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'display' => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			'value'   => ' (&#36;42.00)',
+			'display' => ' (&#36;42.00)',
 		];
 
 		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
-		$this->assertSame( $expected['name'], $actual['name'] );
-		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['value'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
-		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['display'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
+		$this->assertSame( $expected, $this->array_strip_tags( $actual ) );
 	}
 
 	public function test_get_item_data_returns_multiplier_price_data_correctly() {
@@ -484,8 +482,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 		$expected  = [
 			'name'    => 'Multiplier',
-			'value'   => '42.00',
-			'display' => '42.00',
+			'value'   => '2 (+ &#36;42.00)',
+			'display' => '',
 		];
 
 		$this->mock_multi_currency
@@ -501,9 +499,7 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			);
 
 		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
-		$this->assertSame( $expected['name'], $actual['name'] );
-		$this->assertNotEmpty( $actual['value'], 'Multiplier price data value should not be empty.' );
-		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['value'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), 'Multiplier price data value does not contain currency symbol and value.' );
+		$this->assertSame( $expected, $this->array_strip_tags( $actual ) );
 	}
 
 	// Handles flat_fee and quantity_based.
@@ -523,15 +519,13 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 		$expected  = [
 			'name'    => 'Checkbox',
-			'value'   => 'Flat fee (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
+			'value'   => 'Flat fee (+ &#36;42.00)',
 			'display' => '',
 		];
 
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price );
 		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
-		$this->assertSame( $expected['name'], $actual['name'] );
-		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['value'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), 'Price data value does not contain currency symbol and value.' );
-		$this->assertSame( '', $actual['display'], 'Checkbox display should be empty.' );
+		$this->assertSame( $expected, $this->array_strip_tags( $actual ) );
 	}
 
 	public function test_get_item_data_returns_percentage_price_data_correctly() {
@@ -558,8 +552,26 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 
 		$this->mock_multi_currency->method( 'get_price' )->with( 10, 'product' )->willReturn( 10.00 );
 		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
-		$this->assertSame( $expected['name'], $actual['name'] );
-		$this->assertSame( $expected['value'], strip_tags( $actual['value'] ) );
-		$this->assertSame( $expected['display'], $actual['display'] );
+		$this->assertSame( $expected, $this->array_strip_tags( $actual ) );
+	}
+
+	/**
+	 * Strip HTML tags from all values in an array while preserving keys.
+	 *
+	 * @param array $array The array to process.
+	 * @return array The array with HTML tags stripped from all values.
+	 */
+	private function array_strip_tags( array $array ): array {
+		$result = [];
+		foreach ( $array as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$result[ $key ] = $this->array_strip_tags( $value );
+			} elseif ( is_string( $value ) ) {
+				$result[ $key ] = strip_tags( $value );
+			} else {
+				$result[ $key ] = $value;
+			}
+		}
+		return $result;
 	}
 }

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-product-add-ons.php
@@ -221,7 +221,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'key'   => 'checkboxes',
 			'value' => 42.0,
 		];
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->order_line_item_meta( [ 'key' => 'checkboxes' ], $addon, $item, [ 'data' => '' ] ) );
+		$actual   = $this->woocommerce_product_add_ons->order_line_item_meta( [ 'key' => 'checkboxes' ], $addon, $item, [ 'data' => '' ] );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_update_product_price_returns_flat_fee_data_correctly() {
@@ -403,7 +404,13 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'display' => 'display',
 		];
 
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
+		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
+		// Compare user-facing values.
+		$this->assertSame( $expected['name'], $actual['name'] );
+		// Only check label for zero price case.
+		$this->assertSame( $expected['name'], $actual['name'] );
+		$this->assertSame( $expected['value'], strip_tags( $actual['value'] ) );
+		$this->assertSame( $expected['display'], strip_tags( $actual['display'] ) );
 	}
 
 	public function test_get_item_data_returns_zero_percentage_price_data_correctly() {
@@ -426,7 +433,12 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'display' => '',
 		];
 
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
+		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
+		$this->assertSame( $expected['name'], $actual['name'] );
+		// Only check label for zero percentage price case.
+		$this->assertSame( $expected['name'], $actual['name'] );
+		$this->assertSame( $expected['value'], strip_tags( $actual['value'] ) );
+		$this->assertSame( $expected['display'], strip_tags( $actual['display'] ) );
 	}
 
 	public function test_get_item_data_returns_custom_price_data_correctly() {
@@ -449,7 +461,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 			'display' => ' (<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
 		];
 
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
+		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
+		$this->assertSame( $expected['name'], $actual['name'] );
+		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['value'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
+		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['display'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
 	}
 
 	public function test_get_item_data_returns_multiplier_price_data_correctly() {
@@ -469,8 +484,8 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 		$expected  = [
 			'name'    => 'Multiplier',
-			'value'   => '2 (+ <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&#36;</span>42.00</bdi></span>)',
-			'display' => '',
+			'value'   => '42.00',
+			'display' => '42.00',
 		];
 
 		$this->mock_multi_currency
@@ -485,7 +500,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 				(float) $price / $value
 			);
 
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
+		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
+		$this->assertSame( $expected['name'], $actual['name'] );
+		$this->assertNotEmpty( $actual['value'], 'Multiplier price data value should not be empty.' );
+		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['value'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), 'Multiplier price data value does not contain currency symbol and value.' );
 	}
 
 	// Handles flat_fee and quantity_based.
@@ -510,7 +528,10 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 
 		$this->mock_multi_currency->method( 'get_price' )->with( $price, 'product' )->willReturn( (float) $price );
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
+		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
+		$this->assertSame( $expected['name'], $actual['name'] );
+		$this->assertStringContainsString( '$42.00', html_entity_decode( strip_tags( $actual['value'] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ), 'Price data value does not contain currency symbol and value.' );
+		$this->assertSame( '', $actual['display'], 'Checkbox display should be empty.' );
 	}
 
 	public function test_get_item_data_returns_percentage_price_data_correctly() {
@@ -536,6 +557,9 @@ class WCPay_Multi_Currency_WooCommerceProductAddOns_Tests extends WCPAY_UnitTest
 		];
 
 		$this->mock_multi_currency->method( 'get_price' )->with( 10, 'product' )->willReturn( 10.00 );
-		$this->assertSame( $expected, $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item ) );
+		$actual = $this->woocommerce_product_add_ons->get_item_data( [], $addon, $cart_item );
+		$this->assertSame( $expected['name'], $actual['name'] );
+		$this->assertSame( $expected['value'], strip_tags( $actual['value'] ) );
+		$this->assertSame( $expected['display'], $actual['display'] );
 	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5300

#### Changes proposed in this Pull Request

Refactor WooCommerce Product Add-Ons multi-currency tests to use a new `array_strip_tags` utility for markup-agnostic assertions.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm all tests pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
