### PR TITLE
Fix edge case when shipping information is added by mistake for digital products

### DIFF
--- a/changelog/fix-edge-case-when-shipping-information-is-added-by-mistake
+++ b/changelog/fix-edge-case-when-shipping-information-is-added-by-mistake
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix edge case when shipping information is added by mistake for digital products.

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -397,6 +397,21 @@ export default ( { query }: { query: { id: string } } ) => {
 		setIsAccordionOpen( currentStep === 0 );
 	}, [ currentStep ] );
 
+	// Clear shipping information when shipping is not needed
+	useEffect( () => {
+		if ( ! hasShipping ) {
+			setShippingCarrier( '' );
+			setShippingDate( '' );
+			setShippingTrackingNumber( '' );
+			setShippingAddress( '' );
+			// Clear shipping documentation from evidence
+			setEvidence( ( prev: any ) => ( {
+				...prev,
+				shipping_documentation: '',
+			} ) );
+		}
+	}, [ hasShipping ] );
+
 	// --- File upload logic ---
 	const isUploadingEvidence = () =>
 		Object.values( isUploading ).some( Boolean );
@@ -462,30 +477,62 @@ export default ( { query }: { query: { id: string } } ) => {
 					: 'wcpay_dispute_save_evidence_clicked'
 			);
 
-			// Only include file keys in the evidence object if they have a non-empty value
+			// Build base evidence object
+			const baseEvidence = {
+				...dispute.evidence,
+				product_description: productDescription,
+				receipt: evidence.receipt,
+				customer_communication: evidence.customer_communication,
+				customer_signature: evidence.customer_signature,
+				refund_policy: evidence.refund_policy,
+				duplicate_charge_documentation:
+					evidence.duplicate_charge_documentation,
+				service_documentation: evidence.service_documentation,
+				cancellation_policy: evidence.cancellation_policy,
+				access_activity_log: evidence.access_activity_log,
+				uncategorized_file: evidence.uncategorized_file,
+				uncategorized_text: coverLetter,
+				customer_purchase_ip: dispute.order?.ip_address,
+			};
+
+			// Only include shipping information if shipping is needed
+			if ( hasShipping ) {
+				baseEvidence.shipping_documentation =
+					evidence.shipping_documentation;
+				baseEvidence.shipping_carrier = shippingCarrier;
+				baseEvidence.shipping_date = shippingDate;
+				baseEvidence.shipping_tracking_number = shippingTrackingNumber;
+				baseEvidence.shipping_address = shippingAddress;
+			} else {
+				// Clear shipping information when not needed
+				baseEvidence.shipping_documentation = '';
+				baseEvidence.shipping_carrier = '';
+				baseEvidence.shipping_date = '';
+				baseEvidence.shipping_tracking_number = '';
+				baseEvidence.shipping_address = '';
+			}
+
+			// Define shipping field keys that need special handling
+			// These fields must always be sent to Stripe (even when empty) to clear existing data when shipping is not needed
+			const shippingFieldKeys = [
+				'shipping_documentation',
+				'shipping_carrier',
+				'shipping_date',
+				'shipping_tracking_number',
+				'shipping_address',
+			];
+
+			// Filter evidence: include shipping fields even if empty (to clear them),
+			// but filter out other empty fields
 			const evidenceToSend = Object.fromEntries(
-				Object.entries( {
-					...dispute.evidence,
-					product_description: productDescription,
-					receipt: evidence.receipt,
-					customer_communication: evidence.customer_communication,
-					customer_signature: evidence.customer_signature,
-					refund_policy: evidence.refund_policy,
-					duplicate_charge_documentation:
-						evidence.duplicate_charge_documentation,
-					shipping_documentation: evidence.shipping_documentation,
-					service_documentation: evidence.service_documentation,
-					cancellation_policy: evidence.cancellation_policy,
-					access_activity_log: evidence.access_activity_log,
-					uncategorized_file: evidence.uncategorized_file,
-					uncategorized_text: coverLetter,
-					// Add shipping details
-					shipping_carrier: shippingCarrier,
-					shipping_date: shippingDate,
-					shipping_tracking_number: shippingTrackingNumber,
-					shipping_address: shippingAddress,
-					customer_purchase_ip: dispute.order?.ip_address,
-				} ).filter( ( [ , value ] ) => value && value !== '' )
+				Object.entries( baseEvidence ).filter( ( [ key, value ] ) => {
+					// Always include shipping fields (even if empty) to ensure they're cleared on Stripe
+					if ( shippingFieldKeys.includes( key ) ) {
+						return true;
+					}
+					// For non-shipping fields, only include if they have a value
+					return value && value !== '';
+				} )
 			);
 
 			// Update metadata with the current productType

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -58,7 +58,7 @@ import {
 	getRecommendedDocumentFields,
 	getRecommendedShippingDocumentFields,
 } from './recommended-document-fields';
