### PR TITLE
New AccountDetals: Remove the payout icon status

### DIFF
--- a/changelog/update-remove-payout-status-icon
+++ b/changelog/update-remove-payout-status-icon
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: New Account Details: Remove the payout icon status to be consistent with account status (without icon)
+
+

--- a/client/components/account-details/__tests__/index.test.tsx
+++ b/client/components/account-details/__tests__/index.test.tsx
@@ -47,7 +47,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Available',
 				background_color: 'green',
-				icon: 'published',
 			},
 			banner: null,
 		};
@@ -70,7 +69,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Disabled',
 				background_color: 'red',
-				icon: 'error',
 			},
 			banner: {
 				text: 'Your account has been restricted by Stripe.',
@@ -98,7 +96,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Disabled',
 				background_color: 'red',
-				icon: 'error',
 			},
 			banner: {
 				text: 'Your account has been rejected.',
@@ -127,7 +124,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Available in 2 days',
 				background_color: 'yellow',
-				icon: 'caution',
 				popover: {
 					text: 'Payouts are processed within 2 business days.',
 					cta_text: 'Learn more',
@@ -154,7 +150,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Available',
 				background_color: 'green',
-				icon: 'published',
 			},
 			banner: null,
 		};
@@ -180,7 +175,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Available',
 				background_color: 'green',
-				icon: 'published',
 			},
 			banner: null,
 		};
@@ -206,7 +200,6 @@ describe( 'AccountDetails', () => {
 			payout_status: {
 				text: 'Available',
 				background_color: 'green',
-				icon: 'published',
 			},
 			banner: null,
 		};

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Card, CardBody, CardHeader, Flex } from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/client/components/account-details/payout-status-wrapper.tsx
+++ b/client/components/account-details/payout-status-wrapper.tsx
@@ -23,11 +23,7 @@ const PayoutStatus: React.FC< {
 
 	return (
 		<Flex align="center" gap={ 0 } justify="flex-start">
-			<Chip
-				type={ chipType }
-				message={ payoutStatus.text }
-				icon={ getIconByName( payoutStatus.icon ) }
-			/>
+			<Chip type={ chipType } message={ payoutStatus.text } />
 			{ payoutStatus.popover && (
 				<ClickTooltip
 					className={ 'payout-click-tooltip' }

--- a/client/components/account-details/payout-status-wrapper.tsx
+++ b/client/components/account-details/payout-status-wrapper.tsx
@@ -14,7 +14,7 @@ import HelpOutlineIcon from 'gridicons/dist/help-outline';
 import Chip from 'wcpay/components/chip';
 import { ClickTooltip } from 'wcpay/components/tooltip';
 import { AccountDetailsData } from 'wcpay/types/account/account-details';
-import { getChipTypeFromColor, getIconByName } from './utils';
+import { getChipTypeFromColor } from './utils';
 
 const PayoutStatus: React.FC< {
 	payoutStatus: AccountDetailsData[ 'payout_status' ];

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -18,8 +18,8 @@ export interface AccountDetailsData {
 		background_color: StatusBackgroundColor;
 		popover?: {
 			text: string;
-			cta_text: string;
-			cta_link: string;
+			cta_text?: string;
+			cta_link?: string;
 		} | null;
 	};
 	banner?: {

--- a/client/types/account/account-details.d.ts
+++ b/client/types/account/account-details.d.ts
@@ -16,7 +16,6 @@ export interface AccountDetailsData {
 	payout_status: {
 		text: string;
 		background_color: StatusBackgroundColor;
-		icon?: IconName;
 		popover?: {
 			text: string;
 			cta_text: string;


### PR DESCRIPTION
Fixes WOOPMNT-5384

#### Changes proposed in this Pull Request

- This simply removes the payout status icon based on the design's decision. See the Linear isuse. 
- Clean up all places are using `payout_status.icon` property.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use this script, zip it and upload as a plugin in your testing site https://gist.github.com/htdat/7739a89568f8472d236f72c52387c07b 
* Go to WP Admin > Tools > Simulate WooPayments Status
 or directly http://localhost:8082/wp-admin/tools.php?page=WooPayments_New_Account_Details_Simulator
* Apply different options (at least two first options) and confirm things look good at WP Admin -> WooPayments -> Overview 

<img width="2916" height="920" alt="Screen Shot on 2025-11-05 at 14:34:18" src="https://github.com/user-attachments/assets/8605f4cd-ee11-48b2-8884-de5046c910a0" />
(Note: please ignore the text content, which is just for the testing purpose, please focus more on design). 


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
