### PR TITLE
Use capability pay_for_order when checking the owner of order

### DIFF
--- a/changelog/fix-WOOPMNT-5355
+++ b/changelog/fix-WOOPMNT-5355
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use Woo custom cap `pay_for_order` for validating the owner of order

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -269,7 +269,7 @@ class WC_Payments_Checkout {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
 
-			if ( is_a( $order, 'WC_Order' ) && get_current_user_id() === $order->get_user_id() ) {
+			if ( is_a( $order, 'WC_Order' ) && current_user_can( 'pay_for_order', $order->get_id() ) ) {
 				$payment_fields['isOrderPay'] = true;
 				$payment_fields['orderId']    = $order_id;
 				$order_currency               = $order->get_currency();


### PR DESCRIPTION
Fixes WOOPMNT-5355

#### Changes proposed in this Pull Request

- Use the `pay_for_order` custom capability rather than check on the owner of the order by our logic.
- With this, merchants/admins can customize who can really pay for orders, such as admins pay for customers' orders.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow up instructions in the issue, and confirm that with this patch the issue is no longer there.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
