### PR TITLE
Simplify Free Shipping Currency Conversion

### DIFF
--- a/changelog/woopmnt-5332-wc_shipping_zonesget_zones-gets-called-on-every-page-load
+++ b/changelog/woopmnt-5332-wc_shipping_zonesget_zones-gets-called-on-every-page-load
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Avoid loading shipping zones when adjusting currencies for free shipping methods.

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -65,7 +65,7 @@ class FrontendPrices {
 		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ], 99 );
 
 		// Shipping methods hooks.
-		add_action( 'init', [ $this, 'register_free_shipping_filters' ], 99 );
+		add_action( 'woocommerce_shipping_zone_shipping_methods', [ $this, 'convert_free_shipping_method_min_amount' ], 99 );
 		add_filter( 'woocommerce_shipping_method_add_rate_args', [ $this, 'convert_shipping_method_rate_cost' ], 99 );
 
 		// Coupon hooks.
@@ -336,42 +336,20 @@ class FrontendPrices {
 	}
 
 	/**
-	 * Returns the free shipping zone settings with converted min_amount.
+	 * Converts the min_amount of free shipping methods.
 	 *
-	 * @param array $data The shipping zone settings.
-	 *
-	 * @return array The shipping zone settings with converted min_amount.
+	 * @param array $methods The shipping methods.
 	 */
