### PR TITLE
Handle dispute counts for menu items between live and test mode

### DIFF
--- a/changelog/woopmnt-5346-disputes-menu-item-badged-in-live-mode-for-test-disputes
+++ b/changelog/woopmnt-5346-disputes-menu-item-badged-in-live-mode-for-test-disputes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Handle dispute counts for menu items between live and test mode

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1343,6 +1343,9 @@ class WC_Payments_Admin {
 	 * @return int The number of disputes which need a response.
 	 */
 	private function get_disputes_awaiting_response_count() {
+		$test_mode = WC_Payments::mode()->is_test();
+		$cache_key = $test_mode ? Database_Cache::DISPUTE_STATUS_COUNTS_KEY_TEST_MODE : Database_Cache::DISPUTE_STATUS_COUNTS_KEY;
+
 		$send_callback = function () {
 			$request = Request::get( WC_Payments_API_Client::DISPUTES_API . '/status_counts' );
 			$request->assign_hook( 'wcpay_get_dispute_status_counts' );
@@ -1350,7 +1353,7 @@ class WC_Payments_Admin {
 		};
 
 		$disputes_status_counts = $this->database_cache->get_or_add(
-			Database_Cache::DISPUTE_STATUS_COUNTS_KEY,
+			$cache_key,
 			$send_callback,
 			// We'll consider all array values to be valid as the cache is only invalidated when it is deleted or it expires.
 			'is_array'

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -47,6 +47,13 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	const DISPUTE_STATUS_COUNTS_KEY = 'wcpay_dispute_status_counts_cache';
 
 	/**
+	 * Dispute status counts cache key for test mode.
+	 *
+	 * @var string
+	 */
+	const DISPUTE_STATUS_COUNTS_KEY_TEST_MODE = 'wcpay_test_dispute_status_counts_cache';
+
+	/**
 	 * Active disputes cache key.
 	 *
 	 * @var string
@@ -257,6 +264,7 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 			self::FRAUD_SERVICES_KEY,
 			self::RECOMMENDED_PAYMENT_METHODS,
 			self::DISPUTE_STATUS_COUNTS_KEY,
+			self::DISPUTE_STATUS_COUNTS_KEY_TEST_MODE,
 			self::ACTIVE_DISPUTES_KEY,
 			self::AUTHORIZATION_SUMMARY_KEY,
 			self::AUTHORIZATION_SUMMARY_KEY_TEST_MODE,
@@ -283,6 +291,18 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 */
 	public function disable_refresh() {
 		$this->refresh_disabled = true;
+	}
+
+	/**
+	 * Delete all dispute-related cache entries.
+	 * This ensures both live and test mode dispute counts are refreshed.
+	 *
+	 * @return void
+	 */
+	public function delete_dispute_caches() {
+		$this->delete( self::DISPUTE_STATUS_COUNTS_KEY );
+		$this->delete( self::DISPUTE_STATUS_COUNTS_KEY_TEST_MODE );
+		$this->delete( self::ACTIVE_DISPUTES_KEY );
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -583,8 +583,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->order_service->mark_payment_dispute_created( $order, $charge_id, $amount, $reason, $due_by, $status );
 
 		// Clear dispute caches to trigger a fetch of new data.
-		$this->database_cache->delete( DATABASE_CACHE::DISPUTE_STATUS_COUNTS_KEY );
-		$this->database_cache->delete( DATABASE_CACHE::ACTIVE_DISPUTES_KEY );
+		$this->database_cache->delete_dispute_caches();
 	}
 
 	/**
@@ -614,8 +613,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->order_service->mark_payment_dispute_closed( $order, $charge_id, $status );
 
 		// Clear dispute caches to trigger a fetch of new data.
-		$this->database_cache->delete( DATABASE_CACHE::DISPUTE_STATUS_COUNTS_KEY );
-		$this->database_cache->delete( DATABASE_CACHE::ACTIVE_DISPUTES_KEY );
+		$this->database_cache->delete_dispute_caches();
 	}
 
 	/**
@@ -670,8 +668,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$order->add_order_note( $note );
 
 		// Clear dispute caches to trigger a fetch of new data.
-		$this->database_cache->delete( DATABASE_CACHE::DISPUTE_STATUS_COUNTS_KEY );
-		$this->database_cache->delete( DATABASE_CACHE::ACTIVE_DISPUTES_KEY );
+		$this->database_cache->delete_dispute_caches();
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -684,8 +684,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 
 		$dispute = $this->request( $request, self::DISPUTES_API . '/' . $dispute_id, self::POST );
 		// Invalidate the dispute caches.
-		\WC_Payments::get_database_cache()->delete( Database_Cache::DISPUTE_STATUS_COUNTS_KEY );
-		\WC_Payments::get_database_cache()->delete( Database_Cache::ACTIVE_DISPUTES_KEY );
+		\WC_Payments::get_database_cache()->delete_dispute_caches();
 
 		if ( is_wp_error( $dispute ) ) {
 			return $dispute;
@@ -714,8 +713,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 
 		$dispute = $this->request( [], self::DISPUTES_API . '/' . $dispute_id . '/close', self::POST );
 		// Invalidate the dispute caches.
-		\WC_Payments::get_database_cache()->delete( Database_Cache::DISPUTE_STATUS_COUNTS_KEY );
-		\WC_Payments::get_database_cache()->delete( Database_Cache::ACTIVE_DISPUTES_KEY );
+		\WC_Payments::get_database_cache()->delete_dispute_caches();
 
 		if ( is_wp_error( $dispute ) ) {
 			return $dispute;


### PR DESCRIPTION
Fixes WOOPMNT-5346

#### Changes proposed in this Pull Request

- Created the `DISPUTE_STATUS_COUNTS_KEY_TEST_MODE` constant following the same pattern as authorization summary caches, PR https://github.com/Automattic/woocommerce-payments/pull/5250
- Centralized all validation calls into a single method in Database_Cache. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This is a bit tricky for testing. But I tested on the live site by Adam, and it's working well. In case, reviewers would like to test it, let me know so that I can share it. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] No need - Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.