### PR TITLE
Replace BOTWOO_TOKEN in pr-build-live-branch workflow with github-actions bot

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: "Add/update the information as a comment in the PR"
         env:
-          GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.head_ref }}
@@ -136,8 +136,13 @@ jobs:
           _Note: the build is updated when a new commit is pushed to this PR._"
           # End declaring variable BODY
 
-          # Try to update the last comment first. If not work, just create a new comment.
-          if ! gh pr comment ${PR_NUMBER} --body "${BODY}" --edit-last
-          then
+          # Find existing build comment by searching for unique identifier
+          COMMENT_ID=$(gh pr view ${PR_NUMBER} --json comments --jq '.comments[] | select(.body | contains("### Test the build")) | .url' | head -1 | grep -o '[0-9]*$')
+
+          if [ -n "$COMMENT_ID" ]; then
+            # Update existing comment
+            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}"
+          else
+            # Create new comment if none found
             gh pr comment ${PR_NUMBER} --body "${BODY}"
           fi

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -154,7 +154,7 @@ jobs:
           if [ -n "$COMMENT_ID" ]; then
             echo "Found existing comment ID: $COMMENT_ID"
             echo "Updating existing comment..."
-            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}"  2>/dev/nul || {
+            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}"  2>/dev/null || {
               echo "ERROR: Failed to update existing comment"
               exit 1
             }

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -113,8 +113,6 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.head_ref }}
         run: |
-          set -e  # Exit on any error
-
           # Debug: Check environment variables
           echo "=== Debug: Environment Variables ==="
           echo "PR_NUMBER: ${PR_NUMBER}"
@@ -122,13 +120,6 @@ jobs:
           echo "PR_HEAD_SHA: ${PR_HEAD_SHA}"
           echo "GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
           echo "===================================="
-
-          # Test GitHub CLI access
-          echo "Testing GitHub CLI access..."
-          gh pr view ${PR_NUMBER} --json number || {
-            echo "ERROR: Failed to access PR via GitHub CLI"
-            exit 1
-          }
 
           echo "Creating comment body..."
           BODY="### Test the build 
@@ -163,14 +154,14 @@ jobs:
           if [ -n "$COMMENT_ID" ]; then
             echo "Found existing comment ID: $COMMENT_ID"
             echo "Updating existing comment..."
-            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}" || {
+            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}"  2>/dev/nul || {
               echo "ERROR: Failed to update existing comment"
               exit 1
             }
             echo "Comment updated successfully"
           else
             echo "No existing comment found, creating new one..."
-            gh api repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments -f body="${BODY}" || {
+            gh api repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments -f body="${BODY}" 2>/dev/null || {
               echo "ERROR: Failed to create new comment"
               exit 1
             }

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -130,38 +130,29 @@ jobs:
             exit 1
           }
 
-          # Create BODY variable using here-document for better handling
           echo "Creating comment body..."
