### PR TITLE
Fix payment method logos overflow in shortcode checkout

### DIFF
--- a/changelog/fix-woopmnt-5397-regression-pm-logos-overflow-in-short-code-checkout
+++ b/changelog/fix-woopmnt-5397-regression-pm-logos-overflow-in-short-code-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix payment method logos overflow in shortcode checkout after adding JCB and UnionPay logos.

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -181,19 +181,15 @@ jQuery( function ( $ ) {
 		const paymentMethods = getCardBrands();
 
 		function getMaxElements() {
-			const paymentMethodElement = document.querySelector(
-				'.payment_method_woocommerce_payments'
-			);
-			if ( ! paymentMethodElement ) {
-				return 4; // Default fallback
-			}
+			// Use viewport width as primary indicator (similar to blocks checkout)
+			const viewportWidth = window.innerWidth;
 
-			const elementWidth = paymentMethodElement.offsetWidth;
-			if ( elementWidth <= 300 ) {
+			// Specific tablet viewport range (768-781px) - needs room for Test Mode badge
+			if ( viewportWidth >= 768 && viewportWidth <= 900 ) {
 				return 1;
-			} else if ( elementWidth <= 330 ) {
-				return 2;
 			}
+			// Default - show 3 logos + counter badge = 4 visual elements total
+			return 3;
 		}
 
 		function shouldHavePopover() {

--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -41,6 +41,15 @@
 			img:last-of-type {
 				margin-right: 0;
 			}
+
+			&-count {
+				margin-left: 4px;
+
+				// Tighter spacing on tablet viewports (768-900px) to conserve space for Test Mode badge
+				@media ( min-width: 768px ) and ( max-width: 900px ) {
+					margin-left: 0;
+				}
+			}
 		}
 		img {
 			float: right;


### PR DESCRIPTION
Fixes #WOOPMNT-5397

After adding JCB, UnionPay, and Cartes Bancaires logos, the classic/shortcode checkout began displaying all 6-7 card logos inline, causing them to overflow and wrap to a new line instead of showing a "+N" counter badge.

#### Changes proposed in this Pull Request
1. Fixed `getMaxElements()` to return appropriate values for all viewports:
     - Returns `3` for most viewports (3 logos + counter badge = 4 visual elements)
     - Returns `1` for 768-900px viewports (to accommodate Test Mode badge)
     - Uses `window.innerWidth` instead of element width for more reliable responsive behavior
2. Added CSS spacing for the counter badge:
     - Default: 4px margin-left (comfortable spacing)
     - 768-900px: 0px margin-left (tight spacing to conserve space for Test Mode badge)

**Trade-offs:**
  - Shows 3 logos + counter instead of all 6-7 logos on desktop to maintain visual consistency across viewports and ensure space for the Test Mode badge

#### Screenshots

| Breakpoint | Before (10.1.1) | Now |
|--------|--------|--------|
|400px |<img width="360" height="166" alt="Screenshot 2025-10-31 at 16 58 44" src="https://github.com/user-attachments/assets/2f36c923-ae2a-42c8-b950-35cb4bd8d0af" />|<img width="359" height="153" alt="Screenshot 2025-10-31 at 16 59 37" src="https://github.com/user-attachments/assets/eed58942-e8ca-4adf-9719-3087030fe833" />|
|568px|<img width="525" height="137" alt="Screenshot 2025-10-31 at 17 00 41" src="https://github.com/user-attachments/assets/13abc8b3-4cfc-4c4d-a4da-319b75b2d589" />|<img width="526" height="133" alt="Screenshot 2025-10-31 at 17 02 44" src="https://github.com/user-attachments/assets/25feb82a-96d0-42c7-a172-11bf910c3c79" />|
| 768px |<img width="284" height="187" alt="Screenshot 2025-10-31 at 17 03 23" src="https://github.com/user-attachments/assets/8ac01e05-0bcc-41aa-8528-bf9f752ea9bd" />|<img width="285" height="179" alt="Screenshot 2025-10-31 at 17 04 13" src="https://github.com/user-attachments/assets/1337bd03-50bc-4b0e-a4b3-0a545abfc98f" />|
|Large viewport |<img width="408" height="169" alt="Screenshot 2025-10-31 at 17 04 53" src="https://github.com/user-attachments/assets/46fbc297-5ef5-4065-9de3-7dd78ed189da" />|<img width="407" height="163" alt="Screenshot 2025-10-31 at 17 07 00" src="https://github.com/user-attachments/assets/ae83a91a-e368-450b-9ac6-4eee0b774498" />| 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

  1. **Test classic/shortcode checkout** (not blocks checkout):
     - Navigate to classic checkout page
     - Ensure you see the Card payment method
  2. **Test various viewport sizes:**
     - **400px:** Should show 3 card logos + "+3" counter with 4px spacing
     - **768px:** Should show 1 card logo + "+5" counter with no spacing (tight)
     - **781px:** Should show 1 card logo + "+5" counter with no spacing (tight)
     - **900px:** Should show 1 card logo + "+5" counter with no spacing (tight)
     - **1024px+:** Should show 3 card logos + "+3" counter with 4px spacing

  3. **Test for France merchants (if possible):**
     - Set store country to France
     - Should show 1 logo + "+6" counter (7 total brands including JCB)

  4. **Verify blocks checkout is unaffected:**
     - Navigate to block-based checkout
     - Logos should display correctly (no regression)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
