### PR TITLE
Add instructions to work with Docker and Woo core repo

### DIFF
--- a/changelog/dev-work-with-core-and-docker
+++ b/changelog/dev-work-with-core-and-docker
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add instructions to work with Docker and Woo core repo
+
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,6 +86,21 @@ services:
 I used port `9003` as an example.
 To apply the change, restart your containers using `npm run down && npm run up`
 
+### Mapping WooCommerce development repo plugin folder
+
+If you also work on [WooCommerce core](https://github.com/woocommerce/woocommerce) that you want to use in your Docker environment, you can map it by adding a volume mapping to `docker-compose.override.yml`. 
+
+For example: if your WooCommerce core repo path is `/path/to/your/repo/woocommerce`, you should append `plugins/woocommerce` to this path and configure it like this.
+
+```
+services:
+  wordpress:
+    volumes:
+      - /path/to/your/repo/woocommerce/plugins/woocommerce:/var/www/html/wp-content/plugins/woocommerce
+```
+
+To apply the change, restart your containers using `npm run down && npm run up`. In case, it's not working properly yet, ensure that you follow the WooCommerce code README.md and build the plugin there. 
+
 ### Adding local helper scripts/hacks
 
 You can add local PHP scripts in the `docker/mu-plugins` directory since it's mounted as the `wp-content/mu-plugins` WordPress directory in your Docker container. These PHP scripts will be loaded automatically because they are treated as [WordPress must-use plugins](https://developer.wordpress.org/advanced-administration/plugins/mu-plugins/).


### PR DESCRIPTION
Fixes #

Also FYI @RadoslavGeorgiev as you might keep working on https://github.com/woocommerce/woocommerce/pull/61216 p1759328490663349-slack-C09EWAXSYD9

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- Just a doc change to work on WooPayments and Woo core repos at the same time.
- No need to spin up another Docker and keep using the current WooPayments docker.