### PR TITLE
Follow-up: Sync store setup with the Transact Platform

### DIFF
--- a/changelog/update-WOOPMNT-5362-platform-settings-sync
+++ b/changelog/update-WOOPMNT-5362-platform-settings-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Switch to using recurring action to send store setup data.
+
+

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -565,7 +565,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		}
 
 		// Sync the store setup with the Transact Platform.
-		$this->account->schedule_store_setup_sync();
+		$this->account->store_setup_sync();
 
 		return new WP_REST_Response( $this->get_settings(), 200 );
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2641,8 +2641,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	 * Gather the latest store setup state and send it to the Transact Platform.
 	 *
 	 * @return void
-	 *
-	 * @throws Throwable When the sync fails.
 	 */
 	public function store_setup_sync() {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
@@ -2654,7 +2652,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
 		} catch ( Throwable $e ) {
 			Logger::error( 'Failed to sync store setup state with the Transact Platform: ' . $e->getMessage() );
-			throw $e;
 		}
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2821,7 +2821,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 		$plugins_list = [];
 
-		$active_plugin_ids = ! empty( $wc_plugin_util ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
+		$active_plugin_ids = ( ! empty( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'get_all_active_valid_plugins' ] ) ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
 		foreach ( $active_plugin_ids as $plugin_file ) {
 			if ( isset( $all_plugins[ $plugin_file ] ) ) {
 				$plugin_data                  = $all_plugins[ $plugin_file ];
@@ -2829,7 +2829,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					'name'     => $plugin_data['Name'],
 					'slug'     => dirname( $plugin_file ),
 					'version'  => $plugin_data['Version'],
-					'wc_aware' => ! empty( $wc_plugin_util ) ? $wc_plugin_util->is_woocommerce_aware_plugin( $plugin_data ) : null,
+					'wc_aware' => ( ! empty( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'is_woocommerce_aware_plugin' ] ) ) ? $wc_plugin_util->is_woocommerce_aware_plugin( $plugin_data ) : null,
 				];
 			}
 		}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2642,6 +2642,8 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	 * Gather the latest store setup state and send it to the Transact Platform.
 	 *
 	 * @return void
+	 *
+	 * @throws Throwable When the sync fails.
 	 */
 	public function store_setup_sync() {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
@@ -2653,6 +2655,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
 		} catch ( Throwable $e ) {
 			Logger::error( 'Failed to sync store setup state with the Transact Platform: ' . $e->getMessage() );
+			throw $e;
 		}
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use Automattic\WooCommerce\Utilities\PluginUtil;
 use WCPay\Constants\Country_Code;
 use WCPay\Constants\Currency_Code;
 use WCPay\Core\Server\Request\Get_Account;
@@ -2814,17 +2813,19 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 		// Get active plugins using the PluginUtil from WC, if available.
 		$wc_plugin_util = null;
-		try {
-			$wc_plugin_util = wc_get_container()->get( PluginUtil::class );
-		} catch ( Exception $e ) {
-			// If we can't get the PluginUtil, we won't be able to get the active plugins.
-			// This is not a critical failure, so we can log it and continue.
-			Logger::error( 'Failed to get PluginUtil: ' . $e->getMessage() );
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\PluginUtil' ) ) {
+			try {
+				$wc_plugin_util = wc_get_container()->get( '\Automattic\WooCommerce\Utilities\PluginUtil' );
+			} catch ( Throwable $e ) {
+				// If we can't get the PluginUtil, we won't be able to accurately get the active plugins.
+				// This is not a critical failure, so we can log it and continue.
+				Logger::error( 'Failed to get PluginUtil: ' . $e->getMessage() );
+			}
 		}
 
 		$plugins_list = [];
 
-		$active_plugin_ids = ( ! empty( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'get_all_active_valid_plugins' ] ) ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
+		$active_plugin_ids = ( is_object( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'get_all_active_valid_plugins' ] ) ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
 		foreach ( $active_plugin_ids as $plugin_file ) {
 			if ( isset( $all_plugins[ $plugin_file ] ) ) {
 				$plugin_data                  = $all_plugins[ $plugin_file ];
@@ -2832,7 +2833,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					'name'     => $plugin_data['Name'],
 					'slug'     => dirname( $plugin_file ),
 					'version'  => $plugin_data['Version'],
-					'wc_aware' => ( ! empty( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'is_woocommerce_aware_plugin' ] ) ) ? $wc_plugin_util->is_woocommerce_aware_plugin( $plugin_data ) : null,
+					'wc_aware' => ( is_object( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'is_woocommerce_aware_plugin' ] ) ) ? $wc_plugin_util->is_woocommerce_aware_plugin( $plugin_data ) : null,
 				];
 			}
 		}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2678,7 +2678,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 		$payment_methods_available = $gateway->get_upe_available_payment_methods();
 		$payment_methods_enabled   = $gateway->get_upe_enabled_payment_method_ids();
-		$payment_methods_disabled  = array_diff( $payment_methods_available, $payment_methods_enabled );
+		$payment_methods_disabled  = array_values( array_diff( $payment_methods_available, $payment_methods_enabled ) );
 
 		// Map enabled payment methods to capabilities.
 		// This is needed because the capabilities in the Transact Platform are named differently.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2648,12 +2648,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			return;
 		}
 
-		try {
-			// This is a fire-and-forget operation, so we don't care about the result.
-			$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
-		} catch ( Throwable $e ) {
-			Logger::error( 'Failed to sync store setup state with the Transact Platform: ' . $e->getMessage() );
-		}
+		$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2767,7 +2767,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			],
 			'wc_setup'               => [
 				'version'                     => defined( 'WC_VERSION' ) ? explode( '-', WC_VERSION, 2 )[0] : '',
-				'store_id'                    => get_option( 'woocommerce_store_id', null ),
+				'store_id'                    => ( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) ) ? get_option( \WC_Install::STORE_ID_OPTION, null ) : null,
 				'currency'                    => get_woocommerce_currency(),
 				'tracking_enabled'            => WC_Site_Tracking::is_tracking_enabled(),
 				'registered_payment_gateways' => $this->get_store_registered_gateway_ids(),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2760,6 +2760,12 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			'multi_currency_enabled' => WC_Payments_Features::is_customer_multi_currency_enabled(),
 			'stripe_billing_enabled' => WC_Payments_Features::is_stripe_billing_enabled(),
 
