### PR TITLE
[E2E][QIT] Migrate Github Actions workflows to work with QIT

### DIFF
--- a/.github/scripts/generate-qit-wc-matrix.sh
+++ b/.github/scripts/generate-qit-wc-matrix.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Simplified script for QIT WooCommerce version matrix
+# QIT handles version resolution for stable, rc, beta, nightly keywords
+# We only need to fetch L-1 version for backward compatibility testing
+
+set -e
+
+# Function to get the latest WooCommerce version from WordPress.org API
+get_latest_wc_version() {
+    curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.version'
+}
+
+# Function to get the latest stable version for a specific major version
+get_latest_stable_for_major() {
+    local major_version=$1
+    curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
+    jq -r --arg major "$major_version" '.versions | with_entries(select(.key | startswith($major + ".") and (contains("-") | not))) | keys | sort_by( . | split(".") | map(tonumber) ) | last'
+}
+
+# Function to get the L-1 version (previous major version's latest stable)
+get_l1_version() {
+    local latest_version=$1
+    local major_version=$(echo "$latest_version" | cut -d. -f1)
+    local l1_major=$((major_version - 1))
+    get_latest_stable_for_major "$l1_major"
+}
+
+# Get the latest WooCommerce version
+echo "Fetching latest WooCommerce version..." >&2
+LATEST_WC_VERSION=$(get_latest_wc_version)
+echo "Latest WC version: $LATEST_WC_VERSION" >&2
+
+# Get the L-1 version (we need the actual version number for this)
+L1_VERSION=$(get_l1_version "$LATEST_WC_VERSION")
+echo "L-1 version: $L1_VERSION" >&2
+
+# Validate L-1 version
+if [[ -z "$L1_VERSION" || "$L1_VERSION" == "null" ]]; then
+    echo "Error: Could not extract L-1 version" >&2
+    exit 1
+fi
+
+if [[ ! "$L1_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid L-1 version: $L1_VERSION" >&2
+    exit 1
+fi
+
+# Check if RC and beta are available (for metadata only)
+# QIT will handle the actual version resolution
+RC_AVAILABLE="false"
+BETA_AVAILABLE="false"
+
+LATEST_RC=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
+    jq -r '.versions | with_entries(select(.key|match("rc";"i"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last')
+
+if [[ -n "$LATEST_RC" && "$LATEST_RC" != "null" ]]; then
+    RC_BASE="${LATEST_RC%%-*}"
+    HIGHEST=$(printf '%s\n%s\n' "$RC_BASE" "$LATEST_WC_VERSION" | sort -V | tail -n1)
+    if [[ "$HIGHEST" == "$RC_BASE" && "$RC_BASE" != "$LATEST_WC_VERSION" ]]; then
+        RC_AVAILABLE="true"
+        echo "RC available: $LATEST_RC" >&2
+    else
+        echo "RC not applicable (stable $LATEST_WC_VERSION already released)" >&2
+    fi
+else
+    echo "No RC version available" >&2
+fi
+
+LATEST_BETA=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
+    jq -r --arg major "$(echo "$LATEST_WC_VERSION" | cut -d. -f1)" \
+    '.versions | with_entries(select(.key | startswith($major + ".") and contains("beta"))) | keys | sort_by( . | split("-")[0] | split(".") | map(tonumber) ) | last')
+
+if [[ -n "$LATEST_BETA" && "$LATEST_BETA" != "null" ]]; then
+    BETA_AVAILABLE="true"
+    echo "Beta available: $LATEST_BETA" >&2
+else
+    echo "No beta version available" >&2
+fi
+
+# Output JSON with L-1 version and availability flags
+# QIT workflows will use keywords (stable, rc, beta) and check availability flags
+RESULT=$(jq -n \
+    --arg l1_version "$L1_VERSION" \
+    --arg rc_available "$RC_AVAILABLE" \
+    --arg beta_available "$BETA_AVAILABLE" \
+    '{
+        l1_version: $l1_version,
+        rc_available: ($rc_available == "true"),
+        beta_available: ($beta_available == "true")
+    }')
+
+echo "$RESULT"

--- a/.github/workflows/qit-e2e-pull-request.yml
+++ b/.github/workflows/qit-e2e-pull-request.yml
@@ -348,3 +348,12 @@ jobs:
             --woo=${WC_VERSION} \
             --wp=${WP_VERSION} \
             --pw_options="--retries=0 --grep '(${SPEC_PATTERN})'"
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qit-results-wc-${{ matrix.woocommerce }}-php-${{ matrix.php }}-${{ matrix.test_name }}-${{ github.run_id }}
+          path: /tmp/qit-results-*/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/qit-e2e-pull-request.yml
+++ b/.github/workflows/qit-e2e-pull-request.yml
@@ -1,13 +1,14 @@
-name: QIT E2E Tests - Scheduled & Push
+name: QIT E2E Tests - Pull Request
 
 on:
-  push:
-    branches:
-      - 'develop'
-      - 'trunk'
-  schedule:
-    # Run every 6 hours like legacy e2e-test.yml. TODO: Should this be nightly only?
-    - cron: '0 */6 * * *'
+  pull_request:
+    paths:
+      - 'client/**'
+      - 'includes/**'
+      - 'src/**'
+      - 'tests/qit/e2e/**'
+      - 'tests/qit/qit.yml'
+      - '.github/workflows/qit-e2e-pull-request.yml' # Trigger on changes to this workflow for testing
   workflow_dispatch:
     inputs:
       woocommerce_version:
@@ -41,21 +42,15 @@ on:
           - 'nightly'
           - 'rc'
       test_tag:
-        description: 'Playwright test tag to run (e.g., @shopper, @merchant, @critical)'
+        description: 'Test tag to run (e.g., "merchant" or "shopper subscriptions")'
         required: false
+        default: ''
         type: string
       run_ui_mode:
-        description: 'Run tests in UI mode for debugging'
+        description: 'Run in UI mode'
         required: false
         default: false
         type: boolean
-
-permissions:
-  contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   generate-matrix:
@@ -75,37 +70,20 @@ jobs:
 
           # Extract versions and metadata from JSON
           L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
-          RC_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.rc_version')
-          BETA_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.beta_version')
-
-          if [[ "$BETA_VERSION" == "null" ]]; then
-            BETA_VERSION=""
-          fi
 
           echo "Using L-1 version: $L1_VERSION" >&2
-          echo "Using RC version: $RC_VERSION" >&2
-          if [[ -n "$BETA_VERSION" ]]; then
-            echo "Using beta version: $BETA_VERSION" >&2
-          else
-            echo "No beta version available" >&2
-          fi
 
           # Define common values to reduce repetition
-          PHP_LEGACY="7.4"
           PHP_STABLE="8.3"
-          PHP_LATEST="8.4"
 
           # Initialize empty matrix array
           MATRIX_ENTRIES=()
 
-          # Scheduled/push matrix: Run comprehensive test suite across multiple versions
-          echo "Scheduled/push run detected - running full test suite" >&2
-
-          # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+          # PR matrix: Match e2e-pull-request.yml coverage
+          # Test L-1 with all test combinations (merchant, shopper, subscriptions, blocks)
+          # Strategy:
+          # - Single tag (e.g., "merchant") for base tests - uses --grep-invert "@(subscriptions|blocks)"
+          # - Multiple tags (e.g., "merchant subscriptions") for combined tests - uses AND logic
 
           # Add L-1 version with PHP 8.3
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
@@ -114,44 +92,15 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
-          # Add latest with PHP 8.3
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
-
-          # Add beta with PHP 8.3 (if available)
-          if [[ -n "$BETA_VERSION" ]]; then
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
-          fi
-
-          # Add rc with PHP 8.4 (only if RC version is available)
-          if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-          else
-            echo "No RC version available, skipping RC matrix entries" >&2
-          fi
-
-          # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
-          # Test new WordPress features with latest stable WooCommerce
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
-
           # Convert array to JSON
           MATRIX_INCLUDE=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s . -c)
 
-          echo "matrix={\"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
+          # Output the full matrix
+          echo "matrix={\"include\":${MATRIX_INCLUDE}}" >> $GITHUB_OUTPUT
+
+          # Debug: log matrix to stderr so it appears in actions log
+          echo "Generated matrix with ${#MATRIX_ENTRIES[@]} combinations:" >&2
+          echo "$MATRIX_INCLUDE" | jq . >&2
 
   build-plugin:
     name: "Build plugin artifact"
@@ -159,14 +108,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo
 
       - name: "Build the plugin"
-        id: build_plugin
         uses: ./.github/actions/build
 
       - name: "Upload plugin artifact"
@@ -176,38 +122,33 @@ jobs:
           path: woocommerce-payments.zip
           retention-days: 1
 
-  qit-e2e-tests:
-    runs-on: ubuntu-latest
+  run-qit-tests:
+    name: "WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_name }}"
     needs: [generate-matrix, build-plugin]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    name: "${{ matrix.wordpress && format('WP - {0} | ', matrix.wordpress) || '' }}WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_name }}"
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
 