-import { RecommendedDocument } from './types';
+import { RecommendedDocument, EvidenceState } from './types';
 
 import './style.scss';
 import RefundStatus from './refund-status';
@@ -102,7 +102,7 @@ function needsShipping( reason: string | undefined, productType = '' ) {
 export default ( { query }: { query: { id: string } } ) => {
 	const path = `/wc/v3/payments/disputes/${ query.id }`;
 	const [ dispute, setDispute ] = useState< any >();
-	const [ evidence, setEvidence ] = useState< any >( {} );
+	const [ evidence, setEvidence ] = useState< EvidenceState >( {} );
 	const [ productType, setProductType ] = useState< string >( '' );
 	const [ isInitialLoading, setIsInitialLoading ] = useState( true );
 	const [ currentStep, setCurrentStep ] = useState( 0 );
@@ -173,7 +173,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				);
 				setShippingAddress( d.evidence?.shipping_address || '' );
 				// Load saved file IDs from evidence
-				setEvidence( ( prev: any ) => ( {
+				setEvidence( ( prev: EvidenceState ) => ( {
 					...prev,
 					receipt: d.evidence?.receipt || '',
 					customer_communication:
@@ -405,7 +405,7 @@ export default ( { query }: { query: { id: string } } ) => {
 			setShippingTrackingNumber( '' );
 			setShippingAddress( '' );
 			// Clear shipping documentation from evidence
-			setEvidence( ( prev: any ) => ( {
+			setEvidence( ( prev: EvidenceState ) => ( {
 				...prev,
 				shipping_documentation: '',
 			} ) );
@@ -716,7 +716,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	const updateProductDescription = ( value: string ) => {
 		setProductDescription( value );
-		setEvidence( ( prev: any ) => ( {
+		setEvidence( ( prev: EvidenceState ) => ( {
 			...prev,
 			product_description: value,
 		} ) );
@@ -724,7 +724,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	const updateShippingCarrier = ( value: string ) => {
 		setShippingCarrier( value );
-		setEvidence( ( prev: any ) => ( {
+		setEvidence( ( prev: EvidenceState ) => ( {
 			...prev,
 			shipping_carrier: value,
 		} ) );
@@ -732,7 +732,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	const updateShippingDate = ( value: string ) => {
 		setShippingDate( value );
-		setEvidence( ( prev: any ) => ( {
+		setEvidence( ( prev: EvidenceState ) => ( {
 			...prev,
 			shipping_date: value,
 		} ) );
@@ -740,7 +740,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	const updateShippingTrackingNumber = ( value: string ) => {
 		setShippingTrackingNumber( value );
-		setEvidence( ( prev: any ) => ( {
+		setEvidence( ( prev: EvidenceState ) => ( {
 			...prev,
 			shipping_tracking_number: value,
 		} ) );
@@ -748,7 +748,7 @@ export default ( { query }: { query: { id: string } } ) => {
 
 	const updateShippingAddress = ( value: string ) => {
 		setShippingAddress( value );
-		setEvidence( ( prev: any ) => ( {
+		setEvidence( ( prev: EvidenceState ) => ( {
 			...prev,
 			shipping_address: value,
 		} ) );
@@ -795,7 +795,7 @@ export default ( { query }: { query: { id: string } } ) => {
 		setIsUploading( ( prev ) => ( { ...prev, [ key ]: true } ) );
 
 		// Force reload evidence components.
-		setEvidence( ( e: any ) => ( { ...e, [ key ]: '' } ) );
+		setEvidence( ( e: EvidenceState ) => ( { ...e, [ key ]: '' } ) );
 
 		try {
 			const uploadedFile: any = await apiFetch( {
@@ -805,7 +805,10 @@ export default ( { query }: { query: { id: string } } ) => {
 			} );
 
 			// Store uploaded file name in metadata to display in submitted evidence or saved for later form.
-			setEvidence( ( e: any ) => ( { ...e, [ key ]: uploadedFile.id } ) );
+			setEvidence( ( e: EvidenceState ) => ( {
+				...e,
+				[ key ]: uploadedFile.id,
+			} ) );
 			// Store uploaded file name to avoid fetching the file details again.
 			setUploadedFiles( ( prev ) => ( {
 				...prev,
@@ -833,14 +836,14 @@ export default ( { query }: { query: { id: string } } ) => {
 			);
 
 			// Force reload evidence components.
-			setEvidence( ( e: any ) => ( { ...e, [ key ]: '' } ) );
+			setEvidence( ( e: EvidenceState ) => ( { ...e, [ key ]: '' } ) );
 		} finally {
 			setIsUploading( ( prev ) => ( { ...prev, [ key ]: false } ) );
 		}
 	};
 
 	const doRemoveFile = ( key: string ) => {
-		setEvidence( ( e: any ) => ( { ...e, [ key ]: '' } ) );
+		setEvidence( ( e: EvidenceState ) => ( { ...e, [ key ]: '' } ) );
 		setFileSizes( ( prev ) => ( { ...prev, [ key ]: 0 } ) );
 		// Remove the file name from the uploaded files.
 		setUploadedFiles( ( prev ) => ( { ...prev, [ key ]: '' } ) );

--- a/client/disputes/new-evidence/types.ts
+++ b/client/disputes/new-evidence/types.ts
@@ -94,3 +94,28 @@ export interface RecommendedDocumentsProps {
 	fields: DocumentField[];
 	readOnly?: boolean;
 }
+
+export interface BaseEvidence {
+	product_description: string;
+	receipt: string;
+	customer_communication: string;
+	customer_signature: string;
+	refund_policy: string;
+	duplicate_charge_documentation: string;
+	shipping_documentation: string;
+	service_documentation: string;
+	cancellation_policy: string;
+	access_activity_log: string;
+	uncategorized_file: string;
+	uncategorized_text: string;
+	shipping_carrier: string;
+	shipping_date: string;
+	shipping_tracking_number: string;
+	shipping_address: string;
+	customer_purchase_ip: string;
+	[ key: string ]: string;
+}
+
+export type EvidenceState = Partial< BaseEvidence > & {
+	[ key: string ]: string | undefined;
+};


### PR DESCRIPTION
Fixes WOOPMNT-5342

#### Changes proposed in this Pull Request

This PR attempts to fix an edge case when shipping information is added by mistake for digital products. Undesired behavior:

Unwanted behavior:
- Challenge dispute.
- In the Purchase info section, keep the product type dropdown on “Physical products”
- You can fill any other fields, and then proceed to step 2, enter shipping information in the fields there.
- Click, Save for later
- Go back to step 1, change it to “Digital products”
- Note that the section shipping information is gone
- Finalize the steps and then submit the challenge
Undesired outcome: **the shipping information is sent even when the dropdown has changed.**

#### Testing instructions

1. Create the dispute
   1. Navigate to Payments > Settings.
   2. Ensure that WooPayments is in test mode.
   3. If it isn't, enable test mode and save your settings.
   4. Add a virtual product to your cart.
   5. Navigate to the checkout page.
   6. Add [a dispute test card](https://docs.stripe.com/testing#disputes) (e.g., 4000000000000259) to the Payment Element.
   7. Add a future-dated expiration
   8. Add any three numbers for the CVC
   9. Place the order.
2. Challenge the dispute
   1. Navigate to Payments > Disputes.
   2. Locate the dispute that resulted from step 1.
   11. Select Respond.
   12. Select Challenge dispute.
   13. In the Purchase info section, keep the product type dropdown on “Physical products”
   14. You can fill any other fields, and then proceed to step 2, enter shipping information in the fields there.
   15. Go back to step 1, change it to “Digital products”
   16. Note that the section shipping information is gone
   17. Finalize the steps and then submit the challenge
3. Check the evidence
   1. Go to the Stripe dashboard for that store
   3. Go to transactions
   21. Find the transaction disputed and select it
   22. You have to find the option to see the evidence sent, and then check that shipping info was **not** sent.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
