### PR TITLE
Remove MultiCurrency clear_cache method

### DIFF
--- a/changelog/fix-mc-cache-clear
+++ b/changelog/fix-mc-cache-clear
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Removed clear_cache method from the mutli-currency interface

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -266,11 +266,6 @@ class MultiCurrency {
 	public function init() {
 		$store_currency_updated = $this->check_store_currency_for_change();
 
-		// If the store currency has been updated, clear the cache to make sure we fetch fresh rates from the server.
-		if ( $store_currency_updated ) {
-			$this->clear_cache();
-		}
-
 		$this->initialize_available_currencies();
 		$this->set_default_currency();
 		$this->initialize_enabled_currencies();
@@ -406,16 +401,6 @@ class MultiCurrency {
 		$config['isMultiCurrencyEnabled'] = true;
 
 		return $config;
-	}
-
-	/**
-	 * Wipes the cached currency data option, forcing to re-fetch the data from WPCOM.
-	 *
-	 * @return void
-	 */
-	public function clear_cache() {
-		Logger::debug( 'Clearing the cache to force new rates to be fetched from the server.' );
-		$this->cache->delete( MultiCurrencyCacheInterface::CURRENCIES_KEY );
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOPMNT-5328

As in the linked issue, the cache clear is unnecessary and in some cases affects performance.

#### Changes proposed in this Pull Request

* Removed the `clear_cache` method altogether.

#### Testing instructions

* Tests should pass
