### PR TITLE
Show WooPay error message only on connection errors

### DIFF
--- a/changelog/fix-woopay-email-input-error-message-connection-only
+++ b/changelog/fix-woopay-email-input-error-message-connection-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only show WooPay error messages on connection errors.

--- a/changelog/fix-woopay-email-input-error-message-connection-only
+++ b/changelog/fix-woopay-email-input-error-message-connection-only
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Only show WooPay error messages on connection errors.
+Only show WooPay error messages for connection errors in available countries.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -231,11 +231,11 @@ export const handleWooPayEmailInput = async (
 
 	// Error message to display when there's an error contacting WooPay.
 	const errorMessage = document.createElement( 'div' );
-	errorMessage.style[ 'white-space' ] = 'normal';
 	errorMessage.textContent = __(
 		'WooPay is unavailable at this time. Please complete your checkout below. Sorry for the inconvenience.',
 		'woocommerce-payments'
 	);
+	errorMessage.classList.add( 'wc-block-checkout__guest-checkout-notice' );
 
 	const closeIframe = ( focus = true ) => {
 		window.removeEventListener( 'resize', getWindowSize );
@@ -273,7 +273,7 @@ export const handleWooPayEmailInput = async (
 		urlParams.append( 'is_blocks', isBlocksCheckout ? 'true' : 'false' );
 		urlParams.append(
 			'source_url',
-			wcSettings?.storePages?.checkout?.permalink
+			window.wcSettings?.storePages?.checkout?.permalink
 		);
 		urlParams.append(
 			'viewport',
@@ -298,7 +298,9 @@ export const handleWooPayEmailInput = async (
 	};
 
 	const showErrorMessage = () => {
-		parentDiv.insertBefore( errorMessage, woopayEmailInput.nextSibling );
+		const node = isBlocksCheckout ? parentDiv.parentNode : parentDiv;
+
+		node.insertBefore( errorMessage, null );
 	};
 
 	document.addEventListener( 'keyup', ( event ) => {
@@ -344,8 +346,8 @@ export const handleWooPayEmailInput = async (
 	const woopayLocateUser = async ( email, shouldOpenIframe = true ) => {
 		parentDiv.insertBefore( spinner, woopayEmailInput );
 
-		if ( parentDiv.contains( errorMessage ) ) {
-			parentDiv.removeChild( errorMessage );
+		if ( parentDiv.parentNode.contains( errorMessage ) ) {
+			parentDiv.parentNode.removeChild( errorMessage );
 		}
 
 		recordUserEvent( 'checkout_email_address_woopay_check' );
@@ -429,12 +431,16 @@ export const handleWooPayEmailInput = async (
 				}
 			} )
 			.catch( ( err ) => {
-				// Only show the error if it's not an AbortError,
-				// it occur when the fetch request is aborted because user
-				// clicked the Place Order button while loading.
-				if ( err.name !== 'AbortError' ) {
-					showErrorMessage();
+				// Only show the error if it's a connection related error
+				// connecting to WooPay.
+				if (
+					! window.wcpayConfig.woopayIsCountryAvailable ||
+					err.name !== 'TypeError'
+				) {
+					return;
 				}
+
+				showErrorMessage();
 			} )
 			.finally( () => {
 				spinner.remove();

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -346,8 +346,10 @@ export const handleWooPayEmailInput = async (
 	const woopayLocateUser = async ( email, shouldOpenIframe = true ) => {
 		parentDiv.insertBefore( spinner, woopayEmailInput );
 
-		if ( parentDiv.parentNode.contains( errorMessage ) ) {
-			parentDiv.parentNode.removeChild( errorMessage );
+		const node = isBlocksCheckout ? parentDiv.parentNode : parentDiv;
+
+		if ( node.contains( errorMessage ) ) {
+			node.removeChild( errorMessage );
 		}
 
 		recordUserEvent( 'checkout_email_address_woopay_check' );

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -156,11 +156,12 @@ class WC_Payments_WooPay_Button_Handler {
 	public function add_woopay_config( $config ) {
 		$user = wp_get_current_user();
 
-		$config['woopayButton']           = $this->get_button_settings();
-		$config['woopayButtonNonce']      = wp_create_nonce( 'woopay_button_nonce' );
-		$config['addToCartNonce']         = wp_create_nonce( 'wcpay-add-to-cart' );
-		$config['shouldShowWooPayButton'] = $this->should_show_woopay_button();
-		$config['woopaySessionEmail']     = WooPay_Session::get_user_email( $user );
+		$config['woopayButton']             = $this->get_button_settings();
+		$config['woopayButtonNonce']        = wp_create_nonce( 'woopay_button_nonce' );
+		$config['addToCartNonce']           = wp_create_nonce( 'wcpay-add-to-cart' );
+		$config['shouldShowWooPayButton']   = $this->should_show_woopay_button();
+		$config['woopaySessionEmail']       = WooPay_Session::get_user_email( $user );
+		$config['woopayIsCountryAvailable'] = $this->woopay_utilities->is_country_available( $this->gateway );
 
 		return $config;
 	}


### PR DESCRIPTION
Fixes WOOPAY-390
Fixes WOOPAY-391

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
There are cases where the WooPay error messages are displayed when an unrelated error occur, for example `wcSettings` not being available because of an issue on the store theme.

This PR modifies the error message to be displayed only when there's a error while connecting to WooPay, and only if the request comes from a country that WooPay is available.

This PR also fixes the error message not being correctly displayed on recent blocks checkout versions.

| Before | After |
|-|-|
| <img width="507" height="174" alt="Screenshot 2025-10-22 at 10 07 08 PM" src="https://github.com/user-attachments/assets/24ffc34c-9c16-4492-89a7-89fd979f7ed1" /> | <img width="505" height="204" alt="Screenshot 2025-10-22 at 10 47 17 PM" src="https://github.com/user-attachments/assets/72c53d6d-29d6-41c9-9e76-212dcbad8d0a" /> |

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add products to the cart.
* Access the blocks checkout page.
* Stop WooPay server.
* Enter a valid WooPay email address.
* The error message should be displayed.
* Set [this line](https://github.com/Automattic/woocommerce-payments/blob/120b634a923ea9702c8df88a6ba75dab5987d0de/includes/class-wc-payments-woopay-button-handler.php#L164) to `false`.
* Reload the checkout page.
* Enter a valid WooPay email address.
* No error message should be displayed.
* Undo the changes on [this line](https://github.com/Automattic/woocommerce-payments/blob/120b634a923ea9702c8df88a6ba75dab5987d0de/includes/class-wc-payments-woopay-button-handler.php#L164).
* Restart WooPay server.
* Modify [this line](https://github.com/Automattic/woocommerce-payments/blob/120b634a923ea9702c8df88a6ba75dab5987d0de/client/checkout/woopay/email-input-iframe.js#L276) to `invalid?.storePages?.checkout?.permalink`.
* Reload the checkout page.
* Enter a valid WooPay email address.
* No error message should be displayed.

Redo the tests with shortcode checkout.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