-      - name: "Download plugin artifact"
+      - name: Set up repository
+        uses: ./.github/actions/setup-repo
+
+      - name: Download plugin artifact
         uses: actions/download-artifact@v4
         with:
           name: woocommerce-payments-plugin
 
-      - name: "Install QIT CLI for running tests"
-        run: |
-          # Install dev dependencies to get QIT CLI
-          composer install --optimize-autoloader
-
-      - name: Authenticate QIT
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        run: ./vendor/bin/qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'
-
-      - name: Set test options
+      - name: Set up test options
         id: test_options
         run: |
           OPTIONS=""
+
+          # UI mode is primarily for manual testing
           if [[ "${{ inputs.run_ui_mode }}" == "true" ]]; then
             OPTIONS="${OPTIONS} --ui"
           fi
@@ -221,7 +162,7 @@ jobs:
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
 
           # Determine test selection using tags
-          # Single tag (e.g., "merchant") needs to exclude subscriptions/blocks tests
+          # Single tag (e.g., "merchant") runs only base tests (excludes subscriptions/blocks)
           # Multiple tags (e.g., "merchant subscriptions") use AND logic to run combined tests
           if [[ -n "$TEST_TAG" ]]; then
             # Remove @ prefix if present (QIT will add it)

--- a/.github/workflows/qit-e2e-pull-request.yml
+++ b/.github/workflows/qit-e2e-pull-request.yml
@@ -143,6 +143,15 @@ jobs:
         with:
           name: woocommerce-payments-plugin
 
+      - name: "Install QIT CLI for running tests"
+        run: |
+          # Install dev dependencies to get QIT CLI
+          composer install --optimize-autoloader
+
+      - name: Authenticate QIT
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        run: ./vendor/bin/qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'
+
       - name: Set up test options
         id: test_options
         run: |

--- a/.github/workflows/qit-e2e-pull-request.yml
+++ b/.github/workflows/qit-e2e-pull-request.yml
@@ -65,11 +65,11 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          # Use dynamic script to get WooCommerce versions (L-1 policy)
-          SCRIPT_RESULT=$( .github/scripts/generate-wc-matrix.sh )
+          # Use simplified QIT script - QIT handles version resolution for stable
+          SCRIPT_RESULT=$( .github/scripts/generate-qit-wc-matrix.sh )
 
-          # Extract versions and metadata from JSON
-          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
+          # Extract L-1 version from JSON
+          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.l1_version')
 
           echo "Using L-1 version: $L1_VERSION" >&2
 

--- a/.github/workflows/qit-e2e-pull-request.yml
+++ b/.github/workflows/qit-e2e-pull-request.yml
@@ -234,6 +234,7 @@ jobs:
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
+            --no_upload_report \
             ${{ steps.test_options.outputs.options }}
 
           QIT_EXIT_CODE=$?
@@ -342,6 +343,7 @@ jobs:
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
+            --no_upload_report \
             --php_version=${PHP_VERSION} \
             --woo=${WC_VERSION} \
             --wp=${WP_VERSION} \

--- a/.github/workflows/qit-e2e-pull-request.yml
+++ b/.github/workflows/qit-e2e-pull-request.yml
@@ -79,18 +79,24 @@ jobs:
           # Initialize empty matrix array
           MATRIX_ENTRIES=()
 
-          # PR matrix: Match e2e-pull-request.yml coverage
-          # Test L-1 with all test combinations (merchant, shopper, subscriptions, blocks)
+          # PR matrix: Test both L-1 and stable versions for comprehensive coverage
           # Strategy:
           # - Single tag (e.g., "merchant") for base tests - uses --grep-invert "@(subscriptions|blocks)"
           # - Multiple tags (e.g., "merchant subscriptions") for combined tests - uses AND logic
 
-          # Add L-1 version with PHP 8.3
+          # Add L-1 version with PHP 8.3 (backward compatibility)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
+
+          # Add stable version with PHP 8.3 (current WooCommerce release compatibility)
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
           # Convert array to JSON
           MATRIX_INCLUDE=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s . -c)

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -383,30 +383,38 @@ jobs:
             echo " - $spec"
           done
 
-          # Build pw_options with specific spec files and --retries=0
+          # Build grep pattern to match only failed spec files
           # CTRF filePath format: /qit/tests/e2e/woocommerce-payments/local/specs/...
-          # We need to extract the relative path from /qit/tests/e2e/
-          SPEC_FILES=""
+          # Extract filenames and build regex pattern
+          SPEC_PATTERN=""
           for spec in "${FAILED_SPECS[@]}"; do
-            # Extract path after /qit/tests/e2e/ or use as-is if already relative
-            RELATIVE_SPEC=$(echo "$spec" | sed 's|^/qit/tests/e2e/woocommerce-payments/local/||')
-            SPEC_FILES="${SPEC_FILES} ${RELATIVE_SPEC}"
+            # Extract just the filename without path (e.g., merchant-disputes-respond.spec.ts)
+            SPEC_NAME=$(basename "$spec")
+            if [[ -z "$SPEC_PATTERN" ]]; then
+              SPEC_PATTERN="$SPEC_NAME"
+            else
+              SPEC_PATTERN="${SPEC_PATTERN}|${SPEC_NAME}"
+            fi
           done
 
           # Always use full test directory for retry
           TEST_DIR="tests/qit/e2e"
 
-          # Get base options without --pw_options and --pw_test_tag (we'll run specific files)
-          BASE_OPTIONS="${{ steps.test_options.outputs.options }}"
-          # Remove --pw_options and --pw_test_tag since we're specifying exact spec files
-          BASE_OPTIONS=$(echo "$BASE_OPTIONS" | sed 's/--pw_options="[^"]*"//g' | sed 's/--pw_test_tag="[^"]*"//g')
+          # For retry, we only need PHP, WC, and WP versions
+          WC_VERSION="${{ matrix.woocommerce }}"
+          PHP_VERSION="${{ matrix.php }}"
+          WP_VERSION="${{ matrix.wordpress || 'stable' }}"
 
-          # Re-run QIT with only the failed specs and --retries=0
+          echo "Retry grep pattern: ($SPEC_PATTERN)"
+
+          # Re-run QIT with grep pattern matching only failed specs
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \
             --config tests/qit/qit.yml \
             --source woocommerce-payments.zip \
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
-            ${BASE_OPTIONS} \
-            --pw_options="--retries=0 ${SPEC_FILES}"
+            --php_version=${PHP_VERSION} \
+            --woo=${WC_VERSION} \
+            --wp=${WP_VERSION} \
+            --pw_options="--retries=0 --grep '(${SPEC_PATTERN})'"

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -127,11 +127,11 @@ jobs:
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
           else
             echo "Scheduled/push run detected - running full test suite" >&2
 
@@ -292,8 +292,14 @@ jobs:
         # Use continue-on-error to allow parsing results even if tests fail
         continue-on-error: true
         run: |
-          # Use specific test path if provided, otherwise use full test directory
-          TEST_DIR="${{ steps.test_options.outputs.test_path || 'tests/qit/e2e' }}"
+          # Determine test directory - if test_path is specified, prepend with tests/qit/e2e/
+          if [[ -n "${{ steps.test_options.outputs.test_path }}" ]]; then
+            TEST_DIR="tests/qit/e2e/${{ steps.test_options.outputs.test_path }}"
+          else
+            TEST_DIR="tests/qit/e2e"
+          fi
+
+          echo "Running tests from: $TEST_DIR"
 
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \
             --config tests/qit/qit.yml \
@@ -387,8 +393,12 @@ jobs:
             SPEC_FILES="${SPEC_FILES} ${RELATIVE_SPEC}"
           done
 
-          # Use same test directory as first run
-          TEST_DIR="${{ steps.test_options.outputs.test_path || 'tests/qit/e2e' }}"
+          # Determine test directory same as first run
+          if [[ -n "${{ steps.test_options.outputs.test_path }}" ]]; then
+            TEST_DIR="tests/qit/e2e/${{ steps.test_options.outputs.test_path }}"
+          else
+            TEST_DIR="tests/qit/e2e"
+          fi
 
           # Re-run QIT with only the failed specs
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -115,75 +115,72 @@ jobs:
 
             # PR matrix: Match e2e-pull-request.yml coverage
             # Test L-1 and latest with all test combinations (merchant, shopper, subscriptions, blocks)
-            # Note: Tags are without @ symbol - QIT adds it automatically
-            # Use space-separated tags (e.g., "merchant subscriptions") not regex
-            # Base merchant/shopper jobs exclude subscriptions and blocks to avoid duplication
+            # Strategy: Use paths for base tests, tags for combined tests
+            # - Paths (specs/woopayments/*) for base merchant/shopper to exclude subscriptions/blocks
+            # - Tags for combined tests (subscriptions, blocks) using AND logic
 
             # Add L-1 version with PHP 8.3
-            # Use space-separated tags - Playwright will match tests with ALL specified tags
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
           else
             echo "Scheduled/push run detected - running full test suite" >&2
 
             # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
-            # Note: Tags without @ - QIT adds it. Use space-separated tags for multiple tags.
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
 
             # Add L-1 version with PHP 8.3
