### PR TITLE
Fix missing payment method logos (JCB, CUP, CB) in checkout

### DIFF
--- a/changelog/woopmnt-5353-missing-card-payment-logos
+++ b/changelog/woopmnt-5353-missing-card-payment-logos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing payment method logos (JCB, CUP, CB) in checkout.

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -2,37 +2,13 @@
  * Internal dependencies
  */
 import { PaymentMethodsLogos } from './payment-methods-logos';
-import Visa from 'assets/images/payment-method-icons/visa.svg?asset';
-import Mastercard from 'assets/images/payment-method-icons/mastercard.svg?asset';
-import Amex from 'assets/images/payment-method-icons/amex.svg?asset';
-import Discover from 'assets/images/payment-method-icons/discover.svg?asset';
+import { getCardBrands } from 'wcpay/utils/card-brands';
 import { useStripeForUPE } from 'wcpay/hooks/use-stripe-async';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import { __ } from '@wordpress/i18n';
 import './style.scss';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { getAppearance } from 'wcpay/checkout/upe-styles';
-
-const paymentMethods = [
-	{
-		name: 'visa',
-		component: Visa,
-	},
-	{
-		name: 'mastercard',
-		component: Mastercard,
-	},
-	{
-		name: 'amex',
-		component: Amex,
-	},
-	{
-		name: 'discover',
-		component: Discover,
-	},
-	// TODO: Missing Diners Club
-	// TODO: What other card payment methods should be here?
-];
 const breakpointConfigs = [
 	{ breakpoint: 550, maxElements: 2 },
 	{ breakpoint: 330, maxElements: 1 },
@@ -90,7 +66,7 @@ export default ( { api, title, iconLight, iconDark, upeName } ) => {
 			{ upeName === 'card' ? (
 				<PaymentMethodsLogos
 					maxElements={ 4 }
-					paymentMethods={ paymentMethods }
+					paymentMethods={ getCardBrands() }
 					breakpointConfigs={ breakpointConfigs }
 				/>
 			) : (

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -32,10 +32,7 @@ import { isPreviewing } from 'wcpay/checkout/preview';
 import { recordUserEvent } from 'tracks';
 import '../utils/copy-test-number';
 import { SHORTCODE_BILLING_ADDRESS_FIELDS } from '../constants';
-import Visa from 'assets/images/payment-method-icons/visa.svg?asset';
-import Mastercard from 'assets/images/payment-method-icons/mastercard.svg?asset';
-import Amex from 'assets/images/payment-method-icons/amex.svg?asset';
-import Discover from 'assets/images/payment-method-icons/discover.svg?asset';
+import { getCardBrands } from 'wcpay/utils/card-brands';
 
 jQuery( function ( $ ) {
 	enqueueFraudScripts( getUPEConfig( 'fraudServices' ) );
@@ -181,12 +178,7 @@ jQuery( function ( $ ) {
 		innerContainer.setAttribute( 'tabindex', '0' );
 		innerContainer.setAttribute( 'data-testid', 'payment-methods-logos' );
 
-		const paymentMethods = [
-			{ name: 'visa', component: Visa },
-			{ name: 'mastercard', component: Mastercard },
-			{ name: 'amex', component: Amex },
-			{ name: 'discover', component: Discover },
-		];
+		const paymentMethods = getCardBrands();
 
 		function getMaxElements() {
 			const paymentMethodElement = document.querySelector(

--- a/client/utils/__tests__/card-brands.test.js
+++ b/client/utils/__tests__/card-brands.test.js
@@ -1,0 +1,113 @@
+/**
+ * Jest environment configuration
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getCardBrands } from '../card-brands';
+import { getUPEConfig } from 'wcpay/utils/checkout';
+
+// Mock the getUPEConfig function
+jest.mock( 'wcpay/utils/checkout', () => ( {
+	getUPEConfig: jest.fn(),
+} ) );
+
+// Mock the global wcpaySettings will be set in each test
+
+describe( 'getCardBrands', () => {
+	test( 'returns base brands for non-France merchants', () => {
+		global.window.wcpaySettings = {
+			accountStatus: {
+				country: 'US',
+			},
+		};
+		// Mock getUPEConfig to return null
+		getUPEConfig.mockReturnValue( null );
+
+		const brands = getCardBrands();
+
+		// Should include the 4 base brands plus JCB and CUP
+		expect( brands ).toHaveLength( 6 );
+		expect( brands.map( ( b ) => b.name ) ).toEqual( [
+			'visa',
+			'mastercard',
+			'amex',
+			'discover',
+			'jcb',
+			'unionpay',
+		] );
+	} );
+
+	test( 'includes CB for France merchants', () => {
+		global.window.wcpaySettings = {
+			accountStatus: {
+				country: 'FR',
+			},
+		};
+		// Mock getUPEConfig to return France
+		getUPEConfig.mockReturnValue( 'FR' );
+
+		const brands = getCardBrands();
+
+		// Should include all brands including CB
+		expect( brands ).toHaveLength( 7 );
+		expect( brands.map( ( b ) => b.name ) ).toEqual( [
+			'visa',
+			'mastercard',
+			'amex',
+			'discover',
+			'jcb',
+			'unionpay',
+			'cartes_bancaires',
+		] );
+	} );
+
+	test( 'handles missing account status gracefully', () => {
+		global.window.wcpaySettings = {};
+		// Mock getUPEConfig to return null
+		getUPEConfig.mockReturnValue( null );
+
+		const brands = getCardBrands();
+
+		// Should still return base brands without CB
+		expect( brands ).toHaveLength( 6 );
+		expect( brands.map( ( b ) => b.name ) ).not.toContain(
+			'cartes_bancaires'
+		);
+	} );
+
+	test( 'handles missing wcpaySettings gracefully', () => {
+		global.window.wcpaySettings = undefined;
+		// Mock getUPEConfig to return null
+		getUPEConfig.mockReturnValue( null );
+
+		const brands = getCardBrands();
+
+		// Should still return base brands without CB
+		expect( brands ).toHaveLength( 6 );
+		expect( brands.map( ( b ) => b.name ) ).not.toContain(
+			'cartes_bancaires'
+		);
+	} );
+
+	test( 'uses UPE config storeCountry when wcpaySettings is not available', () => {
+		global.window.wcpaySettings = undefined;
+		// Mock getUPEConfig to return France for storeCountry
+		getUPEConfig.mockImplementation( ( key ) => {
+			if ( key === 'storeCountry' ) {
+				return 'FR';
+			}
+			return null;
+		} );
+
+		const brands = getCardBrands();
+
+		// Check if getUPEConfig was called
+		expect( getUPEConfig ).toHaveBeenCalledWith( 'storeCountry' );
+
+		// Should include CB for France
+		expect( brands ).toHaveLength( 7 );
+		expect( brands.map( ( b ) => b.name ) ).toContain( 'cartes_bancaires' );
+	} );
+} );

--- a/client/utils/card-brands.ts
+++ b/client/utils/card-brands.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import Visa from 'assets/images/payment-method-icons/visa.svg?asset';
+import Mastercard from 'assets/images/payment-method-icons/mastercard.svg?asset';
+import Amex from 'assets/images/payment-method-icons/amex.svg?asset';
+import Discover from 'assets/images/payment-method-icons/discover.svg?asset';
+import Jcb from 'assets/images/payment-method-icons/jcb.svg?asset';
+import UnionPay from 'assets/images/cards/unionpay.svg?asset';
+import Cartebancaire from 'assets/images/cards/cartes_bancaires.svg?asset';
+import { getUPEConfig } from 'wcpay/utils/checkout';
+
+/**
+ * Card brand object interface
+ */
+interface CardBrand {
+	name: string;
+	component: string;
+}
+
+/**
+ * Get card brands array for payment method logos display.
+ * Returns standard brands (Visa, MC, Amex, Discover) plus JCB, CUP, and CB (if France).
+ *
+ * @return {CardBrand[]} Array of card brand objects with name and component properties
+ */
+export const getCardBrands = (): CardBrand[] => {
+	const baseBrands: CardBrand[] = [
+		{ name: 'visa', component: Visa },
+		{ name: 'mastercard', component: Mastercard },
+		{ name: 'amex', component: Amex },
+		{ name: 'discover', component: Discover },
+	];
+
+	// Always add JCB and CUP
+	const additionalBrands: CardBrand[] = [
+		{ name: 'jcb', component: Jcb },
+		{ name: 'unionpay', component: UnionPay },
+	];
+
+	// Add CB (Cartes Bancaires) only for France merchants
+	// Try multiple approaches to get the country
+	const accountCountry = getUPEConfig( 'storeCountry' );
+
+	if ( accountCountry === 'FR' ) {
+		additionalBrands.push( {
+			name: 'cartes_bancaires',
+			component: Cartebancaire,
+		} );
+	}
+
+	return [ ...baseBrands, ...additionalBrands ];
+};


### PR DESCRIPTION
Fixes WOOPMNT-5353

#### Changes proposed in this Pull Request

**Problem:**
When payment method logos were moved from the card number field to the radio button, logos for JCB, CUP, and CB (Cartes Bancaires) were incorrectly excluded from the checkout display.

- Created a new `getCardBrands()` utility function that returns appropriate card brands based on merchant location
- Updated both blocks and classic checkout implementations to use the new utility
- Added proper regional filtering: CB (Cartes Bancaires) only shows for France merchants

<img width="934" height="299" alt="image" src="https://github.com/user-attachments/assets/68d942b9-9a21-4777-b568-564f194bbae8" />

#### Testing instructions

* Go to the checkout page
* All merchants should see: Visa, Mastercard, Amex, Discover, JCB, CUP logos
*  France merchants additionally see: CB (Cartes Bancaires) logo

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
