### PR TITLE
Changed `add_action` to `add_filter`

### DIFF
--- a/changelog/fix-11094-action-filter-change
+++ b/changelog/fix-11094-action-filter-change
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Just swapping `add_action` for `add_filter` in a previous PR. Does not change behavior.
+
+

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -65,7 +65,7 @@ class FrontendPrices {
 		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ], 99 );
 
 		// Shipping methods hooks.
-		add_action( 'woocommerce_shipping_zone_shipping_methods', [ $this, 'convert_free_shipping_method_min_amount' ], 99 );
+		add_filter( 'woocommerce_shipping_zone_shipping_methods', [ $this, 'convert_free_shipping_method_min_amount' ], 99 );
 		add_filter( 'woocommerce_shipping_method_add_rate_args', [ $this, 'convert_shipping_method_rate_cost' ], 99 );
 
 		// Coupon hooks.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #11094, I mistakenly left behind `add_action` when switching to a filter. This updates that `add_action` to be correct. This didn't cause any issues in the original PR so it went unnoticed.

#### Testing instructions

You _can_ follow the testing instructions from the original PR, however, there is a unit test covering this behavior and it might not be necessary since it's just a action -> filter registration change:

1. Set up multi-currency with another currency set to a 1.5 scaling ratio.
2. Set up `min_amount` on a free shipping gateway and make it $20 USD.
3. Add an $18 item to the cart and confirm there is no free shipping.
4. Switch to the other currency and confirm that there is no free shipping. The cart total (in local currency) will be over the minimum numerical value of USD but will not be available because the converted total is too low.
5. Add a second item to the cart and confirm that free shipping is available in both currencies.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