-            # Use space-separated tags - Playwright will match tests with ALL specified tags
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add beta with PHP 8.3 (if available)
             if [[ -n "$BETA_VERSION" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
             fi
 
             # Add rc with PHP 8.4 (only if RC version is available)
             if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             else
               echo "No RC version available, skipping RC matrix entries" >&2
             fi
 
             # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
             # Test new WordPress features with latest stable WooCommerce
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
           fi
 
           # Convert array to JSON
@@ -191,14 +188,9 @@ jobs:
 
           echo "matrix={\"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
 
-  qit-e2e-tests:
+  build-plugin:
+    name: "Build plugin artifact"
     runs-on: ubuntu-latest
-    needs: generate-matrix
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    name: "${{ matrix.wordpress && format('WP - {0} | ', matrix.wordpress) || '' }}WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_tag }}"
-
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
@@ -211,6 +203,32 @@ jobs:
       - name: "Build the plugin"
         id: build_plugin
         uses: ./.github/actions/build
+
+      - name: "Upload plugin artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: woocommerce-payments-plugin
+          path: woocommerce-payments.zip
+          retention-days: 1
+
+  qit-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: [generate-matrix, build-plugin]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    name: "${{ matrix.wordpress && format('WP - {0} | ', matrix.wordpress) || '' }}WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_name }}"
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: "Download plugin artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: woocommerce-payments-plugin
 
       - name: "Install QIT CLI for running tests"
         run: |
@@ -233,6 +251,7 @@ jobs:
           WC_VERSION="${{ inputs.woocommerce_version || matrix.woocommerce }}"
           PHP_VERSION="${{ inputs.php_version || matrix.php }}"
           TEST_TAG="${{ inputs.test_tag || matrix.test_tag }}"
+          TEST_PATH="${{ matrix.test_path }}"
           WP_VERSION="${{ inputs.wordpress_version || matrix.wordpress || 'stable' }}"
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
@@ -240,19 +259,24 @@ jobs:
           # Disable retries to match non-QIT workflow behavior (retries: 0)
           OPTIONS="${OPTIONS} --pw_options=\"--retries=0\""
 
-          # Add tag if specified - strip leading @ symbol as QIT adds it automatically
-          if [[ -n "$TEST_TAG" ]]; then
+          # Determine test selection: use path for base tests, tags for combined tests
+          if [[ -n "$TEST_PATH" ]]; then
+            # Use specific directory path (e.g., specs/woopayments/merchant)
+            echo "test_path=$TEST_PATH" >> $GITHUB_OUTPUT
+            echo "Using test path: $TEST_PATH"
+          elif [[ -n "$TEST_TAG" ]]; then
+            # Use tags for combined tests (e.g., "merchant subscriptions")
             # Remove @ prefix if present (QIT will add it)
             CLEAN_TAG="${TEST_TAG#@}"
             # For combined tags like "@shopper and @subscriptions", strip all @ symbols
             CLEAN_TAG="${CLEAN_TAG//@/}"
             OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\""
+            echo "Using test tags: ${TEST_TAG} (cleaned: ${CLEAN_TAG})"
           fi
 
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT
           echo "Will run with options: ${OPTIONS}"
           echo "WordPress: ${WP_VERSION}"
-          echo "Test tag: ${TEST_TAG} (cleaned: ${CLEAN_TAG:-none})"
 
       - name: Mask sensitive values
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -268,7 +292,10 @@ jobs:
         # Use continue-on-error to allow parsing results even if tests fail
         continue-on-error: true
         run: |
-          ./vendor/bin/qit run:e2e woocommerce-payments tests/qit/e2e \
+          # Use specific test path if provided, otherwise use full test directory
+          TEST_DIR="${{ steps.test_options.outputs.test_path || 'tests/qit/e2e' }}"
+
+          ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \
             --config tests/qit/qit.yml \
             --source woocommerce-payments.zip \
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
@@ -280,28 +307,44 @@ jobs:
         id: parse_failed_specs
         if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.first_run_qit_tests.outcome == 'failure' }}
         run: |
-          # QIT outputs results to a temporary directory
+          # QIT outputs results to a temporary directory like /tmp/qit-results-XXXXX
           # Find the most recent QIT results directory
-          QIT_RESULTS_DIR=$(find /tmp -name "qit-results-*" -type d 2>/dev/null | sort -r | head -1)
+          QIT_RESULTS_DIR=$(find /tmp -maxdepth 1 -name "qit-results-*" -type d 2>/dev/null | sort -r | head -1)
 
           if [[ -z "$QIT_RESULTS_DIR" ]]; then
-            echo "No QIT results directory found"
+            echo "No QIT results directory found in /tmp"
+            ls -la /tmp | grep qit || echo "No qit directories found"
             echo "failed_specs_count=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Look for Playwright JSON results
-          RESULTS_JSON=$(find "$QIT_RESULTS_DIR" -name "results.json" -o -name "test-results.json" 2>/dev/null | head -1)
+          echo "Found QIT results directory: $QIT_RESULTS_DIR"
+          ls -la "$QIT_RESULTS_DIR" || true
 
-          if [[ ! -f "$RESULTS_JSON" ]]; then
+          # QIT uses Playwright which outputs results to a JSON file
+          # Look for common Playwright result file names
+          RESULTS_JSON=""
+          for filename in "results.json" "test-results.json" "ctrf-report.json"; do
+            FOUND=$(find "$QIT_RESULTS_DIR" -name "$filename" -type f 2>/dev/null | head -1)
+            if [[ -n "$FOUND" ]]; then
+              RESULTS_JSON="$FOUND"
+              break
+            fi
+          done
+
+          if [[ -z "$RESULTS_JSON" || ! -f "$RESULTS_JSON" ]]; then
             echo "No results JSON found in $QIT_RESULTS_DIR"
+            find "$QIT_RESULTS_DIR" -name "*.json" -type f 2>/dev/null || echo "No JSON files found"
             echo "failed_specs_count=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           echo "Found results at: $RESULTS_JSON"
+          echo "Results file content preview:"
+          head -20 "$RESULTS_JSON" || true
 
           # Extract failed spec files using same logic as non-QIT workflow
