### PR TITLE
Implement AccountDetails component with server data

### DIFF
--- a/changelog/woopmnt-5282-implement-all-elements-with-data-from-the-server
+++ b/changelog/woopmnt-5282-implement-all-elements-with-data-from-the-server
@@ -1,4 +1,5 @@
-Significance: minor
-Type: add
+Significance: patch
+Type: update
+Comment: New Account Details (behind the feature flag): implement complete component
 
-New Account Details: implement complete component
+

--- a/changelog/woopmnt-5282-implement-all-elements-with-data-from-the-server
+++ b/changelog/woopmnt-5282-implement-all-elements-with-data-from-the-server
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New Account Details: implement complete component

--- a/client/components/account-details/__tests__/index.test.tsx
+++ b/client/components/account-details/__tests__/index.test.tsx
@@ -12,6 +12,20 @@ import { render, screen } from '@testing-library/react';
 import AccountDetails from '../index';
 import type { AccountDetailsType } from 'wcpay/types/account/account-details';
 
+// Mock the components that have external dependencies
+jest.mock( 'wcpay/components/account-status/account-tools', () => ( {
+	AccountTools: () => <div data-testid="account-tools">Account Tools</div>,
+} ) );
+
+jest.mock( 'wcpay/components/account-status/account-fees', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="account-fees">Account Fees</div>,
+} ) );
+
+jest.mock( 'wcpay/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
 describe( 'AccountDetails', () => {
 	test( 'renders error when accountDetails is null', () => {
 		const accountDetails: AccountDetailsType = null;
@@ -24,10 +38,10 @@ describe( 'AccountDetails', () => {
 		expect( screen.getByText( 'Account details' ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders account details content when data is provided', () => {
+	test( 'renders account details with basic data', () => {
 		const accountDetails: AccountDetailsType = {
 			account_status: {
-				text: 'Active',
+				text: 'Complete',
 				background_color: 'green',
 			},
 			payout_status: {
@@ -41,8 +55,169 @@ describe( 'AccountDetails', () => {
 		render( <AccountDetails accountDetails={ accountDetails } /> );
 
 		expect( screen.getByText( 'Account details' ) ).toBeInTheDocument();
-		expect( screen.getByText( /"account_status"/ ) ).toBeInTheDocument();
-		expect( screen.getByText( /"payout_status"/ ) ).toBeInTheDocument();
-		expect( screen.getByText( /"banner": null/ ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Complete' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Payouts:' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Available' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'account-tools' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders banner when provided', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Restricted',
+				background_color: 'yellow',
+			},
+			payout_status: {
+				text: 'Disabled',
+				background_color: 'red',
+				icon: 'error',
+			},
+			banner: {
+				text: 'Your account has been restricted by Stripe.',
+				background_color: 'yellow',
+				cta_text: 'Contact support',
+				cta_link: 'https://example.com/support',
+				icon: 'caution',
+			},
+		};
+
+		render( <AccountDetails accountDetails={ accountDetails } /> );
+
+		expect(
+			screen.getByText( 'Your account has been restricted by Stripe.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Contact support' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders banner without CTA when only text is provided', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Rejected',
+				background_color: 'red',
+			},
+			payout_status: {
+				text: 'Disabled',
+				background_color: 'red',
+				icon: 'error',
+			},
+			banner: {
+				text: 'Your account has been rejected.',
+				background_color: 'red',
+				icon: 'caution',
+			},
+		};
+
+		render( <AccountDetails accountDetails={ accountDetails } /> );
+
+		expect(
+			screen.getByText( 'Your account has been rejected.' )
+		).toBeInTheDocument();
+		// Should not render CTA when cta_text and cta_link are not provided
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders payout popover when provided', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Complete',
+				background_color: 'green',
+			},
+			payout_status: {
+				text: 'Available in 2 days',
+				background_color: 'yellow',
+				icon: 'caution',
+				popover: {
+					text: 'Payouts are processed within 2 business days.',
+					cta_text: 'Learn more',
+					cta_link: 'https://example.com/payouts',
+				},
+			},
+			banner: null,
+		};
+
+		render( <AccountDetails accountDetails={ accountDetails } /> );
+
+		expect( screen.getByText( 'Available in 2 days' ) ).toBeInTheDocument();
+		expect(
+			screen.getByLabelText( 'More information about payout status' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders edit details button when accountLink is provided', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Complete',
+				background_color: 'green',
+			},
+			payout_status: {
+				text: 'Available',
+				background_color: 'green',
+				icon: 'published',
+			},
+			banner: null,
+		};
+
+		render(
+			<AccountDetails
+				accountDetails={ accountDetails }
+				accountLink="https://example.com/account"
+			/>
+		);
+
+		expect( screen.getByText( 'Edit details' ) ).toBeInTheDocument();
+		const editButton = screen.getByText( 'Edit details' ).closest( 'a' );
+		expect( editButton ).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	test( 'renders account fees when provided', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Complete',
+				background_color: 'green',
+			},
+			payout_status: {
+				text: 'Available',
+				background_color: 'green',
+				icon: 'published',
+			},
+			banner: null,
+		};
+
+		const accountFees = [ { payment_method: 'card', fee: { base: 2.9 } } ];
+
+		render(
+			<AccountDetails
+				accountDetails={ accountDetails }
+				accountFees={ accountFees }
+			/>
+		);
+
+		expect( screen.getByTestId( 'account-fees' ) ).toBeInTheDocument();
+	} );
+
+	test( 'does not render account fees when array is empty', () => {
+		const accountDetails: AccountDetailsType = {
+			account_status: {
+				text: 'Complete',
+				background_color: 'green',
+			},
+			payout_status: {
+				text: 'Available',
+				background_color: 'green',
+				icon: 'published',
+			},
+			banner: null,
+		};
+
+		render(
+			<AccountDetails
+				accountDetails={ accountDetails }
+				accountFees={ [] }
+			/>
+		);
+
+		expect(
+			screen.queryByTestId( 'account-fees' )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/account-details/__tests__/index.test.tsx
+++ b/client/components/account-details/__tests__/index.test.tsx
@@ -109,9 +109,11 @@ describe( 'AccountDetails', () => {
 
 		render( <AccountDetails accountDetails={ accountDetails } /> );
 
-		expect(
-			screen.getByText( 'Your account has been rejected.' )
-		).toBeInTheDocument();
+		const banner = document.querySelector(
+			'.woopayments-account-details__banner'
+		);
+		expect( banner ).toBeInTheDocument();
+		expect( banner ).toHaveTextContent( 'Your account has been rejected.' );
 		// Should not render CTA when cta_text and cta_link are not provided
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );

--- a/client/components/account-details/banner.tsx
+++ b/client/components/account-details/banner.tsx
@@ -1,0 +1,51 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { ExternalLink } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import InlineNotice from 'wcpay/components/inline-notice';
+import { AccountDetailsData } from 'wcpay/types/account/account-details';
+import { getIconByName } from './utils';
+
+interface BannerProps {
+	banner: AccountDetailsData[ 'banner' ];
+}
+
+const getNoticeStatusFromColor = ( color: 'yellow' | 'red' ) => {
+	return color === 'yellow' ? 'warning' : 'error';
+};
+
+const Banner: React.FC< BannerProps > = ( { banner } ) => {
+	if ( ! banner ) {
+		return null;
+	}
+
+	return (
+		<InlineNotice
+			status={ getNoticeStatusFromColor( banner.background_color ) }
+			icon={ getIconByName( banner.icon ) }
+			className="woopayments-account-details__banner"
+			isDismissible={ false }
+		>
+			<div>
+				{ banner.text }
+				{ banner.cta_text && banner.cta_link && (
+					<>
+						{ ' ' }
+						<ExternalLink href={ banner.cta_link }>
+							{ banner.cta_text }
+						</ExternalLink>
+					</>
+				) }
+			</div>
+		</InlineNotice>
+	);
+};
+
+export default Banner;

--- a/client/components/account-details/banner.tsx
+++ b/client/components/account-details/banner.tsx
@@ -17,8 +17,21 @@ interface BannerProps {
 	banner: AccountDetailsData[ 'banner' ];
 }
 
-const getNoticeStatusFromColor = ( color: 'yellow' | 'red' ) => {
-	return color === 'yellow' ? 'warning' : 'error';
+const getNoticeStatusFromColor = (
+	color: 'green' | 'blue' | 'yellow' | 'red'
+) => {
+	switch ( color ) {
+		case 'green':
+			return 'success';
+		case 'blue':
+			return 'info';
+		case 'yellow':
+			return 'warning';
+		case 'red':
+			return 'error';
+		default:
+			return 'info';
+	}
 };
 
 const Banner: React.FC< BannerProps > = ( { banner } ) => {

--- a/client/components/account-details/banner.tsx
+++ b/client/components/account-details/banner.tsx
@@ -47,7 +47,7 @@ const Banner: React.FC< BannerProps > = ( { banner } ) => {
 			className="woopayments-account-details__banner"
 			isDismissible={ false }
 		>
-			<div>
+			<>
 				{ banner.text }
 				{ banner.cta_text && banner.cta_link && (
 					<>
@@ -57,7 +57,7 @@ const Banner: React.FC< BannerProps > = ( { banner } ) => {
 						</ExternalLink>
 					</>
 				) }
-			</div>
+			</>
 		</InlineNotice>
 	);
 };

--- a/client/components/account-details/banner.tsx
+++ b/client/components/account-details/banner.tsx
@@ -10,16 +10,17 @@ import { ExternalLink } from '@wordpress/components';
  * Internal dependencies
  */
 import InlineNotice from 'wcpay/components/inline-notice';
-import { AccountDetailsData } from 'wcpay/types/account/account-details';
+import {
+	AccountDetailsData,
+	BannerBackgroundColor,
+} from 'wcpay/types/account/account-details';
 import { getIconByName } from './utils';
 
 interface BannerProps {
 	banner: AccountDetailsData[ 'banner' ];
 }
 
-const getNoticeStatusFromColor = (
-	color: 'green' | 'blue' | 'yellow' | 'red'
-) => {
+const getNoticeStatusFromColor = ( color: BannerBackgroundColor ) => {
 	switch ( color ) {
 		case 'green':
 			return 'success';

--- a/client/components/account-details/header-title.tsx
+++ b/client/components/account-details/header-title.tsx
@@ -1,0 +1,62 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, FlexBlock, FlexItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Chip from 'wcpay/components/chip';
+import { recordEvent } from 'wcpay/tracks';
+import { AccountDetailsData } from 'wcpay/types/account/account-details';
+import { getChipTypeFromColor } from './utils';
+
+interface HeaderTitleProps {
+	accountStatus: AccountDetailsData[ 'account_status' ];
+	accountLink?: string | null;
+}
+
+const HeaderTitle: React.FC< HeaderTitleProps > = ( {
+	accountStatus,
+	accountLink,
+} ) => {
+	return (
+		<>
+			<FlexItem className="account-details">
+				{ __( 'Account details', 'woocommerce-payments' ) }
+			</FlexItem>
+			<FlexBlock className="account-status">
+				<Chip
+					message={ accountStatus.text }
+					type={ getChipTypeFromColor(
+						accountStatus.background_color
+					) }
+				/>
+			</FlexBlock>
+			{ accountLink && (
+				<FlexItem className="edit-details">
+					<Button
+						variant="link"
+						onClick={ () =>
+							recordEvent( 'wcpay_account_details_link_clicked', {
+								from: 'WCPAY_ACCOUNT_DETAILS',
+								source: 'wcpay-account-details',
+							} )
+						}
+						href={ accountLink }
+						target="_blank"
+						__next40pxDefaultSize
+					>
+						{ __( 'Edit details', 'woocommerce-payments' ) }
+					</Button>
+				</FlexItem>
+			) }
+		</>
+	);
+};
+
+export default HeaderTitle;

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -5,7 +5,19 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader, FlexItem } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	ExternalLink,
+	Flex,
+	FlexBlock,
+	FlexItem,
+} from '@wordpress/components';
+import HelpOutlineIcon from 'gridicons/dist/help-outline';
+import { published, caution, error, info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -15,26 +27,138 @@ import {
 	AccountDetailsType,
 	AccountDetailsData,
 } from 'wcpay/types/account/account-details';
+import Chip, { ChipType } from 'wcpay/components/chip';
+import InlineNotice from 'wcpay/components/inline-notice';
+import { ClickTooltip } from 'wcpay/components/tooltip';
+import { AccountTools } from 'wcpay/components/account-status/account-tools';
+import AccountFees from 'wcpay/components/account-status/account-fees';
+import { recordEvent } from 'wcpay/tracks';
 
-interface AccountDetailsCardProps {
-	title: React.ReactNode;
-	children?: React.ReactNode;
-	value?: React.ReactNode;
+interface AccountDetailsProps {
+	accountDetails: AccountDetailsType;
+	accountFees?: any[];
+	accountLink?: string;
 }
 
-const AccountDetailsCard = ( props: AccountDetailsCardProps ) => {
-	const { title, children, value } = props;
+interface StatusItemProps {
+	label: string;
+	align?: 'center' | 'top' | 'bottom';
+	children: React.ReactNode;
+}
+
+const PayoutStatusItem: React.FC< StatusItemProps > = ( {
+	label,
+	align = 'center',
+	children,
+} ) => {
+	return (
+		<Flex
+			direction="row"
+			align={ align }
+			justify="left"
+			gap={ 3 }
+			className="wcpay-account-details-payout-status-item" // @todo
+		>
+			<FlexItem className="item-label">{ label }</FlexItem>
+			<FlexBlock className="item-value">{ children }</FlexBlock>
+		</Flex>
+	);
+};
+
+const getChipTypeFromColor = (
+	color: 'green' | 'yellow' | 'red'
+): ChipType => {
+	switch ( color ) {
+		case 'green':
+			return 'success';
+		case 'yellow':
+			return 'warning';
+		case 'red':
+			return 'alert';
+		default:
+			return 'primary';
+	}
+};
+
+const getNoticeStatusFromColor = ( color: 'yellow' | 'red' ) => {
+	return color === 'yellow' ? 'warning' : 'error';
+};
+
+const iconMap = {
+	published: published,
+	caution: caution,
+	error: error,
+	info: info,
+};
+const PayoutStatus: React.FC< {
+	payoutStatus: AccountDetailsData[ 'payout_status' ];
+} > = ( { payoutStatus } ) => {
+	const chipType = getChipTypeFromColor( payoutStatus.background_color );
+
+	return (
+		<Flex align="center" gap={ 0 } justify="flex-start">
+			<Chip
+				type={ chipType }
+				className={ `payout-status-chip payout-status-chip--${ payoutStatus.background_color }` }
+				message={ payoutStatus.text }
+				icon={ iconMap[ payoutStatus.icon ] ?? 'info' }
+			/>
+			{ payoutStatus.popover && (
+				<ClickTooltip
+					buttonIcon={ <HelpOutlineIcon /> }
+					buttonLabel={ __(
+						'More information about payout status',
+						'woocommerce-payments'
+					) }
+					buttonSize={ 24 }
+					maxWidth={ '300px' }
+					content={
+						<div className="payout-popover-content">
+							{ payoutStatus.popover.text }
+							{ payoutStatus.popover.cta_text &&
+								payoutStatus.popover.cta_link && (
+									<>
+										{ ' ' }
+										<ExternalLink
+											href={
+												payoutStatus.popover.cta_link
+											}
+										>
+											{ payoutStatus.popover.cta_text }
+										</ExternalLink>
+									</>
+								) }
+						</div>
+					}
+				/>
+			) }
+		</Flex>
+	);
+};
+
+const AccountDetailsCard: React.FC< {
+	title: React.ReactNode;
+	children: React.ReactNode;
+} > = ( { title, children } ) => {
 	return (
 		<Card size="medium">
-			<CardHeader className="woocommerce-account-details__header">
-				{ title }
+			<CardHeader className="woocommerce-account-status__header">
+				<Flex
+					direction="row"
+					align="center"
+					justify="left"
+					gap={ 3 }
+					expanded
+				>
+					{ title }
+				</Flex>
 			</CardHeader>
-			<CardBody>{ children || value || null }</CardBody>
+			<CardBody>{ children }</CardBody>
 		</Card>
 	);
 };
 
-const AccountDetailsError = () => {
+const AccountDetailsError: React.FC = () => {
 	const cardTitle = __( 'Account details', 'woocommerce-payments' );
 	return (
 		<AccountDetailsCard title={ cardTitle }>
@@ -43,35 +167,108 @@ const AccountDetailsError = () => {
 	);
 };
 
-const AccountDetailsContent = ( {
-	accountDetails,
-}: {
+const AccountDetailsContent: React.FC< {
 	accountDetails: AccountDetailsData;
-} ) => {
+	accountFees: any[];
+	accountLink?: string;
+} > = ( { accountDetails, accountFees, accountLink } ) => {
+	const processedAccountLink = accountLink
+		? addQueryArgs( accountLink, {
+				from: 'WCPAY_ACCOUNT_DETAILS',
+				source: 'wcpay-account-details',
+		  } )
+		: null;
+
 	const cardTitle = (
 		<>
-			<FlexItem className={ 'account-details-title' }>
+			<FlexItem className="account-details">
 				{ __( 'Account details', 'woocommerce-payments' ) }
 			</FlexItem>
+			<FlexBlock className="account-status">
+				<Chip
+					message={ accountDetails.account_status.text }
+					type={ getChipTypeFromColor(
+						accountDetails.account_status.background_color
+					) }
+				/>
+			</FlexBlock>
+			{ processedAccountLink && (
+				<FlexItem className="edit-details">
+					<Button
+						variant="link"
+						onClick={ () =>
+							recordEvent( 'wcpay_account_details_link_clicked', {
+								from: 'WCPAY_ACCOUNT_DETAILS',
+								source: 'wcpay-account-details',
+							} )
+						}
+						href={ processedAccountLink }
+						target="_blank"
+						__next40pxDefaultSize
+					>
+						{ __( 'Edit details', 'woocommerce-payments' ) }
+					</Button>
+				</FlexItem>
+			) }
 		</>
 	);
 
 	return (
 		<AccountDetailsCard title={ cardTitle }>
-			<pre>{ JSON.stringify( accountDetails, null, 2 ) }</pre>
+			{ accountDetails.banner && (
+				<InlineNotice
+					status={ getNoticeStatusFromColor(
+						accountDetails.banner.background_color
+					) }
+					icon={ iconMap[ accountDetails.banner.icon ?? 'info' ] }
+					className="account-details-banner"
+					isDismissible={ false }
+				>
+					<div>
+						{ accountDetails.banner.text }
+						{ accountDetails.banner.cta_text &&
+							accountDetails.banner.cta_link && (
+								<>
+									{ ' ' }
+									<ExternalLink
+										href={ accountDetails.banner.cta_link }
+									>
+										{ accountDetails.banner.cta_text }
+									</ExternalLink>
+								</>
+							) }
+					</div>
+				</InlineNotice>
+			) }
+
+			<PayoutStatusItem
+				label={ __( 'Payouts:', 'woocommerce-payments' ) }
+			>
+				<PayoutStatus payoutStatus={ accountDetails.payout_status } />
+			</PayoutStatusItem>
+
+			<AccountTools />
+
+			{ accountFees && accountFees.length > 0 && (
+				<AccountFees accountFees={ accountFees } />
+			) }
 		</AccountDetailsCard>
 	);
 };
 
-const AccountDetails = ( {
+const AccountDetails: React.FC< AccountDetailsProps > = ( {
 	accountDetails,
-}: {
-	accountDetails: AccountDetailsType;
+	accountFees = [],
+	accountLink,
 } ) => {
 	return null === accountDetails ? (
 		<AccountDetailsError />
 	) : (
-		<AccountDetailsContent accountDetails={ accountDetails } />
+		<AccountDetailsContent
+			accountDetails={ accountDetails }
+			accountFees={ accountFees }
+			accountLink={ accountLink }
+		/>
 	);
 };
 

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -57,7 +57,7 @@ const PayoutStatusItem: React.FC< StatusItemProps > = ( {
 			align={ align }
 			justify="left"
 			gap={ 3 }
-			className="wcpay-account-details-payout-status-item" // @todo
+			className="woopayments-account-details__payout-status-item"
 		>
 			<FlexItem className="item-label">{ label }</FlexItem>
 			<FlexBlock className="item-value">{ children }</FlexBlock>
@@ -113,7 +113,7 @@ const PayoutStatus: React.FC< {
 					buttonSize={ 24 }
 					maxWidth={ '300px' }
 					content={
-						<div className="payout-popover-content">
+						<div>
 							{ payoutStatus.popover.text }
 							{ payoutStatus.popover.cta_text &&
 								payoutStatus.popover.cta_link && (
@@ -142,7 +142,7 @@ const AccountDetailsCard: React.FC< {
 } > = ( { title, children } ) => {
 	return (
 		<Card size="medium">
-			<CardHeader className="woocommerce-account-status__header">
+			<CardHeader className="woopayments-account-details__header">
 				<Flex
 					direction="row"
 					align="center"
@@ -221,7 +221,7 @@ const AccountDetailsContent: React.FC< {
 						accountDetails.banner.background_color
 					) }
 					icon={ iconMap[ accountDetails.banner.icon ?? 'info' ] }
-					className="account-details-banner"
+					className="woopayments-account-details__banner"
 					isDismissible={ false }
 				>
 					<div>

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -35,15 +35,7 @@ const AccountDetailsCard: React.FC< {
 	return (
 		<Card size="medium">
 			<CardHeader className="woopayments-account-details__header">
-				<Flex
-					direction="row"
-					align="center"
-					justify="left"
-					gap={ 3 }
-					expanded
-				>
-					{ title }
-				</Flex>
+				{ title }
 			</CardHeader>
 			<CardBody>{ children }</CardBody>
 		</Card>
@@ -72,16 +64,17 @@ const AccountDetailsContent: React.FC< {
 		: null;
 
 	const cardTitle = (
-		<HeaderTitle
-			accountStatus={ accountDetails.account_status }
-			accountLink={ processedAccountLink }
-		/>
+		<>
+			<HeaderTitle
+				accountStatus={ accountDetails.account_status }
+				accountLink={ processedAccountLink }
+			/>
+			<Banner banner={ accountDetails.banner } />
+		</>
 	);
 
 	return (
 		<AccountDetailsCard title={ cardTitle }>
-			<Banner banner={ accountDetails.banner } />
-
 			<PayoutStatusWrapper
 				payoutStatus={ accountDetails.payout_status }
 			/>

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -6,18 +6,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	ExternalLink,
-	Flex,
-	FlexBlock,
-	FlexItem,
-} from '@wordpress/components';
-import HelpOutlineIcon from 'gridicons/dist/help-outline';
-import { published, caution, error, info } from '@wordpress/icons';
+import { Card, CardBody, CardHeader, Flex } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -27,114 +16,17 @@ import {
 	AccountDetailsType,
 	AccountDetailsData,
 } from 'wcpay/types/account/account-details';
-import Chip, { ChipType } from 'wcpay/components/chip';
-import InlineNotice from 'wcpay/components/inline-notice';
-import { ClickTooltip } from 'wcpay/components/tooltip';
 import { AccountTools } from 'wcpay/components/account-status/account-tools';
 import AccountFees from 'wcpay/components/account-status/account-fees';
-import { recordEvent } from 'wcpay/tracks';
+import Banner from './banner';
+import PayoutStatusWrapper from './payout-status-wrapper';
+import HeaderTitle from './header-title';
 
 interface AccountDetailsProps {
 	accountDetails: AccountDetailsType;
 	accountFees?: any[];
 	accountLink?: string;
 }
-
-interface StatusItemProps {
-	label: string;
-	align?: 'center' | 'top' | 'bottom';
-	children: React.ReactNode;
-}
-
-const PayoutStatusItem: React.FC< StatusItemProps > = ( {
-	label,
-	align = 'center',
-	children,
-} ) => {
-	return (
-		<Flex
-			direction="row"
-			align={ align }
-			justify="left"
-			gap={ 3 }
-			className="woopayments-account-details__payout-status-item"
-		>
-			<FlexItem className="item-label">{ label }</FlexItem>
-			<FlexBlock className="item-value">{ children }</FlexBlock>
-		</Flex>
-	);
-};
-
-const getChipTypeFromColor = (
-	color: 'green' | 'yellow' | 'red'
-): ChipType => {
-	switch ( color ) {
-		case 'green':
-			return 'success';
-		case 'yellow':
-			return 'warning';
-		case 'red':
-			return 'alert';
-		default:
-			return 'primary';
-	}
-};
-
-const getNoticeStatusFromColor = ( color: 'yellow' | 'red' ) => {
-	return color === 'yellow' ? 'warning' : 'error';
-};
-
-const iconMap = {
-	published: published,
-	caution: caution,
-	error: error,
-	info: info,
-};
-const PayoutStatus: React.FC< {
-	payoutStatus: AccountDetailsData[ 'payout_status' ];
-} > = ( { payoutStatus } ) => {
-	const chipType = getChipTypeFromColor( payoutStatus.background_color );
-
-	return (
-		<Flex align="center" gap={ 0 } justify="flex-start">
-			<Chip
-				type={ chipType }
-				className={ `payout-status-chip payout-status-chip--${ payoutStatus.background_color }` }
-				message={ payoutStatus.text }
-				icon={ iconMap[ payoutStatus.icon ] ?? 'info' }
-			/>
-			{ payoutStatus.popover && (
-				<ClickTooltip
-					buttonIcon={ <HelpOutlineIcon /> }
-					buttonLabel={ __(
-						'More information about payout status',
-						'woocommerce-payments'
-					) }
-					buttonSize={ 24 }
-					maxWidth={ '300px' }
-					content={
-						<div>
-							{ payoutStatus.popover.text }
-							{ payoutStatus.popover.cta_text &&
-								payoutStatus.popover.cta_link && (
-									<>
-										{ ' ' }
-										<ExternalLink
-											href={
-												payoutStatus.popover.cta_link
-											}
-										>
-											{ payoutStatus.popover.cta_text }
-										</ExternalLink>
-									</>
-								) }
-						</div>
-					}
-				/>
-			) }
-		</Flex>
-	);
-};
 
 const AccountDetailsCard: React.FC< {
 	title: React.ReactNode;
@@ -180,72 +72,19 @@ const AccountDetailsContent: React.FC< {
 		: null;
 
 	const cardTitle = (
-		<>
-			<FlexItem className="account-details">
-				{ __( 'Account details', 'woocommerce-payments' ) }
-			</FlexItem>
-			<FlexBlock className="account-status">
-				<Chip
-					message={ accountDetails.account_status.text }
-					type={ getChipTypeFromColor(
-						accountDetails.account_status.background_color
-					) }
-				/>
-			</FlexBlock>
-			{ processedAccountLink && (
-				<FlexItem className="edit-details">
-					<Button
-						variant="link"
-						onClick={ () =>
-							recordEvent( 'wcpay_account_details_link_clicked', {
-								from: 'WCPAY_ACCOUNT_DETAILS',
-								source: 'wcpay-account-details',
-							} )
-						}
-						href={ processedAccountLink }
-						target="_blank"
-						__next40pxDefaultSize
-					>
-						{ __( 'Edit details', 'woocommerce-payments' ) }
-					</Button>
-				</FlexItem>
-			) }
-		</>
+		<HeaderTitle
+			accountStatus={ accountDetails.account_status }
+			accountLink={ processedAccountLink }
+		/>
 	);
 
 	return (
 		<AccountDetailsCard title={ cardTitle }>
-			{ accountDetails.banner && (
-				<InlineNotice
-					status={ getNoticeStatusFromColor(
-						accountDetails.banner.background_color
-					) }
-					icon={ iconMap[ accountDetails.banner.icon ?? 'info' ] }
-					className="woopayments-account-details__banner"
-					isDismissible={ false }
-				>
-					<div>
-						{ accountDetails.banner.text }
-						{ accountDetails.banner.cta_text &&
-							accountDetails.banner.cta_link && (
-								<>
-									{ ' ' }
-									<ExternalLink
-										href={ accountDetails.banner.cta_link }
-									>
-										{ accountDetails.banner.cta_text }
-									</ExternalLink>
-								</>
-							) }
-					</div>
-				</InlineNotice>
-			) }
+			<Banner banner={ accountDetails.banner } />
 
-			<PayoutStatusItem
-				label={ __( 'Payouts:', 'woocommerce-payments' ) }
-			>
-				<PayoutStatus payoutStatus={ accountDetails.payout_status } />
-			</PayoutStatusItem>
+			<PayoutStatusWrapper
+				payoutStatus={ accountDetails.payout_status }
+			/>
 
 			<AccountTools />
 

--- a/client/components/account-details/payout-status-wrapper.tsx
+++ b/client/components/account-details/payout-status-wrapper.tsx
@@ -25,12 +25,12 @@ const PayoutStatus: React.FC< {
 		<Flex align="center" gap={ 0 } justify="flex-start">
 			<Chip
 				type={ chipType }
-				className={ `payout-status-chip payout-status-chip--${ payoutStatus.background_color }` }
 				message={ payoutStatus.text }
 				icon={ getIconByName( payoutStatus.icon ) }
 			/>
 			{ payoutStatus.popover && (
 				<ClickTooltip
+					className={ 'payout-click-tooltip' }
 					buttonIcon={ <HelpOutlineIcon /> }
 					buttonLabel={ __(
 						'More information about payout status',
@@ -46,6 +46,9 @@ const PayoutStatus: React.FC< {
 									<>
 										{ ' ' }
 										<ExternalLink
+											className={
+												'payout-tooltip-external-link'
+											}
 											href={
 												payoutStatus.popover.cta_link
 											}

--- a/client/components/account-details/payout-status-wrapper.tsx
+++ b/client/components/account-details/payout-status-wrapper.tsx
@@ -1,0 +1,91 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Flex, FlexBlock, FlexItem, ExternalLink } from '@wordpress/components';
+import HelpOutlineIcon from 'gridicons/dist/help-outline';
+
+/**
+ * Internal dependencies
+ */
+import Chip from 'wcpay/components/chip';
+import { ClickTooltip } from 'wcpay/components/tooltip';
+import { AccountDetailsData } from 'wcpay/types/account/account-details';
+import { getChipTypeFromColor, getIconByName } from './utils';
+
+const PayoutStatus: React.FC< {
+	payoutStatus: AccountDetailsData[ 'payout_status' ];
+} > = ( { payoutStatus } ) => {
+	const chipType = getChipTypeFromColor( payoutStatus.background_color );
+
+	return (
+		<Flex align="center" gap={ 0 } justify="flex-start">
+			<Chip
+				type={ chipType }
+				className={ `payout-status-chip payout-status-chip--${ payoutStatus.background_color }` }
+				message={ payoutStatus.text }
+				icon={ getIconByName( payoutStatus.icon ) }
+			/>
+			{ payoutStatus.popover && (
+				<ClickTooltip
+					buttonIcon={ <HelpOutlineIcon /> }
+					buttonLabel={ __(
+						'More information about payout status',
+						'woocommerce-payments'
+					) }
+					buttonSize={ 24 }
+					maxWidth={ '300px' }
+					content={
+						<div>
+							{ payoutStatus.popover.text }
+							{ payoutStatus.popover.cta_text &&
+								payoutStatus.popover.cta_link && (
+									<>
+										{ ' ' }
+										<ExternalLink
+											href={
+												payoutStatus.popover.cta_link
+											}
+										>
+											{ payoutStatus.popover.cta_text }
+										</ExternalLink>
+									</>
+								) }
+						</div>
+					}
+				/>
+			) }
+		</Flex>
+	);
+};
+
+interface PayoutStatusWrapperProps {
+	payoutStatus: AccountDetailsData[ 'payout_status' ];
+}
+
+const PayoutStatusWrapper: React.FC< PayoutStatusWrapperProps > = ( {
+	payoutStatus,
+} ) => {
+	return (
+		<Flex
+			direction="row"
+			align="center"
+			justify="left"
+			gap={ 3 }
+			className="woopayments-account-details__payout-status-item"
+		>
+			<FlexItem className="item-label">
+				{ __( 'Payouts:', 'woocommerce-payments' ) }
+			</FlexItem>
+			<FlexBlock className="item-value">
+				<PayoutStatus payoutStatus={ payoutStatus } />
+			</FlexBlock>
+		</Flex>
+	);
+};
+
+export default PayoutStatusWrapper;
+export { PayoutStatus };

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -1,4 +1,12 @@
-.wcpay-account-details-payout-status-item {
+.woopayments-account-details__header {
+	h2 {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+	}
+}
+
+.woopayments-account-details__payout-status-item {
 	line-height: 16px;
 	flex-wrap: wrap;
 	height: auto;
@@ -29,33 +37,6 @@
 	}
 }
 
-.woocommerce-account-details__header {
-	h2 {
-		margin: 0;
-		font-size: 16px;
-		font-weight: 600;
-	}
-}
-
-.account-details-banner {
+.woopayments-account-details__banner {
 	margin-bottom: 16px;
-}
-
-.payout-status-chip {
-	&--green {
-		background-color: #dff0d8;
-		color: #3c763d;
-	}
-	&--yellow {
-		background-color: #fcf8e3;
-		color: #8a6d3b;
-	}
-	&--red {
-		background-color: #f2dede;
-		color: #a94442;
-	}
-}
-
-.payout-popover-content {
-	max-width: 300px;
 }

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -1,8 +1,12 @@
 .woopayments-account-details__header {
-	h2 {
-		margin: 0;
-		font-size: 16px;
-		font-weight: 600;
+	//h2 {
+	//	margin: 0;
+	//	font-size: 16px;
+	//	font-weight: 600;
+	//}
+
+	.edit-details .components-button.is-link {
+		text-decoration: none;
 	}
 }
 

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -67,4 +67,9 @@
 	.item-value {
 		color: $gray-700;
 	}
+
+	a.payout-tooltip-external-link {
+		// Disable underline for arrow icon in the end of external link.
+		text-decoration: none;
+	}
 }

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -1,6 +1,40 @@
 .woopayments-account-details__header {
+	flex-wrap: wrap;
+
 	.edit-details .components-button.is-link {
 		text-decoration: none;
+	}
+
+	.edit-details,
+	.account-details,
+	.account-status {
+		flex-basis: auto;
+		min-width: max-content;
+	}
+
+	// on a smaller viewports controls section should move in front of the
+	// status chip
+	@media screen and ( max-width: $break-mobile ) {
+		.account-details {
+			order: 1;
+			flex-grow: 1;
+			margin-bottom: 8px;
+		}
+		.edit-details {
+			order: 2;
+			margin-bottom: 8px;
+		}
+		.account-status {
+			order: 3;
+		}
+
+		.woopayments-account-details__banner {
+			order: 5;
+			margin-bottom: 16px;
+			a.components-external-link {
+				white-space: wrap;
+			}
+		}
 	}
 }
 
@@ -24,7 +58,7 @@
 		white-space: nowrap;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@media screen and ( max-width: $break-mobile ) {
 		.item-label {
 			min-width: 80px;
 		}
@@ -33,8 +67,4 @@
 	.item-value {
 		color: $gray-700;
 	}
-}
-
-.woopayments-account-details__banner {
-	margin-bottom: 16px;
 }

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -1,7 +1,61 @@
+.wcpay-account-details-payout-status-item {
+	line-height: 16px;
+	flex-wrap: wrap;
+	height: auto;
+	min-height: 2em;
+	margin-bottom: 8px;
+
+	.item-label,
+	.item-value {
+		flex-shrink: 1;
+		flex-basis: auto;
+		width: min-content;
+	}
+
+	.item-label {
+		color: $gray-900;
+		min-width: 130px;
+		white-space: nowrap;
+	}
+
+	@include breakpoint( '<480px' ) {
+		.item-label {
+			min-width: 80px;
+		}
+	}
+
+	.item-value {
+		color: $gray-700;
+	}
+}
+
 .woocommerce-account-details__header {
 	h2 {
 		margin: 0;
 		font-size: 16px;
 		font-weight: 600;
 	}
+}
+
+.account-details-banner {
+	margin-bottom: 16px;
+}
+
+.payout-status-chip {
+	&--green {
+		background-color: #dff0d8;
+		color: #3c763d;
+	}
+	&--yellow {
+		background-color: #fcf8e3;
+		color: #8a6d3b;
+	}
+	&--red {
+		background-color: #f2dede;
+		color: #a94442;
+	}
+}
+
+.payout-popover-content {
+	max-width: 300px;
 }

--- a/client/components/account-details/style.scss
+++ b/client/components/account-details/style.scss
@@ -1,10 +1,4 @@
 .woopayments-account-details__header {
-	//h2 {
-	//	margin: 0;
-	//	font-size: 16px;
-	//	font-weight: 600;
-	//}
-
 	.edit-details .components-button.is-link {
 		text-decoration: none;
 	}

--- a/client/components/account-details/utils.ts
+++ b/client/components/account-details/utils.ts
@@ -9,9 +9,13 @@ import { published, caution, error, info } from '@wordpress/icons';
  * Internal dependencies
  */
 import { ChipType } from 'wcpay/components/chip';
+import {
+	StatusBackgroundColor,
+	IconName,
+} from 'wcpay/types/account/account-details';
 
 export const getChipTypeFromColor = (
-	color: 'green' | 'yellow' | 'red' | 'blue' | 'gray'
+	color: StatusBackgroundColor
 ): ChipType => {
 	switch ( color ) {
 		case 'green':
@@ -29,9 +33,7 @@ export const getChipTypeFromColor = (
 	}
 };
 
-export const getIconByName = (
-	iconName?: 'published' | 'caution' | 'error'
-) => {
+export const getIconByName = ( iconName?: IconName ) => {
 	const iconMap = {
 		published: published,
 		caution: caution,

--- a/client/components/account-details/utils.ts
+++ b/client/components/account-details/utils.ts
@@ -11,7 +11,7 @@ import { published, caution, error, info } from '@wordpress/icons';
 import { ChipType } from 'wcpay/components/chip';
 
 export const getChipTypeFromColor = (
-	color: 'green' | 'yellow' | 'red'
+	color: 'green' | 'yellow' | 'red' | 'blue' | 'gray'
 ): ChipType => {
 	switch ( color ) {
 		case 'green':
@@ -20,6 +20,10 @@ export const getChipTypeFromColor = (
 			return 'warning';
 		case 'red':
 			return 'alert';
+		case 'blue':
+			return 'primary';
+		case 'gray':
+			return 'light';
 		default:
 			return 'primary';
 	}

--- a/client/components/account-details/utils.ts
+++ b/client/components/account-details/utils.ts
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { published, caution, error, info } from '@wordpress/icons';
+import * as icons from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -34,12 +34,5 @@ export const getChipTypeFromColor = (
 };
 
 export const getIconByName = ( iconName?: IconName ) => {
-	const iconMap = {
-		published: published,
-		caution: caution,
-		error: error,
-		info: info,
-	};
-
-	return iconMap[ iconName ?? 'info' ];
+	return icons[ iconName ?? 'info' ];
 };

--- a/client/components/account-details/utils.ts
+++ b/client/components/account-details/utils.ts
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import * as icons from '@wordpress/icons';
+import { published, caution, error, info, check } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -34,5 +34,13 @@ export const getChipTypeFromColor = (
 };
 
 export const getIconByName = ( iconName?: IconName ) => {
-	return icons[ iconName ?? 'info' ];
+	const iconMap = {
+		published,
+		caution,
+		error,
+		info,
+		check,
+	};
+
+	return iconMap[ iconName ?? 'info' ] ?? info;
 };

--- a/client/components/account-details/utils.ts
+++ b/client/components/account-details/utils.ts
@@ -1,0 +1,39 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { published, caution, error, info } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { ChipType } from 'wcpay/components/chip';
+
+export const getChipTypeFromColor = (
+	color: 'green' | 'yellow' | 'red'
+): ChipType => {
+	switch ( color ) {
+		case 'green':
+			return 'success';
+		case 'yellow':
+			return 'warning';
+		case 'red':
+			return 'alert';
+		default:
+			return 'primary';
+	}
+};
+
+export const getIconByName = (
+	iconName?: 'published' | 'caution' | 'error'
+) => {
+	const iconMap = {
+		published: published,
+		caution: caution,
+		error: error,
+		info: info,
+	};
+
+	return iconMap[ iconName ?? 'info' ];
+};

--- a/client/components/chip/index.tsx
+++ b/client/components/chip/index.tsx
@@ -29,7 +29,12 @@ const Chip: React.FC< React.PropsWithChildren< Props > > = ( {
 	tooltip,
 	icon,
 } ) => {
-	const classNames = clsx( 'chip', `chip-${ type }`, className );
+	const classNames = clsx(
+		'chip',
+		`chip-${ type }`,
+		icon && 'chip-has-icon',
+		className
+	);
 
 	const content = (
 		<>

--- a/client/components/chip/index.tsx
+++ b/client/components/chip/index.tsx
@@ -4,6 +4,8 @@
  * External dependencies
  */
 import React from 'react';
+import { Icon } from '@wordpress/icons';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -18,25 +20,32 @@ interface Props {
 	type?: ChipType;
 	className?: string;
 	tooltip?: string;
+	icon?: React.JSX.Element;
 }
 const Chip: React.FC< React.PropsWithChildren< Props > > = ( {
 	message,
 	type = 'primary',
 	className,
 	tooltip,
+	icon,
 } ) => {
-	const classNames = [ 'chip', `chip-${ type }`, className ?? '' ];
+	const classNames = clsx( 'chip', `chip-${ type }`, className );
+
+	const content = (
+		<>
+			{ icon && <Icon icon={ icon } size={ 16 } /> }
+			{ message }
+		</>
+	);
 
 	if ( tooltip ) {
 		return (
 			<HoverTooltip content={ tooltip }>
-				<span className={ classNames.join( ' ' ).trim() }>
-					{ message }
-				</span>
+				<span className={ classNames }>{ content }</span>
 			</HoverTooltip>
 		);
 	}
-	return <span className={ classNames.join( ' ' ).trim() }>{ message }</span>;
+	return <span className={ classNames }>{ content }</span>;
 };
 
 export default Chip;

--- a/client/components/chip/style.scss
+++ b/client/components/chip/style.scss
@@ -11,6 +11,10 @@
 	line-height: 1.5;
 	white-space: nowrap;
 
+	&.chip-has-icon {
+		padding-inline-start: 4px;
+	}
+
 	&.chip-primary {
 		& svg {
 			fill: $wp-blue-70;

--- a/client/components/chip/style.scss
+++ b/client/components/chip/style.scss
@@ -13,6 +13,7 @@
 
 	&.chip-has-icon {
 		padding-inline-start: 4px;
+		gap: 2px;
 	}
 
 	&.chip-primary {

--- a/client/components/chip/style.scss
+++ b/client/components/chip/style.scss
@@ -12,26 +12,41 @@
 	white-space: nowrap;
 
 	&.chip-primary {
+		& svg {
+			fill: $wp-blue-70;
+		}
 		background: $wp-blue-0;
 		color: $wp-blue-70;
 	}
 
 	&.chip-success {
+		& svg {
+			fill: $wp-green-70;
+		}
 		background: $wp-green-0;
 		color: $wp-green-70;
 	}
 
 	&.chip-light {
+		& svg {
+			fill: $wp-gray-80;
+		}
 		background: $wp-gray-0;
 		color: $wp-gray-80;
 	}
 
 	&.chip-alert {
+		& svg {
+			fill: $wp-red-70;
+		}
 		background: $wp-red-0;
 		color: $wp-red-70;
 	}
 
 	&.chip-warning {
+		& svg {
+			fill: $wp-yellow-70;
+		}
 		background: $wp-yellow-0;
 		color: $wp-yellow-70;
 	}

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -377,7 +377,11 @@ const OverviewPage = () => {
 			) }
 			<ErrorBoundary>
 				{ isAccountDetailsEnabled && accountDetails ? (
-					<AccountDetails accountDetails={ accountDetails } />
+					<AccountDetails
+						accountDetails={ accountDetails }
+						accountFees={ activeAccountFees }
+						accountLink={ accountStatus.accountLink }
+					/>
 				) : (
 					<AccountStatus
 						accountStatus={ accountStatus }

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -1,6 +1,3 @@
-/**
- * Current design only uses `green`, `yellow`, `red` but add all front-end assisted options.
- */
 export type StatusBackgroundColor =
 	| 'green'
 	| 'yellow'
@@ -8,9 +5,6 @@ export type StatusBackgroundColor =
 	| 'blue'
 	| 'gray';
 
-/**
- * Current design only uses `yellow`, `red` but add all front-end assisted options.
- */
 export type BannerBackgroundColor = 'yellow' | 'red' | 'green' | 'blue';
 
 export type IconName = 'published' | 'caution' | 'error' | 'info' | 'check';
@@ -22,9 +16,6 @@ export interface AccountDetailsData {
 	payout_status: {
 		text: string;
 		background_color: StatusBackgroundColor;
-		/**
-		 * Current design only use `published` `caution` `error`, but it can support any icon in https://wordpress.github.io/gutenberg/?path=/docs/icons-icon--docs
-		 */
 		icon?: IconName;
 		popover?: {
 			text: string;
@@ -37,9 +28,6 @@ export interface AccountDetailsData {
 		background_color: BannerBackgroundColor;
 		cta_text?: string;
 		cta_link?: string;
-		/**
-		 * Current design only use `caution` but it can support any icon in https://wordpress.github.io/gutenberg/?path=/docs/icons-icon--docs.
-		 */
 		icon?: IconName;
 	} | null;
 }

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -13,7 +13,7 @@ export type StatusBackgroundColor =
  */
 export type BannerBackgroundColor = 'yellow' | 'red' | 'green' | 'blue';
 
-export type IconName = 'published' | 'caution' | 'error' | 'info';
+export type IconName = 'published' | 'caution' | 'error';
 export interface AccountDetailsData {
 	account_status: {
 		text: string;
@@ -22,6 +22,9 @@ export interface AccountDetailsData {
 	payout_status: {
 		text: string;
 		background_color: StatusBackgroundColor;
+		/**
+		 * Current design only use `published` `caution` `error`, but it can support any icon in https://wordpress.github.io/gutenberg/?path=/docs/icons-icon--docs
+		 */
 		icon?: IconName;
 		popover?: {
 			text: string;
@@ -35,7 +38,7 @@ export interface AccountDetailsData {
 		cta_text?: string;
 		cta_link?: string;
 		/**
-		 * Current design only use `caution` but add all front-end assisted options.
+		 * Current design only use `caution` but it can support any icon in https://wordpress.github.io/gutenberg/?path=/docs/icons-icon--docs.
 		 */
 		icon?: IconName;
 	} | null;

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -1,12 +1,28 @@
+/**
+ * Current design only uses `green`, `yellow`, `red` but add all front-end assisted options.
+ */
+export type StatusBackgroundColor =
+	| 'green'
+	| 'yellow'
+	| 'red'
+	| 'blue'
+	| 'gray';
+
+/**
+ * Current design only uses `yellow`, `red` but add all front-end assisted options.
+ */
+export type BannerBackgroundColor = 'yellow' | 'red' | 'green' | 'blue';
+
+export type IconName = 'published' | 'caution' | 'error' | 'info';
 export interface AccountDetailsData {
 	account_status: {
 		text: string;
-		background_color: 'green' | 'yellow' | 'red';
+		background_color: StatusBackgroundColor;
 	};
 	payout_status: {
 		text: string;
-		background_color: 'green' | 'yellow' | 'red';
-		icon?: 'published' | 'caution' | 'error';
+		background_color: StatusBackgroundColor;
+		icon?: IconName;
 		popover?: {
 			text: string;
 			cta_text: string;
@@ -15,10 +31,13 @@ export interface AccountDetailsData {
 	};
 	banner?: {
 		text: string;
-		background_color: 'yellow' | 'red';
+		background_color: BannerBackgroundColor;
 		cta_text?: string;
 		cta_link?: string;
-		icon?: 'caution';
+		/**
+		 * Current design only use `caution` but add all front-end assisted options.
+		 */
+		icon?: IconName;
 	} | null;
 }
 

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -13,7 +13,7 @@ export type StatusBackgroundColor =
  */
 export type BannerBackgroundColor = 'yellow' | 'red' | 'green' | 'blue';
 
-export type IconName = 'published' | 'caution' | 'error';
+export type IconName = 'published' | 'caution' | 'error' | 'info' | 'check';
 export interface AccountDetailsData {
 	account_status: {
 		text: string;

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -6,7 +6,7 @@ export interface AccountDetailsData {
 	payout_status: {
 		text: string;
 		background_color: 'green' | 'yellow' | 'red';
-		icon: 'published' | 'caution' | 'error';
+		icon?: 'published' | 'caution' | 'error';
 		popover?: {
 			text: string;
 			cta_text: string;
@@ -18,7 +18,7 @@ export interface AccountDetailsData {
 		background_color: 'yellow' | 'red';
 		cta_text?: string;
 		cta_link?: string;
-		icon: 'caution';
+		icon?: 'caution';
 	} | null;
 }
 


### PR DESCRIPTION
Fixes WOOPMNT-5282

#### Changes proposed in this Pull Request

- Replace JSON display with proper UI components including account status badge, banner notifications, payout status with popover.
- Preserve functionalities from the current `AccountStatus` component including: `Edit details`, `AccountTools`, and `AccountFees`. 
    - After the project is finished, it's expected that we will remove `AccountStatus` but these functionalities are kept.
- Display all possible options from the Figma design (See in WOOPMNT-5282).

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


> [!IMPORTANT]
> At this stage, please focus on design and components. All text copies are still work-in-progress and not yet final. They will be delivered from the server.

I have prepared a script for testing various scenarios. Steps to use it: 

- Download this zip file as a plugin:  
[WooPayments_PR_11048_Status_Simulator.php.zip](https://github.com/user-attachments/files/22419147/WooPayments_PR_11048_Status_Simulator.php.zip) (this is [the source](https://gist.github.com/htdat/7739a89568f8472d236f72c52387c07b) in case you'd like to see it) 
- Upload it as a plugin in WP Admin > Plugins > Add new, and activate it. 
- Go to your-site.com/wp-admin/tools.php?page=woopayments_pr_11048_testing_option to choose which case you'd like to test: 
<img width="3044" height="1012" alt="Screen Shot on 2025-09-17 at 23:22:23" src="https://github.com/user-attachments/assets/9d03fa1c-b3e3-40cd-8cd1-14140eeb501c" />

- In case you're not an engineer and want to test on your site, please follow option 1 in the comment below https://github.com/Automattic/woocommerce-payments/pull/11048#issuecomment-3303681347

- Go to WP Admin > Payments > Overview, you will see the new component with the selected scenario.

These are a few cases:

## restricted_soon
<img width="2868" height="860" alt="restricted_soon" src="https://github.com/user-attachments/assets/bc56d9d6-f726-4625-b3f2-e8fe398a5a48" />

## good_standing_no_requirements
<img width="2848" height="520" alt="good_standing_no_requirements" src="https://github.com/user-attachments/assets/ecf48d82-d861-495b-9611-8da0161b12ba" />

## new_account_no_activity
<img width="2808" height="588" alt="new_account_no_activity" src="https://github.com/user-attachments/assets/283a94b2-93d6-4d6b-a659-6f786a4541eb" />

## stripe_rejection
<img width="2840" height="908" alt="stripe_rejection" src="https://github.com/user-attachments/assets/1be7636d-90e8-43c6-89a3-58f5c4f13654" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