-	public function get_free_shipping_min_amount( $data ) {
-		if ( empty( $data['min_amount'] ) ) {
-			return $data;
-		}
-
-		// Free shipping min amount is treated as products to avoid inconsistencies with charm pricing
-		// making a method invalid when its min amount is the same as the product's price.
-		$data['min_amount'] = $this->multi_currency->get_price( $data['min_amount'], 'product' );
-		return $data;
-	}
-
-	/**
-	 * Register the hooks to set the min amount for free shipping methods.
-	 */
-	public function register_free_shipping_filters() {
-		$shipping_zones = \WC_Shipping_Zones::get_zones();
-
-		$default_zone = \WC_Shipping_Zones::get_zone( 0 );
-		if ( $default_zone ) {
-			$shipping_zones[] = [ 'shipping_methods' => $default_zone->get_shipping_methods() ];
-		}
-
-		foreach ( $shipping_zones as $shipping_zone ) {
-			foreach ( $shipping_zone['shipping_methods'] as $shipping_method ) {
-				if ( 'free_shipping' === $shipping_method->id ) {
-					$option_name = 'option_woocommerce_' . trim( $shipping_method->id ) . '_' . (int) $shipping_method->instance_id . '_settings';
-					add_filter( $option_name, [ $this, 'get_free_shipping_min_amount' ], 99 );
-				}
+	public function convert_free_shipping_method_min_amount( $methods ) {
+		foreach ( $methods as $method ) {
+			// Free shipping min amount is treated as products to avoid inconsistencies with charm pricing
+			// making a method invalid when its min amount is the same as the product's price.
+			if ( 'free_shipping' === $method->id && ! empty( $method->min_amount ) ) {
+				$method->min_amount = $this->multi_currency->get_price( $method->min_amount, 'product' );
 			}
 		}
+
+		return $methods;
 	}
 
 	/**

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -89,7 +89,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 		];
 	}
 
-	public function test_converts_free_shipping_method_min_amount() {
+	public function test_convert_free_shipping_method_min_amount() {
 		// Add multiple shipping methods to the default zone.
 		$default_zone = \WC_Shipping_Zones::get_zone( 0 );
 		$default_zone->add_shipping_method( 'flat_rate' );
@@ -115,7 +115,13 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 		$methods = $default_zone->get_shipping_methods();
 
 		$this->assertCount( 2, $methods );
-		$this->assertEquals( 25.0, $methods[ $free_shipping_id ]->min_amount );
+
+		$test_gateway = $methods[ $free_shipping_id ];
+		$this->assertInstanceOf( \WC_Shipping_Free_Shipping::class, $test_gateway );
+		$this->assertEquals( 25.0, $test_gateway->min_amount );
+
+		// Make sure it doesn't change the gateway's settings directly.
+		$this->assertEquals( 10.0, $test_gateway->instance_settings['min_amount'] );
 	}
 
 	public function test_get_product_price_returns_empty_price() {

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -347,20 +347,6 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 		$this->assertSame( 12.5, $this->frontend_prices->get_coupon_min_max_amount( '5.0' ) );
 	}
 
-	public function test_get_free_shipping_min_amount_returns_empty_amount() {
-		$this->assertSame( [ 'key' => 'value' ], $this->frontend_prices->get_free_shipping_min_amount( [ 'key' => 'value' ] ) );
-	}
-
-	public function test_get_free_shipping_min_amount_returns_zero_amount() {
-		$this->assertSame( [ 'min_amount' => '0' ], $this->frontend_prices->get_free_shipping_min_amount( [ 'min_amount' => '0' ] ) );
-	}
-
-	public function test_get_free_shipping_min_amount_converts_amount_as_product() {
-		$this->mock_multi_currency->method( 'get_price' )->with( 5.0, 'product' )->willReturn( 12.5 );
-
-		$this->assertSame( [ 'min_amount' => 12.5 ], $this->frontend_prices->get_free_shipping_min_amount( [ 'min_amount' => '5.0' ] ) );
-	}
-
 	public function test_add_order_meta_skips_default_currency() {
 		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( new WCPay\MultiCurrency\Currency( $this->localization_service, 'USD' ) );
 

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -81,7 +81,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 			[ 'woocommerce_variation_prices', 'get_variation_price_range' ],
 			[ 'woocommerce_get_variation_prices_hash', 'add_exchange_rate_to_variation_prices_hash' ],
 			[ 'woocommerce_shipping_method_add_rate_args', 'convert_shipping_method_rate_cost' ],
-			[ 'init', 'register_free_shipping_filters' ],
+			[ 'woocommerce_shipping_zone_shipping_methods', 'convert_free_shipping_method_min_amount' ],
 			[ 'woocommerce_coupon_get_amount', 'get_coupon_amount' ],
 			[ 'woocommerce_coupon_get_minimum_amount', 'get_coupon_min_max_amount' ],
 			[ 'woocommerce_coupon_get_maximum_amount', 'get_coupon_min_max_amount' ],
@@ -89,18 +89,33 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 		];
 	}
 
-	public function test_registers_woocommerce_filters_for_free_shipping_methods() {
-		// Add a free shipping method to the default zone.
-		$default_zone_free_method = \WC_Shipping_Zones::get_zone( 0 )->add_shipping_method( 'free_shipping' );
+	public function test_converts_free_shipping_method_min_amount() {
+		// Add multiple shipping methods to the default zone.
+		$default_zone = \WC_Shipping_Zones::get_zone( 0 );
+		$default_zone->add_shipping_method( 'flat_rate' );
+		$free_shipping_id     = $default_zone->add_shipping_method( 'free_shipping' );
+		$free_shipping_method = \WC_Shipping_Zones::get_shipping_method( $free_shipping_id );
+		$this->assertNotNull( $free_shipping_method );
 
-		// Create a new shipping zone and shipping method.
-		$new_zone             = new WC_Shipping_Zone();
-		$new_zone_free_method = $new_zone->add_shipping_method( 'free_shipping' );
+		// Set a min_amount to be converted.
+		$free_shipping_method->instance_settings['min_amount'] = 10.0;
+		update_option(
+			$free_shipping_method->get_instance_option_key(),
+			$free_shipping_method->instance_settings,
+			'yes'
+		);
 
-		$this->frontend_prices->register_free_shipping_filters();
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'get_price' )
+			->with( 10.0, 'product' )
+			->willReturn( 25.0 );
 
-		$this->assertGreaterThan( 98, has_filter( 'option_woocommerce_free_shipping_' . $default_zone_free_method . '_settings', [ $this->frontend_prices, 'get_free_shipping_min_amount' ] ) );
-		$this->assertGreaterThan( 98, has_filter( 'option_woocommerce_free_shipping_' . $new_zone_free_method . '_settings', [ $this->frontend_prices, 'get_free_shipping_min_amount' ] ) );
+		// The filter should be registered when the zone's shipping methods are retrieved.
+		$methods = $default_zone->get_shipping_methods();
+
+		$this->assertCount( 2, $methods );
+		$this->assertEquals( 25.0, $methods[ $free_shipping_id ]->min_amount );
 	}
 
 	public function test_get_product_price_returns_empty_price() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Right now, we are loading all of the shipping zones on every frontend request. This is done so that multi-currency is able to convert the `min_price` to match the other currency conversions. WooCommerce provides a `woocommerce_shipping_zone_shipping_methods` filter that allows developers to modify the shipping methods before consumers are given access to them. This avoids loading the zones altogether.

##### Performance Increase

I tested using 15 shipping zones with a few options each including a free shipping method.

- `develop`: 0.0176s on _every frontend request_
- PR: 0.0001s on frontend requests when an item is in the cart

##### Possible Compatibility Issue

One thing about this PR is that it doesn't cover `WC_Shipping_Zones::get_shipping_method()` since there is no filter in place there. In my review, this method is only used to load it for editing the instance settings or otherwise checking things in a way that does not impact this filtering.

If we aren't comfortable with that risk, another approach we could take abuses the fact that `WC_Shipping_Free_Shipping::__construct()` ends up calling `get_option()` before any instance-specific code. We could attach a filter to that and register filters for the instance-specific price fetching. What we're doing now (filtering the instance settings) and this option could theoretically be persisted and doesn't feel like what we should be doing either though.

#### Testing instructions

1. Set up multi-currency with another currency set to a 1.5 scaling ratio.
2. Set up `min_amount` on a free shipping gateway and make it $20 USD.
3. Add an $18 item to the cart and confirm there is no free shipping.
4. Switch to the other currency and confirm that there is no free shipping. The cart total (in local currency) will be over the minimum numerical value of USD but will not be available because the converted total is too low.
5. Add a second item to the cart and confirm that free shipping is available in both currencies.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