+          # This jq query looks for Playwright's standard results format
           FAILED_SPECS_COUNT=$(jq -r '[ .. | objects | select(has("specs")) | .specs[]
               | select( ( any(.tests[]?; (.status=="unexpected") or (.status=="failed")) )
                         or ( any(.tests[]?.results[]?; (.status=="failed") or (.status=="timedOut") or (.status=="interrupted")) ) )
@@ -344,8 +387,11 @@ jobs:
             SPEC_FILES="${SPEC_FILES} ${RELATIVE_SPEC}"
           done
 
+          # Use same test directory as first run
+          TEST_DIR="${{ steps.test_options.outputs.test_path || 'tests/qit/e2e' }}"
+
           # Re-run QIT with only the failed specs
-          ./vendor/bin/qit run:e2e woocommerce-payments tests/qit/e2e \
+          ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \
             --config tests/qit/qit.yml \
             --source woocommerce-payments.zip \
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -354,12 +354,9 @@ jobs:
           echo "Results file content preview:"
           head -20 "$RESULTS_JSON" || true
 
-          # Extract failed spec files using same logic as non-QIT workflow
-          # This jq query looks for Playwright's standard results format
-          FAILED_SPECS_COUNT=$(jq -r '[ .. | objects | select(has("specs")) | .specs[]
-              | select( ( any(.tests[]?; (.status=="unexpected") or (.status=="failed")) )
-                        or ( any(.tests[]?.results[]?; (.status=="failed") or (.status=="timedOut") or (.status=="interrupted")) ) )
-              | .file ] | unique | length' "$RESULTS_JSON" 2>/dev/null || echo "0")
+          # Extract failed spec files from CTRF format
+          # CTRF format: .results.tests[] with .status and .filePath fields
+          FAILED_SPECS_COUNT=$(jq -r '[.results.tests[] | select(.status == "failed") | .filePath] | unique | length' "$RESULTS_JSON" 2>/dev/null || echo "0")
 
           echo "failed_specs_count=$FAILED_SPECS_COUNT" >> $GITHUB_OUTPUT
           echo "results_json=$RESULTS_JSON" >> $GITHUB_OUTPUT
@@ -373,11 +370,8 @@ jobs:
         run: |
           RESULTS_JSON="${{ steps.parse_failed_specs.outputs.results_json }}"
 
-          # Extract failed spec file paths
-          mapfile -t FAILED_SPECS < <(jq -r '[ .. | objects | select(has("specs")) | .specs[]
-            | select( ( any(.tests[]?; (.status=="unexpected") or (.status=="failed")) )
-              or ( any(.tests[]?.results[]?; (.status=="failed") or (.status=="timedOut") or (.status=="interrupted")) ) )
-            | .file ] | unique | .[]' "$RESULTS_JSON")
+          # Extract failed spec file paths from CTRF format
+          mapfile -t FAILED_SPECS < <(jq -r '[.results.tests[] | select(.status == "failed") | .filePath] | unique | .[]' "$RESULTS_JSON")
 
           if [[ ${#FAILED_SPECS[@]} -eq 0 ]]; then
             echo "::notice::No failed specs found. Skipping retry."
@@ -390,20 +384,17 @@ jobs:
           done
 
           # Build pw_options with specific spec files
-          # Convert absolute paths to relative paths if needed
+          # CTRF filePath format: /qit/tests/e2e/woocommerce-payments/local/specs/...
+          # We need to extract the relative path from /qit/tests/e2e/
           SPEC_FILES=""
           for spec in "${FAILED_SPECS[@]}"; do
-            # Extract just the filename relative to tests/qit/e2e
-            RELATIVE_SPEC=$(echo "$spec" | sed 's|.*/tests/qit/e2e/||' | sed 's|^/qit/tests/e2e/||')
+            # Extract path after /qit/tests/e2e/ or use as-is if already relative
+            RELATIVE_SPEC=$(echo "$spec" | sed 's|^/qit/tests/e2e/woocommerce-payments/local/||')
             SPEC_FILES="${SPEC_FILES} ${RELATIVE_SPEC}"
           done
 
-          # Determine test directory same as first run
-          if [[ -n "${{ steps.test_options.outputs.test_path }}" ]]; then
-            TEST_DIR="tests/qit/e2e/${{ steps.test_options.outputs.test_path }}"
-          else
-            TEST_DIR="tests/qit/e2e"
-          fi
+          # Always use full test directory for retry
+          TEST_DIR="tests/qit/e2e"
 
           # Re-run QIT with only the failed specs
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -274,6 +274,7 @@ jobs:
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
+            --no_upload_report \
             ${{ steps.test_options.outputs.options }}
 
           QIT_EXIT_CODE=$?
@@ -382,6 +383,7 @@ jobs:
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
+            --no_upload_report \
             --php_version=${PHP_VERSION} \
             --woo=${WC_VERSION} \
             --wp=${WP_VERSION} \

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -388,3 +388,12 @@ jobs:
             --woo=${WC_VERSION} \
             --wp=${WP_VERSION} \
             --pw_options="--retries=0 --grep '(${SPEC_PATTERN})'"
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qit-results-wc-${{ matrix.woocommerce }}-php-${{ matrix.php }}-${{ matrix.test_name }}-${{ github.run_id }}
+          path: /tmp/qit-results-*/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -13,7 +13,6 @@ on:
     branches:
       # - 'develop' Temporarily disable develop branch runs to reduce CI load
       # - 'trunk' Temporarily disable trunk branch runs to reduce CI load
-      - 'dev/qit-e2e-enhance-workflows'  # Testing QIT E2E workflow enhancements
   schedule:
     # Run every 6 hours like legacy e2e-test.yml
     - cron: '0 */6 * * *'

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -305,6 +305,7 @@ jobs:
 
           echo "Running tests from: $TEST_DIR"
 
+          # Run QIT tests - exit code 0 = all passed, non-zero = tests failed or QIT error
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \
             --config tests/qit/qit.yml \
             --source woocommerce-payments.zip \
@@ -312,6 +313,18 @@ jobs:
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
             ${{ steps.test_options.outputs.options }}
+
+          QIT_EXIT_CODE=$?
+          echo "qit_exit_code=$QIT_EXIT_CODE" >> $GITHUB_OUTPUT
+
+          # Check if QIT actually ran tests by looking for results directory
+          QIT_RESULTS_DIR=$(find /tmp -maxdepth 1 -name "qit-results-*" -type d 2>/dev/null | sort -r | head -1)
+          if [[ -z "$QIT_RESULTS_DIR" ]]; then
+            echo "::error::QIT did not produce test results. This indicates an environment or setup failure."
+            exit 1
+          fi
+
+          exit $QIT_EXIT_CODE
 
       - name: Parse Failed Specs
         id: parse_failed_specs

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -40,6 +40,15 @@ on:
           - '8.2'
           - '8.1'
           - '7.4'
+      wordpress_version:
+        description: 'WordPress version to test against'
+        required: false
+        default: 'stable'
+        type: choice
+        options:
+          - 'stable'
+          - 'nightly'
+          - 'rc'
       test_tag:
         description: 'Playwright test tag to run (e.g., @shopper, @merchant, @critical)'
         required: false
@@ -98,16 +107,29 @@ jobs:
           # Initialize empty matrix array
           MATRIX_ENTRIES=()
 
-          # Determine if this is a PR - for PRs, only run critical tests
+          # Determine if this is a PR - for PRs, run full test suite on L-1 and latest
           IS_PR="${{ github.event_name == 'pull_request' }}"
 
           if [[ "$IS_PR" == "true" ]]; then
-            echo "Pull request detected - running critical tests only" >&2
+            echo "Pull request detected - running full test suite on L-1 and latest" >&2
 
-            # PR matrix: Only critical tests on L-1 and latest with PHP 8.3
+            # PR matrix: Match e2e-pull-request.yml coverage
+            # Test L-1 and latest with all test combinations (merchant, shopper, subscriptions, blocks)
             # Note: Tags are without @ symbol - QIT adds it automatically
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"critical\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"critical\"}")
+
+            # Add L-1 version with PHP 8.3
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+
+            # Add latest with PHP 8.3
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
           else
             echo "Scheduled/push run detected - running full test suite" >&2
 
@@ -150,6 +172,14 @@ jobs:
             else
               echo "No RC version available, skipping RC matrix entries" >&2
             fi
+
+            # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
+            # Test new WordPress features with latest stable WooCommerce
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
           fi
 
           # Convert array to JSON
@@ -163,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    name: "WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_tag }}"
+    name: "${{ matrix.wordpress && format('WP - {0} | ', matrix.wordpress) || '' }}WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_tag }}"
 
     steps:
       - name: "Checkout repository"
@@ -199,8 +229,9 @@ jobs:
           WC_VERSION="${{ inputs.woocommerce_version || matrix.woocommerce }}"
           PHP_VERSION="${{ inputs.php_version || matrix.php }}"
           TEST_TAG="${{ inputs.test_tag || matrix.test_tag }}"
+          WP_VERSION="${{ inputs.wordpress_version || matrix.wordpress || 'stable' }}"
 
-          OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION}"
+          OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
 
           # Add tag if specified - strip leading @ symbol as QIT adds it automatically
           if [[ -n "$TEST_TAG" ]]; then
@@ -213,6 +244,7 @@ jobs:
 
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT
           echo "Will run with options: ${OPTIONS}"
+          echo "WordPress: ${WP_VERSION}"
           echo "Test tag: ${TEST_TAG} (cleaned: ${CLEAN_TAG:-none})"
 
       - name: Mask sensitive values

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -115,20 +115,20 @@ jobs:
 
             # PR matrix: Match e2e-pull-request.yml coverage
             # Test L-1 and latest with all test combinations (merchant, shopper, subscriptions, blocks)
-            # Strategy: Use paths for base tests, tags for combined tests
-            # - Paths (specs/woopayments/*) for base merchant/shopper to exclude subscriptions/blocks
-            # - Tags for combined tests (subscriptions, blocks) using AND logic
+            # Strategy:
+            # - Single tag (e.g., "merchant") for base tests - uses --grep-invert to exclude @subscriptions and @blocks
+            # - Multiple tags (e.g., "merchant subscriptions") for combined tests - uses AND logic
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add latest with PHP 8.3
-            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
             # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
             # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             # MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
@@ -136,29 +136,29 @@ jobs:
             echo "Scheduled/push run detected - running full test suite" >&2
 
             # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
             # Add beta with PHP 8.3 (if available)
             if [[ -n "$BETA_VERSION" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
@@ -166,8 +166,8 @@ jobs:
 
             # Add rc with PHP 8.4 (only if RC version is available)
             if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             else
@@ -176,8 +176,8 @@ jobs:
 
             # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
             # Test new WordPress features with latest stable WooCommerce
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_path\":\"specs/woopayments/merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_path\":\"specs/woopayments/shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
@@ -251,26 +251,32 @@ jobs:
           WC_VERSION="${{ inputs.woocommerce_version || matrix.woocommerce }}"
           PHP_VERSION="${{ inputs.php_version || matrix.php }}"
           TEST_TAG="${{ inputs.test_tag || matrix.test_tag }}"
-          TEST_PATH="${{ matrix.test_path }}"
           WP_VERSION="${{ inputs.wordpress_version || matrix.wordpress || 'stable' }}"
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
 
-          # Determine test selection: use path pattern for base tests, tags for combined tests
-          if [[ -n "$TEST_PATH" ]]; then
-            # Use Playwright's grep to filter by file path pattern
-            # e.g., specs/woopayments/merchant becomes a grep pattern
-            # Combine --retries=0 with --grep in single --pw_options
-            OPTIONS="${OPTIONS} --pw_options=\"--retries=0 --grep \\\"$TEST_PATH\\\"\""
-            echo "Using test path filter: $TEST_PATH"
-          elif [[ -n "$TEST_TAG" ]]; then
-            # Use tags for combined tests (e.g., "merchant subscriptions")
+          # Determine test selection using tags
+          # Single tag (e.g., "merchant") needs to exclude subscriptions/blocks tests
+          # Multiple tags (e.g., "merchant subscriptions") use AND logic to run combined tests
+          if [[ -n "$TEST_TAG" ]]; then
             # Remove @ prefix if present (QIT will add it)
             CLEAN_TAG="${TEST_TAG#@}"
             # For combined tags like "@shopper and @subscriptions", strip all @ symbols
             CLEAN_TAG="${CLEAN_TAG//@/}"
-            OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\" --pw_options=\"--retries=0\""
-            echo "Using test tags: ${TEST_TAG} (cleaned: ${CLEAN_TAG})"
+
+            # Check if this is a single tag (base test) or multiple tags (combined test)
+            WORD_COUNT=$(echo "$CLEAN_TAG" | wc -w | tr -d ' ')
+
+            if [[ "$WORD_COUNT" -eq 1 ]]; then
+              # Single tag: exclude subscriptions and blocks tests using multiple --grep-invert
+              # Example: --grep @shopper --grep-invert @subscriptions --grep-invert @blocks
+              OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\" --pw_options=\"--retries=0 --grep-invert @subscriptions --grep-invert @blocks\""
+              echo "Using test tag: ${CLEAN_TAG} (excluding @subscriptions and @blocks)"
+            else
+              # Multiple tags: use AND logic for combined tests
+              OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\" --pw_options=\"--retries=0\""
+              echo "Using test tags: ${CLEAN_TAG}"
+            fi
           else
             # No specific test selection, just disable retries
             OPTIONS="${OPTIONS} --pw_options=\"--retries=0\""
@@ -295,7 +301,7 @@ jobs:
         continue-on-error: true
         run: |
           # Always use the full tests/qit/e2e directory
-          # Path filtering is handled via --grep in --pw_options
+          # Test filtering is handled via --pw_test_tag and --grep-invert
           TEST_DIR="tests/qit/e2e"
 
           echo "Running tests from: $TEST_DIR"

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -262,8 +262,11 @@ jobs:
           echo "::add-mask::${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}"
           echo "::add-mask::${{ secrets.E2E_QIT_JP_USER_TOKEN }}"
 
-      - name: Run QIT Tests
+      - name: First Run QIT Tests
+        id: first_run_qit_tests
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        # Use continue-on-error to allow parsing results even if tests fail
+        continue-on-error: true
         run: |
           ./vendor/bin/qit run:e2e woocommerce-payments tests/qit/e2e \
             --config tests/qit/qit.yml \
@@ -272,3 +275,81 @@ jobs:
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
             ${{ steps.test_options.outputs.options }}
+
+      - name: Parse Failed Specs
+        id: parse_failed_specs
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.first_run_qit_tests.outcome == 'failure' }}
+        run: |
+          # QIT outputs results to a temporary directory
+          # Find the most recent QIT results directory
+          QIT_RESULTS_DIR=$(find /tmp -name "qit-results-*" -type d 2>/dev/null | sort -r | head -1)
+
+          if [[ -z "$QIT_RESULTS_DIR" ]]; then
+            echo "No QIT results directory found"
+            echo "failed_specs_count=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Look for Playwright JSON results
+          RESULTS_JSON=$(find "$QIT_RESULTS_DIR" -name "results.json" -o -name "test-results.json" 2>/dev/null | head -1)
+
+          if [[ ! -f "$RESULTS_JSON" ]]; then
+            echo "No results JSON found in $QIT_RESULTS_DIR"
+            echo "failed_specs_count=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Found results at: $RESULTS_JSON"
+
+          # Extract failed spec files using same logic as non-QIT workflow
+          FAILED_SPECS_COUNT=$(jq -r '[ .. | objects | select(has("specs")) | .specs[]
+              | select( ( any(.tests[]?; (.status=="unexpected") or (.status=="failed")) )
+                        or ( any(.tests[]?.results[]?; (.status=="failed") or (.status=="timedOut") or (.status=="interrupted")) ) )
+              | .file ] | unique | length' "$RESULTS_JSON" 2>/dev/null || echo "0")
+
+          echo "failed_specs_count=$FAILED_SPECS_COUNT" >> $GITHUB_OUTPUT
+          echo "results_json=$RESULTS_JSON" >> $GITHUB_OUTPUT
+
+          if [[ ${FAILED_SPECS_COUNT} -gt 0 ]]; then
+            echo "::notice::${FAILED_SPECS_COUNT} spec file(s) failed in the first run. Will re-run only the failed specs."
+          fi
+
+      - name: Re-try Failed Specs
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && steps.parse_failed_specs.outputs.failed_specs_count > 0 }}
+        run: |
+          RESULTS_JSON="${{ steps.parse_failed_specs.outputs.results_json }}"
+
+          # Extract failed spec file paths
+          mapfile -t FAILED_SPECS < <(jq -r '[ .. | objects | select(has("specs")) | .specs[]
+            | select( ( any(.tests[]?; (.status=="unexpected") or (.status=="failed")) )
+              or ( any(.tests[]?.results[]?; (.status=="failed") or (.status=="timedOut") or (.status=="interrupted")) ) )
+            | .file ] | unique | .[]' "$RESULTS_JSON")
+
+          if [[ ${#FAILED_SPECS[@]} -eq 0 ]]; then
+            echo "::notice::No failed specs found. Skipping retry."
+            exit 0
+          fi
+
+          echo "Retrying ${#FAILED_SPECS[@]} failed spec(s):"
+          for spec in "${FAILED_SPECS[@]}"; do
+            echo " - $spec"
+          done
+
+          # Build pw_options with specific spec files
+          # Convert absolute paths to relative paths if needed
+          SPEC_FILES=""
+          for spec in "${FAILED_SPECS[@]}"; do
+            # Extract just the filename relative to tests/qit/e2e
+            RELATIVE_SPEC=$(echo "$spec" | sed 's|.*/tests/qit/e2e/||' | sed 's|^/qit/tests/e2e/||')
+            SPEC_FILES="${SPEC_FILES} ${RELATIVE_SPEC}"
+          done
+
+          # Re-run QIT with only the failed specs
+          ./vendor/bin/qit run:e2e woocommerce-payments tests/qit/e2e \
+            --config tests/qit/qit.yml \
+            --source woocommerce-payments.zip \
+            --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
+            --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
+            --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
+            ${{ steps.test_options.outputs.options }} \
+            --pw_options="${SPEC_FILES}"

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -116,59 +116,60 @@ jobs:
             # PR matrix: Match e2e-pull-request.yml coverage
             # Test L-1 and latest with all test combinations (merchant, shopper, subscriptions, blocks)
             # Note: Tags are without @ symbol - QIT adds it automatically
+            # Use space-separated tags (e.g., "merchant subscriptions") not regex
 
             # Add L-1 version with PHP 8.3
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add latest with PHP 8.3
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
           else
             echo "Scheduled/push run detected - running full test suite" >&2
 
             # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
-            # Note: Tags without @ - QIT adds it. For multiple tags, use regex: "tag1.*tag2|tag2.*tag1"
+            # Note: Tags without @ - QIT adds it. Use space-separated tags for multiple tags.
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\"}")
 
             # Add L-1 version with PHP 8.3
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add latest with PHP 8.3
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add beta with PHP 8.3 (if available)
             if [[ -n "$BETA_VERSION" ]]; then
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
             fi
 
             # Add rc with PHP 8.4 (only if RC version is available)
             if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\"}")
             else
               echo "No RC version available, skipping RC matrix entries" >&2
             fi
@@ -177,9 +178,9 @@ jobs:
             # Test new WordPress features with latest stable WooCommerce
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\"}")
           fi
 
           # Convert array to JSON

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -256,22 +256,24 @@ jobs:
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
 