+			// Other WooPayments details.
+			'plugin'                 => [
+				'version'              => WCPAY_VERSION_NUMBER,
+				'activation_timestamp' => get_option( 'wcpay_activation_timestamp', null ),
+			],
+
 			// Other store setup details.
 			'wp_setup'               => [
 				'name'           => get_bloginfo( 'name' ),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2752,7 +2752,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 			// Other WooPayments details.
 			'plugin'                 => [
-				'version'              => WCPAY_VERSION_NUMBER,
+				'version'              => defined( 'WCPAY_VERSION_NUMBER' ) ? explode( '-', WCPAY_VERSION_NUMBER, 2 )[0] : '',
 				'activation_timestamp' => get_option( 'wcpay_activation_timestamp', null ),
 			],
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -135,10 +135,10 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
 		add_action( 'updated_option', [ $this, 'possibly_update_wcpay_account_locale' ], 10, 3 );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_cache' ] );
-		// Hook into the account refreshed action to schedule a store setup sync.
-		add_action( 'woocommerce_payments_account_refreshed', [ $this, 'schedule_store_setup_sync' ] );
-		// Hook into the store setup sync action (triggered by the scheduled job) and do the sync.
+		// Hook into the recurring store setup sync action and do the store setup sync.
 		add_action( self::STORE_SETUP_SYNC_ACTION, [ $this, 'store_setup_sync' ] );
+		// Also do a store setup sync when the client is updated to a new version.
+		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'store_setup_sync' ] );
 	}
 
 	/**
@@ -2636,25 +2636,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	public function is_card_testing_protection_eligible(): bool {
 		$account = $this->get_cached_account_data();
 		return $account['card_testing_protection_eligible'] ?? false;
-	}
-
-	/**
-	 * Schedule a store setup sync to run in 5 minutes, if there isn't one already scheduled.
-	 *
-	 * @return void
-	 */
-	public function schedule_store_setup_sync() {
-		$action_hook = self::STORE_SETUP_SYNC_ACTION;
-
-		// If there is already a pending action, do nothing.
-		if ( $this->action_scheduler_service->pending_action_exists( $action_hook ) ) {
-			return;
-		}
-
-		// Schedule the action to run in 5 minutes.
-		// Further attempts to schedule the action will be ignored until it runs.
-		$run_time = time() + 5 * MINUTE_IN_SECONDS;
-		$this->action_scheduler_service->schedule_job( $run_time, $action_hook );
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2651,7 +2651,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		try {
 			// This is a fire-and-forget operation, so we don't care about the result.
 			$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			Logger::error( 'Failed to sync store setup state with the Transact Platform: ' . $e->getMessage() );
 		}
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2698,16 +2698,6 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		}
 		$provider_capabilities_available = array_unique( array_merge( $provider_capabilities_enabled, $provider_capabilities_disabled ) );
 
-		// Get active plugins using the PluginUtil from WC, if available.
-		$wc_plugin_util = null;
-		try {
-			$wc_plugin_util = wc_get_container()->get( PluginUtil::class );
-		} catch ( Exception $e ) {
-			// If we can't get the PluginUtil, we won't be able to get the active plugins.
-			// This is not a critical failure, so we can log it and continue.
-			Logger::error( 'Failed to get PluginUtil: ' . $e->getMessage() );
-		}
-
 		return [
 			// The WooPayments setup details.
 			'gateway'                => [
@@ -2771,17 +2761,19 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 				'name'           => get_bloginfo( 'name' ),
 				'url'            => home_url(),
 				'active_theme'   => $this->get_store_theme_details(),
-				'active_plugins' => ! empty( $wc_plugin_util ) ? $wc_plugin_util->get_all_active_valid_plugins() : [],
+				'active_plugins' => $this->get_store_active_plugins(),
 				'version'        => get_bloginfo( 'version' ),
 				'locale'         => get_locale(),
 			],
 			'wc_setup'               => [
-				'version'                  => defined( 'WC_VERSION' ) ? explode( '-', WC_VERSION, 2 )[0] : '',
-				'store_id'                 => get_option( 'woocommerce_store_id', null ),
-				'currency'                 => get_woocommerce_currency(),
-				'tracking_enabled'         => WC_Site_Tracking::is_tracking_enabled(),
-				'wc_subscriptions_active'  => $gateway->is_subscriptions_plugin_active(),
-				'wc_subscriptions_version' => $gateway->get_subscriptions_plugin_version(),
+				'version'                     => defined( 'WC_VERSION' ) ? explode( '-', WC_VERSION, 2 )[0] : '',
+				'store_id'                    => get_option( 'woocommerce_store_id', null ),
+				'currency'                    => get_woocommerce_currency(),
+				'tracking_enabled'            => WC_Site_Tracking::is_tracking_enabled(),
+				'registered_payment_gateways' => $this->get_store_registered_gateway_ids(),
+				'enabled_payment_gateways'    => $this->get_store_enabled_gateway_ids(),
+				'wc_subscriptions_active'     => $gateway->is_subscriptions_plugin_active(),
+				'wc_subscriptions_version'    => $gateway->get_subscriptions_plugin_version(),
 			],
 		];
 	}
