### PR TITLE
Fix missing method SessionHandler::get_session_data()

### DIFF
--- a/changelog/fix-missing-method
+++ b/changelog/fix-missing-method
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix missing method. 

--- a/includes/woopay/class-woopay-store-api-session-handler.php
+++ b/includes/woopay/class-woopay-store-api-session-handler.php
@@ -64,17 +64,6 @@ final class SessionHandler extends WC_Session {
 	}
 
 	/**
-	 * Process the token header to load the correct session.
-	 */
-	protected function init_session_from_token() {
-		$payload = JsonWebToken::get_parts( $this->token )->payload;
-
-		$this->_customer_id       = $payload->user_id;
-		$this->session_expiration = $payload->exp;
-		$this->_data              = (array) $this->get_session( $this->_customer_id, [] );
-	}
-
-	/**
 	 * Return true if the current user has an active session,.
 	 *
 	 * @return bool
@@ -114,15 +103,6 @@ final class SessionHandler extends WC_Session {
 	}
 
 	/**
-	 * Gets a cache prefix. This is used in session names so the entire cache can be invalidated with 1 function call.
-	 *
-	 * @return string
-	 */
-	private function get_cache_prefix() {
-		return \WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP );
-	}
-
-	/**
 	 * Save data and delete user session.
 	 */
 	public function save_data() {
@@ -141,5 +121,34 @@ final class SessionHandler extends WC_Session {
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->session_expiration - time() );
 			$this->_dirty = false;
 		}
+	}
+
+	/**
+	 * Get session data.
+	 *
+	 * @return array
+	 */
+	public function get_session_data() {
+		return $this->has_session() ? (array) $this->get_session( $this->get_customer_id(), [] ) : [];
+	}
+
+	/**
+	 * Process the token header to load the correct session.
+	 */
+	protected function init_session_from_token() {
+		$payload = JsonWebToken::get_parts( $this->token )->payload;
+
+		$this->_customer_id       = $payload->user_id;
+		$this->session_expiration = $payload->exp;
+		$this->_data              = (array) $this->get_session( $this->_customer_id, [] );
+	}
+
+	/**
+	 * Gets a cache prefix. This is used in session names so the entire cache can be invalidated with 1 function call.
+	 *
+	 * @return string
+	 */
+	private function get_cache_prefix() {
+		return \WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the missing method from our implementation of `WCPay\Platform_Checkout\SessionHandler::get_session_data()`

#### Testing instructions

* code review

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