-          # Disable retries to match non-QIT workflow behavior (retries: 0)
-          OPTIONS="${OPTIONS} --pw_options=\"--retries=0\""
-
-          # Determine test selection: use path for base tests, tags for combined tests
+          # Determine test selection: use path pattern for base tests, tags for combined tests
           if [[ -n "$TEST_PATH" ]]; then
-            # Use specific directory path (e.g., specs/woopayments/merchant)
-            echo "test_path=$TEST_PATH" >> $GITHUB_OUTPUT
-            echo "Using test path: $TEST_PATH"
+            # Use Playwright's grep to filter by file path pattern
+            # e.g., specs/woopayments/merchant becomes a grep pattern
+            # Combine --retries=0 with --grep in single --pw_options
+            OPTIONS="${OPTIONS} --pw_options=\"--retries=0 --grep \\\"$TEST_PATH\\\"\""
+            echo "Using test path filter: $TEST_PATH"
           elif [[ -n "$TEST_TAG" ]]; then
             # Use tags for combined tests (e.g., "merchant subscriptions")
             # Remove @ prefix if present (QIT will add it)
             CLEAN_TAG="${TEST_TAG#@}"
             # For combined tags like "@shopper and @subscriptions", strip all @ symbols
             CLEAN_TAG="${CLEAN_TAG//@/}"
-            OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\""
+            OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\" --pw_options=\"--retries=0\""
             echo "Using test tags: ${TEST_TAG} (cleaned: ${CLEAN_TAG})"