@@ -2792,18 +2784,109 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	 * @return array Store theme details.
 	 */
 	private function get_store_theme_details(): array {
-		$theme_data           = wp_get_theme();
-		$theme_child_theme    = wc_bool_to_string( is_child_theme() );
-		$theme_wc_support     = wc_bool_to_string( current_theme_supports( 'woocommerce' ) );
-		$theme_is_block_theme = wc_bool_to_string( wp_is_block_theme() );
+		$theme_data = wp_get_theme();
 
 		return [
 			'name'        => $theme_data->Name, // @phpcs:ignore
 			'version'     => $theme_data->Version, // @phpcs:ignore
-			'child_theme' => $theme_child_theme,
-			'wc_support'  => $theme_wc_support,
-			'block_theme' => $theme_is_block_theme,
+			'child_theme' => is_child_theme(),
+			'wc_support'  => current_theme_supports( 'woocommerce' ),
+			'block_theme' => wp_is_block_theme(),
 		];
+	}
+
+	/**
+	 * Gathers the current store active (and valid) plugins.
+	 *
+	 * @return array Store active plugins details with each plugin slug and version.
+	 */
+	private function get_store_active_plugins(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$all_plugins = get_plugins();
+		if ( empty( $all_plugins ) ) {
+			return [];
+		}
+
+		// Get active plugins using the PluginUtil from WC, if available.
+		$wc_plugin_util = null;
+		try {
+			$wc_plugin_util = wc_get_container()->get( PluginUtil::class );
+		} catch ( Exception $e ) {
+			// If we can't get the PluginUtil, we won't be able to get the active plugins.
+			// This is not a critical failure, so we can log it and continue.
+			Logger::error( 'Failed to get PluginUtil: ' . $e->getMessage() );
+		}
+
+		$plugins_list = [];
+
+		$active_plugin_ids = ! empty( $wc_plugin_util ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
+		foreach ( $active_plugin_ids as $plugin_file ) {
+			if ( isset( $all_plugins[ $plugin_file ] ) ) {
+				$plugin_data                  = $all_plugins[ $plugin_file ];
+				$plugins_list[ $plugin_file ] = [
+					'name'     => $plugin_data['Name'],
+					'slug'     => dirname( $plugin_file ),
+					'version'  => $plugin_data['Version'],
+					'wc_aware' => ! empty( $wc_plugin_util ) ? $wc_plugin_util->is_woocommerce_aware_plugin( $plugin_data ) : null,
+				];
+			}
+		}
+
+		return array_values( $plugins_list );
+	}
+
+	/**
+	 * Gets the IDs of all payment gateways registered in the store.
+	 *
+	 * @return array Array of payment gateway IDs.
+	 */
+	private function get_store_registered_gateway_ids(): array {
+		$payment_gateways = WC()->payment_gateways()->payment_gateways();
+		if ( empty( $payment_gateways ) ) {
+			return [];
+		}
+
+		// Go through the gateways and get their IDs.
+		return array_unique(
+			array_values(
+				array_filter(
+					array_map(
+						function ( $gateway ) {
+							return $gateway->id ?? null;
+						},
+						$payment_gateways
+					)
+				)
+			)
+		);
+	}
+
+	/**
+	 * Gets the IDs of all enabled payment gateways registered in the store.
+	 *
+	 * @return array Array of enabled payment gateway IDs.
+	 */
+	private function get_store_enabled_gateway_ids(): array {
+		$payment_gateways = WC()->payment_gateways()->payment_gateways();
+		if ( empty( $payment_gateways ) ) {
+			return [];
+		}
+
+		// Go through the gateways and get the IDs of enabled ones.
+		return array_unique(
+			array_values(
+				array_filter(
+					array_map(
+						function ( $gateway ) {
+							return ( $gateway instanceof WC_Payment_Gateway && wc_string_to_bool( $gateway->enabled ) ) ? $gateway->id : null;
+						},
+						$payment_gateways
+					)
+				)
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2648,7 +2648,12 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			return;
 		}
 
-		$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
+		try {
+			// This is a fire-and-forget operation, so we don't care about the result.
+			$this->payments_api_client->send_store_setup( $this->get_store_setup_details() );
+		} catch ( Throwable $e ) {
+			Logger::error( 'Failed to sync store setup state with the Transact Platform: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2670,7 +2670,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		$gateway = WC_Payments::get_gateway();
 		// If the gateway is not available, return an empty array.
 		// This should never happen, but better safe than sorry.
-		if ( empty( $gateway ) ) {
+		if ( empty( $gateway ) || ! $gateway instanceof WC_Payment_Gateway_WCPay ) {
 			return [];
 		}
 

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -190,15 +190,7 @@ class WC_Payments_Action_Scheduler_Service {
 	 * @return bool
 	 */
 	public function pending_action_exists( string $hook ): bool {
-		$actions = as_get_scheduled_actions(
-			[
-				'hook'   => $hook,
-				'status' => ActionScheduler_Store::STATUS_PENDING,
-				'group'  => self::GROUP_ID,
-			]
-		);
-
-		return ( is_countable( $actions ) ? count( $actions ) : 0 ) > 0;
+		return as_has_scheduled_action( $hook, [], self::GROUP_ID );
 	}
 
 	/**

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -53,8 +53,52 @@ class WC_Payments_Action_Scheduler_Service {
 		$this->payments_api_client   = $payments_api_client;
 		$this->order_service         = $order_service;
 		$this->compatibility_service = $compatibility_service;
+	}
 
+	/**
+	 * Initialize all hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		$this->ensure_recurring_actions();
 		$this->add_action_scheduler_hooks();
+	}
+
+	/**
+	 * Ensure all recurring actions are scheduled.
+	 *
+	 * @return void
+	 */
+	public function ensure_recurring_actions() {
+		if ( function_exists( 'as_supports' ) && as_supports( 'ensure_recurring_actions_hook' ) ) {
+			// Preferred since AS v3.9.3 (WC 10.1): runs periodically in the background.
+			add_action( 'action_scheduler_ensure_recurring_actions', [ $this, 'schedule_recurring_actions' ] );
+		} elseif ( is_admin() ) {
+			// Backward compatible fallback: runs on every admin request.
+			$this->schedule_recurring_actions();
+		}
+	}
+
+	/**
+	 * Schedule all recurring actions.
+	 *
+	 * If the action is already scheduled, it won't be rescheduled again.
+	 *
+	 * @return void
+	 */
+	public function schedule_recurring_actions() {
+		// Check if Action Scheduler is available.
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+
+		if ( ! as_has_scheduled_action( WC_Payments_Account::STORE_SETUP_SYNC_ACTION ) ) {
+			// Delay the first run by 10 to 60 seconds (randomly) so it doesn't occur in the same request.
+			// The random delay is to avoid large number of sites hitting the API at the same time if they all
+			// get updated at the same time (e.g. via WP cron).
+			as_schedule_recurring_action( time() + wp_rand( 10, 60 ), 6 * HOUR_IN_SECONDS, WC_Payments_Account::STORE_SETUP_SYNC_ACTION, [], self::GROUP_ID, true );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -568,6 +568,7 @@ class WC_Payments {
 		( new WooPay_Scheduler( self::$api_client ) )->init();
 
 		// Initialise hooks.
+		self::$action_scheduler_service->init_hooks();
 		self::$account->init_hooks();
 		self::$fraud_service->init_hooks();
 		self::$onboarding_service->init_hooks();

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1356,7 +1356,7 @@ class WC_Payments {
 	/**
 	 * Sets the card gateway instance.
 	 *
-	 * @param WC_Payment_Gateway_WCPay $gateway The card gateway instance..
+	 * @param WC_Payment_Gateway_WCPay $gateway The card gateway instance.
 	 */
 	public static function set_gateway( $gateway ) {
 		self::$card_gateway = $gateway;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2494,11 +2494,12 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	 * @param bool   $use_user_token   - If true, the request will be signed with the user token rather than blog token. Defaults to false.
 	 * @param bool   $raw_response     - If true, the raw response will be returned. Defaults to false.
 	 * @param bool   $use_v2_api       - If true, the request will be sent to the V2 API endpoint. Defaults to false.
+	 * @param bool   $blocking         - If true, the request will be blocking. Defaults to true.
 	 *
 	 * @return array
 	 * @throws API_Exception - If the account ID hasn't been set.
 	 */
-	protected function request( $params, $api, $method, $is_site_specific = true, $use_user_token = false, bool $raw_response = false, bool $use_v2_api = false ) {
+	protected function request( $params, $api, $method, $is_site_specific = true, $use_user_token = false, bool $raw_response = false, bool $use_v2_api = false, bool $blocking = true ) {
 		// Apply the default params that can be overridden by the calling method.
 		$params = wp_parse_args(
 			$params,
@@ -2562,6 +2563,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 				'headers'         => $headers,
 				'timeout'         => self::API_TIMEOUT_SECONDS,
 				'connect_timeout' => self::API_TIMEOUT_SECONDS,
+				'blocking'        => $blocking,
 			];
 
 			$log_request_id = uniqid();

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2467,6 +2467,8 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	/**
 	 * Send store setup data to the Transact Platform.
 	 *
+	 * Use a non-blocking request as this is not critical data, and it should have minimal impact on the user experience.
+	 *
 	 * @param array $store_setup The store setup data.
 	 *
 	 * @return array Response from the API.
@@ -2480,7 +2482,11 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			],
 			self::STORE_SETUP_API,
 			self::POST,
-			true
+			true,
+			false,
+			false,
+			false,
+			false
 		);
 	}
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -542,9 +542,9 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->controller->update_settings( $request );
 	}
 
-	public function test_update_settings_schedules_store_setup_sync() {
+	public function test_update_settings_calls_store_setup_sync() {
 		$this->mock_wcpay_account->expects( $this->once() )
-			->method( 'schedule_store_setup_sync' );
+			->method( 'store_setup_sync' );
 
 		$request = new WP_REST_Request();
 		$request->set_param( 'is_wcpay_enabled', true );

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3617,19 +3617,19 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		);
 		$mock_gateway->method( 'get_upe_available_payment_methods' )->willReturn( [ 'card', 'bancontact', 'eps', 'ideal', 'p24', 'klarna', 'multibanco', 'alipay', 'wechat_pay' ] );
 		$mock_gateway->method( 'get_upe_enabled_payment_method_ids' )->willReturn( [ 'card', 'klarna' ] );
-		$mock_gateway->method( 'get_payment_method_capability_key_map' )->willReturn(
-			[
-				'card'       => 'card_payments',
-				'bancontact' => 'bancontact_payments',
-				'eps'        => 'eps_payments',
-				'ideal'      => 'ideal_payments',
-				'p24'        => 'p24_payments',
-				'klarna'     => 'klarna_payments',
-				'multibanco' => 'multibanco_payments',
-				'alipay'     => 'alipay_payments',
-				'wechat_pay' => 'wechat_payments',
-			]
-		);
+
+		$payment_method_capability_map = [
+			'card'       => 'card_payments',
+			'bancontact' => 'bancontact_payments',
+			'eps'        => 'eps_payments',
+			'ideal'      => 'ideal_payments',
+			'p24'        => 'p24_payments',
+			'klarna'     => 'klarna_payments',
+			'multibanco' => 'multibanco_payments',
+			'alipay'     => 'alipay_payments',
+			'wechat_pay' => 'wechat_payments',
+		];
+		$mock_gateway->method( 'get_payment_method_capability_key_map' )->willReturn( $payment_method_capability_map );
 		$mock_gateway->method( 'find_duplicates' )->willReturn( [ 'card' => [ 'woocommerce_payments', 'some_other_gateway' ] ] );
 		$mock_gateway->method( 'get_option' )->willReturnCallback(
 			function ( $key, $default = null ) {
@@ -3652,8 +3652,13 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		);
 		$mock_gateway->method( 'is_saved_cards_enabled' )->willReturn( true );
 
-		// Mock WC_Payments static methods.
+		// Replace the real gateway with the mock.
 		WC_Payments::set_gateway( $mock_gateway );
+
+		// Set the account mode to test mode.
+		WC_Payments::mode()->test();
+		// Set the onboarding to test mode.
+		WC_Payments::mode()->test_mode_onboarding();
 
 		// Capture the argument passed to send_store_setup.
 		$captured_data = null;
@@ -3668,6 +3673,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		// Act: Call store_setup_sync.
 		$this->wcpay_account->store_setup_sync();
 
+		$this->assertIsArray( $captured_data, 'Expected send_store_setup to be called with an array argument.' );
 		// Assert: Verify that the data structure contains expected top-level keys.
 		$this->assertArrayHasKey( 'gateway', $captured_data );
 		$this->assertArrayHasKey( 'payment_methods', $captured_data );
@@ -3689,6 +3695,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'test_mode', $captured_data['gateway'] );
 		$this->assertArrayHasKey( 'test_mode_onboarding', $captured_data['gateway'] );
 		$this->assertTrue( $captured_data['gateway']['enabled'] );
+		$this->assertTrue( $captured_data['gateway']['test_mode'] );
+		$this->assertTrue( $captured_data['gateway']['test_mode_onboarding'] );
 
 		// Assert: Verify payment_methods sub-entries and values.
 		$this->assertArrayHasKey( 'available', $captured_data['payment_methods'] );
@@ -3704,9 +3712,18 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'available', $captured_data['provider_capabilities'] );
 		$this->assertArrayHasKey( 'enabled', $captured_data['provider_capabilities'] );
 		$this->assertArrayHasKey( 'disabled', $captured_data['provider_capabilities'] );
-		$this->assertContains( 'card_payments', $captured_data['provider_capabilities']['available'] );
-		$this->assertContains( 'klarna_payments', $captured_data['provider_capabilities']['available'] );
-		$this->assertEquals( [ 'card_payments', 'klarna_payments' ], $captured_data['provider_capabilities']['enabled'] );
+		$this->assertContains( $payment_method_capability_map['card'], $captured_data['provider_capabilities']['available'] );
+		$this->assertContains( $payment_method_capability_map['klarna'], $captured_data['provider_capabilities']['available'] );
+		$this->assertEquals( [ $payment_method_capability_map['card'], $payment_method_capability_map['klarna'] ], $captured_data['provider_capabilities']['enabled'] );
+		$this->assertEquals(
+			array_values(
+				array_diff(
+					$payment_method_capability_map,
+					[ $payment_method_capability_map['card'], $payment_method_capability_map['klarna'] ]
+				)
+			),
+			$captured_data['provider_capabilities']['disabled']
+		);
 
 		// Assert: Verify simple boolean/string values match mocked data.
 		$this->assertEquals( 'yes', $captured_data['apple_google_pay_in_payment_methods_options_enabled'] );
@@ -3749,6 +3766,10 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'active_plugins', $captured_data['wp_setup'] );
 		$this->assertArrayHasKey( 'version', $captured_data['wp_setup'] );
 		$this->assertArrayHasKey( 'locale', $captured_data['wp_setup'] );
+		$this->assertSame( get_bloginfo( 'name' ), $captured_data['wp_setup']['name'] );
+		$this->assertSame( get_bloginfo( 'url' ), $captured_data['wp_setup']['url'] );
+		$this->assertSame( get_bloginfo( 'version' ), $captured_data['wp_setup']['version'] );
+		$this->assertSame( get_locale(), $captured_data['wp_setup']['locale'] );
 
 		// Assert: Verify wc_setup sub-entries.
 		$this->assertArrayHasKey( 'version', $captured_data['wc_setup'] );
@@ -3788,6 +3809,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$mock_gateway->method( 'get_option' )->willReturn( 'yes' );
 		$mock_gateway->method( 'is_saved_cards_enabled' )->willReturn( true );
 
+		// Replace the real gateway with the mock.
 		WC_Payments::set_gateway( $mock_gateway );
 
 		// Mock send_store_setup to throw an exception.

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3602,6 +3602,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 
 		// Mock the gateway and its methods.
+		$temp_gateway = WC_Payments::get_gateway();
 		$mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
 		$mock_gateway->method( 'is_enabled' )->willReturn( true );
 		$mock_gateway->method( 'get_form_fields' )->willReturn(
@@ -3758,6 +3759,9 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'enabled_payment_gateways', $captured_data['wc_setup'] );
 		$this->assertArrayHasKey( 'wc_subscriptions_active', $captured_data['wc_setup'] );
 		$this->assertArrayHasKey( 'wc_subscriptions_version', $captured_data['wc_setup'] );
+
+		// Restore the original gateway.
+		WC_Payments::set_gateway( $temp_gateway );
 	}
 
 	public function test_store_setup_sync_handles_exception_gracefully() {
@@ -3765,6 +3769,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 
 		// Mock the gateway.
+		$temp_gateway = WC_Payments::get_gateway();
 		$mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
 		$mock_gateway->method( 'is_enabled' )->willReturn( true );
 		$mock_gateway->method( 'get_form_fields' )->willReturn(
@@ -3797,6 +3802,9 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		// Assert: If we reach here without an exception being thrown, the test passes.
 		// The method should handle the exception gracefully.
 		$this->assertTrue( true );
+
+		// Restore the original gateway.
+		WC_Payments::set_gateway( $temp_gateway );
 	}
 
 	public function test_store_setup_sync_handles_gateway_not_available() {
@@ -3804,6 +3812,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 
 		// Mock WC_Payments to return null gateway.
+		$temp_gateway = WC_Payments::get_gateway();
 		WC_Payments::set_gateway( null );
 
 		// Assert: send_store_setup should be called with empty array when gateway is not available.
@@ -3813,5 +3822,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		// Act: Call store_setup_sync.
 		$this->wcpay_account->store_setup_sync();
+
+		// Restore the original gateway.
+		WC_Payments::set_gateway( $temp_gateway );
 	}
 }

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -65,6 +65,13 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 	private $mock_redirect_service;
 
 	/**
+	 * Backup of the original card gateway instance.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $card_gateway_backup;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -75,6 +82,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 			'page' => 'wc-admin',
 			'path' => '/payments/connect',
 		];
+
+		$this->card_gateway_backup = WC_Payments::get_gateway();
 
 		// Always start off with live mode. If you want another mode, you should set it in the test.
 		WC_Payments::mode()->live();
@@ -94,6 +103,10 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		delete_option( WC_Payments_Onboarding_Service::TEST_MODE_OPTION );
 		unset( $_GET );
 		unset( $_REQUEST );
+
+		// Restore the card gateway instance.
+		WC_Payments::set_gateway( $this->card_gateway_backup );
+
 		parent::tear_down();
 	}
 
@@ -3602,7 +3615,6 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 
 		// Mock the gateway and its methods.
-		$temp_gateway = WC_Payments::get_gateway();
 		$mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
 		$mock_gateway->method( 'is_enabled' )->willReturn( true );
 		$mock_gateway->method( 'get_form_fields' )->willReturn(
@@ -3662,7 +3674,8 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		// Capture the argument passed to send_store_setup.
 		$captured_data = null;
-		$this->mock_api_client->expects( $this->once() )
+		$this->mock_api_client
+			->expects( $this->once() )
 			->method( 'send_store_setup' )
 			->with(
 				$this->callback(
@@ -3784,9 +3797,6 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'enabled_payment_gateways', $captured_data['wc_setup'] );
 		$this->assertArrayHasKey( 'wc_subscriptions_active', $captured_data['wc_setup'] );
 		$this->assertArrayHasKey( 'wc_subscriptions_version', $captured_data['wc_setup'] );
-
-		// Restore the original gateway.
-		WC_Payments::set_gateway( $temp_gateway );
 	}
 
 	public function test_store_setup_sync_handles_exception_gracefully() {
@@ -3794,7 +3804,6 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 
 		// Mock the gateway.
-		$temp_gateway = WC_Payments::get_gateway();
 		$mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
 		$mock_gateway->method( 'is_enabled' )->willReturn( true );
 		$mock_gateway->method( 'get_form_fields' )->willReturn(
@@ -3828,9 +3837,6 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		// Assert: If we reach here without an exception being thrown, the test passes.
 		// The method should handle the exception gracefully.
 		$this->assertTrue( true );
-
-		// Restore the original gateway.
-		WC_Payments::set_gateway( $temp_gateway );
 	}
 
 	public function test_store_setup_sync_handles_gateway_not_available() {
@@ -3838,7 +3844,6 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
 
 		// Mock WC_Payments to return null gateway.
-		$temp_gateway = WC_Payments::get_gateway();
 		WC_Payments::set_gateway( null );
 
 		// Assert: send_store_setup should be called with empty array when gateway is not available.
@@ -3848,8 +3853,5 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		// Act: Call store_setup_sync.
 		$this->wcpay_account->store_setup_sync();
-
-		// Restore the original gateway.
-		WC_Payments::set_gateway( $temp_gateway );
 	}
 }

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3584,4 +3584,234 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( $account_details, $result );
 	}
+
+	public function test_store_setup_sync_returns_early_when_server_not_connected() {
+		// Arrange: Server is not connected.
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( false );
+
+		// Assert: send_store_setup should not be called.
+		$this->mock_api_client->expects( $this->never() )
+			->method( 'send_store_setup' );
+
+		// Act: Call store_setup_sync.
+		$this->wcpay_account->store_setup_sync();
+	}
+
+	public function test_store_setup_sync_sends_store_setup_when_server_connected() {
+		// Arrange: Server is connected and gateway is available.
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
+
+		// Mock the gateway and its methods.
+		$mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$mock_gateway->method( 'is_enabled' )->willReturn( true );
+		$mock_gateway->method( 'get_form_fields' )->willReturn(
+			[
+				'payment_request_button_locations' => [
+					'options' => [
+						'product' => 'Product page',
+						'cart'    => 'Cart page',
+					],
+				],
+			]
+		);
+		$mock_gateway->method( 'get_upe_available_payment_methods' )->willReturn( [ 'card', 'bancontact', 'eps', 'ideal', 'p24', 'klarna', 'multibanco', 'alipay', 'wechat_pay' ] );
+		$mock_gateway->method( 'get_upe_enabled_payment_method_ids' )->willReturn( [ 'card', 'klarna' ] );
+		$mock_gateway->method( 'get_payment_method_capability_key_map' )->willReturn(
+			[
+				'card'       => 'card_payments',
+				'bancontact' => 'bancontact_payments',
+				'eps'        => 'eps_payments',
+				'ideal'      => 'ideal_payments',
+				'p24'        => 'p24_payments',
+				'klarna'     => 'klarna_payments',
+				'multibanco' => 'multibanco_payments',
+				'alipay'     => 'alipay_payments',
+				'wechat_pay' => 'wechat_payments',
+			]
+		);
+		$mock_gateway->method( 'find_duplicates' )->willReturn( [ 'card' => [ 'woocommerce_payments', 'some_other_gateway' ] ] );
+		$mock_gateway->method( 'get_option' )->willReturnCallback(
+			function ( $key, $default = null ) {
+				$options = [
+					'apple_google_pay_in_payment_methods_options' => 'yes',
+					'manual_capture'                       => 'no',
+					'enable_logging'                       => 'no',
+					'payment_request'                      => 'yes',
+					'payment_request_button_locations'     => [ 'product', 'cart' ],
+					'payment_request_button_type'          => 'default',
+					'payment_request_button_size'          => 'default',
+					'payment_request_button_theme'         => 'dark',
+					'payment_request_button_border_radius' => '4',
+					'platform_checkout_button_locations'   => [ 'product', 'cart' ],
+					'platform_checkout_store_logo'         => '',
+					'platform_checkout_custom_message'     => '',
+				];
+				return $options[ $key ] ?? $default;
+			}
+		);
+		$mock_gateway->method( 'is_saved_cards_enabled' )->willReturn( true );
+
+		// Mock WC_Payments static methods.
+		WC_Payments::set_gateway( $mock_gateway );
+
+		// Capture the argument passed to send_store_setup.
+		$captured_data = null;
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'send_store_setup' )
+			->willReturnCallback(
+				function ( $data ) use ( &$captured_data ) {
+					$captured_data = $data;
+				}
+			);
+
+		// Act: Call store_setup_sync.
+		$this->wcpay_account->store_setup_sync();
+
+		// Assert: Verify that the data structure contains expected top-level keys.
+		$this->assertArrayHasKey( 'gateway', $captured_data );
+		$this->assertArrayHasKey( 'payment_methods', $captured_data );
+		$this->assertArrayHasKey( 'provider_capabilities', $captured_data );
+		$this->assertArrayHasKey( 'apple_google_pay_in_payment_methods_options_enabled', $captured_data );
+		$this->assertArrayHasKey( 'saved_cards_enabled', $captured_data );
+		$this->assertArrayHasKey( 'manual_capture_enabled', $captured_data );
+		$this->assertArrayHasKey( 'debug_log_enabled', $captured_data );
+		$this->assertArrayHasKey( 'payment_request', $captured_data );
+		$this->assertArrayHasKey( 'woopay', $captured_data );
+		$this->assertArrayHasKey( 'multi_currency_enabled', $captured_data );
+		$this->assertArrayHasKey( 'stripe_billing_enabled', $captured_data );
+		$this->assertArrayHasKey( 'plugin', $captured_data );
+		$this->assertArrayHasKey( 'wp_setup', $captured_data );
+		$this->assertArrayHasKey( 'wc_setup', $captured_data );
+
+		// Assert: Verify gateway sub-entries and values.
+		$this->assertArrayHasKey( 'enabled', $captured_data['gateway'] );
+		$this->assertArrayHasKey( 'test_mode', $captured_data['gateway'] );
+		$this->assertArrayHasKey( 'test_mode_onboarding', $captured_data['gateway'] );
+		$this->assertTrue( $captured_data['gateway']['enabled'] );
+
+		// Assert: Verify payment_methods sub-entries and values.
+		$this->assertArrayHasKey( 'available', $captured_data['payment_methods'] );
+		$this->assertArrayHasKey( 'enabled', $captured_data['payment_methods'] );
+		$this->assertArrayHasKey( 'disabled', $captured_data['payment_methods'] );
+		$this->assertArrayHasKey( 'duplicates', $captured_data['payment_methods'] );
+		$this->assertEquals( [ 'card', 'bancontact', 'eps', 'ideal', 'p24', 'klarna', 'multibanco', 'alipay', 'wechat_pay' ], $captured_data['payment_methods']['available'] );
+		$this->assertEquals( [ 'card', 'klarna' ], $captured_data['payment_methods']['enabled'] );
+		$this->assertEquals( [ 'bancontact', 'eps', 'ideal', 'p24', 'multibanco', 'alipay', 'wechat_pay' ], $captured_data['payment_methods']['disabled'] );
+		$this->assertEquals( [ 'card' => [ 'woocommerce_payments', 'some_other_gateway' ] ], $captured_data['payment_methods']['duplicates'] );
+
+		// Assert: Verify provider_capabilities sub-entries and values.
+		$this->assertArrayHasKey( 'available', $captured_data['provider_capabilities'] );
+		$this->assertArrayHasKey( 'enabled', $captured_data['provider_capabilities'] );
+		$this->assertArrayHasKey( 'disabled', $captured_data['provider_capabilities'] );
+		$this->assertContains( 'card_payments', $captured_data['provider_capabilities']['available'] );
+		$this->assertContains( 'klarna_payments', $captured_data['provider_capabilities']['available'] );
+		$this->assertEquals( [ 'card_payments', 'klarna_payments' ], $captured_data['provider_capabilities']['enabled'] );
+
+		// Assert: Verify simple boolean/string values match mocked data.
+		$this->assertEquals( 'yes', $captured_data['apple_google_pay_in_payment_methods_options_enabled'] );
+		$this->assertTrue( $captured_data['saved_cards_enabled'] );
+		$this->assertFalse( $captured_data['manual_capture_enabled'] );
+		$this->assertFalse( $captured_data['debug_log_enabled'] );
+
+		// Assert: Verify payment_request sub-entries and values.
+		$this->assertArrayHasKey( 'enabled', $captured_data['payment_request'] );
+		$this->assertArrayHasKey( 'enabled_locations', $captured_data['payment_request'] );
+		$this->assertArrayHasKey( 'button_type', $captured_data['payment_request'] );
+		$this->assertArrayHasKey( 'button_size', $captured_data['payment_request'] );
+		$this->assertArrayHasKey( 'button_theme', $captured_data['payment_request'] );
+		$this->assertArrayHasKey( 'button_border_radius', $captured_data['payment_request'] );
+		$this->assertTrue( $captured_data['payment_request']['enabled'] );
+		$this->assertEquals( [ 'product', 'cart' ], $captured_data['payment_request']['enabled_locations'] );
+		$this->assertEquals( 'default', $captured_data['payment_request']['button_type'] );
+		$this->assertEquals( 'default', $captured_data['payment_request']['button_size'] );
+		$this->assertEquals( 'dark', $captured_data['payment_request']['button_theme'] );
+		$this->assertEquals( '4', $captured_data['payment_request']['button_border_radius'] );
+
+		// Assert: Verify woopay sub-entries and values.
+		$this->assertArrayHasKey( 'enabled', $captured_data['woopay'] );
+		$this->assertArrayHasKey( 'enabled_locations', $captured_data['woopay'] );
+		$this->assertArrayHasKey( 'store_logo', $captured_data['woopay'] );
+		$this->assertArrayHasKey( 'custom_message', $captured_data['woopay'] );
+		$this->assertArrayHasKey( 'invalid_extension_found', $captured_data['woopay'] );
+		$this->assertEquals( [ 'product', 'cart' ], $captured_data['woopay']['enabled_locations'] );
+		$this->assertEquals( '', $captured_data['woopay']['store_logo'] );
+		$this->assertEquals( '', $captured_data['woopay']['custom_message'] );
+
+		// Assert: Verify plugin sub-entries.
+		$this->assertArrayHasKey( 'version', $captured_data['plugin'] );
+		$this->assertArrayHasKey( 'activation_timestamp', $captured_data['plugin'] );
+
+		// Assert: Verify wp_setup sub-entries.
+		$this->assertArrayHasKey( 'name', $captured_data['wp_setup'] );
+		$this->assertArrayHasKey( 'url', $captured_data['wp_setup'] );
+		$this->assertArrayHasKey( 'active_theme', $captured_data['wp_setup'] );
+		$this->assertArrayHasKey( 'active_plugins', $captured_data['wp_setup'] );
+		$this->assertArrayHasKey( 'version', $captured_data['wp_setup'] );
+		$this->assertArrayHasKey( 'locale', $captured_data['wp_setup'] );
+
+		// Assert: Verify wc_setup sub-entries.
+		$this->assertArrayHasKey( 'version', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'store_id', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'currency', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'tracking_enabled', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'registered_payment_gateways', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'enabled_payment_gateways', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'wc_subscriptions_active', $captured_data['wc_setup'] );
+		$this->assertArrayHasKey( 'wc_subscriptions_version', $captured_data['wc_setup'] );
+	}
+
+	public function test_store_setup_sync_handles_exception_gracefully() {
+		// Arrange: Server is connected but send_store_setup throws an exception.
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
+
+		// Mock the gateway.
+		$mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$mock_gateway->method( 'is_enabled' )->willReturn( true );
+		$mock_gateway->method( 'get_form_fields' )->willReturn(
+			[
+				'payment_request_button_locations' => [
+					'options' => [
+						'product' => 'Product page',
+					],
+				],
+			]
+		);
+		$mock_gateway->method( 'get_upe_available_payment_methods' )->willReturn( [ 'card' ] );
+		$mock_gateway->method( 'get_upe_enabled_payment_method_ids' )->willReturn( [ 'card' ] );
+		$mock_gateway->method( 'get_payment_method_capability_key_map' )->willReturn( [ 'card' => 'card_payments' ] );
+		$mock_gateway->method( 'find_duplicates' )->willReturn( [] );
+		$mock_gateway->method( 'get_option' )->willReturn( 'yes' );
+		$mock_gateway->method( 'is_saved_cards_enabled' )->willReturn( true );
+
+		WC_Payments::set_gateway( $mock_gateway );
+
+		// Mock send_store_setup to throw an exception.
+		$exception = new Exception( 'API Error' );
+		$this->mock_api_client->method( 'send_store_setup' )
+			->willThrowException( $exception );
+
+		// Act: Call store_setup_sync - it should not throw the exception.
+		// The exception should be caught and logged internally.
+		$this->wcpay_account->store_setup_sync();
+
+		// Assert: If we reach here without an exception being thrown, the test passes.
+		// The method should handle the exception gracefully.
+		$this->assertTrue( true );
+	}
+
+	public function test_store_setup_sync_handles_gateway_not_available() {
+		// Arrange: Server is connected but gateway is not available.
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
+
+		// Mock WC_Payments to return null gateway.
+		WC_Payments::set_gateway( null );
+
+		// Assert: send_store_setup should be called with empty array when gateway is not available.
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'send_store_setup' )
+			->with( [] );
+
+		// Act: Call store_setup_sync.
+		$this->wcpay_account->store_setup_sync();
+	}
 }

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3664,10 +3664,14 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$captured_data = null;
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'send_store_setup' )
-			->willReturnCallback(
-				function ( $data ) use ( &$captured_data ) {
-					$captured_data = $data;
-				}
+			->with(
+				$this->callback(
+					function ( $data ) use ( &$captured_data ) {
+						$captured_data = $data;
+
+						return is_array( $data );
+					}
+				)
 			);
 
 		// Act: Call store_setup_sync.

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -113,7 +113,6 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertNotFalse( has_action( 'jetpack_site_registered', [ $this->wcpay_account, 'clear_cache' ] ), 'jetpack_site_registered action does not exist.' );
 		$this->assertNotFalse( has_action( 'updated_option', [ $this->wcpay_account, 'possibly_update_wcpay_account_locale' ] ), 'updated_option action does not exist.' );
 		$this->assertNotFalse( has_action( 'woocommerce_woocommerce_payments_updated', [ $this->wcpay_account, 'clear_cache' ] ), 'woocommerce_woocommerce_payments_updated action does not exist.' );
-		$this->assertNotFalse( has_action( 'woocommerce_payments_account_refreshed', [ $this->wcpay_account, 'schedule_store_setup_sync' ] ), 'schedule_store_setup_sync action does not exist.' );
 		$this->assertNotFalse( has_action( WC_Payments_Account::STORE_SETUP_SYNC_ACTION, [ $this->wcpay_account, 'store_setup_sync' ] ), 'store_setup_sync action does not exist.' );
 	}
 

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -55,6 +55,8 @@ class WC_Payments_Action_Scheduler_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_compatibility_data_hook_registered() {
+		$this->action_scheduler_service->init_hooks();
+
 		$this->assertEquals( 10, has_action( Compatibility_Service::UPDATE_COMPATIBILITY_DATA, [ $this->mock_compatibility_service, 'update_compatibility_data_hook' ] ) );
 	}
 


### PR DESCRIPTION
Related to WOOPMNT-5362

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR is a follow-up to [this PR](https://github.com/Automattic/woocommerce-payments/pull/11077): we avoid tying the data sending to the account cache refresh and instead use a recurring Action Scheduler action (every 6 hours). During both settings and client updates, data is sent synchronously (but using a non-blocking request).

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR needs to be tested together with this platform PR (193661-ghe-Automattic/wpcom). See the testing instructions there.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
