### PR TITLE
Turn off bundled subscription features

### DIFF
--- a/changelog/update-woopmnt-5367-turn-off-bundled-subscription-features
+++ b/changelog/update-woopmnt-5367-turn-off-bundled-subscription-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Hide bundled subscription management UI while preserving renewal processing functionality

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -18,12 +18,17 @@ const WCPaySubscriptionsToggle = () => {
 	] = useWCPaySubscriptions();
 
 	const handleWCPaySubscriptionsStatusChange = ( value ) => {
+		// Prevent enabling subscriptions - feature has been removed.
+		if ( value ) {
+			return;
+		}
 		updateIsWCPaySubscriptionsEnabled( value );
 	};
 
 	/**
-	 * Only show the toggle if the site doesn't have WC Subscriptions active and is eligible
-	 * for wcpay subscriptions or if wcpay subscriptions are already enabled.
+	 * Show the toggle if the site doesn't have WC Subscriptions active.
+	 * The toggle is disabled to prevent enabling bundled subscriptions.
+	 * However, if subscriptions are currently enabled, allow disabling them.
 	 */
 	return ! wcpaySettings.isSubscriptionsActive &&
 		isWCPaySubscriptionsEligible ? (
@@ -34,24 +39,22 @@ const WCPaySubscriptionsToggle = () => {
 				'WooPayments'
 			) }
 			help={ interpolateComponents( {
-				mixedString: sprintf(
-					/* translators: %s: WooPayments */
-					__(
-						'Sell subscription products and services with %s. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-						'woocommerce-payments'
-					),
-					'WooPayments'
+				mixedString: __(
+					// eslint-disable-next-line max-len
+					'This feature is deprecated. Existing subscription renewals will continue to work, but creating or managing subscriptions is no longer available. Install {{learnMoreLink}}WooCommerce Subscriptions{{/learnMoreLink}} to continue managing subscriptions.',
+					'woocommerce-payments'
 				),
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
 						// @ts-expect-error: children is provided when interpolating the component
-						<ExternalLink href="https://woocommerce.com/document/woopayments/subscriptions/" />
+						<ExternalLink href="https://woocommerce.com/products/woocommerce-subscriptions/" />
 					),
 				},
 			} ) }
 			checked={ isWCPaySubscriptionsEnabled }
 			onChange={ handleWCPaySubscriptionsStatusChange }
