### PR TITLE
ECE on Product Page: check that product can be added before any changes

### DIFF
--- a/changelog/woopmnt-5357-express-buttons-blocked-after-quantity-change-on-a-variable
+++ b/changelog/woopmnt-5357-express-buttons-blocked-after-quantity-change-on-a-variable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent Express Checkout from being disabled on product page when updating quantity of variable products.

--- a/client/express-checkout/compatibility/wc-product-page.js
+++ b/client/express-checkout/compatibility/wc-product-page.js
@@ -25,7 +25,12 @@ jQuery( ( $ ) => {
 	}
 
 	const $quantityInput = $( '.quantity' );
+	const addToCartButton = $( '.single_add_to_cart_button' );
 	const handleQuantityChange = () => {
+		// First check if product can be added to cart.
+		if ( addToCartButton.is( '.disabled' ) ) {
+			return;
+		}
 		expressCheckoutButtonUi.blockButton();
 	};
 	$quantityInput.on( 'input', '.qty', handleQuantityChange );

--- a/client/express-checkout/compatibility/wc-product-page.js
+++ b/client/express-checkout/compatibility/wc-product-page.js
@@ -25,12 +25,7 @@ jQuery( ( $ ) => {
 	}
 
 	const $quantityInput = $( '.quantity' );
-	const addToCartButton = $( '.single_add_to_cart_button' );
 	const handleQuantityChange = () => {
-		// First check if product can be added to cart.
-		if ( addToCartButton.is( '.disabled' ) ) {
-			return;
-		}
 		expressCheckoutButtonUi.blockButton();
 	};
 	$quantityInput.on( 'input', '.qty', handleQuantityChange );

--- a/client/express-checkout/index.js
+++ b/client/express-checkout/index.js
@@ -479,6 +479,7 @@ jQuery( ( $ ) => {
 
 						// First check if product can be added to cart.
 						if ( addToCartButton.is( '.disabled' ) ) {
+							expressCheckoutButtonUi.unblockButton();
 							return;
 						}
 					}


### PR DESCRIPTION
Fixes WOOPMNT-5357

#### Changes proposed in this Pull Request


When quantity is updated on the product page, unblock the Express Checkout buttons if product cannot be added to the cart yet.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Before (taken from WOOPMNT-5357):

https://github.com/user-attachments/assets/495fde01-a853-48c2-9d58-ff6c469842a5

After:

https://github.com/user-attachments/assets/f87cf420-757c-453f-9c9e-d6e98911163f



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 - Install WooCommerce and WooPayments
 - Activate the express checkout buttons on the product page
 - Create a variable product
 - Access the product page and change the quantity. Verify that buttons are available, but prodcut cannot be bought with ECE yet.
 - Select the variation. Verify that product can be bought with ECE now.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
