### PR TITLE
Fix: Using manual Pay For Order page for a customer's order causes failure

### DIFF
--- a/changelog/woopmnt-5355-using-manual-pay-for-order-page-for-a-customers-order-causes
+++ b/changelog/woopmnt-5355-using-manual-pay-for-order-page-for-a-customers-order-causes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Phone number missing for Pay For Order page.

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -192,6 +192,7 @@ async function createStripePaymentMethod(
 			billing_details: {
 				name: wcpayCustomerData.name || undefined,
 				email: wcpayCustomerData.email,
+				phone: wcpayCustomerData.billing_phone,
 				address: wcpayCustomerData.address || {
 					country: wcpayCustomerData.billing_country,
 				},

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -117,6 +117,7 @@ export const getUpeSettings = ( paymentMethodType ) => {
 			billingDetails: {
 				name: window.wcpayCustomerData.name,
 				email: window.wcpayCustomerData.email,
+				phone: window.wcpayCustomerData.billing_phone,
 				address: {
 					country: window.wcpayCustomerData.billing_country,
 				},

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -397,64 +397,6 @@ class WC_Payments_Customer_Service {
 	}
 
 	/**
-	 * Recreates the customer for this user.
-	 *
-	 * @param WP_User|null $user          User to recreate a customer for.
-	 * @param array        $customer_data Customer data.
-	 *
-	 * @return string The newly created customer's ID
-	 *
-	 * @throws API_Exception Error creating customer.
-	 */
-	private function recreate_customer( ?WP_User $user, array $customer_data ): string {
-		if ( $user instanceof WP_User && $user->ID > 0 ) {
-			$result = delete_user_option( $user->ID, $this->get_customer_id_option() );
-			if ( ! $result ) {
-				// Log the error, but continue since we'll be trying to update this option in create_customer.
-				Logger::error( 'Failed to delete old customer ID for user ' . $user->ID );
-			}
-		}
-
-		return $this->create_customer_for_user( $user, $customer_data );
-	}
-
-	/**
-	 * Returns the name of the customer option meta, taking test mode into account.
-	 *
-	 * @return string The customer ID option name.
-	 */
-	private function get_customer_id_option(): string {
-		return WC_Payments::mode()->is_test()
-			? self::WCPAY_TEST_CUSTOMER_ID_OPTION
-			: self::WCPAY_LIVE_CUSTOMER_ID_OPTION;
-	}
-
-	/**
-	 * Migrate any customer ID that might be in the DEPRECATED_WCPAY_CUSTOMER_ID_OPTION.
-	 *
-	 * @param int $user_id The user ID to look for a customer ID with.
-	 */
-	private function maybe_migrate_deprecated_customer( $user_id ) {
-		$customer_id = get_user_option( self::DEPRECATED_WCPAY_CUSTOMER_ID_OPTION, $user_id );
-		if ( false !== $customer_id ) {
-			// A customer was found in the deprecated key. Migrate it to the appropriate one and delete the old meta.
-			// If an account is live mode, we optimistically assume that the customer is live mode, to avoid losing
-			// live mode customer data. If the account is not live mode, it can only have test mode objects, so we
-			// can safely migrate them to the test key.
-			// If is_live cannot be determined, default it to true to avoid considering a live account as test.
-			$account_is_live    = null === $this->account->get_is_live() || $this->account->get_is_live();
-			$customer_option_id = $account_is_live
-				? self::WCPAY_LIVE_CUSTOMER_ID_OPTION
-				: self::WCPAY_TEST_CUSTOMER_ID_OPTION;
-			if ( update_user_option( $user_id, $customer_option_id, $customer_id ) ) {
-				delete_user_option( $user_id, self::DEPRECATED_WCPAY_CUSTOMER_ID_OPTION );
-			} else {
-				Logger::error( 'Failed to store new customer ID for user ' . $user_id . '; legacy customer was kept.' );
-			}
-		}
-	}
-
-	/**
 	 * Get the WCPay customer ID associated with an order, or create one if none found.
 	 *
 	 * @param WC_Order $order WC Order object.
@@ -580,5 +522,63 @@ class WC_Payments_Customer_Service {
 			'billing_country' => $billing_country,
 			'address'         => $address,
 		];
+	}
+
+	/**
+	 * Recreates the customer for this user.
+	 *
+	 * @param WP_User|null $user          User to recreate a customer for.
+	 * @param array        $customer_data Customer data.
+	 *
+	 * @return string The newly created customer's ID
+	 *
+	 * @throws API_Exception Error creating customer.
+	 */
+	private function recreate_customer( ?WP_User $user, array $customer_data ): string {
+		if ( $user instanceof WP_User && $user->ID > 0 ) {
+			$result = delete_user_option( $user->ID, $this->get_customer_id_option() );
+			if ( ! $result ) {
+				// Log the error, but continue since we'll be trying to update this option in create_customer.
+				Logger::error( 'Failed to delete old customer ID for user ' . $user->ID );
+			}
+		}
+
+		return $this->create_customer_for_user( $user, $customer_data );
+	}
+
+	/**
+	 * Returns the name of the customer option meta, taking test mode into account.
+	 *
+	 * @return string The customer ID option name.
+	 */
+	private function get_customer_id_option(): string {
+		return WC_Payments::mode()->is_test()
+			? self::WCPAY_TEST_CUSTOMER_ID_OPTION
+			: self::WCPAY_LIVE_CUSTOMER_ID_OPTION;
+	}
+
+	/**
+	 * Migrate any customer ID that might be in the DEPRECATED_WCPAY_CUSTOMER_ID_OPTION.
+	 *
+	 * @param int $user_id The user ID to look for a customer ID with.
+	 */
+	private function maybe_migrate_deprecated_customer( $user_id ) {
+		$customer_id = get_user_option( self::DEPRECATED_WCPAY_CUSTOMER_ID_OPTION, $user_id );
+		if ( false !== $customer_id ) {
+			// A customer was found in the deprecated key. Migrate it to the appropriate one and delete the old meta.
+			// If an account is live mode, we optimistically assume that the customer is live mode, to avoid losing
+			// live mode customer data. If the account is not live mode, it can only have test mode objects, so we
+			// can safely migrate them to the test key.
+			// If is_live cannot be determined, default it to true to avoid considering a live account as test.
+			$account_is_live    = null === $this->account->get_is_live() || $this->account->get_is_live();
+			$customer_option_id = $account_is_live
+				? self::WCPAY_LIVE_CUSTOMER_ID_OPTION
+				: self::WCPAY_TEST_CUSTOMER_ID_OPTION;
+			if ( update_user_option( $user_id, $customer_option_id, $customer_id ) ) {
+				delete_user_option( $user_id, self::DEPRECATED_WCPAY_CUSTOMER_ID_OPTION );
+			} else {
+				Logger::error( 'Failed to store new customer ID for user ' . $user_id . '; legacy customer was kept.' );
+			}
+		}
 	}
 }

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -535,6 +535,7 @@ class WC_Payments_Customer_Service {
 		$user_email      = '';
 		$firstname       = '';
 		$lastname        = '';
+		$billing_phone   = '';
 		$billing_country = '';
 		$address         = null;
 
@@ -546,6 +547,7 @@ class WC_Payments_Customer_Service {
 				$firstname       = $order->get_billing_first_name();
 				$lastname        = $order->get_billing_last_name();
 				$user_email      = $order->get_billing_email();
+				$billing_phone   = $order->get_billing_phone();
 				$billing_country = $order->get_billing_country();
 				$address         = [
 					'city'        => $order->get_billing_city(),
@@ -566,6 +568,7 @@ class WC_Payments_Customer_Service {
 				$lastname        = $user->user_lastname;
 				$user_email      = get_user_meta( $user->ID, 'billing_email', true );
 				$user_email      = ! empty( $user_email ) ? $user_email : $user->user_email;
+				$billing_phone   = get_user_meta( $user->ID, 'billing_phone', true );
 				$billing_country = get_user_meta( $user->ID, 'billing_country', true );
 			}
 		}
@@ -573,6 +576,7 @@ class WC_Payments_Customer_Service {
 		return [
 			'name'            => $firstname . ' ' . $lastname,
 			'email'           => $user_email,
+			'billing_phone'   => $billing_phone,
 			'billing_country' => $billing_country,
 			'address'         => $address,
 		];


### PR DESCRIPTION
Fixes WOOPMNT-5355

#### Changes proposed in this Pull Request

Phone number wasn't being sent when calling the createPaymentMethod. This PR attempt to fix that.

#### Testing instructions

First add this filter:
```
function allow_admin_to_pay_for_order(){
	$administrator = get_role('administrator');
	$administrator->add_cap( 'pay_for_order' );
}
add_action('init', 'allow_admin_to_pay_for_order');
```

- Log into the dashboard as an admin user.
- Create a manual order under WooCommerce > Orders.
- Assign this order to a customer's profile (this is important), add address info and products, create order.
- After it is saved, click on the "Customer Payment Page" link that is just above the Status on the order.
- Note that it will show the admin saved cards, if present, so you have to add a new credit card for this, no need for saving the payment method.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