+          else
+            # No specific test selection, just disable retries
+            OPTIONS="${OPTIONS} --pw_options=\"--retries=0\""
           fi
 
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT
@@ -292,12 +294,9 @@ jobs:
         # Use continue-on-error to allow parsing results even if tests fail
         continue-on-error: true
         run: |
-          # Determine test directory - if test_path is specified, prepend with tests/qit/e2e/
-          if [[ -n "${{ steps.test_options.outputs.test_path }}" ]]; then
-            TEST_DIR="tests/qit/e2e/${{ steps.test_options.outputs.test_path }}"
-          else
-            TEST_DIR="tests/qit/e2e"
-          fi
+          # Always use the full tests/qit/e2e directory
+          # Path filtering is handled via --grep in --pw_options
+          TEST_DIR="tests/qit/e2e"
 
           echo "Running tests from: $TEST_DIR"
 

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -220,9 +220,9 @@ jobs:
       - name: Run QIT Tests
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
-          cd tests/qit
-          ../../vendor/bin/qit run:e2e woocommerce-payments ./e2e \
-            --source ../../woocommerce-payments.zip \
+          ./vendor/bin/qit run:e2e woocommerce-payments tests/qit/e2e \
+            --config tests/qit/qit.yml \
+            --source woocommerce-payments.zip \
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -11,8 +11,8 @@ on:
       - '.github/workflows/qit-e2e.yml'
   push:
     branches:
-      - 'develop'
-      - 'trunk'
+      # - 'develop' Temporarily disable develop branch runs to reduce CI load
+      # - 'trunk' Temporarily disable trunk branch runs to reduce CI load
       - 'dev/qit-e2e-enhance-workflows'  # Testing QIT E2E workflow enhancements
   schedule:
     # Run every 6 hours like legacy e2e-test.yml

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -13,10 +13,10 @@ on:
     branches:
       - 'develop'
       - 'trunk'
-      - 'dev/qit-e2e-*'  # Allow testing on QIT E2E development branches
+      - 'dev/qit-e2e-enhance-workflows'  # Testing QIT E2E workflow enhancements
   schedule:
-    # Run daily at 2 AM UTC
-    - cron: '0 2 * * *'
+    # Run every 6 hours like legacy e2e-test.yml
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       woocommerce_version:
@@ -40,6 +40,10 @@ on:
           - '8.2'
           - '8.1'
           - '7.4'
+      test_tag:
+        description: 'Playwright test tag to run (e.g., @shopper, @merchant, @critical)'
+        required: false
+        type: string
       run_ui_mode:
         description: 'Run tests in UI mode for debugging'
         required: false
@@ -54,23 +58,110 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate-matrix:
+    name: "Generate the test matrix dynamically"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate_matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: "Generate matrix"
+        id: generate_matrix
+        run: |
+          # Use dynamic script to get WooCommerce versions (L-1 policy)
+          SCRIPT_RESULT=$( .github/scripts/generate-wc-matrix.sh )
+
+          # Extract versions and metadata from JSON
+          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
+          RC_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.rc_version')
+          BETA_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.beta_version')
+
+          if [[ "$BETA_VERSION" == "null" ]]; then
+            BETA_VERSION=""
+          fi
+
+          echo "Using L-1 version: $L1_VERSION" >&2
+          echo "Using RC version: $RC_VERSION" >&2
+          if [[ -n "$BETA_VERSION" ]]; then
+            echo "Using beta version: $BETA_VERSION" >&2
+          else
+            echo "No beta version available" >&2
+          fi
+
+          # Define common values to reduce repetition
+          PHP_LEGACY="7.4"
+          PHP_STABLE="8.3"
+          PHP_LATEST="8.4"
+
+          # Initialize empty matrix array
+          MATRIX_ENTRIES=()
+
+          # Determine if this is a PR - for PRs, only run critical tests
+          IS_PR="${{ github.event_name == 'pull_request' }}"
+
+          if [[ "$IS_PR" == "true" ]]; then
+            echo "Pull request detected - running critical tests only" >&2
+
+            # PR matrix: Only critical tests on L-1 and latest with PHP 8.3
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@critical\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@critical\"}")
+          else
+            echo "Scheduled/push run detected - running full test suite" >&2
+
+            # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@merchant and @subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@shopper and @subscriptions\"}")
+
+            # Add L-1 version with PHP 8.3
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant and @subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @blocks\"}")
+
+            # Add latest with PHP 8.3
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant and @subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @blocks\"}")
+
+            # Add beta with PHP 8.3 (if available)
+            if [[ -n "$BETA_VERSION" ]]; then
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant and @subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @blocks\"}")
+            fi
+
+            # Add rc with PHP 8.4 (only if RC version is available)
+            if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@merchant and @subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@shopper and @subscriptions\"}")
+            else
+              echo "No RC version available, skipping RC matrix entries" >&2
+            fi
+          fi
+
+          # Convert array to JSON
+          MATRIX_INCLUDE=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s . -c)
+
+          echo "matrix={\"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
+
   qit-e2e-tests:
     runs-on: ubuntu-latest
+    needs: generate-matrix
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # Pull requests: Test against stable and L-1 WooCommerce versions
-          - wc_version: "stable"
-            php_version: "8.3"
-            test_group: "basic"
-          - wc_version: "8.9.3"  # L-1 version
-            php_version: "8.3"
-            test_group: "basic"
-          # Full runs: Include business continuity version
-          - wc_version: "7.7.0"
-            php_version: "7.4"
-            test_group: "basic"
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    name: "WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_tag }}"
 
     steps:
       - name: "Checkout repository"
@@ -103,13 +194,20 @@ jobs:
           fi
 
           # Use input versions if provided, otherwise use matrix
-          WC_VERSION="${{ inputs.woocommerce_version || matrix.wc_version }}"
-          PHP_VERSION="${{ inputs.php_version || matrix.php_version }}"
+          WC_VERSION="${{ inputs.woocommerce_version || matrix.woocommerce }}"
+          PHP_VERSION="${{ inputs.php_version || matrix.php }}"
+          TEST_TAG="${{ inputs.test_tag || matrix.test_tag }}"
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION}"
 
+          # Add tag if specified
+          if [[ -n "$TEST_TAG" ]]; then
+            OPTIONS="${OPTIONS} --pw_test_tag=\"${TEST_TAG}\""
+          fi
+
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT
           echo "Will run with options: ${OPTIONS}"
+          echo "Test tag: ${TEST_TAG}"
 
       - name: Mask sensitive values
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -383,7 +383,7 @@ jobs:
             echo " - $spec"
           done
 
-          # Build pw_options with specific spec files
+          # Build pw_options with specific spec files and --retries=0
           # CTRF filePath format: /qit/tests/e2e/woocommerce-payments/local/specs/...
           # We need to extract the relative path from /qit/tests/e2e/
           SPEC_FILES=""
@@ -396,12 +396,17 @@ jobs:
           # Always use full test directory for retry
           TEST_DIR="tests/qit/e2e"
 
-          # Re-run QIT with only the failed specs
+          # Get base options without --pw_options (we'll add our own with spec files)
+          BASE_OPTIONS="${{ steps.test_options.outputs.options }}"
+          # Remove any existing --pw_options from base options to avoid conflicts
+          BASE_OPTIONS=$(echo "$BASE_OPTIONS" | sed 's/--pw_options="[^"]*"//g')
+
+          # Re-run QIT with only the failed specs and --retries=0
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \
             --config tests/qit/qit.yml \
             --source woocommerce-payments.zip \
             --env E2E_JP_SITE_ID="${{ secrets.E2E_QIT_JP_SITE_ID }}" \
             --env E2E_JP_BLOG_TOKEN="${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}" \
             --env E2E_JP_USER_TOKEN="${{ secrets.E2E_QIT_JP_USER_TOKEN }}" \
-            ${{ steps.test_options.outputs.options }} \
-            --pw_options="${SPEC_FILES}"
+            ${BASE_OPTIONS} \
+            --pw_options="--retries=0 ${SPEC_FILES}"

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -117,17 +117,18 @@ jobs:
             # Test L-1 and latest with all test combinations (merchant, shopper, subscriptions, blocks)
             # Note: Tags are without @ symbol - QIT adds it automatically
             # Use space-separated tags (e.g., "merchant subscriptions") not regex
+            # Base merchant/shopper jobs exclude subscriptions and blocks to avoid duplication
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
@@ -136,29 +137,30 @@ jobs:
 
             # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
             # Note: Tags without @ - QIT adds it. Use space-separated tags for multiple tags.
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\"}")
+            # Base merchant/shopper jobs exclude subscriptions and blocks to avoid duplication
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\"}")
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add beta with PHP 8.3 (if available)
             if [[ -n "$BETA_VERSION" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
@@ -166,8 +168,8 @@ jobs:
 
             # Add rc with PHP 8.4 (only if RC version is available)
             if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\"}")
             else
@@ -176,8 +178,8 @@ jobs:
 
             # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
             # Test new WordPress features with latest stable WooCommerce
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\"}")
@@ -230,6 +232,7 @@ jobs:
           WC_VERSION="${{ inputs.woocommerce_version || matrix.woocommerce }}"
           PHP_VERSION="${{ inputs.php_version || matrix.php }}"
           TEST_TAG="${{ inputs.test_tag || matrix.test_tag }}"
