### PR TITLE
New Account Details: Add feature flag, TypeScript definition, and basic component

### DIFF
--- a/changelog/woopmnt-5281-implement-feature-flag-for-client-and-a-skeleton-component
+++ b/changelog/woopmnt-5281-implement-feature-flag-for-client-and-a-skeleton-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New AccountDetails: Add feature flag, TypeScript definition, and basic component

--- a/client/components/account-details/__tests__/index.test.tsx
+++ b/client/components/account-details/__tests__/index.test.tsx
@@ -1,0 +1,48 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AccountDetails from '../index';
+import type { AccountDetailsType } from 'wcpay/types/account/account-details';
+
+describe( 'AccountDetails', () => {
+	test( 'renders error when accountDetails is null', () => {
+		const accountDetails: AccountDetailsType = null;
+
+		render( <AccountDetails accountDetails={ accountDetails } /> );
+
+		expect(
+			screen.getByText( 'Error loading account details.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Account details' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders account details content when data is provided', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Active',
+				background_color: 'green',
+			},
+			payout_status: {
+				text: 'Available',
+				background_color: 'green',
+				icon: 'published',
+			},
+			banner: null,
+		};
+
+		render( <AccountDetails accountDetails={ accountDetails } /> );
+
+		expect( screen.getByText( 'Account details' ) ).toBeInTheDocument();
+		expect( screen.getByText( /"account_status"/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /"payout_status"/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /"banner": null/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -1,0 +1,78 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Card, CardBody, CardHeader, FlexItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import {
+	AccountDetailsType,
+	AccountDetailsData,
+} from 'wcpay/types/account/account-details';
+
+interface AccountDetailsCardProps {
+	title: React.ReactNode;
+	children?: React.ReactNode;
+	value?: React.ReactNode;
+}
+
+const AccountDetailsCard = ( props: AccountDetailsCardProps ) => {
+	const { title, children, value } = props;
+	return (
+		<Card size="medium">
+			<CardHeader className="woocommerce-account-details__header">
+				{ title }
+			</CardHeader>
+			<CardBody>{ children || value || null }</CardBody>
+		</Card>
+	);
+};
+
+const AccountDetailsError = () => {
+	const cardTitle = __( 'Account details', 'woocommerce-payments' );
+	return (
+		<AccountDetailsCard title={ cardTitle }>
+			{ __( 'Error loading account details.', 'woocommerce-payments' ) }
+		</AccountDetailsCard>
+	);
+};
+
+const AccountDetailsContent = ( {
+	accountDetails,
+}: {
+	accountDetails: AccountDetailsData;
+} ) => {
+	const cardTitle = (
+		<>
+			<FlexItem className={ 'account-details-title' }>
+				{ __( 'Account details', 'woocommerce-payments' ) }
+			</FlexItem>
+		</>
+	);
+
+	return (
+		<AccountDetailsCard title={ cardTitle }>
+			<pre>{ JSON.stringify( accountDetails, null, 2 ) }</pre>
+		</AccountDetailsCard>
+	);
+};
+
+const AccountDetails = ( {
+	accountDetails,
+}: {
+	accountDetails: AccountDetailsType;
+} ) => {
+	return null === accountDetails ? (
+		<AccountDetailsError />
+	) : (
+		<AccountDetailsContent accountDetails={ accountDetails } />
+	);
+};
+
+export default AccountDetails;

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -1,0 +1,7 @@
+.woocommerce-account-details__header {
+	h2 {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+	}
+}

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -4,7 +4,7 @@
 import type { MccsDisplayTreeItem, Country } from 'onboarding/types';
 import { PaymentMethodToPluginsMap } from './components/duplicate-notice';
 import { WCPayExpressCheckoutParams } from './express-checkout/utils';
-import { AccountDetails } from 'wcpay/types/account/account-details';
+import { AccountDetailsType } from 'wcpay/types/account/account-details';
 
 declare global {
 	interface TosSettingsStripeConnected {
@@ -100,7 +100,7 @@ declare global {
 			has_past_loans: boolean;
 			loans: Array< string >;
 		};
-		accountDetails: null | undefined | AccountDetails;
+		accountDetails: AccountDetailsType;
 		connect: {
 			country: string;
 			availableStates: Array< Record< string, string > >;

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -4,6 +4,7 @@
 import type { MccsDisplayTreeItem, Country } from 'onboarding/types';
 import { PaymentMethodToPluginsMap } from './components/duplicate-notice';
 import { WCPayExpressCheckoutParams } from './express-checkout/utils';
+import { AccountDetails } from 'wcpay/types/account/account-details';
 
 declare global {
 	interface TosSettingsStripeConnected {
@@ -32,6 +33,7 @@ declare global {
 			isDisputeIssuerEvidenceEnabled: boolean;
 			multiCurrency?: boolean;
 			isFRTReviewFeatureActive: boolean;
+			isAccountDetailsEnabled: boolean;
 		};
 		accountFees: Record< string, any >;
 		fraudServices: unknown[];
@@ -98,6 +100,7 @@ declare global {
 			has_past_loans: boolean;
 			loans: Array< string >;
 		};
+		accountDetails: null | undefined | AccountDetails;
 		connect: {
 			country: string;
 			availableStates: Array< Record< string, string > >;

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -15,6 +15,7 @@ import { Card, Notice, ExternalLink } from '@wordpress/components';
  */
 import AccountBalances from 'components/account-balances';
 import AccountStatus from 'components/account-status';
+import AccountDetails from 'components/account-details';
 import ActiveLoanSummary from 'components/active-loan-summary';
 import ConnectionSuccessModal from './modal/connection-success';
 import DepositsOverview from 'components/deposits-overview';
@@ -64,6 +65,8 @@ const OverviewPage = () => {
 		accountLoans: { has_active_loan: hasActiveLoan },
 		overviewTasksVisibility,
 		wpcomReconnectUrl,
+		featureFlags: { isAccountDetailsEnabled },
+		accountDetails,
 	} = wcpaySettings;
 
 	// Don't show the update details and verify business tasks by default due to embedded component.
@@ -373,10 +376,14 @@ const OverviewPage = () => {
 				</ErrorBoundary>
 			) }
 			<ErrorBoundary>
-				<AccountStatus
-					accountStatus={ accountStatus }
-					accountFees={ activeAccountFees }
-				/>
+				{ isAccountDetailsEnabled && accountDetails ? (
+					<AccountDetails accountDetails={ accountDetails } />
+				) : (
+					<AccountStatus
+						accountStatus={ accountStatus }
+						accountFees={ activeAccountFees }
+					/>
+				) }
 			</ErrorBoundary>
 			{ hasActiveLoan && (
 				<ErrorBoundary>

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -1,0 +1,23 @@
+export interface AccountDetails {
+	account_status: {
+		text: string;
+		background_color: 'green' | 'yellow' | 'red';
+	};
+	payout_status: {
+		text: string;
+		background_color: 'green' | 'yellow' | 'red';
+		icon: 'published' | 'caution' | 'error';
+		popover?: {
+			text: string;
+			cta_text: string;
+			cta_link: string;
+		} | null;
+	};
+	banner?: {
+		text: string;
+		background_color: 'yellow' | 'red';
+		cta_text?: string;
+		cta_link?: string;
+		icon: 'caution';
+	} | null;
+}

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -1,4 +1,4 @@
-export interface AccountDetails {
+export interface AccountDetailsData {
 	account_status: {
 		text: string;
 		background_color: 'green' | 'yellow' | 'red';
@@ -21,3 +21,5 @@ export interface AccountDetails {
 		icon: 'caution';
 	} | null;
 }
+
+export type AccountDetailsType = AccountDetailsData | null;

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -887,9 +887,8 @@ class WC_Payments_Admin {
 			];
 		}
 
-		$account_status_data  = $this->account->get_account_status_data();
-		$account_details_data = $this->account->get_account_details();
-		$account_is_valid     = $this->account->is_stripe_account_valid();
+		$account_status_data = $this->account->get_account_status_data();
+		$account_is_valid    = $this->account->is_stripe_account_valid();
 
 		$test_mode = false;
 		try {
@@ -954,7 +953,7 @@ class WC_Payments_Admin {
 			'accountFees'                        => $this->account->get_fees(),
 			'accountLoans'                       => $this->account->get_capital(),
 			'accountEmail'                       => $this->account->get_account_email(),
-			'accountDetails'                     => $account_details_data,
+			'accountDetails'                     => $this->account->get_account_details(),
 			'showUpdateDetailsTask'              => $this->get_should_show_update_business_details_task( $account_status_data ),
 			'wpcomReconnectUrl'                  => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
 			'multiCurrencySetup'                 => [

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -887,8 +887,9 @@ class WC_Payments_Admin {
 			];
 		}
 
-		$account_status_data = $this->account->get_account_status_data();
-		$account_is_valid    = $this->account->is_stripe_account_valid();
+		$account_status_data  = $this->account->get_account_status_data();
+		$account_details_data = $this->account->get_account_details();
+		$account_is_valid     = $this->account->is_stripe_account_valid();
 
 		$test_mode = false;
 		try {
@@ -953,6 +954,7 @@ class WC_Payments_Admin {
 			'accountFees'                        => $this->account->get_fees(),
 			'accountLoans'                       => $this->account->get_capital(),
 			'accountEmail'                       => $this->account->get_account_email(),
+			'accountDetails'                     => $account_details_data,
 			'showUpdateDetailsTask'              => $this->get_should_show_update_business_details_task( $account_status_data ),
 			'wpcomReconnectUrl'                  => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
 			'multiCurrencySetup'                 => [

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -392,11 +392,8 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$account_details = $account['account_details'];
-		if ( isset( $account_details['account_status'], $account_details['payout_status'], $account_details['banner'] ) ) {
-			return null;
-		}
-
-		return $account_details;
+		$is_valid        = isset( $account_details['account_status'], $account_details['payout_status'] ) && array_key_exists( 'banner', $account_details );
+		return $is_valid ? $account_details : null;
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -392,7 +392,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 
 		$account_details = $account['account_details'];
-		$is_valid        = isset( $account_details['account_status'], $account_details['payout_status'] ) && array_key_exists( 'banner', $account_details );
+		$is_valid        = is_array( $account_details )
+							&& isset( $account_details['account_status'], $account_details['payout_status'] )
+							&& array_key_exists( 'banner', $account_details );
 		return $is_valid ? $account_details : null;
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -381,6 +381,25 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	}
 
 	/**
+	 * Get structured account details including status, payout info, and banners for frontend display.
+	 *
+	 * @return null|array Account details array with nested status objects, or null if unavailable.
+	 */
+	public function get_account_details(): ?array {
+		$account = $this->get_cached_account_data();
+		if ( empty( $account['account_details'] ) ) {
+			return null;
+		}
+
+		$account_details = $account['account_details'];
+		if ( isset( $account_details['account_status'], $account_details['payout_status'], $account_details['banner'] ) ) {
+			return null;
+		}
+
+		return $account_details;
+	}
+
+	/**
 	 * Gets the account statement descriptor for rendering on the settings page.
 	 *
 	 * @return string Account statement descriptor.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -28,6 +28,7 @@ class WC_Payments_Features {
 	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME      = '_wcpay_feature_woopay_direct_checkout';
 	const DISPUTE_ISSUER_EVIDENCE               = '_wcpay_feature_dispute_issuer_evidence';
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME = '_wcpay_feature_woopay_global_theme_support';
+	const ACCOUNT_DETAILS_FLAG_NAME             = '_wcpay_feature_account_details';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -331,6 +332,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the Account Details feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_account_details_enabled(): bool {
+		return '1' === get_option( self::ACCOUNT_DETAILS_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -344,6 +354,7 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'          => self::is_woopay_express_checkout_enabled(),
 				'isDisputeIssuerEvidenceEnabled' => self::is_dispute_issuer_evidence_enabled(),
 				'isFRTReviewFeatureActive'       => self::is_frt_review_feature_active(),
+				'isAccountDetailsEnabled'        => self::is_account_details_enabled(),
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3477,4 +3477,103 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		$current_screen->method( 'in_admin' )->willReturn( $is_admin );
 	}
+
+	public function test_get_account_details_returns_null_when_empty() {
+		$this->mock_database_cache->method( 'get' )->willReturn( [] );
+
+		$result = $this->wcpay_account->get_account_details();
+
+		$this->assertNull( $result );
+	}
+
+	public function test_get_account_details_returns_null_when_missing_key() {
+		$cached_account_data = [
+			'some_other_key' => 'some_value',
+		];
+
+		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+
+		$result = $this->wcpay_account->get_account_details();
+
+		$this->assertNull( $result );
+	}
+
+	public function test_get_account_details_returns_null_when_invalid_structure() {
+		$cached_account_data = [
+			'account_details' => [
+				'account_status' => [
+					'text'             => 'Active',
+					'background_color' => 'green',
+				],
+				// Missing payout_status - invalid structure.
+			],
+		];
+
+		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+
+		$result = $this->wcpay_account->get_account_details();
+
+		$this->assertNull( $result );
+	}
+
+	public function test_get_account_details_returns_valid_data_minimal() {
+		$account_details = [
+			'account_status' => [
+				'text'             => 'Active',
+				'background_color' => 'green',
+			],
+			'payout_status'  => [
+				'text'             => 'Available',
+				'background_color' => 'green',
+				'icon'             => 'published',
+			],
+			'banner'         => null,
+		];
+
+		$cached_account_data = [
+			'account_details' => $account_details,
+		];
+
+		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+
+		$result = $this->wcpay_account->get_account_details();
+
+		$this->assertEquals( $account_details, $result );
+	}
+
+	public function test_get_account_details_returns_valid_data_with_banner() {
+		$account_details = [
+			'account_status' => [
+				'text'             => 'Restricted',
+				'background_color' => 'red',
+			],
+			'payout_status'  => [
+				'text'             => 'Suspended',
+				'background_color' => 'red',
+				'icon'             => 'error',
+				'popover'          => [
+					'text'     => 'Account suspended',
+					'cta_text' => 'Learn more',
+					'cta_link' => 'https://example.com',
+				],
+			],
+			'banner'         => [
+				'text'             => 'Account needs attention',
+				'background_color' => 'yellow',
+				'cta_text'         => 'Fix now',
+				'cta_link'         => 'https://example.com/fix',
+				'icon'             => 'caution',
+			],
+		];
+
+		$cached_account_data = [
+			'account_details' => $account_details,
+		];
+
+		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+
+		$result = $this->wcpay_account->get_account_details();
+
+		$this->assertEquals( $account_details, $result );
+	}
 }

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3479,7 +3479,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_get_account_details_returns_null_when_empty() {
-		$this->mock_database_cache->method( 'get' )->willReturn( [] );
+		$this->cache_account_details( [] );
 
 		$result = $this->wcpay_account->get_account_details();
 
@@ -3488,10 +3488,11 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 	public function test_get_account_details_returns_null_when_missing_key() {
 		$cached_account_data = [
+			'is_live'        => true,
 			'some_other_key' => 'some_value',
 		];
 
-		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+		$this->cache_account_details( $cached_account_data );
 
 		$result = $this->wcpay_account->get_account_details();
 
@@ -3499,7 +3500,9 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_get_account_details_returns_null_when_invalid_structure() {
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 		$cached_account_data = [
+			'is_live'         => true,
 			'account_details' => [
 				'account_status' => [
 					'text'             => 'Active',
@@ -3509,7 +3512,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 			],
 		];
 
-		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+		$this->cache_account_details( $cached_account_data );
 
 		$result = $this->wcpay_account->get_account_details();
 
@@ -3517,6 +3520,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_get_account_details_returns_valid_data_minimal() {
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 		$account_details = [
 			'account_status' => [
 				'text'             => 'Active',
@@ -3531,10 +3535,11 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		];
 
 		$cached_account_data = [
+			'is_live'         => true,
 			'account_details' => $account_details,
 		];
 
-		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+		$this->cache_account_details( $cached_account_data );
 
 		$result = $this->wcpay_account->get_account_details();
 
@@ -3542,6 +3547,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_get_account_details_returns_valid_data_with_banner() {
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 		$account_details = [
 			'account_status' => [
 				'text'             => 'Restricted',
@@ -3567,10 +3573,11 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		];
 
 		$cached_account_data = [
+			'is_live'         => true,
 			'account_details' => $account_details,
 		];
 
-		$this->mock_database_cache->method( 'get' )->willReturn( $cached_account_data );
+		$this->cache_account_details( $cached_account_data );
 
 		$result = $this->wcpay_account->get_account_details();
 

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -323,4 +323,29 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 			remove_all_filters( 'pre_option_' . $option );
 		}
 	}
+
+	public function test_is_account_details_enabled_returns_false_when_disabled() {
+		$this->set_feature_flag_option( WC_Payments_Features::ACCOUNT_DETAILS_FLAG_NAME, '0' );
+
+		$result = WC_Payments_Features::is_account_details_enabled();
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_account_details_enabled_returns_true_when_enabled() {
+		$this->set_feature_flag_option( WC_Payments_Features::ACCOUNT_DETAILS_FLAG_NAME, '1' );
+
+		$result = WC_Payments_Features::is_account_details_enabled();
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_to_array_includes_account_details_flag() {
+		$this->set_feature_flag_option( WC_Payments_Features::ACCOUNT_DETAILS_FLAG_NAME, '1' );
+
+		$result = WC_Payments_Features::to_array();
+
+		$this->assertArrayHasKey( 'isAccountDetailsEnabled', $result );
+		$this->assertTrue( $result['isAccountDetailsEnabled'] );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5281

#### Changes proposed in this Pull Request

- Add feature flag, TypeScript definition, and basic component for New Account Details.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `wp option set _wcpay_feature_account_details 1` to enable the client feature flag.
* Check out server PR 7662 and add the proper account meta flag. 
* Visit WooPayments > Settings and confirm the new component is being used. For now, it's just displaying the JSON content from the server `account_details`. There will be a follow-up issue WOOPMNT-5282 to implement this component completely: 

<img width="4072" height="1944" alt="Screen Shot on 2025-09-08 at 16:03:40" src="https://github.com/user-attachments/assets/d326e069-9a7a-4108-8ad5-d56ef803c8e8" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
