### PR TITLE
Only load autocomplete scripts if core setting is enabled

### DIFF
--- a/changelog/fix-address-autocomplete-always-enabled
+++ b/changelog/fix-address-autocomplete-always-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Overrides the core `AbstractAutomatticAddressProvider`'s `load_scripts` method to only run if the core setting (`woocommerce_address_autocomplete_enabled` is enabled).

--- a/includes/class-wc-payments-address-provider.php
+++ b/includes/class-wc-payments-address-provider.php
@@ -65,6 +65,15 @@ class WC_Payments_Address_Provider extends AbstractAutomatticAddressProvider {
 		parent::__construct();
 	}
 
+	/**
+	 * Checks if the core setting is enabled before loading scripts.
+	 * The parent method does not check this (will be patched and this override can be removed when WC 10.4 is released)
+	 */
+	public function load_scripts() {
+		if ( wc_string_to_bool( get_option( 'woocommerce_address_autocomplete_enabled', 'no' ) ) === true ) {
+			parent::load_scripts();
+		}
+	}
 
 	/**
 	 * Get address service JWT token from the WCPay server.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Overrides the core `AbstractAutomatticAddressProvider`'s `load_scripts` method to only run if the core setting (`woocommerce_address_autocomplete_enabled` is enabled).

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WC -> Settings and disable "Enable Predictive Address Search"
* Go to the shortcode checkout, ensure the address 1 field does not show a search icon, and does not show address suggestions after typing 3+ characters.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
