### PR TITLE
Prevent WooPayments-specific styles in the Checkout block to leak to other payment methods

### DIFF
--- a/changelog/fix-checkout-block-payment-label-styles-leak
+++ b/changelog/fix-checkout-block-payment-label-styles-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WooPayments-specific styles for the Checkout block to leak to other payment methods

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -44,7 +44,8 @@ button.wcpay-stripelink-modal-trigger:hover {
 
 .wc-block-checkout__payment-method {
 	input:checked ~ div {
-		.wc-block-components-radio-control__label:where(#radio-control-wc-payment-method-options-woocommerce_payments__label) {
+		/* stylelint-disable-next-line selector-id-pattern */
+		.wc-block-components-radio-control__label:where( #radio-control-wc-payment-method-options-woocommerce_payments__label ) {
 			> .payment-method-label {
 				.test-mode.badge {
 					// hiding the badge when the payment method is not selected
@@ -54,7 +55,8 @@ button.wcpay-stripelink-modal-trigger:hover {
 		}
 	}
 
-	.wc-block-components-radio-control__label:where(#radio-control-wc-payment-method-options-woocommerce_payments__label) {
+	/* stylelint-disable-next-line selector-id-pattern */
+	.wc-block-components-radio-control__label:where( #radio-control-wc-payment-method-options-woocommerce_payments__label ) {
 		width: 100%;
 		display: block !important;
 

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -44,7 +44,7 @@ button.wcpay-stripelink-modal-trigger:hover {
 
 .wc-block-checkout__payment-method {
 	input:checked ~ div {
-		.wc-block-components-radio-control__label {
+		.wc-block-components-radio-control__label:where(#radio-control-wc-payment-method-options-woocommerce_payments__label) {
 			> .payment-method-label {
 				.test-mode.badge {
 					// hiding the badge when the payment method is not selected
@@ -54,7 +54,7 @@ button.wcpay-stripelink-modal-trigger:hover {
 		}
 	}
 
-	.wc-block-components-radio-control__label {
+	.wc-block-components-radio-control__label:where(#radio-control-wc-payment-method-options-woocommerce_payments__label) {
 		width: 100%;
 		display: block !important;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WooPayments styles are leaking into other payment methods in the _Checkout_ block. I could notice a conflict with WooCommerce PayPal Payments, but other payment methods might be affected as well. This PR makes the CSS selectors match only the WooPayments method. It doesn't affect the specificity by using a `:where()` selector.

Before | After
--- | ---
<img width="775" height="484" alt="imatge" src="https://github.com/user-attachments/assets/8d47e427-97b0-41bc-bc7f-b4c3331f20bb" /> | <img width="775" height="484" alt="imatge" src="https://github.com/user-attachments/assets/c48e3514-6d8d-43a7-9845-8c6ee5935321" />

This PR has no tests because it's CSS-only.

#### Testing instructions

* Install WooPayments and WooCommerce PayPal Payments as payment methods.
* Enable both of them.
* In the frontend, go to a page with the _Checkout_ block.
* Verify the _PayPal_ label and icon are aligned.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