+			disabled={ ! isWCPaySubscriptionsEnabled }
 			__nextHasNoMarginBottom
 		/>
 	) : null;

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -803,13 +803,17 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_is_wcpay_subscriptions_enabled( WP_REST_Request $request ) {
-		if ( ! $request->has_param( 'is_wcpay_subscriptions_enabled' ) ) {
+		if ( ! $request->has_param( 'is_wcpay_subscription_enabled' ) ) {
 			return;
 		}
 
-		$is_wcpay_subscriptions_enabled = $request->get_param( 'is_wcpay_subscriptions_enabled' );
+		$is_wcpay_subscriptions_enabled = $request->get_param( 'is_wcpay_subscription_enabled' );
 
-		update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, $is_wcpay_subscriptions_enabled ? '1' : '0' );
+		// Prevent enabling bundled subscriptions - feature has been removed in 10.2.0.
+		// Only allow disabling the feature if it was previously enabled.
+		if ( ! $is_wcpay_subscriptions_enabled ) {
+			update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '0' );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -2131,8 +2131,10 @@ class WC_Payments {
 	 * Update the Stripe Billing deprecation note.
 	 */
 	public static function maybe_update_stripe_billing_deprecation_note() {
-		// If Stripe Billing is not enabled or WooCommerce Subscriptions is active, do not update the note.
-		if ( ! WC_Payments_Features::is_stripe_billing_enabled() || class_exists( 'WC_Subscriptions' ) ) {
+		// If bundled subscriptions are not enabled or WooCommerce Subscriptions is active, do not update the note.
+		$has_bundled_subs = WC_Payments_Features::is_wcpay_subscriptions_enabled() || WC_Payments_Features::is_stripe_billing_enabled();
+
+		if ( ! $has_bundled_subs || class_exists( 'WC_Subscriptions' ) ) {
 			return;
 		}
 

--- a/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
@@ -63,9 +63,12 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 		} elseif ( version_compare( $wcpay_version, '9.9.0', '<' ) ) {
 			$note->set_title( __( 'WooPayments subscriptions update', 'woocommerce-payments' ) );
 			$note->set_content( __( 'WooPayments no longer supports billing for existing customer subscriptions. All subscriptions data is read-only. Please install WooCommerce Subscriptions to continue managing your subscriptions.', 'woocommerce-payments' ) );
-		} else {
+		} elseif ( version_compare( $wcpay_version, '10.2.0', '<' ) ) {
 			$note->set_title( __( 'WooPayments subscriptions update', 'woocommerce-payments' ) );
 			$note->set_content( __( 'WooPayments no longer supports subscriptions capabilities and subscriptions data can no longer be accessed. Please install WooCommerce Subscriptions to continue managing your subscriptions.', 'woocommerce-payments' ) );
+		} else {
+			$note->set_title( __( 'Built-in subscriptions functionality has been removed. Here\'s what to do', 'woocommerce-payments' ) );
+			$note->set_content( __( 'To continue offering subscriptions and gain access to your data, please install WooCommerce Subscriptions. WooPayments no longer supports this feature.', 'woocommerce-payments' ) );
 		}
 
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
@@ -82,6 +85,9 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 	 * @return bool
 	 */
 	protected static function is_bundled_subscriptions_enabled() {
-		return WC_Payments_Features::is_stripe_billing_enabled() && ! class_exists( 'WC_Subscriptions' );
+		$has_bundled_subs = WC_Payments_Features::is_wcpay_subscriptions_enabled() || WC_Payments_Features::is_stripe_billing_enabled();
+		$has_wc_subs      = class_exists( 'WC_Subscriptions' );
+
+		return $has_bundled_subs && ! $has_wc_subs;
 	}
 }

--- a/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/includes/notes/class-wc-payments-notes-stripe-billing-deprecation.php
@@ -51,25 +51,10 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation {
 	 * Get the note.
 	 */
 	public static function get_note() {
-		$note          = new Note();
-		$wcpay_version = WC_Payments::get_file_version( WCPAY_PLUGIN_FILE );
+		$note = new Note();
 
-		if ( version_compare( $wcpay_version, '9.7.0', '<' ) ) {
-			$note->set_title( __( 'Important information regarding subscriptions in WooPayments', 'woocommerce-payments' ) );
-			$note->set_content( __( 'From version 9.7 of WooPayments (scheduled for 23 July, 2025), you\'ll no longer be able to offer new product subscriptions using the built-in subscriptions functionality. To avoid disruption, please install WooCommerce Subscriptions for free.', 'woocommerce-payments' ) );
-		} elseif ( version_compare( $wcpay_version, '9.8.0', '<' ) ) {
-			$note->set_title( __( 'WooPayments subscriptions update', 'woocommerce-payments' ) );
-			$note->set_content( __( 'WooPayments no longer allows customers to create new subscriptions. Beginning in version 9.8, billing for existing customer subscriptions will no longer be supported. To ensure there is no interruption of service, please install WooCommerce Subscriptions.', 'woocommerce-payments' ) );
-		} elseif ( version_compare( $wcpay_version, '9.9.0', '<' ) ) {
-			$note->set_title( __( 'WooPayments subscriptions update', 'woocommerce-payments' ) );
-			$note->set_content( __( 'WooPayments no longer supports billing for existing customer subscriptions. All subscriptions data is read-only. Please install WooCommerce Subscriptions to continue managing your subscriptions.', 'woocommerce-payments' ) );
-		} elseif ( version_compare( $wcpay_version, '10.2.0', '<' ) ) {
-			$note->set_title( __( 'WooPayments subscriptions update', 'woocommerce-payments' ) );
-			$note->set_content( __( 'WooPayments no longer supports subscriptions capabilities and subscriptions data can no longer be accessed. Please install WooCommerce Subscriptions to continue managing your subscriptions.', 'woocommerce-payments' ) );
-		} else {
-			$note->set_title( __( 'Built-in subscriptions functionality has been removed. Here\'s what to do', 'woocommerce-payments' ) );
-			$note->set_content( __( 'To continue offering subscriptions and gain access to your data, please install WooCommerce Subscriptions. WooPayments no longer supports this feature.', 'woocommerce-payments' ) );
-		}
+		$note->set_title( __( 'Built-in subscriptions functionality has been removed. Here\'s what to do', 'woocommerce-payments' ) );
+		$note->set_content( __( 'To continue offering subscriptions and gain access to your data, please install WooCommerce Subscriptions. WooPayments no longer supports this feature.', 'woocommerce-payments' ) );
 
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-admin-notices.php
@@ -118,9 +118,15 @@ class WC_Payments_Subscriptions_Admin_Notices {
 	/**
 	 * Check if bundled subscriptions are enabled.
 	 *
+	 * This checks for either WCPay Subscriptions or Stripe Billing being enabled,
+	 * as both represent the bundled subscription functionality.
+	 *
 	 * @return bool
 	 */
 	protected function is_bundled_subscriptions_enabled() {
-		return WC_Payments_Features::is_stripe_billing_enabled() && ! class_exists( 'WC_Subscriptions' );
+		$has_bundled_subs = WC_Payments_Features::is_wcpay_subscriptions_enabled() || WC_Payments_Features::is_stripe_billing_enabled();
+		$has_wc_subs      = class_exists( 'WC_Subscriptions' );
+
+		return $has_bundled_subs && ! $has_wc_subs;
 	}
 }

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -14,11 +14,51 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Disables bundled subscriptions management surfaces.
+ *
+ * This class hides UI elements and blocks access to subscription management
+ * interfaces for both merchants and customers. It operates exclusively on
+ * the presentation layer and does NOT affect backend subscription functionality.
+ *
+ * What this class disables:
+ * - Admin menu items (WooCommerce > Subscriptions)
+ * - Admin subscription management screens
+ * - Subscription product types in product creation
+ * - Subscription settings tab
+ * - Customer account subscription pages
+ * - Related subscriptions section on order details
+ *
+ * What this class does NOT affect:
+ * - Stripe Billing webhook processing (invoice.paid, invoice.upcoming, etc.)
+ * - Automatic renewal order creation via wcs_create_renewal_order()
+ * - Subscription payment processing and completion
+ * - Existing subscription data or meta
+ * - Backend subscription status management
+ * - Payment method updates
+ *
+ * This ensures merchants and customers cannot create or manage subscriptions
+ * through the UI while Stripe Billing continues to process renewals automatically.
  */
 class WC_Payments_Subscriptions_Disabler {
 
 	/**
 	 * Initiates hooks that hide bundled subscriptions management entry points.
+	 *
+	 * This method registers UI-layer hooks only. It does NOT hook into:
+	 * - Payment processing (woocommerce_subscription_payment_complete, etc.)
+	 * - Renewal order creation (woocommerce_renewal_order_payment_complete, etc.)
+	 * - Webhook handling (invoice.paid, invoice.upcoming, etc.)
+	 * - Subscription status changes (woocommerce_subscription_status_*, etc.)
+	 *
+	 * Admin hooks (menu/screen blocking):
+	 * - Removes admin menu items
+	 * - Blocks direct access to subscription screens
+	 * - Removes subscription product types from product editor
+	 * - Removes subscription settings tab
+	 *
+	 * Frontend hooks (customer-facing blocking):
+	 * - Removes subscription navigation from My Account
+	 * - Blocks direct access to subscription endpoints
+	 * - Removes subscription details from order views
 	 *
 	 * @return void
 	 */
@@ -39,6 +79,9 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Removes WooCommerce > Subscriptions menu entries.
 	 *
+	 * Hides the subscriptions admin menu for both CPT and HPOS implementations.
+	 * Does not affect subscription data or the ability for renewals to process.
+	 *
 	 * @return void
 	 */
 	public function remove_admin_menu_items() {
@@ -49,6 +92,10 @@ class WC_Payments_Subscriptions_Disabler {
 
 	/**
 	 * Redirects attempts to access admin subscription management screens.
+	 *
+	 * Prevents direct URL access to subscription edit/list screens by redirecting
+	 * to the WooCommerce overview. Does not run during AJAX or REST requests to
+	 * avoid interfering with legitimate background operations.
 	 *
 	 * @param WP_Screen $screen Current screen instance.
 	 * @return void
@@ -88,8 +135,12 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Removes subscription related product types from product selector.
 	 *
+	 * Prevents merchants from creating new subscription products by hiding
+	 * the product types from the dropdown. Existing subscription products
+	 * remain in the database and can still process renewals.
+	 *
 	 * @param array $product_types Registered product types.
-	 * @return array
+	 * @return array Filtered product types without subscription options.
 	 */
 	public function filter_product_type_selector( $product_types ) {
 		unset( $product_types['subscription'], $product_types['variable-subscription'] );
@@ -140,6 +191,14 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Redirects subscription related customer account endpoints.
 	 *
+	 * Prevents customers from accessing subscription management pages including:
+	 * - Subscriptions list (/my-account/subscriptions)
+	 * - View subscription detail (/my-account/view-subscription/123)
+	 * - Payment method management (/my-account/subscription-payment-method/123)
+	 *
+	 * Redirects all attempts to the My Account dashboard. Does not affect
+	 * subscription data or automated renewal payments.
+	 *
 	 * @return void
 	 */
 	public function maybe_redirect_account_endpoints() {
@@ -157,6 +216,13 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Removes the related subscriptions section from order details.
 	 *
+	 * Hides the "Related Subscriptions" section that normally appears on
+	 * order detail pages (both admin and customer-facing). This prevents
+	 * users from viewing subscription information through renewal orders.
+	 *
+	 * The underlying subscription and renewal order relationship remains intact;
+	 * only the display is hidden.
+	 *
 	 * @return void
 	 */
 	public function remove_related_subscriptions_section() {
@@ -172,8 +238,11 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Determines if the given screen ID should be blocked.
 	 *
+	 * Checks if a screen ID contains subscription-related identifiers for
+	 * both CPT (shop_subscription) and HPOS (wc-orders--shop_subscription).
+	 *
 	 * @param string $screen_id Screen ID.
-	 * @return bool
+	 * @return bool True if the screen should be blocked, false otherwise.
 	 */
 	private function is_blocked_admin_screen( $screen_id ) {
 		if ( '' === $screen_id ) {
@@ -227,7 +296,11 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Returns the list of account endpoints which should be blocked.
 	 *
-	 * @return array
+	 * Retrieves all subscription-related My Account endpoints that customers
+	 * should not be able to access. Endpoint slugs are configurable via
+	 * WooCommerce settings, so we fetch them dynamically.
+	 *
+	 * @return array Array of endpoint slugs to block.
 	 */
 	private function get_blocked_account_endpoints() {
 		return [

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -33,6 +33,7 @@ class WC_Payments_Subscriptions_Disabler {
 
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], PHP_INT_MAX );
 		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ] );
+		add_action( 'init', [ $this, 'remove_related_subscriptions_section' ], PHP_INT_MAX );
 	}
 
 	/**
@@ -142,10 +143,6 @@ class WC_Payments_Subscriptions_Disabler {
 	 * @return void
 	 */
 	public function maybe_redirect_account_endpoints() {
-		if ( ! is_account_page() ) {
-			return;
-		}
-
 		foreach ( $this->get_blocked_account_endpoints() as $endpoint ) {
 			if ( empty( $endpoint ) ) {
 				continue;
@@ -154,6 +151,21 @@ class WC_Payments_Subscriptions_Disabler {
 			if ( $this->is_endpoint_url( $endpoint ) ) {
 				$this->redirect( wc_get_page_permalink( 'myaccount' ) );
 			}
+		}
+	}
+
+	/**
+	 * Removes the related subscriptions section from order details.
+	 *
+	 * @return void
+	 */
+	public function remove_related_subscriptions_section() {
+		if ( class_exists( 'WC_Subscriptions_Order' ) ) {
+			remove_action(
+				'woocommerce_order_details_after_order_table',
+				[ 'WC_Subscriptions_Order', 'add_subscriptions_to_view_order_templates' ],
+				10
+			);
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -256,14 +256,29 @@ class WC_Payments_Subscriptions_Disabler {
 	/**
 	 * Determines if the current request is targeting the subscription post type.
 	 *
+	 * This handles:
+	 * - Listing: ?post_type=shop_subscription
+	 * - Adding new: ?post_type=shop_subscription
+	 * - Editing by post ID: ?post=123&action=edit (checked via post type lookup)
+	 *
 	 * @return bool
 	 */
 	private function is_subscription_post_type_request() {
-		if ( empty( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return false;
+		// Check for explicit post_type parameter.
+		if ( ! empty( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return 'shop_subscription' === sanitize_key( wp_unslash( $_GET['post_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
-		return 'shop_subscription' === sanitize_key( wp_unslash( $_GET['post_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// Check if editing a specific post that might be a subscription.
+		if ( ! empty( $_GET['post'] ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$post_id = absint( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( $post_id > 0 ) {
+				$post_type = get_post_type( $post_id );
+				return 'shop_subscription' === $post_type;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -69,6 +69,7 @@ class WC_Payments_Subscriptions_Disabler {
 			add_filter( 'product_type_selector', [ $this, 'filter_product_type_selector' ], 99 );
 			add_filter( 'woocommerce_settings_tabs_array', [ $this, 'filter_settings_tabs' ], 99 );
 			add_action( 'admin_init', [ $this, 'maybe_redirect_settings_tab' ], 99 );
+			add_action( 'admin_notices', [ $this, 'display_subscription_disabled_notice' ] );
 		}
 
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], 99 );
@@ -306,12 +307,67 @@ class WC_Payments_Subscriptions_Disabler {
 	}
 
 	/**
-	 * Redirects the current request to the WooCommerce dashboard.
+	 * Displays an admin notice when users are redirected from disabled subscription features.
+	 *
+	 * @return void
+	 */
+	public function display_subscription_disabled_notice() {
+		if ( empty( $_GET['wcpay_subscription_disabled'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		if ( empty( $_GET['page'] ) || 'wc-settings' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		if ( empty( $_GET['section'] ) || 'woocommerce_payments' !== $_GET['section'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$message = sprintf(
+			/* translators: %1$s: WooCommerce Subscriptions link */
+			__( 'Subscription management is currently unavailable. To create and manage subscriptions, please install <a target="_blank" href="%1$s">WooCommerce Subscriptions</a>.', 'woocommerce-payments' ),
+			'https://woocommerce.com/products/woocommerce-subscriptions/'
+		);
+		?>
+		<div class="notice notice-info wcpay-notice">
+			<p><strong><?php esc_html_e( 'WooPayments', 'woocommerce-payments' ); ?></strong></p>
+			<p>
+			<?php
+			echo wp_kses(
+				$message,
+				[
+					'a' => [
+						'href'   => [],
+						'target' => [],
+					],
+				]
+			);
+			?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Redirects the current request to the WooCommerce Payments settings page.
+	 *
+	 * Adds a query parameter to trigger an informational notice after redirect.
 	 *
 	 * @return void
 	 */
 	protected function redirect_to_admin_overview() {
-		$this->redirect( admin_url( 'admin.php?page=wc-admin' ) );
+		$redirect_url = add_query_arg(
+			[
+				'page'                        => 'wc-settings',
+				'tab'                         => 'checkout',
+				'section'                     => 'woocommerce_payments',
+				'wcpay_subscription_disabled' => '1',
+			],
+			admin_url( 'admin.php' )
+		);
+
+		$this->redirect( $redirect_url );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -16,8 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Disables bundled subscriptions management surfaces.
  *
  * This class hides UI elements and blocks access to subscription management
- * interfaces for both merchants and customers. It operates exclusively on
- * the presentation layer and does NOT affect backend subscription functionality.
+ * interfaces for both merchants and customers. It also prevents new subscription
+ * products from being purchased.
  *
  * What this class disables:
  * - Admin menu items (WooCommerce > Subscriptions)
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Subscription settings tab
  * - Customer account subscription pages
  * - Related subscriptions section on order details
+ * - Purchasing of subscription products (makes them unpurchasable)
  *
  * What this class does NOT affect:
  * - Stripe Billing webhook processing (invoice.paid, invoice.upcoming, etc.)
@@ -34,6 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Existing subscription data or meta
  * - Backend subscription status management
  * - Payment method updates
+ * - Regular (non-subscription) products
  *
  * This ensures merchants and customers cannot create or manage subscriptions
  * through the UI while Stripe Billing continues to process renewals automatically.
@@ -59,6 +61,7 @@ class WC_Payments_Subscriptions_Disabler {
 	 * - Removes subscription navigation from My Account
 	 * - Blocks direct access to subscription endpoints
 	 * - Removes subscription details from order views
+	 * - Makes subscription products unpurchasable (prevents new subscriptions)
 	 *
 	 * @return void
 	 */
@@ -75,6 +78,7 @@ class WC_Payments_Subscriptions_Disabler {
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], 99 );
 		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ] );
 		add_action( 'init', [ $this, 'remove_related_subscriptions_section' ], 99 );
+		add_filter( 'woocommerce_is_purchasable', [ $this, 'make_subscription_products_unpurchasable' ], 10, 2 );
 	}
 
 	/**
@@ -234,6 +238,35 @@ class WC_Payments_Subscriptions_Disabler {
 				10
 			);
 		}
+	}
+
+	/**
+	 * Makes subscription products unpurchasable to prevent new subscriptions.
+	 *
+	 * This prevents customers from adding subscription products to their cart
+	 * or purchasing them during checkout. Runs early in the purchase flow to
+	 * provide the cleanest user experience.
+	 *
+	 * Does NOT affect:
+	 * - Renewal order processing (renewals don't check is_purchasable)
+	 * - Existing subscriptions in the database
+	 * - Regular (non-subscription) products
+	 *
+	 * @param bool       $is_purchasable Whether the product can be purchased.
+	 * @param WC_Product $product        Product object.
+	 * @return bool False for subscription products, original value otherwise.
+	 */
+	public function make_subscription_products_unpurchasable( $is_purchasable, $product ) {
+		if ( ! $product ) {
+			return $is_purchasable;
+		}
+
+		// Check if product is a subscription type.
+		if ( $product->is_type( [ 'subscription', 'variable-subscription', 'subscription_variation' ] ) ) {
+			return false;
+		}
+
+		return $is_purchasable;
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -274,11 +274,35 @@ class WC_Payments_Subscriptions_Disabler {
 			$post_id = absint( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( $post_id > 0 ) {
 				$post_type = get_post_type( $post_id );
-				return 'shop_subscription' === $post_type;
+				// Block subscription orders.
+				if ( 'shop_subscription' === $post_type ) {
+					return true;
+				}
+				// Block subscription products.
+				if ( 'product' === $post_type && $this->is_subscription_product( $post_id ) ) {
+					return true;
+				}
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks if a product ID is a subscription product.
+	 *
+	 * @param int $product_id Product ID to check.
+	 * @return bool True if the product is a subscription product, false otherwise.
+	 */
+	private function is_subscription_product( $product_id ) {
+		$product = wc_get_product( $product_id );
+		if ( ! $product ) {
+			return false;
+		}
+
+		// Check product type directly - more reliable than using WC_Subscriptions_Product
+		// which may not be available in all contexts.
+		return $product->is_type( [ 'subscription', 'variable-subscription', 'subscription_variation' ] );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -28,6 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Related subscriptions section on order details
  * - Purchasing of subscription products (makes them unpurchasable)
  * - Adding subscription products to admin orders (both search and validation)
+ * - Order-pay endpoint when accessed with subscription IDs
  *
  * What this class does NOT affect:
  * - Stripe Billing webhook processing (invoice.paid, invoice.upcoming, etc.)
@@ -79,7 +80,8 @@ class WC_Payments_Subscriptions_Disabler {
 		}
 
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], 99 );
-		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ] );
+		add_action( 'pre_get_posts', [ $this, 'maybe_redirect_subscription_endpoints' ], 1 );
+		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ], 5 );
 		add_action( 'init', [ $this, 'remove_related_subscriptions_section' ], 99 );
 		add_filter( 'woocommerce_is_purchasable', [ $this, 'make_subscription_products_unpurchasable' ], 10, 2 );
 	}
@@ -197,6 +199,42 @@ class WC_Payments_Subscriptions_Disabler {
 	}
 
 	/**
+	 * Redirects subscription endpoints during query parsing.
+	 *
+	 * This runs on the pre_get_posts hook (priority 1) to intercept subscription
+	 * endpoint requests BEFORE WooCommerce Subscriptions can redirect them to
+	 * the order-pay page. This is critical because WCS_Query::maybe_redirect_payment_methods()
+	 * runs at priority 10 on pre_get_posts and would redirect /my-account/subscription-payment-method/ID
+	 * to /checkout/order-pay/ID/?change_payment_method=ID before we can block it.
+	 *
+	 * @param WP_Query $query The WP_Query instance.
+	 * @return void
+	 */
+	public function maybe_redirect_subscription_endpoints( $query ) {
+		// Only process main queries.
+		if ( ! $query->is_main_query() ) {
+			return;
+		}
+
+		// Check each subscription endpoint.
+		$endpoints = [
+			'subscriptions',
+			'view-subscription',
+			'subscription-payment-method',
+		];
+
+		foreach ( $endpoints as $endpoint_key ) {
+			$endpoint_slug = $this->get_account_endpoint_slug( $endpoint_key );
+
+			// Check if this query is for a subscription endpoint.
+			if ( ! empty( $query->get( $endpoint_slug ) ) ) {
+				// Redirect to My Account before WCS can redirect elsewhere.
+				$this->redirect( wc_get_page_permalink( 'myaccount' ) );
+			}
+		}
+	}
+
+	/**
 	 * Redirects subscription related customer account endpoints.
 	 *
 	 * Prevents customers from accessing subscription management pages including:
@@ -218,6 +256,56 @@ class WC_Payments_Subscriptions_Disabler {
 			if ( $this->is_endpoint_url( $endpoint ) ) {
 				$this->redirect( wc_get_page_permalink( 'myaccount' ) );
 			}
+		}
+
+		// Also block order-pay endpoint if it contains a subscription ID.
+		$this->maybe_redirect_order_pay_for_subscription();
+	}
+
+	/**
+	 * Redirects order-pay requests that target subscription IDs.
+	 *
+	 * This prevents users from accessing the "pay for order" page using a
+	 * subscription ID in two ways:
+	 *
+	 * 1. Direct access: /checkout/order-pay/{subscription_id}/
+	 * 2. Via change_payment_method parameter: /checkout/order-pay/ID/?change_payment_method={subscription_id}
+	 *
+	 * The second case occurs when WooCommerce Subscriptions redirects from
+	 * /my-account/subscription-payment-method/{subscription_id}/ to the order-pay
+	 * endpoint during the pre_get_posts hook.
+	 *
+	 * @return void
+	 */
+	private function maybe_redirect_order_pay_for_subscription() {
+		global $wp;
+
+		$subscription_id = null;
+
+		// Check if we're on the order-pay endpoint with a subscription ID.
+		if ( ! empty( $wp->query_vars['order-pay'] ) ) {
+			$order_id  = absint( $wp->query_vars['order-pay'] );
+			$post_type = get_post_type( $order_id );
+
+			if ( 'shop_subscription' === $post_type ) {
+				$subscription_id = $order_id;
+			}
+		}
+
+		// Also check for change_payment_method parameter (when redirected from subscription-payment-method endpoint).
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified by WooCommerce core.
+		if ( ! $subscription_id && ! empty( $_GET['change_payment_method'] ) ) {
+			$change_payment_id = absint( $_GET['change_payment_method'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$post_type         = get_post_type( $change_payment_id );
+
+			if ( 'shop_subscription' === $post_type ) {
+				$subscription_id = $change_payment_id;
+			}
+		}
+
+		// If we found a subscription ID in either place, redirect.
+		if ( $subscription_id ) {
+			$this->redirect( wc_get_page_permalink( 'myaccount' ) );
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Subscription settings tab
  * - Customer account subscription pages
  * - Related subscriptions section on order details
+ * - Related orders meta box on admin order edit screen
  * - Purchasing of subscription products (makes them unpurchasable)
  * - Adding subscription products to admin orders (both search and validation)
  * - Order-pay endpoint when accessed with subscription IDs
@@ -58,6 +59,7 @@ class WC_Payments_Subscriptions_Disabler {
 	 * - Blocks direct access to subscription screens
 	 * - Removes subscription product types from product editor
 	 * - Removes subscription settings tab
+	 * - Removes "Related Orders" meta box from order edit screen
 	 *
 	 * Frontend hooks (customer-facing blocking):
 	 * - Removes subscription navigation from My Account
@@ -77,6 +79,7 @@ class WC_Payments_Subscriptions_Disabler {
 			add_action( 'admin_notices', [ $this, 'display_subscription_disabled_notice' ] );
 			add_filter( 'woocommerce_json_search_found_products', [ $this, 'filter_admin_product_search' ] );
 			add_filter( 'woocommerce_ajax_add_order_item_validation', [ $this, 'validate_admin_order_item' ], 10, 4 );
+			add_action( 'add_meta_boxes', [ $this, 'remove_related_orders_meta_box' ], 99, 2 );
 		}
 
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], 99 );
@@ -98,6 +101,38 @@ class WC_Payments_Subscriptions_Disabler {
 		remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_subscription' );
 		remove_submenu_page( 'woocommerce', 'wc-orders--shop_subscription' );
 		remove_menu_page( 'wc-orders--shop_subscription' );
+	}
+
+	/**
+	 * Removes the "Related Orders" meta box from order edit screens.
+	 *
+	 * This meta box displays subscription-related orders (renewals, parent orders, etc.)
+	 * on the admin order edit screen. We remove it to hide subscription relationships
+	 * from merchants when viewing orders.
+	 *
+	 * The meta box is added by WooCommerce Subscriptions via:
+	 * - WCS_Admin_Meta_Boxes::add_meta_boxes() at priority 10 on 'add_meta_boxes'
+	 * - Meta box ID: 'subscription_renewal_orders'
+	 * - Title: 'Related Orders'
+	 *
+	 * We run this at priority 99 to ensure it executes after WCS adds the meta box.
+	 *
+	 * @param string                $post_type The post type of the current post being edited.
+	 * @param WP_Post|WC_Order|null $post_or_order_object The post or order currently being edited.
+	 * @return void
+	 */
+	public function remove_related_orders_meta_box( $post_type, $post_or_order_object = null ) {
+		// Only process when WCS functions are available.
+		if ( ! function_exists( 'wcs_get_page_screen_id' ) ) {
+			return;
+		}
+
+		// Get the order screen ID (handles both CPT and HPOS).
+		$order_screen_id = wcs_get_page_screen_id( 'shop_order' );
+
+		// Remove the Related Orders meta box from the order edit screen.
+		// The 'normal' context matches where WCS registers the meta box.
+		remove_meta_box( 'subscription_renewal_orders', $order_screen_id, 'normal' );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -326,7 +326,7 @@ class WC_Payments_Subscriptions_Disabler {
 
 		$message = sprintf(
 			/* translators: %1$s: WooCommerce Subscriptions link */
-			__( 'Subscription management is currently unavailable. To create and manage subscriptions, please install <a target="_blank" href="%1$s">WooCommerce Subscriptions</a>.', 'woocommerce-payments' ),
+			__( 'To access your subscriptions data and keep managing recurring payments, please install <a target="_blank" href="%1$s">WooCommerce Subscriptions</a>. Built-in support for subscriptions is no longer available in WooPayments.', 'woocommerce-payments' ),
 			'https://woocommerce.com/products/woocommerce-subscriptions/'
 		);
 		?>

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Class WC_Payments_Subscriptions_Disabler
+ *
+ * Responsible for disabling merchant and customer facing management
+ * interfaces for bundled subscriptions while keeping renewal logic active.
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Disables bundled subscriptions management surfaces.
+ */
+class WC_Payments_Subscriptions_Disabler {
+
+	/**
+	 * Initiates hooks that hide bundled subscriptions management entry points.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		if ( is_admin() ) {
+			add_action( 'admin_menu', [ $this, 'remove_admin_menu_items' ], PHP_INT_MAX );
+			add_action( 'current_screen', [ $this, 'maybe_block_admin_subscription_screen' ] );
+			add_filter( 'product_type_selector', [ $this, 'filter_product_type_selector' ], PHP_INT_MAX );
+		}
+
+		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], PHP_INT_MAX );
+		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ] );
+	}
+
+	/**
+	 * Removes WooCommerce > Subscriptions menu entries.
+	 *
+	 * @return void
+	 */
+	public function remove_admin_menu_items() {
+		remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_subscription' );
+		remove_submenu_page( 'woocommerce', 'wc-orders--shop_subscription' );
+		remove_menu_page( 'wc-orders--shop_subscription' );
+	}
+
+	/**
+	 * Redirects attempts to access admin subscription management screens.
+	 *
+	 * @param WP_Screen $screen Current screen instance.
+	 * @return void
+	 */
+	public function maybe_block_admin_subscription_screen( $screen ) {
+		if ( wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return;
+		}
+
+		if ( ! $screen instanceof WP_Screen ) {
+			return;
+		}
+
+		$screen_id = (string) $screen->id;
+
+		if ( $this->is_blocked_admin_screen( $screen_id ) || $this->is_subscription_post_type_request() ) {
+			$this->redirect_to_admin_overview();
+		}
+	}
+
+	/**
+	 * Removes the subscriptions tab from the My Account navigation.
+	 *
+	 * @param array $items My Account menu items.
+	 * @return array Filtered menu items.
+	 */
+	public function remove_account_menu_item( $items ) {
+		$subscriptions_endpoint = $this->get_account_endpoint_slug( 'subscriptions' );
+
+		if ( isset( $items[ $subscriptions_endpoint ] ) ) {
+			unset( $items[ $subscriptions_endpoint ] );
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Removes subscription related product types from product selector.
+	 *
+	 * @param array $product_types Registered product types.
+	 * @return array
+	 */
+	public function filter_product_type_selector( $product_types ) {
+		unset( $product_types['subscription'], $product_types['variable-subscription'] );
+
+		return $product_types;
+	}
+
+	/**
+	 * Redirects subscription related customer account endpoints.
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_account_endpoints() {
+		if ( ! is_account_page() ) {
+			return;
+		}
+
+		foreach ( $this->get_blocked_account_endpoints() as $endpoint ) {
+			if ( empty( $endpoint ) ) {
+				continue;
+			}
+
+			if ( $this->is_endpoint_url( $endpoint ) ) {
+				$this->redirect( wc_get_page_permalink( 'myaccount' ) );
+			}
+		}
+	}
+
+	/**
+	 * Determines if the given screen ID should be blocked.
+	 *
+	 * @param string $screen_id Screen ID.
+	 * @return bool
+	 */
+	private function is_blocked_admin_screen( $screen_id ) {
+		if ( '' === $screen_id ) {
+			return false;
+		}
+
+		return false !== strpos( $screen_id, 'shop_subscription' )
+			|| false !== strpos( $screen_id, 'wc-orders--shop_subscription' );
+	}
+
+	/**
+	 * Determines if the current request is targeting the subscription post type.
+	 *
+	 * @return bool
+	 */
+	private function is_subscription_post_type_request() {
+		if ( empty( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
+
+		return 'shop_subscription' === sanitize_key( wp_unslash( $_GET['post_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Redirects the current request to the WooCommerce dashboard.
+	 *
+	 * @return void
+	 */
+	protected function redirect_to_admin_overview() {
+		$this->redirect( admin_url( 'admin.php?page=wc-admin' ) );
+	}
+
+	/**
+	 * Gets the account endpoint slug for the supplied option key.
+	 *
+	 * @param string $key Subscriptions endpoint option key suffix.
+	 * @return string
+	 */
+	private function get_account_endpoint_slug( $key ) {
+		switch ( $key ) {
+			case 'view-subscription':
+				return get_option( 'woocommerce_myaccount_view_subscription_endpoint', 'view-subscription' );
+			case 'subscription-payment-method':
+				return get_option( 'woocommerce_myaccount_subscription_payment_method_endpoint', 'subscription-payment-method' );
+			case 'subscriptions':
+			default:
+				return get_option( 'woocommerce_myaccount_subscriptions_endpoint', 'subscriptions' );
+		}
+	}
+
+	/**
+	 * Returns the list of account endpoints which should be blocked.
+	 *
+	 * @return array
+	 */
+	private function get_blocked_account_endpoints() {
+		return [
+			$this->get_account_endpoint_slug( 'subscriptions' ),
+			$this->get_account_endpoint_slug( 'view-subscription' ),
+			$this->get_account_endpoint_slug( 'subscription-payment-method' ),
+		];
+	}
+
+	/**
+	 * Redirects the current request to the provided URL and exits execution.
+	 *
+	 * @param string $target Target URL.
+	 * @return void
+	 */
+	protected function redirect( $target ) {
+		wp_safe_redirect( $target );
+		exit;
+	}
+
+	/**
+	 * Checks whether the current request matches the provided endpoint.
+	 *
+	 * @param string $endpoint Endpoint slug.
+	 * @return bool
+	 */
+	protected function is_endpoint_url( $endpoint ) {
+		return is_wc_endpoint_url( $endpoint );
+	}
+}

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -87,6 +87,7 @@ class WC_Payments_Subscriptions_Disabler {
 		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ], 5 );
 		add_action( 'init', [ $this, 'remove_related_subscriptions_section' ], 99 );
 		add_filter( 'woocommerce_is_purchasable', [ $this, 'make_subscription_products_unpurchasable' ], 10, 2 );
+		add_filter( 'woocommerce_cart_item_removed_message', [ $this, 'filter_subscription_removal_message' ], 10, 2 );
 	}
 
 	/**
@@ -393,6 +394,30 @@ class WC_Payments_Subscriptions_Disabler {
 		}
 
 		return $is_purchasable;
+	}
+
+	/**
+	 * Filters the cart item removal message for subscription products.
+	 *
+	 * When WooCommerce removes unpurchasable products from the cart, this filter
+	 * customizes the message for subscription products to be more customer-friendly.
+	 *
+	 * @param string     $message The default removal message from WooCommerce.
+	 * @param WC_Product $product The product being removed.
+	 * @return string The filtered message.
+	 */
+	public function filter_subscription_removal_message( $message, $product ) {
+		// Only modify the message if this is a subscription product.
+		if ( ! $product || ! $product->is_type( [ 'subscription', 'variable-subscription', 'subscription_variation' ] ) ) {
+			return $message;
+		}
+
+		// Return a customer-friendly message that matches WooCommerce's standard format.
+		return sprintf(
+			/* translators: %s: product name */
+			__( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce-payments' ),
+			$product->get_name()
+		);
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -24,16 +24,16 @@ class WC_Payments_Subscriptions_Disabler {
 	 */
 	public function init_hooks() {
 		if ( is_admin() ) {
-			add_action( 'admin_menu', [ $this, 'remove_admin_menu_items' ], PHP_INT_MAX );
+			add_action( 'admin_menu', [ $this, 'remove_admin_menu_items' ], 99 );
 			add_action( 'current_screen', [ $this, 'maybe_block_admin_subscription_screen' ] );
-			add_filter( 'product_type_selector', [ $this, 'filter_product_type_selector' ], PHP_INT_MAX );
-			add_filter( 'woocommerce_settings_tabs_array', [ $this, 'filter_settings_tabs' ], PHP_INT_MAX );
-			add_action( 'admin_init', [ $this, 'maybe_redirect_settings_tab' ], PHP_INT_MAX );
+			add_filter( 'product_type_selector', [ $this, 'filter_product_type_selector' ], 99 );
+			add_filter( 'woocommerce_settings_tabs_array', [ $this, 'filter_settings_tabs' ], 99 );
+			add_action( 'admin_init', [ $this, 'maybe_redirect_settings_tab' ], 99 );
 		}
 
-		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], PHP_INT_MAX );
+		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], 99 );
 		add_action( 'template_redirect', [ $this, 'maybe_redirect_account_endpoints' ] );
-		add_action( 'init', [ $this, 'remove_related_subscriptions_section' ], PHP_INT_MAX );
+		add_action( 'init', [ $this, 'remove_related_subscriptions_section' ], 99 );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * This class hides UI elements and blocks access to subscription management
  * interfaces for both merchants and customers. It also prevents new subscription
- * products from being purchased.
+ * products from being purchased or added to orders.
  *
  * What this class disables:
  * - Admin menu items (WooCommerce > Subscriptions)
@@ -27,6 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Customer account subscription pages
  * - Related subscriptions section on order details
  * - Purchasing of subscription products (makes them unpurchasable)
+ * - Adding subscription products to admin orders (both search and validation)
  *
  * What this class does NOT affect:
  * - Stripe Billing webhook processing (invoice.paid, invoice.upcoming, etc.)
@@ -73,6 +74,8 @@ class WC_Payments_Subscriptions_Disabler {
 			add_filter( 'woocommerce_settings_tabs_array', [ $this, 'filter_settings_tabs' ], 99 );
 			add_action( 'admin_init', [ $this, 'maybe_redirect_settings_tab' ], 99 );
 			add_action( 'admin_notices', [ $this, 'display_subscription_disabled_notice' ] );
+			add_filter( 'woocommerce_json_search_found_products', [ $this, 'filter_admin_product_search' ] );
+			add_filter( 'woocommerce_ajax_add_order_item_validation', [ $this, 'validate_admin_order_item' ], 10, 4 );
 		}
 
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], 99 );
@@ -267,6 +270,68 @@ class WC_Payments_Subscriptions_Disabler {
 		}
 
 		return $is_purchasable;
+	}
+
+	/**
+	 * Filters subscription products from admin product search results.
+	 *
+	 * Removes subscription products from the AJAX product search used in the
+	 * admin order editor "Add item(s)" modal. This prevents admins from seeing
+	 * subscription products as options when manually creating orders.
+	 *
+	 * @param array $products Array of products (product_id => product_name).
+	 * @return array Filtered array without subscription products.
+	 */
+	public function filter_admin_product_search( $products ) {
+		if ( empty( $products ) ) {
+			return $products;
+		}
+
+		$filtered = [];
+		foreach ( $products as $product_id => $product_name ) {
+			$product = wc_get_product( $product_id );
+
+			// Skip if not a valid product or is a subscription type.
+			if ( ! $product || $product->is_type( [ 'subscription', 'variable-subscription', 'subscription_variation' ] ) ) {
+				continue;
+			}
+
+			$filtered[ $product_id ] = $product_name;
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Validates that subscription products cannot be added to admin orders.
+	 *
+	 * This provides server-side validation as a backup to the search filtering.
+	 * If an admin somehow attempts to add a subscription product to an order
+	 * (e.g., by manipulating the AJAX request), this will block it with an error.
+	 *
+	 * @param WP_Error   $validation_error Error object to populate if validation fails.
+	 * @param WC_Product $product          Product being added to order.
+	 * @param WC_Order   $order            Order object.
+	 * @param int        $qty              Quantity being added.
+	 * @return WP_Error Error object (populated if validation fails).
+	 */
+	public function validate_admin_order_item( $validation_error, $product, $order, $qty ) {
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by filter signature.
+		unset( $order, $qty );
+
+		if ( ! $product ) {
+			return $validation_error;
+		}
+
+		// Check if product is a subscription type.
+		if ( $product->is_type( [ 'subscription', 'variable-subscription', 'subscription_variation' ] ) ) {
+			return new WP_Error(
+				'subscription_not_allowed_in_admin_order',
+				__( 'Subscription products cannot be added to orders. Please install WooCommerce Subscriptions to manage subscriptions.', 'woocommerce-payments' )
+			);
+		}
+
+		return $validation_error;
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -27,6 +27,8 @@ class WC_Payments_Subscriptions_Disabler {
 			add_action( 'admin_menu', [ $this, 'remove_admin_menu_items' ], PHP_INT_MAX );
 			add_action( 'current_screen', [ $this, 'maybe_block_admin_subscription_screen' ] );
 			add_filter( 'product_type_selector', [ $this, 'filter_product_type_selector' ], PHP_INT_MAX );
+			add_filter( 'woocommerce_settings_tabs_array', [ $this, 'filter_settings_tabs' ], PHP_INT_MAX );
+			add_action( 'admin_init', [ $this, 'maybe_redirect_settings_tab' ], PHP_INT_MAX );
 		}
 
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'remove_account_menu_item' ], PHP_INT_MAX );
@@ -92,6 +94,46 @@ class WC_Payments_Subscriptions_Disabler {
 		unset( $product_types['subscription'], $product_types['variable-subscription'] );
 
 		return $product_types;
+	}
+
+	/**
+	 * Removes subscription tab from WooCommerce settings.
+	 *
+	 * @param array $tabs Registered WooCommerce settings tabs.
+	 * @return array
+	 */
+	public function filter_settings_tabs( $tabs ) {
+		unset( $tabs['subscriptions'] );
+
+		return $tabs;
+	}
+
+	/**
+	 * Redirects attempts to access the removed subscriptions settings tab.
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_settings_tab() {
+		if ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$page = sanitize_key( wp_unslash( $_GET['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$tab  = sanitize_key( wp_unslash( $_GET['tab'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( 'wc-settings' !== $page || 'subscriptions' !== $tab ) {
+			return;
+		}
+
+		$this->redirect(
+			add_query_arg(
+				[
+					'page' => 'wc-settings',
+					'tab'  => 'general',
+				],
+				admin_url( 'admin.php' )
+			)
+		);
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -92,7 +92,11 @@ class WC_Payments_Subscriptions {
 		new WC_Payments_Subscriptions_Empty_State_Manager( $account );
 		new WC_Payments_Subscriptions_Onboarding_Handler( $account );
 		new WC_Payments_Subscription_Minimum_Amount_Handler( $api_client );
-		( new WC_Payments_Subscriptions_Disabler() )->init_hooks();
+
+		// Only disable bundled subscriptions UI when the full WooCommerce Subscriptions plugin is not active.
+		if ( ! class_exists( 'WC_Subscriptions' ) ) {
+			( new WC_Payments_Subscriptions_Disabler() )->init_hooks();
+		}
 
 		if ( class_exists( 'WCS_Background_Repairer' ) ) {
 			include_once __DIR__ . '/class-wc-payments-subscriptions-migrator.php';

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -79,6 +79,7 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';
 		include_once __DIR__ . '/class-wc-payments-subscriptions-onboarding-handler.php';
 		include_once __DIR__ . '/class-wc-payments-subscription-minimum-amount-handler.php';
+		include_once __DIR__ . '/class-wc-payments-subscriptions-disabler.php';
 
 		// Instantiate additional classes.
 		self::$product_service      = new WC_Payments_Product_Service( $api_client, $account );
@@ -91,6 +92,7 @@ class WC_Payments_Subscriptions {
 		new WC_Payments_Subscriptions_Empty_State_Manager( $account );
 		new WC_Payments_Subscriptions_Onboarding_Handler( $account );
 		new WC_Payments_Subscription_Minimum_Amount_Handler( $api_client );
+		( new WC_Payments_Subscriptions_Disabler() )->init_hooks();
 
 		if ( class_exists( 'WCS_Background_Repairer' ) ) {
 			include_once __DIR__ . '/class-wc-payments-subscriptions-migrator.php';

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -643,9 +643,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_settings_disables_wcpay_subscriptions() {
-		// Remove the global filter that forces subscriptions to be enabled in tests.
-		remove_all_filters( 'pre_option__wcpay_feature_subscriptions' );
-
 		// Set initial value to enabled.
 		$flag_name = WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME;
 		update_option( $flag_name, '1' );
@@ -665,9 +662,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_settings_does_not_enable_wcpay_subscriptions() {
-		// Remove the global filter that forces subscriptions to be enabled in tests.
-		remove_all_filters( 'pre_option__wcpay_feature_subscriptions' );
-
 		// Set initial value to disabled.
 		update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '0' );
 
@@ -685,9 +679,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_settings_does_not_toggle_wcpay_subscriptions_if_not_supplied() {
-		// Remove the global filter that forces subscriptions to be enabled in tests.
-		remove_all_filters( 'pre_option__wcpay_feature_subscriptions' );
-
 		// Set initial value to enabled.
 		update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '1' );
 		$status_before_request = get_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME );

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -642,6 +642,68 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'no', $this->gateway->get_option( 'saved_cards' ) );
 	}
 
+	public function test_update_settings_disables_wcpay_subscriptions() {
+		// Remove the global filter that forces subscriptions to be enabled in tests.
+		remove_all_filters( 'pre_option__wcpay_feature_subscriptions' );
+
+		// Set initial value to enabled.
+		$flag_name = WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME;
+		update_option( $flag_name, '1' );
+		// Verify it was set correctly.
+		$this->assertEquals( '1', get_option( $flag_name ) );
+
+		// Mock store_setup_sync to avoid side effects.
+		$this->mock_wcpay_account->expects( $this->once() )
+			->method( 'store_setup_sync' );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_wcpay_subscription_enabled', false );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( '0', get_option( $flag_name ) );
+	}
+
+	public function test_update_settings_does_not_enable_wcpay_subscriptions() {
+		// Remove the global filter that forces subscriptions to be enabled in tests.
+		remove_all_filters( 'pre_option__wcpay_feature_subscriptions' );
+
+		// Set initial value to disabled.
+		update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '0' );
+
+		// Mock store_setup_sync to avoid side effects.
+		$this->mock_wcpay_account->expects( $this->once() )
+			->method( 'store_setup_sync' );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_wcpay_subscription_enabled', true );
+
+		$this->controller->update_settings( $request );
+
+		// Should remain disabled - feature is deprecated and cannot be re-enabled.
+		$this->assertEquals( '0', get_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME ) );
+	}
+
+	public function test_update_settings_does_not_toggle_wcpay_subscriptions_if_not_supplied() {
+		// Remove the global filter that forces subscriptions to be enabled in tests.
+		remove_all_filters( 'pre_option__wcpay_feature_subscriptions' );
+
+		// Set initial value to enabled.
+		update_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '1' );
+		$status_before_request = get_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME );
+
+		// Mock store_setup_sync to avoid side effects.
+		$this->mock_wcpay_account->expects( $this->once() )
+			->method( 'store_setup_sync' );
+
+		$request = new WP_REST_Request();
+
+		$this->controller->update_settings( $request );
+
+		// Should remain unchanged when parameter is not supplied.
+		$this->assertEquals( $status_before_request, get_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME ) );
+	}
+
 	public function deposit_schedules_data_provider() {
 		return [
 			[

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -46,12 +46,16 @@ function _manually_load_plugin() {
 	update_option( 'woocommerce_currency', 'USD' );
 
 	// Enable the WCPay Subscriptions feature flag in tests to ensure we can test
-	// subscriptions funtionality.
+	// subscriptions functionality. Using 'default_option_' filter provides a default
+	// only when the option doesn't exist in the database, allowing tests to override
+	// via update_option().
 	add_filter(
-		'pre_option__wcpay_feature_subscriptions',
-		function () {
+		'default_option__wcpay_feature_subscriptions',
+		function ( $default ) {
 			return '1';
-		}
+		},
+		10,
+		1
 	);
 
 	$_plugin_dir = __DIR__ . '/../../';

--- a/tests/unit/notes/test-class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-stripe-billing-deprecation.php
@@ -31,9 +31,12 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation_Test extends WCPAY_UnitTestCa
 		} elseif ( version_compare( $wcpay_version, '9.9.0', '<' ) ) {
 			$title   = 'WooPayments subscriptions update';
 			$content = 'WooPayments no longer supports billing for existing customer subscriptions. All subscriptions data is read-only. Please install WooCommerce Subscriptions to continue managing your subscriptions.';
-		} else {
+		} elseif ( version_compare( $wcpay_version, '10.2.0', '<' ) ) {
 			$title   = 'WooPayments subscriptions update';
 			$content = 'WooPayments no longer supports subscriptions capabilities and subscriptions data can no longer be accessed. Please install WooCommerce Subscriptions to continue managing your subscriptions.';
+		} else {
+			$title   = 'Built-in subscriptions functionality has been removed. Here\'s what to do';
+			$content = 'To continue offering subscriptions and gain access to your data, please install WooCommerce Subscriptions. WooPayments no longer supports this feature.';
 		}
 
 		$note = WC_Payments_Notes_Stripe_Billing_Deprecation::get_note();

--- a/tests/unit/notes/test-class-wc-payments-notes-stripe-billing-deprecation.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-stripe-billing-deprecation.php
@@ -21,29 +21,11 @@ class WC_Payments_Notes_Stripe_Billing_Deprecation_Test extends WCPAY_UnitTestCa
 	 * Tests for WC_Payments_Notes_Stripe_Billing_Deprecation::get_note()
 	 */
 	public function test_get_note() {
-		$wcpay_version = WC_Payments::get_file_version( WCPAY_PLUGIN_FILE );
-		if ( version_compare( $wcpay_version, '9.7.0', '<' ) ) {
-			$title   = 'Important information regarding subscriptions in WooPayments';
-			$content = 'From version 9.7 of WooPayments (scheduled for 23 July, 2025), you\'ll no longer be able to offer new product subscriptions using the built-in subscriptions functionality. To avoid disruption, please install WooCommerce Subscriptions for free.';
-		} elseif ( version_compare( $wcpay_version, '9.8.0', '<' ) ) {
-			$title   = 'WooPayments subscriptions update';
-			$content = 'WooPayments no longer allows customers to create new subscriptions. Beginning in version 9.8, billing for existing customer subscriptions will no longer be supported. To ensure there is no interruption of service, please install WooCommerce Subscriptions.';
-		} elseif ( version_compare( $wcpay_version, '9.9.0', '<' ) ) {
-			$title   = 'WooPayments subscriptions update';
-			$content = 'WooPayments no longer supports billing for existing customer subscriptions. All subscriptions data is read-only. Please install WooCommerce Subscriptions to continue managing your subscriptions.';
-		} elseif ( version_compare( $wcpay_version, '10.2.0', '<' ) ) {
-			$title   = 'WooPayments subscriptions update';
-			$content = 'WooPayments no longer supports subscriptions capabilities and subscriptions data can no longer be accessed. Please install WooCommerce Subscriptions to continue managing your subscriptions.';
-		} else {
-			$title   = 'Built-in subscriptions functionality has been removed. Here\'s what to do';
-			$content = 'To continue offering subscriptions and gain access to your data, please install WooCommerce Subscriptions. WooPayments no longer supports this feature.';
-		}
-
 		$note = WC_Payments_Notes_Stripe_Billing_Deprecation::get_note();
 
 		$this->assertInstanceOf( 'Automattic\WooCommerce\Admin\Notes\Note', $note );
-		$this->assertEquals( $title, $note->get_title() );
-		$this->assertEquals( $content, $note->get_content() );
+		$this->assertEquals( 'Built-in subscriptions functionality has been removed. Here\'s what to do', $note->get_title() );
+		$this->assertEquals( 'To continue offering subscriptions and gain access to your data, please install WooCommerce Subscriptions. WooPayments no longer supports this feature.', $note->get_content() );
 		$this->assertEquals( 'info', $note->get_type() );
 		$this->assertEquals( 'wc-payments-notes-stripe-billing-deprecation', $note->get_name() );
 		$this->assertEquals( 'woocommerce-payments', $note->get_source() );

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -257,4 +257,231 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 
 		$this->assertSame( $account_url, $this->disabler->redirected_to );
 	}
+
+	/**
+	 * Verify that the disabler does NOT interfere with renewal order creation hooks.
+	 *
+	 * This is a critical test to ensure Stripe Billing renewals continue to work
+	 * when the UI is disabled.
+	 */
+	public function test_disabler_does_not_hook_into_renewal_order_creation() {
+		// First, register a test hook to simulate renewal logic being active.
+		$test_callback = function () {
+			return true;
+		};
+		add_action( 'woocommerce_renewal_order_payment_complete', $test_callback );
+
+		// Verify the hook exists before disabler runs.
+		$this->assertIsInt(
+			has_action( 'woocommerce_renewal_order_payment_complete', $test_callback ),
+			'Renewal hook should exist before disabler init'
+		);
+
+		// Initialize the disabler.
+		$this->disabler->init_hooks();
+
+		// Verify the renewal hook still exists and was NOT removed by disabler.
+		$this->assertIsInt(
+			has_action( 'woocommerce_renewal_order_payment_complete', $test_callback ),
+			'Disabler should NOT remove the renewal order payment complete hook'
+		);
+
+		// Clean up.
+		remove_action( 'woocommerce_renewal_order_payment_complete', $test_callback );
+	}
+
+	/**
+	 * Verify that the disabler does NOT hook into payment processing.
+	 *
+	 * Payment processing must continue to work for renewals to succeed.
+	 */
+	public function test_disabler_does_not_hook_into_payment_processing() {
+		// Register test hooks to simulate payment processing being active.
+		$payment_callback  = function () {};
+		$checkout_callback = function () {};
+
+		add_action( 'woocommerce_subscription_payment_complete', $payment_callback );
+		add_action( 'woocommerce_checkout_subscription_created', $checkout_callback );
+
+		// Initialize the disabler.
+		$this->disabler->init_hooks();
+
+		// Verify payment complete hook still exists (not removed by disabler).
+		$this->assertIsInt(
+			has_action( 'woocommerce_subscription_payment_complete', $payment_callback ),
+			'Disabler should NOT remove subscription payment complete hook'
+		);
+
+		// Verify checkout subscription creation hook still exists.
+		$this->assertIsInt(
+			has_action( 'woocommerce_checkout_subscription_created', $checkout_callback ),
+			'Disabler should NOT remove checkout subscription created hook'
+		);
+
+		// Clean up.
+		remove_action( 'woocommerce_subscription_payment_complete', $payment_callback );
+		remove_action( 'woocommerce_checkout_subscription_created', $checkout_callback );
+	}
+
+	/**
+	 * Verify that the disabler does NOT hook into subscription status changes.
+	 *
+	 * Status changes are critical for renewal processing and subscription lifecycle.
+	 */
+	public function test_disabler_does_not_hook_into_status_changes() {
+		$this->disabler->init_hooks();
+
+		// List of critical status change hooks that should NOT be affected.
+		$status_hooks = [
+			'woocommerce_subscription_status_cancelled',
+			'woocommerce_subscription_status_expired',
+			'woocommerce_subscription_status_on-hold',
+			'woocommerce_subscription_status_active',
+			'woocommerce_subscription_status_pending-cancel',
+		];
+
+		foreach ( $status_hooks as $hook ) {
+			$this->assertFalse(
+				has_action( $hook ),
+				"Disabler should NOT hook into {$hook}"
+			);
+		}
+	}
+
+	/**
+	 * Verify that disabler only hooks into UI-layer actions and filters.
+	 *
+	 * This test documents all hooks the disabler DOES use to confirm they're
+	 * all UI/presentation related and not backend functionality.
+	 */
+	public function test_disabler_only_hooks_into_ui_layer() {
+		// Set admin context for admin hooks to be registered.
+		set_current_screen( 'dashboard' );
+
+		$this->disabler->init_hooks();
+
+		// Admin UI hooks that SHOULD be present (only when is_admin()).
+		$hook_priority = has_action( 'admin_menu', [ $this->disabler, 'remove_admin_menu_items' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into admin_menu to remove UI elements'
+		);
+
+		$hook_priority = has_action( 'current_screen', [ $this->disabler, 'maybe_block_admin_subscription_screen' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into current_screen to block admin access'
+		);
+
+		$hook_priority = has_filter( 'product_type_selector', [ $this->disabler, 'filter_product_type_selector' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into product_type_selector to hide subscription types'
+		);
+
+		$hook_priority = has_filter( 'woocommerce_settings_tabs_array', [ $this->disabler, 'filter_settings_tabs' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into settings tabs to remove subscription tab'
+		);
+
+		// Frontend UI hooks that SHOULD be present (these run regardless of is_admin()).
+		$hook_priority = has_filter( 'woocommerce_account_menu_items', [ $this->disabler, 'remove_account_menu_item' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into account menu to remove subscription links'
+		);
+
+		$hook_priority = has_action( 'template_redirect', [ $this->disabler, 'maybe_redirect_account_endpoints' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into template_redirect to block customer access'
+		);
+
+		$hook_priority = has_action( 'init', [ $this->disabler, 'remove_related_subscriptions_section' ] );
+		$this->assertNotFalse(
+			$hook_priority,
+			'Disabler should hook into init to remove subscription display sections'
+		);
+
+		// Clean up.
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Integration test: Verify wcs_create_renewal_order can still be called when disabler is active.
+	 *
+	 * This simulates what happens during a Stripe webhook when invoice.paid is received.
+	 */
+	public function test_renewal_order_creation_works_with_disabler_active() {
+		if ( ! class_exists( 'WC_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Subscription class not available.' );
+		}
+
+		// Initialize the disabler (simulating production state).
+		$this->disabler->init_hooks();
+
+		// Create a mock subscription.
+		$mock_subscription = $this->getMockBuilder( 'WC_Subscription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mock_subscription->method( 'get_id' )->willReturn( 123 );
+
+		// Track if wcs_create_renewal_order was called successfully.
+		$renewal_order_created = false;
+
+		// Mock the wcs_create_renewal_order function.
+		WC_Subscriptions::wcs_create_renewal_order(
+			function ( $subscription ) use ( &$renewal_order_created ) {
+				$renewal_order_created = true;
+				return WC_Helper_Order::create_order();
+			}
+		);
+
+		// Simulate renewal order creation (what happens in webhook handler).
+		$renewal_order = wcs_create_renewal_order( $mock_subscription );
+
+		// Verify renewal order was created successfully.
+		$this->assertTrue( $renewal_order_created, 'Renewal order should be created even with disabler active' );
+		$this->assertInstanceOf( 'WC_Order', $renewal_order, 'Should return a valid WC_Order object' );
+	}
+
+	/**
+	 * Verify that AJAX and REST requests are not blocked by screen blocking.
+	 *
+	 * This ensures backend operations (like webhook processing) continue to work.
+	 */
+	public function test_admin_screen_blocking_skips_ajax_and_rest_requests() {
+		if ( ! class_exists( 'WP_Screen' ) ) {
+			$this->markTestSkipped( 'WP_Screen class not available.' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		// Simulate AJAX request.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		set_current_screen( 'edit-shop_subscription' );
+
+		$screen = get_current_screen();
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		// Should NOT redirect during AJAX.
+		$this->assertNull( $this->disabler->redirected_to, 'Should not redirect during AJAX requests' );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		// Simulate REST request.
+		define( 'REST_REQUEST', true );
+		set_current_screen( 'edit-shop_subscription' );
+
+		$screen = get_current_screen();
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		// Should NOT redirect during REST requests.
+		$this->assertNull( $this->disabler->redirected_to, 'Should not redirect during REST requests' );
+
+		set_current_screen( 'front' );
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -308,6 +308,81 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Verify that editing a subscription product is blocked.
+	 */
+	public function test_block_subscription_product_edit() {
+		if ( ! class_exists( 'WC_Product_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Product_Subscription class not available.' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		// Create a subscription product.
+		$product = new WC_Product_Subscription();
+		$product->set_props(
+			[
+				'name'          => 'Dummy Subscription Product',
+				'regular_price' => 10,
+				'price'         => 10,
+			]
+		);
+		$product->save();
+		$product_id = $product->get_id();
+
+		// Simulate accessing the product edit screen via post ID.
+		$_GET['post']   = $product_id;
+		$_GET['action'] = 'edit';
+
+		set_current_screen( 'product' );
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertSame(
+			admin_url( 'admin.php?page=wc-admin' ),
+			$this->disabler->redirected_to,
+			'Should block editing subscription products via direct post ID URL'
+		);
+
+		// Clean up.
+		unset( $_GET['post'], $_GET['action'] );
+		wp_delete_post( $product_id, true );
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Verify that editing a regular (non-subscription) product is NOT blocked.
+	 */
+	public function test_does_not_block_regular_product_edit() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		// Create a simple product.
+		$product    = WC_Helper_Product::create_simple_product();
+		$product_id = $product->get_id();
+
+		// Simulate accessing the product edit screen via post ID.
+		$_GET['post']   = $product_id;
+		$_GET['action'] = 'edit';
+
+		set_current_screen( 'product' );
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertNull(
+			$this->disabler->redirected_to,
+			'Should NOT block editing regular products'
+		);
+
+		// Clean up.
+		unset( $_GET['post'], $_GET['action'] );
+		wp_delete_post( $product_id, true );
+		set_current_screen( 'front' );
+	}
+
+	/**
 	 * Verify that accessing subscription endpoints on My Account redirects to the dashboard.
 	 */
 	public function test_maybe_redirect_account_endpoints_redirects_to_my_account_page() {

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -527,11 +527,12 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Verify that AJAX and REST requests are not blocked by screen blocking.
+	 * Verify that AJAX requests are not blocked by screen blocking.
 	 *
 	 * This ensures backend operations (like webhook processing) continue to work.
+	 *
 	 */
-	public function test_admin_screen_blocking_skips_ajax_and_rest_requests() {
+	public function test_admin_screen_blocking_skips_ajax_requests() {
 		if ( ! class_exists( 'WP_Screen' ) ) {
 			$this->markTestSkipped( 'WP_Screen class not available.' );
 		}
@@ -550,16 +551,6 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		$this->assertNull( $this->disabler->redirected_to, 'Should not redirect during AJAX requests' );
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );
-
-		// Simulate REST request.
-		define( 'REST_REQUEST', true );
-		set_current_screen( 'edit-shop_subscription' );
-
-		$screen = get_current_screen();
-		$this->disabler->maybe_block_admin_subscription_screen( $screen );
-
-		// Should NOT redirect during REST requests.
-		$this->assertNull( $this->disabler->redirected_to, 'Should not redirect during REST requests' );
 
 		set_current_screen( 'front' );
 	}

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -1159,4 +1159,94 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 			'Should NOT redirect non-main queries'
 		);
 	}
+
+	/**
+	 * Verify that the Related Orders meta box is removed from order edit screens.
+	 */
+	public function test_remove_related_orders_meta_box_removes_subscription_meta_box() {
+		global $wp_meta_boxes;
+
+		// Mock the wcs_get_page_screen_id function.
+		if ( ! function_exists( 'wcs_get_page_screen_id' ) ) {
+			function wcs_get_page_screen_id( $type ) {
+				return 'wc-orders--shop_order';
+			}
+		}
+
+		$screen_id = 'wc-orders--shop_order';
+
+		// Simulate WCS adding the Related Orders meta box.
+		add_meta_box(
+			'subscription_renewal_orders',
+			'Related Orders',
+			'__return_true',
+			$screen_id,
+			'normal',
+			'low'
+		);
+
+		// Verify the meta box was added.
+		$this->assertArrayHasKey(
+			'subscription_renewal_orders',
+			$wp_meta_boxes[ $screen_id ]['normal']['low'],
+			'Related Orders meta box should be added by WCS'
+		);
+
+		// Call our remove method.
+		$this->disabler->remove_related_orders_meta_box( 'shop_order', null );
+
+		// Verify the meta box was removed (marked as false by remove_meta_box).
+		// WordPress's remove_meta_box() sets the meta box to false rather than unsetting it.
+		$this->assertFalse(
+			$wp_meta_boxes[ $screen_id ]['normal']['low']['subscription_renewal_orders'],
+			'Related Orders meta box should be removed (set to false) by disabler'
+		);
+
+		// Clean up global.
+		unset( $wp_meta_boxes[ $screen_id ] );
+	}
+
+	/**
+	 * Verify that remove_related_orders_meta_box does nothing when WCS functions are not available.
+	 */
+	public function test_remove_related_orders_meta_box_does_nothing_without_wcs() {
+		global $wp_meta_boxes;
+
+		// Temporarily rename the function to simulate it not existing.
+		if ( function_exists( 'wcs_get_page_screen_id' ) ) {
+			$this->markTestSkipped( 'Cannot test missing function when it exists in test environment' );
+		}
+
+		$screen_id = 'wc-orders--shop_order';
+
+		// Add a meta box.
+		add_meta_box(
+			'subscription_renewal_orders',
+			'Related Orders',
+			'__return_true',
+			$screen_id,
+			'normal',
+			'low'
+		);
+
+		// Verify the meta box was added.
+		$this->assertArrayHasKey(
+			'subscription_renewal_orders',
+			$wp_meta_boxes[ $screen_id ]['normal']['low'],
+			'Related Orders meta box should be added'
+		);
+
+		// Call our remove method (should do nothing without WCS functions).
+		$this->disabler->remove_related_orders_meta_box( 'shop_order', null );
+
+		// Verify the meta box was NOT removed (function should exit early).
+		$this->assertArrayHasKey(
+			'subscription_renewal_orders',
+			$wp_meta_boxes[ $screen_id ]['normal']['low'],
+			'Related Orders meta box should remain when WCS functions not available'
+		);
+
+		// Clean up global.
+		unset( $wp_meta_boxes[ $screen_id ] );
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -963,4 +963,200 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		wp_delete_post( $regular_product->get_id(), true );
 		wp_delete_post( $order->get_id(), true );
 	}
+
+	/**
+	 * Verify that order-pay endpoint redirects when given a subscription ID.
+	 */
+	public function test_order_pay_redirects_for_subscription_id() {
+		if ( ! class_exists( 'WC_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Subscription class not available.' );
+		}
+
+		global $wp;
+
+		// Create a subscription post.
+		$subscription_id = $this->factory->post->create(
+			[
+				'post_type'   => 'shop_subscription',
+				'post_status' => 'wc-active',
+			]
+		);
+
+		// Simulate the order-pay endpoint with subscription ID.
+		$wp->query_vars['order-pay'] = $subscription_id;
+
+		$this->disabler->init_hooks();
+		$this->disabler->maybe_redirect_account_endpoints();
+
+		// Verify redirect occurred (should not be null).
+		$this->assertNotNull(
+			$this->disabler->redirected_to,
+			'Should redirect to My Account when order-pay contains subscription ID'
+		);
+
+		// Cleanup.
+		unset( $wp->query_vars['order-pay'] );
+		wp_delete_post( $subscription_id, true );
+	}
+
+	/**
+	 * Verify that order-pay endpoint does NOT redirect when given a regular order ID.
+	 */
+	public function test_order_pay_allows_regular_order_id() {
+		global $wp;
+
+		// Create a regular order.
+		$order = WC_Helper_Order::create_order();
+
+		// Simulate the order-pay endpoint with order ID.
+		$wp->query_vars['order-pay'] = $order->get_id();
+
+		$this->disabler->init_hooks();
+		$this->disabler->maybe_redirect_account_endpoints();
+
+		// Verify NO redirect occurred.
+		$this->assertNull(
+			$this->disabler->redirected_to,
+			'Should NOT redirect when order-pay contains regular order ID'
+		);
+
+		// Cleanup.
+		unset( $wp->query_vars['order-pay'] );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
+	 * Verify that order-pay redirects when change_payment_method parameter contains subscription ID.
+	 *
+	 * This simulates the flow when WooCommerce Subscriptions redirects from
+	 * /my-account/subscription-payment-method/765 to /checkout/order-pay/765/?change_payment_method=765
+	 */
+	public function test_order_pay_redirects_for_change_payment_method_with_subscription_id() {
+		if ( ! class_exists( 'WC_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Subscription class not available.' );
+		}
+
+		global $wp;
+
+		// Create a subscription post.
+		$subscription_id = $this->factory->post->create(
+			[
+				'post_type'   => 'shop_subscription',
+				'post_status' => 'wc-active',
+			]
+		);
+
+		// Create a regular order (could be the parent order or renewal order).
+		$order = WC_Helper_Order::create_order();
+
+		// Simulate the order-pay endpoint with change_payment_method parameter.
+		// This is what WC Subscriptions does when redirecting.
+		$wp->query_vars['order-pay']   = $order->get_id();
+		$_GET['change_payment_method'] = $subscription_id;
+		$_GET['pay_for_order']         = 'true';
+		$_GET['key']                   = 'test_key';
+
+		$this->disabler->init_hooks();
+		$this->disabler->maybe_redirect_account_endpoints();
+
+		// Verify redirect occurred due to subscription ID in change_payment_method (should not be null).
+		$this->assertNotNull(
+			$this->disabler->redirected_to,
+			'Should redirect to My Account when change_payment_method parameter contains subscription ID'
+		);
+
+		// Cleanup.
+		unset( $wp->query_vars['order-pay'], $_GET['change_payment_method'], $_GET['pay_for_order'], $_GET['key'] );
+		wp_delete_post( $subscription_id, true );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
+	 * Verify that order-pay does NOT redirect when change_payment_method contains order ID.
+	 */
+	public function test_order_pay_allows_change_payment_method_with_order_id() {
+		global $wp;
+
+		// Create two regular orders.
+		$order1 = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
+
+		// Simulate order-pay with change_payment_method for a regular order.
+		$wp->query_vars['order-pay']   = $order1->get_id();
+		$_GET['change_payment_method'] = $order2->get_id();
+		$_GET['pay_for_order']         = 'true';
+		$_GET['key']                   = 'test_key';
+
+		$this->disabler->init_hooks();
+		$this->disabler->maybe_redirect_account_endpoints();
+
+		// Verify NO redirect occurred (regular order IDs are allowed).
+		$this->assertNull(
+			$this->disabler->redirected_to,
+			'Should NOT redirect when change_payment_method contains regular order ID'
+		);
+
+		// Cleanup.
+		unset( $wp->query_vars['order-pay'], $_GET['change_payment_method'], $_GET['pay_for_order'], $_GET['key'] );
+		wp_delete_post( $order1->get_id(), true );
+		wp_delete_post( $order2->get_id(), true );
+	}
+
+	/**
+	 * Verify that subscription endpoints are redirected during pre_get_posts.
+	 *
+	 * This tests the early redirect that happens BEFORE WooCommerce Subscriptions
+	 * can redirect to the order-pay endpoint.
+	 */
+	public function test_pre_get_posts_redirects_subscription_payment_method_endpoint() {
+		update_option( 'woocommerce_myaccount_subscription_payment_method_endpoint', 'subscription-payment-method' );
+
+		// Create a main query with subscription-payment-method endpoint.
+		$query_args = [
+			'subscription-payment-method' => 765,
+		];
+		$query      = new WP_Query( $query_args );
+
+		// Need to manually set this since we're not running a full WordPress request.
+		global $wp_the_query;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Required for testing is_main_query() in isolation.
+		$wp_the_query = $query;
+
+		$this->disabler->init_hooks();
+		$this->disabler->maybe_redirect_subscription_endpoints( $query );
+
+		// Verify redirect occurred (should not be null).
+		$this->assertNotNull(
+			$this->disabler->redirected_to,
+			'Should redirect subscription-payment-method endpoint during pre_get_posts'
+		);
+
+		// Clean up.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring original state.
+		$wp_the_query = null;
+	}
+
+	/**
+	 * Verify that non-main queries are not redirected.
+	 */
+	public function test_pre_get_posts_ignores_non_main_queries() {
+		update_option( 'woocommerce_myaccount_subscription_payment_method_endpoint', 'subscription-payment-method' );
+
+		// Create a non-main query (not setting as global query).
+		$query_args = [
+			'subscription-payment-method' => 765,
+		];
+		$query      = new WP_Query( $query_args );
+
+		// Don't set as main query - it's a secondary query.
+
+		$this->disabler->init_hooks();
+		$this->disabler->maybe_redirect_subscription_endpoints( $query );
+
+		// Verify NO redirect occurred (non-main queries should be ignored).
+		$this->assertNull(
+			$this->disabler->redirected_to,
+			'Should NOT redirect non-main queries'
+		);
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -179,6 +179,38 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensure related subscriptions section is removed from order detail view.
+	 */
+	public function test_remove_related_subscriptions_section() {
+		if ( ! class_exists( 'WC_Subscriptions_Order' ) ) {
+			$this->markTestSkipped( 'Subscriptions core not available.' );
+		}
+
+		add_action(
+			'woocommerce_order_details_after_order_table',
+			[ 'WC_Subscriptions_Order', 'add_subscriptions_to_view_order_templates' ],
+			10,
+			1
+		);
+
+		$this->assertNotFalse(
+			has_action(
+				'woocommerce_order_details_after_order_table',
+				[ 'WC_Subscriptions_Order', 'add_subscriptions_to_view_order_templates' ]
+			)
+		);
+
+		$this->disabler->remove_related_subscriptions_section();
+
+		$this->assertFalse(
+			has_action(
+				'woocommerce_order_details_after_order_table',
+				[ 'WC_Subscriptions_Order', 'add_subscriptions_to_view_order_templates' ]
+			)
+		);
+	}
+
+	/**
 	 * Verify that admin subscription screens are redirected away.
 	 */
 	public function test_maybe_block_admin_subscription_screen_redirects() {

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -223,7 +223,18 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 
 		$this->disabler->maybe_block_admin_subscription_screen( $screen );
 
-		$this->assertSame( admin_url( 'admin.php?page=wc-admin' ), $this->disabler->redirected_to );
+		$this->assertSame(
+			add_query_arg(
+				[
+					'page'                        => 'wc-settings',
+					'tab'                         => 'checkout',
+					'section'                     => 'woocommerce_payments',
+					'wcpay_subscription_disabled' => '1',
+				],
+				admin_url( 'admin.php' )
+			),
+			$this->disabler->redirected_to
+		);
 
 		set_current_screen( 'front' );
 	}
@@ -243,7 +254,15 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		$this->disabler->maybe_block_admin_subscription_screen( $screen );
 
 		$this->assertSame(
-			admin_url( 'admin.php?page=wc-admin' ),
+			add_query_arg(
+				[
+					'page'                        => 'wc-settings',
+					'tab'                         => 'checkout',
+					'section'                     => 'woocommerce_payments',
+					'wcpay_subscription_disabled' => '1',
+				],
+				admin_url( 'admin.php' )
+			),
 			$this->disabler->redirected_to,
 			'Should block editing individual subscriptions (CPT)'
 		);
@@ -259,7 +278,15 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		$this->disabler->maybe_block_admin_subscription_screen( $screen );
 
 		$this->assertSame(
-			admin_url( 'admin.php?page=wc-admin' ),
+			add_query_arg(
+				[
+					'page'                        => 'wc-settings',
+					'tab'                         => 'checkout',
+					'section'                     => 'woocommerce_payments',
+					'wcpay_subscription_disabled' => '1',
+				],
+				admin_url( 'admin.php' )
+			),
 			$this->disabler->redirected_to,
 			'Should block editing individual subscriptions (HPOS)'
 		);
@@ -296,7 +323,15 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		$this->disabler->maybe_block_admin_subscription_screen( $screen );
 
 		$this->assertSame(
-			admin_url( 'admin.php?page=wc-admin' ),
+			add_query_arg(
+				[
+					'page'                        => 'wc-settings',
+					'tab'                         => 'checkout',
+					'section'                     => 'woocommerce_payments',
+					'wcpay_subscription_disabled' => '1',
+				],
+				admin_url( 'admin.php' )
+			),
 			$this->disabler->redirected_to,
 			'Should block editing subscription via direct post ID URL'
 		);
@@ -340,7 +375,15 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		$this->disabler->maybe_block_admin_subscription_screen( $screen );
 
 		$this->assertSame(
-			admin_url( 'admin.php?page=wc-admin' ),
+			add_query_arg(
+				[
+					'page'                        => 'wc-settings',
+					'tab'                         => 'checkout',
+					'section'                     => 'woocommerce_payments',
+					'wcpay_subscription_disabled' => '1',
+				],
+				admin_url( 'admin.php' )
+			),
 			$this->disabler->redirected_to,
 			'Should block editing subscription products via direct post ID URL'
 		);
@@ -628,5 +671,91 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 
 		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Verify that the redirect URL includes the notice query parameter.
+	 */
+	public function test_redirect_includes_notice_parameter() {
+		if ( ! class_exists( 'WC_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Subscription class not available.' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		$subscription_id = $this->factory->post->create(
+			[
+				'post_type'   => 'shop_subscription',
+				'post_status' => 'publish',
+			]
+		);
+
+		$_GET['post']   = $subscription_id;
+		$_GET['action'] = 'edit';
+
+		set_current_screen( 'shop_subscription' );
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertStringContainsString(
+			'wcpay_subscription_disabled=1',
+			$this->disabler->redirected_to,
+			'Redirect URL should contain notice parameter'
+		);
+
+		unset( $_GET['post'], $_GET['action'] );
+		wp_delete_post( $subscription_id, true );
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Verify that the admin notice is displayed when the query parameter is set.
+	 */
+	public function test_display_subscription_disabled_notice() {
+		$_GET['wcpay_subscription_disabled'] = '1';
+		$_GET['page']                        = 'wc-settings';
+		$_GET['section']                     = 'woocommerce_payments';
+
+		ob_start();
+		$this->disabler->display_subscription_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Subscription management is currently unavailable', $output );
+		$this->assertStringContainsString( 'WooCommerce Subscriptions', $output );
+		$this->assertStringContainsString( 'woocommerce.com/products/woocommerce-subscriptions', $output );
+		$this->assertStringNotContainsString( 'is-dismissible', $output, 'Notice should not be dismissible' );
+
+		unset( $_GET['wcpay_subscription_disabled'], $_GET['page'], $_GET['section'] );
+	}
+
+	/**
+	 * Verify that the notice is not displayed without the query parameter.
+	 */
+	public function test_display_subscription_disabled_notice_not_shown_without_parameter() {
+		unset( $_GET['wcpay_subscription_disabled'] );
+
+		ob_start();
+		$this->disabler->display_subscription_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should not display notice when query parameter is not set' );
+	}
+
+	/**
+	 * Verify that the notice is not displayed on non-WooPayments settings pages.
+	 */
+	public function test_display_subscription_disabled_notice_not_shown_on_other_pages() {
+		$_GET['wcpay_subscription_disabled'] = '1';
+		$_GET['page']                        = 'other-page';
+
+		ob_start();
+		$this->disabler->display_subscription_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should not display notice on non-WooPayments settings pages' );
+
+		unset( $_GET['wcpay_subscription_disabled'], $_GET['page'] );
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -722,7 +722,8 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		$this->disabler->display_subscription_disabled_notice();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Subscription management is currently unavailable', $output );
+		$this->assertStringContainsString( 'To access your subscriptions data and keep managing recurring payments', $output );
+		$this->assertStringContainsString( 'Built-in support for subscriptions is no longer available in WooPayments.', $output );
 		$this->assertStringContainsString( 'WooCommerce Subscriptions', $output );
 		$this->assertStringContainsString( 'woocommerce.com/products/woocommerce-subscriptions', $output );
 		$this->assertStringNotContainsString( 'is-dismissible', $output, 'Notice should not be dismissible' );

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -211,7 +211,7 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Verify that admin subscription screens are redirected away.
+	 * Verify that admin subscription list screens are redirected away.
 	 */
 	public function test_maybe_block_admin_subscription_screen_redirects() {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
@@ -225,6 +225,85 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 
 		$this->assertSame( admin_url( 'admin.php?page=wc-admin' ), $this->disabler->redirected_to );
 
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Verify that editing an individual subscription is blocked.
+	 */
+	public function test_maybe_block_admin_subscription_edit_screen() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		// Test with CPT edit screen.
+		set_current_screen( 'shop_subscription' );
+
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertSame(
+			admin_url( 'admin.php?page=wc-admin' ),
+			$this->disabler->redirected_to,
+			'Should block editing individual subscriptions (CPT)'
+		);
+
+		// Reset for next test.
+		$this->disabler->redirected_to = null;
+
+		// Test with HPOS edit screen.
+		set_current_screen( 'wc-orders--shop_subscription' );
+
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertSame(
+			admin_url( 'admin.php?page=wc-admin' ),
+			$this->disabler->redirected_to,
+			'Should block editing individual subscriptions (HPOS)'
+		);
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Verify that direct post.php?post=X&action=edit URLs are blocked for subscriptions.
+	 */
+	public function test_block_subscription_edit_via_post_id() {
+		if ( ! class_exists( 'WC_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Subscription class not available.' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		// Create a mock subscription post.
+		$subscription_id = $this->factory->post->create(
+			[
+				'post_type'   => 'shop_subscription',
+				'post_status' => 'publish',
+			]
+		);
+
+		// Simulate accessing the edit screen via post ID.
+		$_GET['post']   = $subscription_id;
+		$_GET['action'] = 'edit';
+
+		set_current_screen( 'shop_subscription' );
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertSame(
+			admin_url( 'admin.php?page=wc-admin' ),
+			$this->disabler->redirected_to,
+			'Should block editing subscription via direct post ID URL'
+		);
+
+		// Clean up.
+		unset( $_GET['post'], $_GET['action'] );
+		wp_delete_post( $subscription_id, true );
 		set_current_screen( 'front' );
 	}
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -125,6 +125,60 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensure subscription WooCommerce settings tab is removed.
+	 */
+	public function test_filter_settings_tabs_removes_subscription_tab() {
+		$tabs = [
+			'general'       => 'General',
+			'subscriptions' => 'Subscriptions',
+			'payments'      => 'Payments',
+		];
+
+		$result = $this->disabler->filter_settings_tabs( $tabs );
+
+		$this->assertArrayHasKey( 'general', $result );
+		$this->assertArrayHasKey( 'payments', $result );
+		$this->assertArrayNotHasKey( 'subscriptions', $result );
+	}
+
+	/**
+	 * Ensure direct navigation to the subscriptions settings tab is redirected.
+	 */
+	public function test_maybe_redirect_settings_tab_redirects_subscription_tab() {
+		$_GET['page'] = 'wc-settings';
+		$_GET['tab']  = 'subscriptions';
+
+		$this->disabler->maybe_redirect_settings_tab();
+
+		$this->assertSame(
+			add_query_arg(
+				[
+					'page' => 'wc-settings',
+					'tab'  => 'general',
+				],
+				admin_url( 'admin.php' )
+			),
+			$this->disabler->redirected_to
+		);
+
+		unset( $_GET['page'], $_GET['tab'] );
+	}
+
+	/**
+	 * Ensure non-subscription tabs ignore settings redirect logic.
+	 */
+	public function test_maybe_redirect_settings_tab_ignores_other_tabs() {
+		$_GET['page'] = 'wc-settings';
+		$_GET['tab']  = 'payments';
+
+		$this->disabler->maybe_redirect_settings_tab();
+
+		$this->assertNull( $this->disabler->redirected_to );
+
+		unset( $_GET['page'], $_GET['tab'] );
+	}
+
+	/**
 	 * Verify that admin subscription screens are redirected away.
 	 */
 	public function test_maybe_block_admin_subscription_screen_redirects() {

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -759,4 +759,72 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 
 		unset( $_GET['wcpay_subscription_disabled'], $_GET['page'] );
 	}
+
+	/**
+	 * Verify that subscription products cannot be purchased.
+	 */
+	public function test_make_subscription_products_unpurchasable() {
+		if ( ! class_exists( 'WC_Product_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Product_Subscription class not available.' );
+		}
+
+		$this->disabler->init_hooks();
+
+		// Create subscription product.
+		$subscription_product = new WC_Product_Subscription();
+		$subscription_product->set_props(
+			[
+				'name'          => 'Test Subscription',
+				'regular_price' => 10,
+				'price'         => 10,
+			]
+		);
+		$subscription_product->save();
+
+		// Verify subscription product is not purchasable.
+		$this->assertFalse(
+			$subscription_product->is_purchasable(),
+			'Subscription product should not be purchasable'
+		);
+
+		// Verify regular products are still purchasable.
+		$regular_product = WC_Helper_Product::create_simple_product();
+		$this->assertTrue(
+			$regular_product->is_purchasable(),
+			'Regular products should still be purchasable'
+		);
+
+		// Cleanup.
+		wp_delete_post( $subscription_product->get_id(), true );
+		wp_delete_post( $regular_product->get_id(), true );
+	}
+
+	/**
+	 * Verify that variable subscription products cannot be purchased.
+	 */
+	public function test_make_variable_subscription_products_unpurchasable() {
+		if ( ! class_exists( 'WC_Product_Variable_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Product_Variable_Subscription class not available.' );
+		}
+
+		$this->disabler->init_hooks();
+
+		// Create variable subscription product.
+		$variable_subscription = new WC_Product_Variable_Subscription();
+		$variable_subscription->set_props(
+			[
+				'name' => 'Test Variable Subscription',
+			]
+		);
+		$variable_subscription->save();
+
+		// Verify variable subscription is not purchasable.
+		$this->assertFalse(
+			$variable_subscription->is_purchasable(),
+			'Variable subscription product should not be purchasable'
+		);
+
+		// Cleanup.
+		wp_delete_post( $variable_subscription->get_id(), true );
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -827,4 +827,140 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 		// Cleanup.
 		wp_delete_post( $variable_subscription->get_id(), true );
 	}
+
+	/**
+	 * Verify that subscription products are filtered from admin product search.
+	 */
+	public function test_filter_admin_product_search() {
+		if ( ! class_exists( 'WC_Product_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Product_Subscription class not available.' );
+		}
+
+		$this->disabler->init_hooks();
+
+		// Create subscription product.
+		$subscription_product = new WC_Product_Subscription();
+		$subscription_product->set_props(
+			[
+				'name'          => 'Test Subscription',
+				'regular_price' => 10,
+				'price'         => 10,
+			]
+		);
+		$subscription_product->save();
+
+		// Create regular product.
+		$regular_product = WC_Helper_Product::create_simple_product();
+
+		// Simulate product search results containing both products.
+		$search_results = [
+			$subscription_product->get_id() => 'Test Subscription',
+			$regular_product->get_id()      => $regular_product->get_name(),
+		];
+
+		// Apply filter.
+		$filtered_results = $this->disabler->filter_admin_product_search( $search_results );
+
+		// Verify subscription product is removed.
+		$this->assertArrayNotHasKey(
+			$subscription_product->get_id(),
+			$filtered_results,
+			'Subscription product should be removed from search results'
+		);
+
+		// Verify regular product remains.
+		$this->assertArrayHasKey(
+			$regular_product->get_id(),
+			$filtered_results,
+			'Regular product should remain in search results'
+		);
+
+		// Cleanup.
+		wp_delete_post( $subscription_product->get_id(), true );
+		wp_delete_post( $regular_product->get_id(), true );
+	}
+
+	/**
+	 * Verify that adding subscription products to admin orders is blocked with validation error.
+	 */
+	public function test_validate_admin_order_item_blocks_subscriptions() {
+		if ( ! class_exists( 'WC_Product_Subscription' ) ) {
+			$this->markTestSkipped( 'WC_Product_Subscription class not available.' );
+		}
+
+		$this->disabler->init_hooks();
+
+		// Create subscription product.
+		$subscription_product = new WC_Product_Subscription();
+		$subscription_product->set_props(
+			[
+				'name'          => 'Test Subscription',
+				'regular_price' => 10,
+				'price'         => 10,
+			]
+		);
+		$subscription_product->save();
+
+		// Create mock order.
+		$order = WC_Helper_Order::create_order();
+
+		// Attempt to validate adding subscription to order.
+		$validation_error = new WP_Error();
+		$result           = $this->disabler->validate_admin_order_item(
+			$validation_error,
+			$subscription_product,
+			$order,
+			1
+		);
+
+		// Verify error is returned.
+		$this->assertInstanceOf( 'WP_Error', $result, 'Should return WP_Error for subscription products' );
+		$this->assertEquals(
+			'subscription_not_allowed_in_admin_order',
+			$result->get_error_code(),
+			'Error code should match'
+		);
+		$this->assertStringContainsString(
+			'Subscription products cannot be added to orders',
+			$result->get_error_message(),
+			'Error message should explain why subscription cannot be added'
+		);
+
+		// Cleanup.
+		wp_delete_post( $subscription_product->get_id(), true );
+		wp_delete_post( $order->get_id(), true );
+	}
+
+	/**
+	 * Verify that regular products pass admin order validation.
+	 */
+	public function test_validate_admin_order_item_allows_regular_products() {
+		$this->disabler->init_hooks();
+
+		// Create regular product.
+		$regular_product = WC_Helper_Product::create_simple_product();
+
+		// Create mock order.
+		$order = WC_Helper_Order::create_order();
+
+		// Attempt to validate adding regular product to order.
+		$validation_error = new WP_Error();
+		$result           = $this->disabler->validate_admin_order_item(
+			$validation_error,
+			$regular_product,
+			$order,
+			1
+		);
+
+		// Verify no error is returned (should return the original empty WP_Error).
+		$this->assertInstanceOf( 'WP_Error', $result, 'Should return WP_Error object' );
+		$this->assertEmpty(
+			$result->get_error_codes(),
+			'Should not have any error codes for regular products'
+		);
+
+		// Cleanup.
+		wp_delete_post( $regular_product->get_id(), true );
+		wp_delete_post( $order->get_id(), true );
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Class WC_Payments_Subscriptions_Disabler_Test
+ *
+ * @package WooPayments
+ */
+
+/**
+ * WC_Payments_Subscriptions_Disabler unit tests.
+ */
+class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Test double that allows intercepting redirects.
+	 *
+	 * @var WC_Payments_Subscriptions_Disabler
+	 */
+	private $disabler;
+
+	/**
+	 * Creates the test double for the disabler.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		require_once WCPAY_ABSPATH . 'includes/subscriptions/class-wc-payments-subscriptions-disabler.php';
+
+		if ( ! class_exists( 'WP_Screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+		}
+
+		$this->disabler = new class() extends WC_Payments_Subscriptions_Disabler {
+			/**
+			 * Captured redirect destination.
+			 *
+			 * @var string|null
+			 */
+			public $redirected_to = null;
+
+			/**
+			 * Flag indicating whether account endpoint check should pass.
+			 *
+			 * @var bool
+			 */
+			private $should_match_endpoint = false;
+
+			/**
+			 * Override redirect to capture destination instead of exiting.
+			 *
+			 * @param string $target Target URL.
+			 * @return void
+			 */
+			protected function redirect( $target ) {
+				$this->redirected_to = $target;
+			}
+
+			/**
+			 * Allow tests to toggle endpoint matching.
+			 *
+			 * @param bool $value Whether endpoint should be treated as matched.
+			 * @return void
+			 */
+			public function set_should_match_endpoint( $value ) {
+				$this->should_match_endpoint = (bool) $value;
+			}
+
+			/**
+			 * Override endpoint matcher.
+			 *
+			 * @param string $endpoint Endpoint slug.
+			 * @return bool
+			 */
+			protected function is_endpoint_url( $endpoint ) {
+				unset( $endpoint );
+
+				return $this->should_match_endpoint;
+			}
+		};
+	}
+
+	/**
+	 * Reset redirect capture after each test.
+	 */
+	public function tear_down() {
+		$this->disabler->redirected_to = null;
+		$this->disabler->set_should_match_endpoint( false );
+		parent::tear_down();
+	}
+
+	/**
+	 * Ensure the account menu subscriptions entry is removed.
+	 */
+	public function test_remove_account_menu_item_removes_subscription_entry() {
+		update_option( 'woocommerce_myaccount_subscriptions_endpoint', 'subscriptions' );
+
+		$menu_items = [
+			'dashboard'     => 'Dashboard',
+			'orders'        => 'Orders',
+			'subscriptions' => 'Subscriptions',
+		];
+
+		$filtered_items = $this->disabler->remove_account_menu_item( $menu_items );
+
+		$this->assertArrayNotHasKey( 'subscriptions', $filtered_items );
+		$this->assertSame( [ 'dashboard', 'orders' ], array_keys( $filtered_items ) );
+	}
+
+	/**
+	 * Ensure subscription product types are removed from selector.
+	 */
+	public function test_filter_product_type_selector_removes_subscription_types() {
+		$types = [
+			'simple'                => 'Simple product',
+			'subscription'          => 'Simple subscription',
+			'variable'              => 'Variable product',
+			'variable-subscription' => 'Variable subscription',
+		];
+
+		$result = $this->disabler->filter_product_type_selector( $types );
+
+		$this->assertArrayHasKey( 'simple', $result );
+		$this->assertArrayHasKey( 'variable', $result );
+		$this->assertArrayNotHasKey( 'subscription', $result );
+		$this->assertArrayNotHasKey( 'variable-subscription', $result );
+	}
+
+	/**
+	 * Verify that admin subscription screens are redirected away.
+	 */
+	public function test_maybe_block_admin_subscription_screen_redirects() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		set_current_screen( 'edit-shop_subscription' );
+
+		$screen = get_current_screen();
+
+		$this->disabler->maybe_block_admin_subscription_screen( $screen );
+
+		$this->assertSame( admin_url( 'admin.php?page=wc-admin' ), $this->disabler->redirected_to );
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Verify that accessing subscription endpoints on My Account redirects to the dashboard.
+	 */
+	public function test_maybe_redirect_account_endpoints_redirects_to_my_account_page() {
+		update_option( 'permalink_structure', '/%postname%/' );
+
+		$page_id = $this->factory->post->create(
+			[
+				'post_title'  => 'My account',
+				'post_name'   => 'my-account',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_option( 'woocommerce_myaccount_page_id', $page_id );
+		update_option( 'woocommerce_myaccount_subscriptions_endpoint', 'subscriptions' );
+
+		$account_url = get_permalink( $page_id );
+
+		// Simulate visiting the pretty permalinks endpoint.
+		$this->go_to( trailingslashit( $account_url ) . 'subscriptions/' );
+
+		$this->disabler->set_should_match_endpoint( true );
+
+		$this->disabler->maybe_redirect_account_endpoints();
+
+		$this->assertSame( $account_url, $this->disabler->redirected_to );
+	}
+}


### PR DESCRIPTION
Fixes #WOOPMNT-5367

This pull request hides all merchant and customer-facing subscription management features in WooPayments, while keeping backend renewal processing working as usual.

In practice, this means that existing subscriptions handled by Stripe Billing will continue to renew automatically, but new subscriptions can no longer be created or managed from the WooCommerce interface.

#### Why this change?
WooPayments previously included a small, built-in version of subscription functionality. To reduce overlap and simplify the experience, we’re now retiring these built-in features and recommending the dedicated WooCommerce Subscriptions extension instead.

This transition helps us focus WooPayments on providing a seamless payments experience, while ensuring that merchants who rely on subscriptions have access to the full feature set and flexibility offered by WooCommerce Subscriptions.

#### Changes proposed in this Pull Request

- New disabler class
- Integration into subscriptions initialization
- Unit tests

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test setup**
1. You should have existing active subscriptions to test:
  1. As a merchant, create a subscription product.
  2. As a shopper, complete a test purchase to create an active subscription.
2. Make sure you enable the bundle subscriptions feature flag in your test site. Go to WP Admin > WCPay Dev, check `Enable WCPay Subscriptions` and hit save. DO NOT enable the WooCommerce Subscriptions plugin.

**Hide WooCommerce > Subscriptions Page in wp-admin**
1. Log in as admin
2. Navigate to WooCommerce menu in wp-admin
3. Confirm "Subscriptions" submenu item is NOT visible under WooCommerce
4. Other WooCommerce menu items remain (Orders, Products, etc.)

<img width="339" height="261" alt="Screenshot 2025-10-20 at 18 52 22" src="https://github.com/user-attachments/assets/fa21abb9-e593-440c-aef3-9fd290fa5070" />|<img width="159" height="284" alt="Screenshot 2025-10-20 at 18 52 40" src="https://github.com/user-attachments/assets/95c7a502-971c-42aa-8294-1fca286869ec" />| 

**Direct URL Access Blocked (Custom Post Type)**
1. Attempt to access: `/wp-admin/edit.php?post_type=shop_subscription`
2. Note the redirect to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&wcpay_subscription_disabled=1`
3. No error messages displayed
4. User sees WooPayments settings page and this notice is displayed:
<img width="1104" height="109" alt="Screenshot 2025-10-28 at 11 46 22" src="https://github.com/user-attachments/assets/6bfc3a53-4ac4-4c3c-ab4a-31a33fd0b691" />


**Cannot Create Subscription Products**
1. Go to Products > Add New
2. Check the "Product type" dropdown
3. Confirm "Simple subscription" option is NOT present
4. Confirm "Variable subscription" option is NOT present
6. Confirm Regular product types still available (Simple, Variable, etc.)

<img width="477" height="304" alt="Screenshot 2025-10-20 at 19 00 02" src="https://github.com/user-attachments/assets/9582c483-0a67-46ff-8311-62a9361cd1d7" />

**Settings Tab Hidden**
1. Go to WooCommerce > Settings
2. Look through all available tabs
3. Confirm "Subscriptions" tab is NOT visible
4. Other tabs remain (General, Products, Shipping, etc.)

<img width="1083" height="113" alt="Screenshot 2025-10-20 at 19 10 19" src="https://github.com/user-attachments/assets/456f1ac9-82d1-4459-8e90-a9f23402aecb" />

**Direct Settings URL Blocked**
1. Attempt to access: `/wp-admin/admin.php?page=wc-settings&tab=subscriptions`
2. Note the redirect to: `/wp-admin/admin.php?page=wc-settings&tab=general`
3. Confirm General settings tab displayed and no error messages

**Cannot Edit Existing Subscriptions (List View)**
1. Create a test subscription (before checking out the branch)
2. Attempt to access: `/wp-admin/edit.php?post_type=shop_subscription`
3. Confirm you are redirected to WooPayments settings page and you cannot see the subscription list.

**Cannot Edit Existing Subscriptions (Single Edit)** 
1. Using a known subscription ID, attempt to access: `/wp-admin/post.php?post=[subscription_id]&action=edit`
2. Confirm you are redirected to WooPayments settings page

**My Account Menu Item Hidden**
1. Log in as a customer with an active subscription
2. Navigate to My Account page
3. Confirm "Subscriptions" link is NOT in the menu

<img width="1092" height="495" alt="Screenshot 2025-10-20 at 19 43 56" src="https://github.com/user-attachments/assets/ba10b674-7127-479b-a587-8ad1c9536b95" />

**Direct Subscriptions List URL Blocked**
1. While logged in as customer, attempt to access: `/my-account/subscriptions/`
2. Confirm you are redirected to to `/my-account/`

**Direct Subscription Detail URL Blocked**
1. Attempt to access: `/my-account/view-subscription/[subscription_id]/`
2. Confirm you are redirected to My Account dashboard

**Payment Method Change URL Blocked**
1. Attempt to access: `/my-account/subscription-payment-method/[subscription_id]/`
2. Confirm the redirect to My Account dashboard

**No Subscription Links in Orders**
1. Log in as customer
2. Go to My Account > Orders
3. Click on an order that created a subscription
4. View the order details page
5. Confirm "Related Subscriptions" section is NOT displayed
7. Order details should show normally

<img width="750" height="699" alt="Screenshot 2025-10-20 at 19 57 26" src="https://github.com/user-attachments/assets/3b17baab-8e92-4de0-a063-9de2d2e704ae" />

**Admin Order View (Customer Perspective)**
1. As admin, view an order in wp-admin that has a related subscription
2. Check for "Related Subscriptions" meta box
3. Confirm "Related Subscriptions" section is removed

**Automated Renewal Processing (Webhook-Based)**
Note: I could not make this work on my local, only with JN.
1. Identify an active subscription. Note the number of renewal orders in WooCommerce
2. In Stripe Dashboard (test mode), locate the subscription and click it
3. Locate a "Start Simulation" button on the top right corner of the sceen and click it.
4. Use the modal that appears to advance time to the scheduled renewal (Sometimes I had to add one or two more days)
5. Confirm new renewal order created in the test site
6. Confirm renewal order marked as "Processing"
8. Customer receives order confirmation email

<img width="281" height="181" alt="Screenshot 2025-10-23 at 18 22 47" src="https://github.com/user-attachments/assets/9dd09f4c-71d2-4591-81c5-e3b712d5763d" />



**Failed Renewal Handling** 
1.  Create a test subscription with valid payment method (using a different branch)
2. Change the payment method of the subscription to an invalid payment method (`4000 0000 0000 0341`works for this purpose) or manually fail an invoice in Stripe Dashboard
3. Trigger renewal in Stripe using the simulation tool described in the previous step
4. Confirm renewal order created (in "Failed" status)
5. Subscription status updated (On hold)
6. Customer receives failed payment notification
7. Order notes reflect failure reason

<img width="295" height="500" alt="Screenshot 2025-10-23 at 18 21 55" src="https://github.com/user-attachments/assets/821702d2-f15f-4a1b-b486-44315abcee1e" />

**Prevent creation of new bundled subscription orders (Shopper)**
1. As a shopper, navigate to the product list in the Shop page
2. Locate a subscription product in the list
3. Confirm the 'Add to Cart' button is not available, only the Read More button.
4. Navigate to the product details page of a subscription product
5. Confirm the product cannot be added to the cart.

<img width="411" height="481" alt="Screenshot 2025-10-27 at 10 45 22" src="https://github.com/user-attachments/assets/c08d83d1-604b-44f7-b114-4e01fb21ee32" />

**Prevent creation of new bundled subscription orders (Merchant)**
1. As a merchant, navigate to WooCommerce > Orders and click the `Add Order`
2. Click `Add Item` and then `Add Product`
3. Confirm the bundled subscription product does not show up on the `Add Products` modal search.

**Prevent enabling bundled subscriptions feature (Merchant)**
1. Navigate to Payments > Settings > Advanced settings
2. Locate the "WooPayments Subscriptions" toggle (should be ON/enabled)
3. Toggle the switch OFF and save settings
4. Confirm settings save successfully.
5. Try to toggle the switch back ON
6. Confirm the checkbox appears disabled out and cannot be turned back ON
7. Help text shows: "This feature has been deprecated. To manage subscriptions, please install WooCommerce Subscriptions."

<img width="986" height="182" alt="Screenshot 2025-10-28 at 11 53 23" src="https://github.com/user-attachments/assets/0aa07cad-4776-4e5c-9495-b22db365b334" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-10.2.0#turn-off-bundled-subscription-features
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
