### PR TITLE
Update the cutoff version for that message

### DIFF
--- a/changelog/woopmnt-5366-keep-notice-when-using-bundled-subscriptions-untill-102
+++ b/changelog/woopmnt-5366-keep-notice-when-using-bundled-subscriptions-untill-102
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Show message about bundled subscriptions until 10.2.0.

--- a/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
@@ -39,8 +39,8 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 			return false;
 		}
 
-		// If wcpay version is >= 10.0, bail to not show the notice indefinitely.
-		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.2.0', '>=' ) ) {
+		// If wcpay version is > 10.2 bail to not show the notice indefinitely.
+		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.2.0', '>' ) ) {
 			return false;
 		}
 

--- a/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
@@ -39,7 +39,7 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 			return false;
 		}
 
-		// If wcpay version is > 10.2 bail to not show the notice indefinitely.
+		// If wcpay version is > 10.2.99 bail to not show the notice indefinitely.
 		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.2.99', '>' ) ) {
 			return false;
 		}

--- a/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
@@ -40,7 +40,7 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 		}
 
 		// If wcpay version is > 10.2 bail to not show the notice indefinitely.
-		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.2.0', '>' ) ) {
+		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.2.99', '>' ) ) {
 			return false;
 		}
 

--- a/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
@@ -40,7 +40,7 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 		}
 
 		// If wcpay version is >= 10.0, bail to not show the notice indefinitely.
-		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.0.0', '>=' ) ) {
+		if ( version_compare( WC_Payments::get_file_version( WCPAY_PLUGIN_FILE ), '10.2.0', '>=' ) ) {
 			return false;
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
@@ -36,7 +36,7 @@ class WC_Payments_Subscriptions_Admin_Notices {
 
 		$wcpay_version = $this->get_wcpay_version();
 		// if wcpay version is >= 10.0, bail to not show the notice indefinitely.
-		if ( version_compare( $wcpay_version, '10.0.0', '>=' ) ) {
+		if ( version_compare( $wcpay_version, '10.2.0', '>=' ) ) {
 			return;
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
@@ -35,8 +35,8 @@ class WC_Payments_Subscriptions_Admin_Notices {
 		}
 
 		$wcpay_version = $this->get_wcpay_version();
-		// if wcpay version is >= 10.0, bail to not show the notice indefinitely.
-		if ( version_compare( $wcpay_version, '10.2.0', '>=' ) ) {
+		// if wcpay version is > 10.2, bail to not show the notice indefinitely.
+		if ( version_compare( $wcpay_version, '10.2.0', '>' ) ) {
 			return;
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
@@ -35,8 +35,8 @@ class WC_Payments_Subscriptions_Admin_Notices {
 		}
 
 		$wcpay_version = $this->get_wcpay_version();
-		// if wcpay version is > 10.2, bail to not show the notice indefinitely.
-		if ( version_compare( $wcpay_version, '10.2.0', '>' ) ) {
+		// if wcpay version is > 10.2.99, bail to not show the notice indefinitely.
+		if ( version_compare( $wcpay_version, '10.2.99', '>' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
See WOOPMNT-5366

#### Changes proposed in this Pull Request

A while ago Gamma worked on [adding notices](https://github.com/Automattic/woocommerce-payments/pull/10842) about the bundled subscriptions feature being phased out. Right after that the project got paused and we never got to actually disable the bundled subscriptions. The removal will happen in 10.2 so we need to increase the version to 10.2 to keep showing the message until there.

Message to look for:

> WooPayments no longer supports subscriptions capabilities and subscriptions data can no longer be accessed. Please install [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) to continue managing your subscriptions.

_I'm using old screenshots here just to show the places the message should appear, but the message will be the one above._

Acceptance Criteria

- Display an admin notice on Subscriptions list table, Edit Subscription page and WooCommerce > Settings > Subscriptions on stores with Stripe Billing subscriptions without WooCommerce Subscriptions installed.
- Display an WooCommerce Admin note to merchants also with active legacy Stripe Billing subscriptions
- Installing WooCommerce Subscriptions removes all notices

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/70253294-df66-4ff7-b049-8629c438df98" />

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/b4a0bdfb-ba5a-4f89-997f-c6c1dfc9ae99" />

<img width="805" alt="image" src="https://github.com/user-attachments/assets/6d795820-6625-490c-9a7a-f72067e16927" />

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/7386da41-bdda-4896-8fac-8271c3564fb4" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run
```
wp option update _wcpay_feature_stripe_billing 1 --allow-root && wp option update _wcpay_feature_subscriptions 1 --allow-root
```
* go to WooCommerce > Subscriptions, ensure the notice is there
* go to WooCommerce > Home ensure the message is on the inbox

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
