### PR TITLE
Update to the copy on the WooPayments delete test orders tool.

### DIFF
--- a/changelog/dev-test-mode-text-fix
+++ b/changelog/dev-test-mode-text-fix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Minor copy update to the delete test orders tool.

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -81,11 +81,15 @@ class WC_Payments_Status {
 					'callback' => [ $this->account, 'refresh_account_data' ],
 				],
 				'delete_wcpay_test_orders'  => [
-					'name'     => __( 'Delete test orders', 'woocommerce-payments' ),
+					'name'     => sprintf(
+						/* translators: %s: WooPayments */
+						__( 'Delete %s test orders', 'woocommerce-payments' ),
+						'WooPayments'
+					),
 					'button'   => __( 'Delete', 'woocommerce-payments' ),
 					'desc'     => sprintf(
 						/* translators: %s: WooPayments */
-						__( '<strong class="red">Note:</strong> This option will delete ALL orders created while %s test mode was enabled, use with caution. This action cannot be reversed.', 'woocommerce-payments' ),
+						__( '<strong class="red">Note:</strong> This option deletes all test mode orders placed via %s. Orders placed via other gateways will not be affected. Use with caution, as this action cannot be undone.', 'woocommerce-payments' ),
 						'WooPayments'
 					),
 					'callback' => [ $this, 'delete_test_orders' ],

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -94,13 +94,13 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'desc', $delete_tool );
 		$this->assertArrayHasKey( 'callback', $delete_tool );
 
-		$this->assertEquals( 'Delete test orders', $delete_tool['name'] );
+		$this->assertEquals( 'Delete WooPayments test orders', $delete_tool['name'] );
 		$this->assertEquals( 'Delete', $delete_tool['button'] );
 		$this->assertStringContainsString( 'Note:', $delete_tool['desc'] );
 		$this->assertStringContainsString( 'strong class="red"', $delete_tool['desc'] );
-		$this->assertStringContainsString( 'delete ALL orders created while', $delete_tool['desc'] );
-		$this->assertStringContainsString( 'test mode was enabled', $delete_tool['desc'] );
-		$this->assertStringContainsString( 'cannot be reversed', $delete_tool['desc'] );
+		$this->assertStringContainsString( 'deletes all test mode orders placed via', $delete_tool['desc'] );
+		$this->assertStringContainsString( 'Orders placed via other gateways will not be affected', $delete_tool['desc'] );
+		$this->assertStringContainsString( 'cannot be undone', $delete_tool['desc'] );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This is a minor fix to the copy which appears on the Delete WooPayments Test Orders tool, to make it less ambigious and more clear that it only deletes WooPayments orders that were placed in test mode (and not orders from other payment methods).

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/wp-admin/admin.php?page=wc-status&tab=tools`
* Look for the `Delete WooPayments test orders` tool.
* Verify that the text reads:

`Note: This option deletes all test mode orders placed via WooPayments. Orders placed via other gateways will not be affected. Use with caution, as this action cannot be undone. `

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
