### PR TITLE
Skip SSL when running the tests locally

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -55,6 +55,12 @@ get_db_connection_flags() {
 			EXTRA_FLAGS=" --host=$DB_HOSTNAME --protocol=tcp"
 		fi
 	fi
+
+	# Add --skip-ssl flag for local development (not in CI)
+	if [ -z "$CI" ] && [ -z "$GITHUB_ACTIONS" ]; then
+		EXTRA_FLAGS="$EXTRA_FLAGS --skip-ssl"
+	fi
+
 	echo "--user=$DB_USER --password=$DB_PASS $EXTRA_FLAGS";
 }
 

--- a/changelog/skip-ssl-running-tests-locally
+++ b/changelog/skip-ssl-running-tests-locally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skip SSL verification when running the PHP tests locally.

--- a/changelog/skip-ssl-running-tests-locally
+++ b/changelog/skip-ssl-running-tests-locally
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Skip SSL verification when running the PHP tests locally.
+Comment: Skip SSL verification when running the PHP tests locally.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I was having trouble running the PHP tests locally. This PR adds a check to skip the SSL verification only when running locally.

#### Testing instructions

* Tests should pass
* `git checkout` this branch and run `npm run test:php`

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
