### PR TITLE
Add caching to address autocomplete token

### DIFF
--- a/changelog/fix-woopmt-5349
+++ b/changelog/fix-woopmt-5349
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add caching to address autocomplete token

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -16,12 +16,13 @@ defined( 'ABSPATH' ) || exit; // block direct access.
  * A class for caching data as an option in the database.
  */
 class Database_Cache implements MultiCurrencyCacheInterface {
-	const ACCOUNT_KEY                 = 'wcpay_account_data';
-	const ONBOARDING_FIELDS_DATA_KEY  = 'wcpay_onboarding_fields_data';
-	const BUSINESS_TYPES_KEY          = 'wcpay_business_types_data';
-	const PAYMENT_PROCESS_FACTORS_KEY = 'wcpay_payment_process_factors';
-	const FRAUD_SERVICES_KEY          = 'wcpay_fraud_services_data';
-	const RECOMMENDED_PAYMENT_METHODS = 'wcpay_recommended_payment_methods';
+	const ACCOUNT_KEY                  = 'wcpay_account_data';
+	const ONBOARDING_FIELDS_DATA_KEY   = 'wcpay_onboarding_fields_data';
+	const BUSINESS_TYPES_KEY           = 'wcpay_business_types_data';
+	const PAYMENT_PROCESS_FACTORS_KEY  = 'wcpay_payment_process_factors';
+	const FRAUD_SERVICES_KEY           = 'wcpay_fraud_services_data';
+	const RECOMMENDED_PAYMENT_METHODS  = 'wcpay_recommended_payment_methods';
+	const ADDRESS_AUTOCOMPLETE_JWT_KEY = 'wcpay_address_autocomplete_jwt';
 
 	/**
 	 * Refresh during AJAX calls is avoided, but white-listing
@@ -468,6 +469,9 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 				break;
 			case self::TRACKING_INFO_KEY:
 				$ttl = $cache_contents['errored'] ? 2 * MINUTE_IN_SECONDS : MONTH_IN_SECONDS;
+				break;
+			case self::ADDRESS_AUTOCOMPLETE_JWT_KEY:
+				$ttl = 12 * HOUR_IN_SECONDS;
 				break;
 			default:
 				// Default to 24h.

--- a/includes/class-wc-payments-address-provider.php
+++ b/includes/class-wc-payments-address-provider.php
@@ -14,6 +14,7 @@ if ( ! class_exists( 'Automattic\\WooCommerce\\Internal\\AddressProvider\\Abstra
 }
 
 use Automattic\WooCommerce\Internal\AddressProvider\AbstractAutomatticAddressProvider;
+use WCPay\Database_Cache;
 use WCPay\Logger;
 
 /**
@@ -23,6 +24,11 @@ use WCPay\Logger;
  */
 class WC_Payments_Address_Provider extends AbstractAutomatticAddressProvider {
 	/**
+	 * Placeholder value to use in the cache when the token retrieval fails.
+	 */
+	const INVALID_TOKEN = 'INVALID_TOKEN';
+
+	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -30,14 +36,32 @@ class WC_Payments_Address_Provider extends AbstractAutomatticAddressProvider {
 	protected $payments_api_client;
 
 	/**
+	 * Payments account service.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $account;
+
+	/**
+	 * Database cache instance.
+	 *
+	 * @var Database_Cache
+	 */
+	private $database_cache;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WC_Payments_API_Client $payments_api_client The API client for making requests.
+	 * @param WC_Payments_Account    $account The payments account service.
+	 * @param Database_Cache         $database_cache The database cache instance.
 	 */
-	public function __construct( WC_Payments_API_Client $payments_api_client ) {
+	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account, Database_Cache $database_cache ) {
 		$this->id                  = 'woocommerce_payments';
 		$this->name                = __( 'WooCommerce Payments', 'woocommerce-payments' );
 		$this->payments_api_client = $payments_api_client;
+		$this->account             = $account;
+		$this->database_cache      = $database_cache;
 		parent::__construct();
 	}
 
@@ -53,16 +77,32 @@ class WC_Payments_Address_Provider extends AbstractAutomatticAddressProvider {
 	 * @return string|WP_Error The JWT token on success, WP_Error on failure.
 	 */
 	public function get_address_service_jwt() {
-		try {
-			$response = $this->payments_api_client->get_address_autocomplete_token();
-			return $response['token'];
-		} catch ( \Exception $e ) {
-			Logger::error( 'Unexpected error getting address service JWT: ' . $e->getMessage() );
+		$token = $this->database_cache->get_or_add(
+			Database_Cache::ADDRESS_AUTOCOMPLETE_JWT_KEY,
+			function () {
+				if ( ! $this->account->is_stripe_connected() ) {
+					return self::INVALID_TOKEN;
+				}
+
+				try {
+					$response = $this->payments_api_client->get_address_autocomplete_token();
+					return $response['token'] ?? self::INVALID_TOKEN;
+				} catch ( \Exception $e ) {
+					Logger::error( 'Unexpected error getting address service JWT: ' . $e->getMessage() );
+					return self::INVALID_TOKEN;
+				}
+			},
+			'__return_true'
+		);
+
+		if ( self::INVALID_TOKEN === $token ) {
 			return new WP_Error(
 				'wcpay_address_service_error',
 				'An unexpected error occurred while retrieving the address service token.'
 			);
 		}
+
+		return $token;
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -904,7 +904,7 @@ class WC_Payments {
 
 		include_once __DIR__ . '/class-wc-payments-address-provider.php';
 
-		$providers[] = new WC_Payments_Address_Provider( self::$api_client );
+		$providers[] = new WC_Payments_Address_Provider( self::$api_client, self::$account, self::$database_cache );
 
 		return $providers;
 	}


### PR DESCRIPTION
Fixes WOOPMNT-5349

#### Changes proposed in this Pull Request

* Adds a check for whether the account is fully connected before making the request 
* Added caching for 12h of the returned token or error response
* Tweaked the logic a bit to always return a WP_Error, as expected by Core

#### Testing instructions

* Tests should pass
