### PR TITLE
Cherry-pick #11113: Fix WCPay Subscriptions toggle not saving when unchecked

### DIFF
--- a/changelog/fix-woopmnt-5394-fix-wcpay-subscriptions-toggle-not-saving-when-unchecked
+++ b/changelog/fix-woopmnt-5394-fix-wcpay-subscriptions-toggle-not-saving-when-unchecked
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix - WCPay Subscriptions setting not persisting when unchecked

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -134,7 +134,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_wcpay_subscription_enabled'        => [
+					'is_wcpay_subscriptions_enabled'       => [
 						'description'       => sprintf(
 							/* translators: %s: WooPayments */
 							__( '%s Subscriptions feature flag setting.', 'woocommerce-payments' ),
@@ -803,11 +803,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_is_wcpay_subscriptions_enabled( WP_REST_Request $request ) {
-		if ( ! $request->has_param( 'is_wcpay_subscription_enabled' ) ) {
+		if ( ! $request->has_param( 'is_wcpay_subscriptions_enabled' ) ) {
 			return;
 		}
 
-		$is_wcpay_subscriptions_enabled = $request->get_param( 'is_wcpay_subscription_enabled' );
+		$is_wcpay_subscriptions_enabled = $request->get_param( 'is_wcpay_subscriptions_enabled' );
 
 		// Prevent enabling bundled subscriptions - feature has been removed in 10.2.0.
 		// Only allow disabling the feature if it was previously enabled.

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -654,7 +654,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'store_setup_sync' );
 
 		$request = new WP_REST_Request();
-		$request->set_param( 'is_wcpay_subscription_enabled', false );
+		$request->set_param( 'is_wcpay_subscriptions_enabled', false );
 
 		$this->controller->update_settings( $request );
 
@@ -670,7 +670,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'store_setup_sync' );
 
 		$request = new WP_REST_Request();
-		$request->set_param( 'is_wcpay_subscription_enabled', true );
+		$request->set_param( 'is_wcpay_subscriptions_enabled', true );
 
 		$this->controller->update_settings( $request );
 


### PR DESCRIPTION
Cherry-pick of #11113 onto release/10.2.0

Original PR: https://github.com/Automattic/woocommerce-payments/pull/11113
Fixes #WOOPMNT-5394

#### Changes proposed in this Pull Request
The WCPay Subscriptions toggle in Advanced Settings could not be disabled. When users unchecked the toggle and clicked save, the page would reload with the toggle checked again, preventing users from disabling the deprecated feature.

Updated the backend REST API to use the correct parameter name `is_wcpay_subscriptions_enabled` (matching the frontend)

#### Testing instructions

1. Navigate to Payments → Settings
2. Scroll down to the "Advanced settings" section
3. Locate the "Enable Subscriptions with WooPayments" checkbox (it should be checked)
4. Uncheck the "Enable Subscriptions with WooPayments" toggle
5. Click the "Save changes" button
6. Wait for the page to reload
7. Confirm The toggle remains unchecked after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)