### PR TITLE
Update payout texts for New Account Waiting Period

### DIFF
--- a/changelog/woopmnt-5449-update-payout-banner-in-the-settings
+++ b/changelog/woopmnt-5449-update-payout-banner-in-the-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change payout texts for  New Account Waiting Period to be consistent with new Account Details

--- a/client/components/deposits-overview/__tests__/index.test.tsx
+++ b/client/components/deposits-overview/__tests__/index.test.tsx
@@ -306,9 +306,12 @@ describe( 'Deposits Overview information', () => {
 			setSelectedCurrency: mockSetSelectedCurrency,
 		} );
 		const { getByText, queryByText } = render( <DepositsOverview /> );
-		getByText( /Your first payout is held for/, {
-			ignore: '.a11y-speak-region',
-		} );
+		getByText(
+			/Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete/,
+			{
+				ignore: '.a11y-speak-region',
+			}
+		);
 		expect( queryByText( 'Change deposit schedule' ) ).toBeFalsy();
 		expect( queryByText( 'View full deposits history' ) ).toBeFalsy();
 	} );
@@ -426,7 +429,11 @@ describe( 'Deposits Overview information', () => {
 		} );
 
 		const { queryByText } = render( <DepositsOverview /> );
-		expect( queryByText( /Your first payout is held for/ ) ).toBeFalsy();
+		expect(
+			queryByText(
+				/Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete/
+			)
+		).toBeFalsy();
 	} );
 
 	test( 'Confirm new account waiting period notice shows if within waiting period', () => {
@@ -444,10 +451,13 @@ describe( 'Deposits Overview information', () => {
 		} );
 
 		const { getByText, getByRole } = render( <DepositsOverview /> );
-		getByText( /Your first payout is held for/, {
-			ignore: '.a11y-speak-region',
-		} );
-		expect( getByRole( 'link', { name: /Why\?/ } ) ).toHaveAttribute(
+		getByText(
+			/Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete/,
+			{
+				ignore: '.a11y-speak-region',
+			}
+		);
+		expect( getByRole( 'link', { name: /Learn more/ } ) ).toHaveAttribute(
 			'href',
 			'https://woocommerce.com/document/woopayments/payouts/payout-schedule/#new-accounts'
 		);

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -58,11 +58,11 @@ export const NewAccountWaitingPeriodNotice: React.FC = () => (
 	>
 		{ interpolateComponents( {
 			mixedString: __(
-				'Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete. {{whyLink}}Learn more{{/whyLink}}',
+				'Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 				'woocommerce-payments'
 			),
 			components: {
-				whyLink: (
+				learnMoreLink: (
 					// Link content is in the format string above. Consider disabling jsx-a11y/anchor-has-content.
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -58,7 +58,7 @@ export const NewAccountWaitingPeriodNotice: React.FC = () => (
 	>
 		{ interpolateComponents( {
 			mixedString: __(
-				'Your first payout is held for 7-14 days. {{whyLink}}Why?{{/whyLink}}',
+				'Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete. {{whyLink}}Learn more{{/whyLink}}',
 				'woocommerce-payments'
 			),
 			components: {

--- a/client/settings/deposits/__tests__/index.test.js
+++ b/client/settings/deposits/__tests__/index.test.js
@@ -163,7 +163,7 @@ describe( 'Deposits', () => {
 		);
 
 		const depositsMessage = screen.getByText(
-			/Your first payout will be held for/,
+			/Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete/,
 			{
 				ignore: '.a11y-speak-region',
 			}

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -191,7 +191,7 @@ const DepositsSchedule = () => {
 					mixedString: __(
 						'Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete.' +
 							' ' +
-							'{{whyLink}}Learn more{{/whyLink}}',
+							'{{learnMoreLink}}Learn more{{/learnMoreLink}}',
 						'woocommerce-payments'
 					),
 					components: {

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -189,8 +189,9 @@ const DepositsSchedule = () => {
 			<InlineNotice status="warning" isDismissible={ false } icon>
 				{ interpolateComponents( {
 					mixedString: __(
-						'Your first payout will be held for 7-14 days. ' +
-							'Payout scheduling will be available after this period. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+						'Payout scheduling becomes available after the standard 7-day waiting period for new accounts is complete.' +
+							' ' +
+							'{{whyLink}}Learn more{{/whyLink}}',
 						'woocommerce-payments'
 					),
 					components: {


### PR DESCRIPTION
Fixes WOOPMNT-5449

#### Changes proposed in this Pull Request

Update Payout texts in two screens 

- Payments → Overview screen:
- Payments -> Settings screen, Payouts section
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
<img width="3828" height="908" alt="Screen Shot on 2025-11-04 at 16:24:12" src="https://github.com/user-attachments/assets/64e28f3b-0bc8-4b44-95ae-175cf66e72e2" />
<img width="3496" height="1108" alt="Screen Shot on 2025-11-04 at 16:23:41" src="https://github.com/user-attachments/assets/46ce8d4b-6b98-49c6-9b73-3836b7a4ac31" />



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The most simple way to test is to change the server and always return true for `Account_Service::has_account_completed_the_new_account_waiting_period` method. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
