### PR TITLE
Fix WooPay issue with single use coupons

### DIFF
--- a/changelog/fix-ignore-coupon-usage-limit-preflight-check
+++ b/changelog/fix-ignore-coupon-usage-limit-preflight-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Single use coupons issues on WooPay.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -746,7 +746,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		return false !== strpos( $GLOBALS['wp']->query_vars['rest_route'], '/checkout' );
+		return str_contains( $GLOBALS['wp']->query_vars['rest_route'], '/checkout' );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -52,6 +52,7 @@ use WCPay\Payment_Information;
 use WCPay\Payment_Methods\Link_Payment_Method;
 use WCPay\WooPay\WooPay_Order_Status_Sync;
 use WCPay\WooPay\WooPay_Utilities;
+use WCPay\WooPay\WooPay_Session;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Tracker;
 use WCPay\Internal\Service\Level3Service;
@@ -719,9 +720,33 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			remove_all_filters( 'woocommerce_checkout_registration_required' );
 
 			add_filter( 'woocommerce_coupon_get_usage_limit', '__return_null' );
+		} elseif (
+			WooPay_Session::is_request_from_woopay() &&
+			$this->is_request_to_store_api_checkout() &&
+			WooPay_Session::has_valid_request_signature()
+		) {
+			// We disable the user usage limit check during WooPay actual checkout because
+			// the coupon validation looks for existing orders with the same user email and coupon code,
+			// and the draft order generated during the preflight check meets those criteria.
+			// There is no problem in disabling it because the user usage limit is already checked
+			// during the preflight check.
+			add_filter( 'woocommerce_coupon_get_usage_limit_per_user', '__return_zero' );
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Checks if the request is to the Store API checkout.
+	 *
+	 * @return bool True if the request is to the Store API checkout, false otherwise.
+	 */
+	protected function is_request_to_store_api_checkout() {
+		if ( ! \WC_Payments_Utils::is_store_api_request() ) {
+			return false;
+		}
+
+		return false !== strpos( $GLOBALS['wp']->query_vars['rest_route'], '/checkout' );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -737,7 +737,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		return str_contains( $GLOBALS['wp']->query_vars['rest_route'], '/checkout' );
+		return false !== strpos( $GLOBALS['wp']->query_vars['rest_route'], '/checkout' );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -717,6 +717,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			// Avoid creating new accounts during preflight check.
 			remove_all_filters( 'woocommerce_checkout_registration_required' );
+
+			add_filter(
+				'woocommerce_coupon_get_usage_limit',
+				function () {
+					return null;
+				}
+			);
 		}
 
 		return $response;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -720,16 +720,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			remove_all_filters( 'woocommerce_checkout_registration_required' );
 
 			add_filter( 'woocommerce_coupon_get_usage_limit', '__return_null' );
-		} elseif (
-			WooPay_Session::is_request_from_woopay() &&
-			$this->is_request_to_store_api_checkout() &&
-			WooPay_Session::has_valid_request_signature()
-		) {
-			// We disable the user usage limit check during WooPay actual checkout because
-			// the coupon validation looks for existing orders with the same user email and coupon code,
-			// and the draft order generated during the preflight check meets those criteria.
-			// There is no problem in disabling it because the user usage limit is already checked
-			// during the preflight check.
+
 			add_filter( 'woocommerce_coupon_get_usage_limit_per_user', '__return_zero' );
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -718,12 +718,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// Avoid creating new accounts during preflight check.
 			remove_all_filters( 'woocommerce_checkout_registration_required' );
 
-			add_filter(
-				'woocommerce_coupon_get_usage_limit',
-				function () {
-					return null;
-				}
-			);
+			add_filter( 'woocommerce_coupon_get_usage_limit', '__return_null' );
 		}
 
 		return $response;

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -778,23 +778,12 @@ class WooPay_Session {
 	}
 
 	/**
-	 * Get the WooPay verified email address from the header.
-	 *
-	 * @return string|null The WooPay verified email address if it's set.
-	 */
-	private static function get_woopay_verified_email_address() {
-		$has_woopay_verified_email_address = isset( $_SERVER['HTTP_X_WOOPAY_VERIFIED_EMAIL_ADDRESS'] );
-
-		return $has_woopay_verified_email_address ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WOOPAY_VERIFIED_EMAIL_ADDRESS'] ) ) : null;
-	}
-
-	/**
 	 * Returns true if the request that's currently being processed is from WooPay, false
 	 * otherwise.
 	 *
 	 * @return bool True if request is from WooPay.
 	 */
-	private static function is_request_from_woopay(): bool {
+	public static function is_request_from_woopay(): bool {
 		return isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'];
 	}
 
@@ -803,8 +792,19 @@ class WooPay_Session {
 	 *
 	 * @return bool True if the request signature is valid.
 	 */
-	private static function has_valid_request_signature() {
+	public static function has_valid_request_signature() {
 		return apply_filters( 'wcpay_woopay_is_signed_with_blog_token', Rest_Authentication::is_signed_with_blog_token() );
+	}
+
+	/**
+	 * Get the WooPay verified email address from the header.
+	 *
+	 * @return string|null The WooPay verified email address if it's set.
+	 */
+	private static function get_woopay_verified_email_address() {
+		$has_woopay_verified_email_address = isset( $_SERVER['HTTP_X_WOOPAY_VERIFIED_EMAIL_ADDRESS'] );
+
+		return $has_woopay_verified_email_address ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WOOPAY_VERIFIED_EMAIL_ADDRESS'] ) ) : null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOPAY-365

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
This PR fixes issues when checking out with WooPay while using single use coupons.

This happens because coupons with usage limit [were getting holded](https://github.com/woocommerce/woocommerce/blob/9ba2892dbc2127ca6b62ea64dc154dd6cbaf7874/plugins/woocommerce/includes/abstracts/abstract-wc-order.php#L1162) during the WooPay preflight check, this incremented the `$tentative_usage_count` [here](https://github.com/woocommerce/woocommerce/blob/9ba2892dbc2127ca6b62ea64dc154dd6cbaf7874/plugins/woocommerce/includes/class-wc-discounts.php#L634) causing an error on the WooPay actual checkout request.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a single use coupon.
* Checkout with WooPay.
* Add the coupon on WooPay or merchant site.
* Place order on WooPay.
* You should get no errors.
* Try to use the coupon again.
* You should get an usual coupon usage limit error message.

Redo the test with single use per user coupon and both.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
