### PR TITLE
Fix WCPay Subscriptions toggle not saving when unchecked

### DIFF
--- a/changelog/fix-woopmnt-5394-fix-wcpay-subscriptions-toggle-not-saving-when-unchecked
+++ b/changelog/fix-woopmnt-5394-fix-wcpay-subscriptions-toggle-not-saving-when-unchecked
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix - WCPay Subscriptions setting not persisting when unchecked

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -134,7 +134,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_wcpay_subscription_enabled'        => [
+					'is_wcpay_subscriptions_enabled'       => [
 						'description'       => sprintf(
 							/* translators: %s: WooPayments */
 							__( '%s Subscriptions feature flag setting.', 'woocommerce-payments' ),
@@ -803,11 +803,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_is_wcpay_subscriptions_enabled( WP_REST_Request $request ) {
-		if ( ! $request->has_param( 'is_wcpay_subscription_enabled' ) ) {
+		if ( ! $request->has_param( 'is_wcpay_subscriptions_enabled' ) ) {
 			return;
 		}
 
-		$is_wcpay_subscriptions_enabled = $request->get_param( 'is_wcpay_subscription_enabled' );
+		$is_wcpay_subscriptions_enabled = $request->get_param( 'is_wcpay_subscriptions_enabled' );
 
 		// Prevent enabling bundled subscriptions - feature has been removed in 10.2.0.
 		// Only allow disabling the feature if it was previously enabled.

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -654,7 +654,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'store_setup_sync' );
 
 		$request = new WP_REST_Request();
-		$request->set_param( 'is_wcpay_subscription_enabled', false );
+		$request->set_param( 'is_wcpay_subscriptions_enabled', false );
 
 		$this->controller->update_settings( $request );
 
@@ -670,7 +670,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'store_setup_sync' );
 
 		$request = new WP_REST_Request();
-		$request->set_param( 'is_wcpay_subscription_enabled', true );
+		$request->set_param( 'is_wcpay_subscriptions_enabled', true );
 
 		$this->controller->update_settings( $request );
 


### PR DESCRIPTION
Fixes #WOOPMNT-5394

#### Changes proposed in this Pull Request
The WCPay Subscriptions toggle in Advanced Settings could not be disabled. When users unchecked the toggle and clicked save, the page would reload with the toggle checked again, preventing users from disabling the deprecated feature.

Updated the backend REST API to use the correct parameter name `is_wcpay_subscriptions_enabled` (matching the frontend)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to Payments → Settings
2. Scroll down to the "Advanced settings" section
3. Locate the "Enable Subscriptions with WooPayments" checkbox (it should be checked)
4. Uncheck the "Enable Subscriptions with WooPayments" toggle
5. Click the "Save changes" button
6. Wait for the page to reload
7. Confirm The toggle remains unchecked after page reload

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