+          EXCLUDE_TAG="${{ matrix.exclude_tag || '' }}"
           WP_VERSION="${{ inputs.wordpress_version || matrix.wordpress || 'stable' }}"
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
@@ -241,6 +244,15 @@ jobs:
             # For combined tags like "@shopper and @subscriptions", strip all @ symbols
             CLEAN_TAG="${CLEAN_TAG//@/}"
             OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\""
+          fi
+
+          # Add exclusion tags via --pw_options if specified
+          # This prevents duplication between base merchant/shopper and subscription/blocks jobs
+          if [[ -n "$EXCLUDE_TAG" ]]; then
+            # Build grep-invert pattern for Playwright
+            EXCLUDE_PATTERN="@${EXCLUDE_TAG// / @}"
+            OPTIONS="${OPTIONS} --pw_options=\"--grep-invert ${EXCLUDE_PATTERN}\""
+            echo "Excluding tags: ${EXCLUDE_TAG}"
           fi
 
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -116,7 +116,7 @@ jobs:
             # PR matrix: Match e2e-pull-request.yml coverage
             # Test L-1 and latest with all test combinations (merchant, shopper, subscriptions, blocks)
             # Strategy:
-            # - Single tag (e.g., "merchant") for base tests - uses --grep-invert to exclude @subscriptions and @blocks
+            # - Single tag (e.g., "merchant") for base tests - uses --grep-invert "@(subscriptions|blocks)"
             # - Multiple tags (e.g., "merchant subscriptions") for combined tests - uses AND logic
 
             # Add L-1 version with PHP 8.3
@@ -268,9 +268,9 @@ jobs:
             WORD_COUNT=$(echo "$CLEAN_TAG" | wc -w | tr -d ' ')
 
             if [[ "$WORD_COUNT" -eq 1 ]]; then
-              # Single tag: exclude subscriptions and blocks tests using multiple --grep-invert
-              # Example: --grep @shopper --grep-invert @subscriptions --grep-invert @blocks
-              OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\" --pw_options=\"--retries=0 --grep-invert @subscriptions --grep-invert @blocks\""
+              # Single tag: exclude subscriptions and blocks tests using --grep-invert with regex alternation
+              # Example: --grep @shopper --grep-invert "@(subscriptions|blocks)"
+              OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\" --pw_options=\"--retries=0 --grep-invert '@(subscriptions|blocks)'\""
               echo "Using test tag: ${CLEAN_TAG} (excluding @subscriptions and @blocks)"
             else
               # Multiple tags: use AND logic for combined tests

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -396,10 +396,10 @@ jobs:
           # Always use full test directory for retry
           TEST_DIR="tests/qit/e2e"
 
-          # Get base options without --pw_options (we'll add our own with spec files)
+          # Get base options without --pw_options and --pw_test_tag (we'll run specific files)
           BASE_OPTIONS="${{ steps.test_options.outputs.options }}"
-          # Remove any existing --pw_options from base options to avoid conflicts
-          BASE_OPTIONS=$(echo "$BASE_OPTIONS" | sed 's/--pw_options="[^"]*"//g')
+          # Remove --pw_options and --pw_test_tag since we're specifying exact spec files
+          BASE_OPTIONS=$(echo "$BASE_OPTIONS" | sed 's/--pw_options="[^"]*"//g' | sed 's/--pw_test_tag="[^"]*"//g')
 
           # Re-run QIT with only the failed specs and --retries=0
           ./vendor/bin/qit run:e2e woocommerce-payments "$TEST_DIR" \

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -70,25 +70,17 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          # Use dynamic script to get WooCommerce versions (L-1 policy)
-          SCRIPT_RESULT=$( .github/scripts/generate-wc-matrix.sh )
+          # Use simplified QIT script - QIT handles version resolution for stable/rc/beta
+          SCRIPT_RESULT=$( .github/scripts/generate-qit-wc-matrix.sh )
 
-          # Extract versions and metadata from JSON
-          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
-          RC_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.rc_version')
-          BETA_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.beta_version')
-
-          if [[ "$BETA_VERSION" == "null" ]]; then
-            BETA_VERSION=""
-          fi
+          # Extract L-1 version and availability flags from JSON
+          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.l1_version')
+          RC_AVAILABLE=$(echo "$SCRIPT_RESULT" | jq -r '.rc_available')
+          BETA_AVAILABLE=$(echo "$SCRIPT_RESULT" | jq -r '.beta_available')
 
           echo "Using L-1 version: $L1_VERSION" >&2
-          echo "Using RC version: $RC_VERSION" >&2
-          if [[ -n "$BETA_VERSION" ]]; then
-            echo "Using beta version: $BETA_VERSION" >&2
-          else
-            echo "No beta version available" >&2
-          fi
+          echo "RC available: $RC_AVAILABLE" >&2
+          echo "Beta available: $BETA_AVAILABLE" >&2
 
           # Define common values to reduce repetition
           PHP_LEGACY="7.4"
@@ -107,37 +99,41 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
 
-          # Add L-1 version with PHP 8.3
+          # Add L-1 version with PHP 8.3 (QIT uses actual version number)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
-          # Add latest with PHP 8.3
+          # Add stable with PHP 8.3 (QIT keyword - resolves to latest stable)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
-          # Add beta with PHP 8.3 (if available)
-          if [[ -n "$BETA_VERSION" ]]; then
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
+          # Add beta with PHP 8.3 (QIT keyword - only if available)
+          if [[ "$BETA_AVAILABLE" == "true" ]]; then
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"beta\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"beta\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"beta\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"beta\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"beta\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
+            echo "Including beta tests (QIT will resolve to latest beta)" >&2
+          else
+            echo "Skipping beta tests - no beta available" >&2
           fi
 
-          # Add rc with PHP 8.4 (only if RC version is available)
-          if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+          # Add rc with PHP 8.4 (QIT keyword - only if available)
+          if [[ "$RC_AVAILABLE" == "true" ]]; then
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"rc\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"rc\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"rc\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"rc\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+            echo "Including RC tests (QIT will resolve to latest RC)" >&2
           else
-            echo "No RC version available, skipping RC matrix entries" >&2
+            echo "Skipping RC tests - no RC available" >&2
           fi
 
           # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -105,46 +105,48 @@ jobs:
             echo "Pull request detected - running critical tests only" >&2
 
             # PR matrix: Only critical tests on L-1 and latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@critical\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@critical\"}")
+            # Note: Tags are without @ symbol - QIT adds it automatically
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"critical\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"critical\"}")
           else
             echo "Scheduled/push run detected - running full test suite" >&2
 
             # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@merchant and @subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"@shopper and @subscriptions\"}")
+            # Note: Tags without @ - QIT adds it. For multiple tags, use regex: "tag1.*tag2|tag2.*tag1"
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant and @subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant and @subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
 
             # Add beta with PHP 8.3 (if available)
             if [[ -n "$BETA_VERSION" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@merchant and @subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"@shopper and @blocks\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper.*blocks|blocks.*shopper\"}")
             fi
 
             # Add rc with PHP 8.4 (only if RC version is available)
             if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@merchant\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@shopper\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@merchant and @subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"@shopper and @subscriptions\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant.*subscriptions|subscriptions.*merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper.*subscriptions|subscriptions.*shopper\"}")
             else
               echo "No RC version available, skipping RC matrix entries" >&2
             fi
@@ -200,14 +202,18 @@ jobs:
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION}"
 
-          # Add tag if specified
+          # Add tag if specified - strip leading @ symbol as QIT adds it automatically
           if [[ -n "$TEST_TAG" ]]; then
-            OPTIONS="${OPTIONS} --pw_test_tag=\"${TEST_TAG}\""
+            # Remove @ prefix if present (QIT will add it)
+            CLEAN_TAG="${TEST_TAG#@}"
+            # For combined tags like "@shopper and @subscriptions", strip all @ symbols
+            CLEAN_TAG="${CLEAN_TAG//@/}"
+            OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\""
           fi
 
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT
           echo "Will run with options: ${OPTIONS}"
-          echo "Test tag: ${TEST_TAG}"
+          echo "Test tag: ${TEST_TAG} (cleaned: ${CLEAN_TAG:-none})"
 
       - name: Mask sensitive values
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -323,19 +323,16 @@ jobs:
           QIT_RESULTS_DIR=$(find /tmp -maxdepth 1 -name "qit-results-*" -type d 2>/dev/null | sort -r | head -1)
 
           if [[ -z "$QIT_RESULTS_DIR" ]]; then
-            echo "No QIT results directory found in /tmp"
-            ls -la /tmp | grep qit || echo "No qit directories found"
+            echo "No QIT results directory found"
             echo "failed_specs_count=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           echo "Found QIT results directory: $QIT_RESULTS_DIR"
-          ls -la "$QIT_RESULTS_DIR" || true
 
-          # QIT uses Playwright which outputs results to a JSON file
-          # Look for common Playwright result file names
+          # Look for CTRF report file
           RESULTS_JSON=""