-          BODY=$(cat << 'EOF'
-          ### Test the build
+          BODY="### Test the build 
           
           #### Option 1. Jetpack Beta
           
           - Install and activate [Jetpack Beta](https://jetpack.com/download-jetpack-beta/).
-          - Use this build by searching for PR number `PLACEHOLDER_PR_NUMBER` or branch name `PLACEHOLDER_PR_HEAD_REF` in your-test.site/wp-admin/admin.php?page=jetpack-beta&plugin=woocommerce-payments
+          - Use this build by searching for PR number \`${PR_NUMBER}\` or branch name \`${PR_HEAD_REF}\` in your-test.site/wp-admin/admin.php?page=jetpack-beta&plugin=woocommerce-payments          
           
           #### Option 2. Jurassic Ninja - available for logged-in A12s
+         
+          :rocket: [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=${PR_HEAD_REF}) :rocket:
           
-          🚀 [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=PLACEHOLDER_PR_HEAD_REF) 🚀
-          
-          ℹ️ Install this [Tampermonkey script](https://github.com/Automattic/woocommerce-payments/tree/develop/bin/wcpay-live-branches) to get more options.
+          :information_source: Install this [Tampermonkey script](https://github.com/Automattic/woocommerce-payments/tree/develop/bin/wcpay-live-branches) to get more options.
           
           ---
-          
-          Build info:
-          
-          - Latest commit: PLACEHOLDER_PR_HEAD_SHA
-          - Build time: PLACEHOLDER_BUILD_TIME
-          
-          _Note: the build is updated when a new commit is pushed to this PR._
-          EOF
-          )
 
-          # Substitute variables in BODY
-          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_PR_NUMBER/${PR_NUMBER}/g")
-          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_PR_HEAD_REF/${PR_HEAD_REF}/g")
-          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_PR_HEAD_SHA/${PR_HEAD_SHA}/g")
-          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_BUILD_TIME/$(date -u "+%Y-%m-%d %H:%M:%S UTC")/g")
+          Build info: 
+          
+          - Latest commit: ${PR_HEAD_SHA}
+          - Build time: $(date -u "+%Y-%m-%d %H:%M:%S UTC")
+
+          _Note: the build is updated when a new commit is pushed to this PR._"
+          # End declaring variable BODY
 
           echo "Comment body created successfully"
 

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -113,36 +113,75 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.head_ref }}
         run: |
-          BODY="### Test the build 
+          set -e  # Exit on any error
+
+          # Debug: Check environment variables
+          echo "=== Debug: Environment Variables ==="
+          echo "PR_NUMBER: ${PR_NUMBER}"
+          echo "PR_HEAD_REF: ${PR_HEAD_REF}"
+          echo "PR_HEAD_SHA: ${PR_HEAD_SHA}"
+          echo "GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
+          echo "===================================="
+
+          # Test GitHub CLI access
+          echo "Testing GitHub CLI access..."
+          gh pr view ${PR_NUMBER} --json number || {
+            echo "ERROR: Failed to access PR via GitHub CLI"
+            exit 1
+          }
+
+          # Create BODY variable using here-document for better handling
+          echo "Creating comment body..."
+          BODY=$(cat << 'EOF'
+          ### Test the build
           
           #### Option 1. Jetpack Beta
           
           - Install and activate [Jetpack Beta](https://jetpack.com/download-jetpack-beta/).
-          - Use this build by searching for PR number \`${PR_NUMBER}\` or branch name \`${PR_HEAD_REF}\` in your-test.site/wp-admin/admin.php?page=jetpack-beta&plugin=woocommerce-payments          
+          - Use this build by searching for PR number `PLACEHOLDER_PR_NUMBER` or branch name `PLACEHOLDER_PR_HEAD_REF` in your-test.site/wp-admin/admin.php?page=jetpack-beta&plugin=woocommerce-payments
           
           #### Option 2. Jurassic Ninja - available for logged-in A12s
-         
-          :rocket: [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=${PR_HEAD_REF}) :rocket:
           
-          :information_source: Install this [Tampermonkey script](https://github.com/Automattic/woocommerce-payments/tree/develop/bin/wcpay-live-branches) to get more options.
+          🚀 [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=PLACEHOLDER_PR_HEAD_REF) 🚀
+          
+          ℹ️ Install this [Tampermonkey script](https://github.com/Automattic/woocommerce-payments/tree/develop/bin/wcpay-live-branches) to get more options.
           
           ---
-
-          Build info: 
           
-          - Latest commit: ${PR_HEAD_SHA}
-          - Build time: $(date -u "+%Y-%m-%d %H:%M:%S UTC")
+          Build info:
+          
+          - Latest commit: PLACEHOLDER_PR_HEAD_SHA
+          - Build time: PLACEHOLDER_BUILD_TIME
+          
+          _Note: the build is updated when a new commit is pushed to this PR._
+          EOF
+          )
 
-          _Note: the build is updated when a new commit is pushed to this PR._"
-          # End declaring variable BODY
+          # Substitute variables in BODY
+          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_PR_NUMBER/${PR_NUMBER}/g")
+          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_PR_HEAD_REF/${PR_HEAD_REF}/g")
+          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_PR_HEAD_SHA/${PR_HEAD_SHA}/g")
+          BODY=$(echo "$BODY" | sed "s/PLACEHOLDER_BUILD_TIME/$(date -u "+%Y-%m-%d %H:%M:%S UTC")/g")
 
-          # Find existing build comment by searching for unique identifier
-          COMMENT_ID=$(gh pr view ${PR_NUMBER} --json comments --jq '.comments[] | select(.body | contains("### Test the build")) | .url' | head -1 | grep -o '[0-9]*$')
+          echo "Comment body created successfully"
+
+          # Find existing build comment with better error handling
+          echo "Searching for existing comment..."
+          COMMENT_ID=$(gh pr view ${PR_NUMBER} --json comments --jq '.comments[]? | select(.body | contains("### Test the build")) | .url' 2>/dev/null | head -1 | grep -o '[0-9]*$' || echo "")
 
           if [ -n "$COMMENT_ID" ]; then
-            # Update existing comment
-            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}"
+            echo "Found existing comment ID: $COMMENT_ID"
+            echo "Updating existing comment..."
+            gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}" || {
+              echo "ERROR: Failed to update existing comment"
+              exit 1
+            }
+            echo "Comment updated successfully"
           else
-            # Create new comment if none found
-            gh api repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments -f body="${BODY}"
+            echo "No existing comment found, creating new one..."
+            gh api repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments -f body="${BODY}" || {
+              echo "ERROR: Failed to create new comment"
+              exit 1
+            }
+            echo "New comment created successfully"
           fi

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -144,5 +144,5 @@ jobs:
             gh api repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} -X PATCH -f body="${BODY}"
           else
             # Create new comment if none found
-            gh pr comment ${PR_NUMBER} --body "${BODY}"
+            gh api repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments -f body="${BODY}"
           fi

--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ See: https://github.com/Automattic/woocommerce-payments/blob/trunk/CONTRIBUTING.
 If you are following the Docker setup [here](https://github.com/Automattic/woocommerce-payments/blob/trunk/docker/README.md), Xdebug is ready to use for debugging.
 
 Install [Xdebug Helper browser extension mentioned here](https://xdebug.org/docs/remote) to enable Xdebug on demand.
+<!-- test commit -->

--- a/README.md
+++ b/README.md
@@ -69,4 +69,3 @@ See: https://github.com/Automattic/woocommerce-payments/blob/trunk/CONTRIBUTING.
 If you are following the Docker setup [here](https://github.com/Automattic/woocommerce-payments/blob/trunk/docker/README.md), Xdebug is ready to use for debugging.
 
 Install [Xdebug Helper browser extension mentioned here](https://xdebug.org/docs/remote) to enable Xdebug on demand.
-<!-- test commit -->

--- a/changelog/fix-botwoo-in-pr-live-branch-workflow
+++ b/changelog/fix-botwoo-in-pr-live-branch-workflow
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Fix pr-build-live-branch workflow failure due to BOTWOO_TOKEN
+Comment: Replace BOTWOO_TOKEN in pr-build-live-branch workflow with github-actions bot
 
 

--- a/changelog/fix-botwoo-in-pr-live-branch-workflow
+++ b/changelog/fix-botwoo-in-pr-live-branch-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix pr-build-live-branch workflow failure due to BOTWOO_TOKEN
+
+


### PR DESCRIPTION
Fixes [WOOPMNT-5331](https://linear.app/a8c/issue/WOOPMNT-5331/address-pr-build-live-branch-failure-due-to-botwoo-token)

#### Changes proposed in this Pull Request

- Remove the usage of BOTWOO_TOKEN, use github-actions bot instead.
- Change the approach of detecting the existing comment for this workflow by using `gh api`

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Push commit to this PR to see that the comment about the testing branch is updated and created by `github-actions` bot rather than @botwoo in the current PRs based on the `develop` branch. For this PR, it's https://github.com/Automattic/woocommerce-payments/pull/11050#issuecomment-3303792840

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