-          for filename in "results.json" "test-results.json" "ctrf-report.json"; do
+          for filename in "ctrf-report.json" "results.json" "test-results.json"; do
             FOUND=$(find "$QIT_RESULTS_DIR" -name "$filename" -type f 2>/dev/null | head -1)
             if [[ -n "$FOUND" ]]; then
               RESULTS_JSON="$FOUND"
@@ -344,15 +341,12 @@ jobs:
           done
 
           if [[ -z "$RESULTS_JSON" || ! -f "$RESULTS_JSON" ]]; then
-            echo "No results JSON found in $QIT_RESULTS_DIR"
-            find "$QIT_RESULTS_DIR" -name "*.json" -type f 2>/dev/null || echo "No JSON files found"
+            echo "No results JSON found"
             echo "failed_specs_count=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Found results at: $RESULTS_JSON"
-          echo "Results file content preview:"
-          head -20 "$RESULTS_JSON" || true
+          echo "Parsing results from: $RESULTS_JSON"
 
           # Extract failed spec files from CTRF format
           # CTRF format: .results.tests[] with .status and .filePath fields

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -120,15 +120,16 @@ jobs:
             # Base merchant/shopper jobs exclude subscriptions and blocks to avoid duplication
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+            # Use space-separated tags - Playwright will match tests with ALL specified tags
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
@@ -137,30 +138,30 @@ jobs:
 
             # WC 7.7.0 with PHP 7.4 only (legacy - business continuity)
             # Note: Tags without @ - QIT adds it. Use space-separated tags for multiple tags.
-            # Base merchant/shopper jobs exclude subscriptions and blocks to avoid duplication
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_tag\":\"shopper subscriptions\"}")
 
             # Add L-1 version with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+            # Use space-separated tags - Playwright will match tests with ALL specified tags
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add latest with PHP 8.3
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
 
             # Add beta with PHP 8.3 (if available)
             if [[ -n "$BETA_VERSION" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$BETA_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\"}")
@@ -168,8 +169,8 @@ jobs:
 
             # Add rc with PHP 8.4 (only if RC version is available)
             if [[ -n "$RC_VERSION" && "$RC_VERSION" != "null" ]]; then
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant\"}")
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"merchant subscriptions\"}")
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$RC_VERSION\",\"php\":\"$PHP_LATEST\",\"test_tag\":\"shopper subscriptions\"}")
             else
@@ -178,8 +179,8 @@ jobs:
 
             # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
             # Test new WordPress features with latest stable WooCommerce
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\",\"exclude_tag\":\"subscriptions\"}")
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\",\"exclude_tag\":\"subscriptions blocks\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\"}")
             MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\"}")
@@ -232,10 +233,12 @@ jobs:
           WC_VERSION="${{ inputs.woocommerce_version || matrix.woocommerce }}"
           PHP_VERSION="${{ inputs.php_version || matrix.php }}"
           TEST_TAG="${{ inputs.test_tag || matrix.test_tag }}"
-          EXCLUDE_TAG="${{ matrix.exclude_tag || '' }}"
           WP_VERSION="${{ inputs.wordpress_version || matrix.wordpress || 'stable' }}"
 
           OPTIONS="${OPTIONS} --php_version=${PHP_VERSION} --woo=${WC_VERSION} --wp=${WP_VERSION}"
+
+          # Disable retries to match non-QIT workflow behavior (retries: 0)
+          OPTIONS="${OPTIONS} --pw_options=\"--retries=0\""
 
           # Add tag if specified - strip leading @ symbol as QIT adds it automatically
           if [[ -n "$TEST_TAG" ]]; then
@@ -244,15 +247,6 @@ jobs:
             # For combined tags like "@shopper and @subscriptions", strip all @ symbols
             CLEAN_TAG="${CLEAN_TAG//@/}"
             OPTIONS="${OPTIONS} --pw_test_tag=\"${CLEAN_TAG}\""
-          fi
-
-          # Add exclusion tags via --pw_options if specified
-          # This prevents duplication between base merchant/shopper and subscription/blocks jobs
-          if [[ -n "$EXCLUDE_TAG" ]]; then
-            # Build grep-invert pattern for Playwright
-            EXCLUDE_PATTERN="@${EXCLUDE_TAG// / @}"
-            OPTIONS="${OPTIONS} --pw_options=\"--grep-invert ${EXCLUDE_PATTERN}\""
-            echo "Excluding tags: ${EXCLUDE_TAG}"
           fi
 
           echo "options=${OPTIONS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -115,11 +115,11 @@ jobs:
           MATRIX_ENTRIES+=("{\"woocommerce\":\"$L1_VERSION\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
           # Add latest with PHP 8.3
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
           # Add beta with PHP 8.3 (if available)
           if [[ -n "$BETA_VERSION" ]]; then
@@ -142,11 +142,11 @@ jobs:
 
           # Add WordPress nightly with WC latest and PHP 8.3 (match e2e-test.yml wp-nightly-tests)
           # Test new WordPress features with latest stable WooCommerce
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
-          MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant\",\"test_name\":\"merchant\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper\",\"test_name\":\"shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"merchant subscriptions\",\"test_name\":\"subscriptions-merchant\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper subscriptions\",\"test_name\":\"subscriptions-shopper\"}")
+          MATRIX_ENTRIES+=("{\"woocommerce\":\"stable\",\"php\":\"$PHP_STABLE\",\"wordpress\":\"nightly\",\"test_tag\":\"shopper blocks\",\"test_name\":\"blocks-shopper\"}")
 
           # Convert array to JSON
           MATRIX_INCLUDE=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s . -c)

--- a/tests/qit/e2e/specs/basic.spec.ts
+++ b/tests/qit/e2e/specs/basic.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from '../fixtures/auth';
 
 test.describe(
 	'A basic set of tests to ensure WP, wp-admin and my-account load',
+	{ tag: '@basic' },
 	() => {
 		test( 'Load the home page', async ( { page } ) => {
 			await page.goto( '/' );


### PR DESCRIPTION
Fixes #WOOPMNT-5365

This PR migrates the existing E2E GitHub workflows to use QIT, completing the workflow infrastructure portion of the QIT E2E migration effort. This is part of a stacked PR series where each PR builds incrementally toward full QIT adoption.

#### Current State & Scope

🚧 Important: This PR focuses on infrastructure migration - moving from legacy E2E workflows to QIT-based workflows. The test suite is functionally complete and running in CI, but stability work is needed as a follow-up task (see [WOOPMNT-5361: \[E2E\]\[QIT\] Fix timeout errors and flaky specs in CI](https://linear.app/a8c/issue/WOOPMNT-5361/e2eqit-fix-timeout-errors-and-flaky-specs-in-ci)).

The intent is to get the foundation merged and reviewed without blocking on every flaky test. This should allow parallel work on stabilization while infrastructure is in place and track infrastructure changes separately from test fixes.

⚠️ Current Limitations (to be addressed in follow-up work):
1. Test Flakiness: Some tests have timeout issues and intermittent failures in CI
2. Retry Logic: While automatic retries help, some specs may need additional stability work

#### Changes proposed in this Pull Request

This PR establishes the QIT E2E testing infrastructure with:

1. Separated Workflows for Different Use Cases:
    - `qit-e2e-pull-request.yml`: Focused PR testing (10 jobs: L-1 + stable WC versions across 5 test categories)
    - `qit-e2e.yml `(renamed to "Scheduled & Push"): Comprehensive version matrix (25+ jobs including legacy WC 7.7.0, beta, RC, WP nightly)
2. Dynamic Version Resolution:
    - New script: `.github/scripts/generate-qit-wc-matrix.sh`
    - Automatically fetches L-1 WooCommerce version from WordPress.org API
    - Checks availability of beta/RC versions dynamically
3. Build Once, Test Many:
    - New build-plugin job: Builds `woocommerce-payments.zip` once and uploads as artifact
    - All matrix jobs download the pre-built artifact instead of rebuilding
    - Impact: Saves ~5 minutes × number of matrix jobs (e.g., 50 minutes saved on 10-job PR runs)
    - Ensures all tests run against the identical build artifact
4. Test Execution Features:
    - Tag-based filtering: Single tags (e.g., `merchant`) auto-exclude subscriptions/blocks; multiple tags use AND logic
    - Automatic retries: Failed specs are parsed from CTRF reports and retried once
    - WordPress version support: Can test against stable, nightly, and RC WordPress builds
    - Manual dispatch: Run workflows with custom WC/PHP/WP versions and specific test tags
5. Error Handling:
    - Validates QIT results directory exists before proceeding
    - Parses CTRF format reports to identify failed specs
    - Provides clear error messages for QIT setup failures
    - Uses --no_upload_report to keep CI results internal

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

What Should Work:
  - Workflows trigger on appropriate events (PR, push, schedule)
  - Matrix generates correctly with dynamic versions
  - Tests execute via QIT
  - Failed specs are identified and retried
  - Results are logged (not uploaded to QIT)

What May Not Work (expected, to be fixed later):
  - Some tests may timeout or fail intermittently
  - Retry attempts may not always succeed
  - Full test suite will not be 100% green

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
