### PR TITLE
Visa Compliance disputes: special notice and attention to a higher fee

### DIFF
--- a/changelog/woopmnt-5113-visa-compliance-dispute-requires-attention-to-a-specific-fee
+++ b/changelog/woopmnt-5113-visa-compliance-dispute-requires-attention-to-a-specific-fee
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Handling of the Visa Compliance disputes with attention to a specific dispute fee.

--- a/client/components/account-details/index.tsx
+++ b/client/components/account-details/index.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Card, CardBody, CardHeader, Flex } from '@wordpress/components';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -576,6 +576,13 @@ export default ( { query }: { query: { id: string } } ) => {
 		dispute.status !== 'needs_response' &&
 		dispute.status !== 'warning_needs_response';
 
+	const isVisaComplianceDispute =
+		dispute &&
+		( dispute.reason === 'noncompliant' ||
+			( dispute?.enhanced_eligibility_types || [] ).includes(
+				'visa_compliance'
+			) );
+
 	// --- Accordion summary content (must be before any early returns) ---
 	const summaryItems = useMemo( () => {
 		if ( ! dispute ) return [];
@@ -933,6 +940,25 @@ export default ( { query }: { query: { id: string } } ) => {
 		</InlineNotice>
 	);
 
+	const inlineNoticeVisaCompliance = () => (
+		<InlineNotice
+			icon
+			isDismissible={ false }
+			status="info"
+			className="dispute-steps__notice-content"
+		>
+			{ createInterpolateElement(
+				__(
+					'<strong>The outcome of this dispute will be determined by Visa.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.',
+					'woocommerce-payments'
+				),
+				{
+					strong: <strong />,
+				}
+			) }
+		</InlineNotice>
+	);
+
 	// --- Step content ---
 	const renderStepContent = () => {
 		// if ( ! fields.length ) return null;
@@ -981,7 +1007,9 @@ export default ( { query }: { query: { id: string } } ) => {
 						fields={ recommendedDocumentsFields }
 						readOnly={ readOnly }
 					/>
-					{ inlineNotice( bankName ) }
+					{ isVisaComplianceDispute
+						? inlineNoticeVisaCompliance()
+						: inlineNotice( bankName ) }
 				</>
 			);
 		}
@@ -1015,7 +1043,9 @@ export default ( { query }: { query: { id: string } } ) => {
 						fields={ recommendedShippingDocumentsFields }
 						readOnly={ readOnly }
 					/>
-					{ inlineNotice( bankName ) }
+					{ isVisaComplianceDispute
+						? inlineNoticeVisaCompliance()
+						: inlineNotice( bankName ) }
 				</>
 			);
 		}
@@ -1118,7 +1148,9 @@ export default ( { query }: { query: { id: string } } ) => {
 						} }
 						readOnly={ readOnly }
 					/>
-					{ inlineNotice( bankName ) }
+					{ isVisaComplianceDispute
+						? inlineNoticeVisaCompliance()
+						: inlineNotice( bankName ) }
 				</>
 			);
 		}

--- a/client/disputes/strings.ts
+++ b/client/disputes/strings.ts
@@ -349,6 +349,13 @@ export const reasons: Record<
 			),
 		],
 	},
+	noncompliant: {
+		display: __( 'Non-compliant', 'woocommerce-payments' ),
+		claim: __(
+			'Your customer’s bank claims this payment violates Visa’s rules.',
+			'woocommerce-payments'
+		),
+	},
 };
 
 // Mapping of disputes status to display string.

--- a/client/disputes/strings.ts
+++ b/client/disputes/strings.ts
@@ -355,6 +355,12 @@ export const reasons: Record<
 			'Your customer’s bank claims this payment violates Visa’s rules.',
 			'woocommerce-payments'
 		),
+		summary: [
+			__(
+				'The customer’s bank claims this transaction doesn’t conform to Visa’s network rules.',
+				'woocommerce-payments'
+			),
+		],
 	},
 };
 

--- a/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-awaiting-response-details.test.tsx.snap
+++ b/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-awaiting-response-details.test.tsx.snap
@@ -1,0 +1,545 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DisputeAwaitingResponseDetails - Visa Compliance renders Visa compliance dispute with NonCompliantDisputeSteps 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-16 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-16 *,
+.emotion-16 *::before,
+.emotion-16 *::after {
+  box-sizing: inherit;
+}
+
+.components-panel__row .emotion-18 {
+  margin-bottom: inherit;
+}
+
+.emotion-20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  width: 100%;
+}
+
+.emotion-20>* {
+  min-width: 0;
+}
+
+<div>
+  <div
+    class="transaction-details-dispute-details-wrapper"
+  >
+    <hr />
+    <h2
+      class="transaction-details-dispute-details-title"
+    >
+      Dispute details
+    </h2>
+    <div
+      class="transaction-details-dispute-details-body"
+    >
+      <div
+        class="wcpay-inline-notice wcpay-inline-error-notice dispute-notice components-notice is-error"
+      >
+        <div
+          class="components-visually-hidden emotion-0 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="VisuallyHidden"
+          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+        >
+          Error notice
+        </div>
+        <div
+          class="components-notice__content"
+        >
+          <div
+            class="components-flex emotion-2 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="Flex"
+          >
+            <div
+              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon emotion-4 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="FlexItem"
+            >
+              <svg
+                class="gridicon gridicons-notice-outline"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                  />
+                </g>
+              </svg>
+            </div>
+            <div
+              class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="FlexItem"
+            >
+              Your customer’s bank, Chase Bank, claims this payment violates Visa’s rules. 
+              <strong>
+                You can challenge the dispute by 7:59 PM on September 9, 2023, or accept it.
+              </strong>
+               If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.
+            </div>
+          </div>
+          <div
+            class="components-notice__actions"
+          />
+        </div>
+      </div>
+      <div
+        class="dispute-summary-row"
+      >
+        <ul
+          class="woocommerce-list woocommerce-list--horizontal"
+          role="menu"
+        >
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Dispute Amount
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  $50.00
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Disputed On
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  000000830f36830
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Reason
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  Non-compliant
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Respond By
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  <span
+                    class="dispute-steps__steps__response-date"
+                  >
+                    September 9, 2023 7:59 PM
+                    <span
+                      class="dispute-steps__steps__response-date--urgent"
+                    >
+                       (Past due)
+                    </span>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+      <div
+        class="dispute-steps"
+      >
+        <div
+          class="wcpay-accordion"
+        >
+          <div
+            class="wcpay-accordion__body is-opened"
+          >
+            <h2
+              class="wcpay-accordion__body-title"
+            >
+              <button
+                class="components-button wcpay-accordion__body-toggle is-md is-lg"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="wcpay-accordion__arrow"
+                    focusable="false"
+                    size="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+                    />
+                  </svg>
+                </span>
+                <div
+                  class="wcpay-accordion__title-content"
+                >
+                  Steps you can take
+                  <div
+                    class="wcpay-accordion__subtitle"
+                  >
+                    We recommend reviewing your options before responding by the deadline. 
+                  </div>
+                </div>
+              </button>
+            </h2>
+            <div
+              class="wcpay-accordion__row"
+            >
+              <div
+                class="dispute-steps__content"
+              >
+                <div
+                  class="dispute-steps__items"
+                >
+                  <div
+                    class="dispute-steps__item"
+                  >
+                    <div
+                      class="dispute-steps__item-icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        focusable="false"
+                        size="24"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15.5 7.5h-7V9h7V7.5Zm-7 3.5h7v1.5h-7V11Zm7 3.5h-7V16h7v-1.5Z"
+                        />
+                        <path
+                          d="M17 4H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2ZM7 5.5h10a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5H7a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5Z"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="dispute-steps__item-content"
+                    >
+                      <div
+                        class="dispute-steps__item-name"
+                      >
+                        Accepting the dispute
+                      </div>
+                      <div
+                        class="dispute-steps__item-description"
+                      >
+                        Accepting the dispute means you’ll forfeit the funds, pay the standard dispute fee, and avoid the $500 USD Visa fee.
+                      </div>
+                    </div>
+                    <div
+                      class="dispute-steps__item-action"
+                    >
+                      <a
+                        class="components-button is-secondary"
+                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Learn more
+                      </a>
+                    </div>
+                  </div>
+                  <div
+                    class="dispute-steps__item"
+                  >
+                    <div
+                      class="dispute-steps__item-icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        focusable="false"
+                        size="24"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M3 7c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Zm2-.5h14c.3 0 .5.2.5.5v1L12 13.5 4.5 7.9V7c0-.3.2-.5.5-.5Zm-.5 3.3V17c0 .3.2.5.5.5h14c.3 0 .5-.2.5-.5V9.8L12 15.4 4.5 9.8Z"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="dispute-steps__item-content"
+                    >
+                      <div
+                        class="dispute-steps__item-name"
+                      >
+                        Challenge the dispute
+                      </div>
+                      <div
+                        class="dispute-steps__item-description"
+                      >
+                        Challenging the dispute will incur a $500 USD network fee, charged by our partner Stripe when you submit evidence. This fee will be refunded if you win the dispute.
+                      </div>
+                    </div>
+                    <div
+                      class="dispute-steps__item-action"
+                    >
+                      <a
+                        class="components-button is-secondary"
+                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Learn more
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="dispute-steps__notice"
+                >
+                  <div
+                    class="wcpay-inline-notice wcpay-inline-info-notice dispute-steps__notice-content components-notice is-info"
+                  >
+                    <div
+                      class="components-visually-hidden emotion-0 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="VisuallyHidden"
+                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                    >
+                      Information notice
+                    </div>
+                    <div
+                      class="components-notice__content"
+                    >
+                      <div
+                        class="components-flex emotion-2 emotion-1"
+                        data-wp-c16t="true"
+                        data-wp-component="Flex"
+                      >
+                        <div
+                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-4 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
+                        >
+                          <svg
+                            class="gridicon gridicons-info-outline"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <g>
+                              <path
+                                d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                        <div
+                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-4 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="FlexItem"
+                        >
+                          <strong>
+                            The outcome of this dispute will be determined by Visa.
+                          </strong>
+                           WooPayments has no influence over the decision and is not liable for any chargebacks.
+                        </div>
+                      </div>
+                      <div
+                        class="components-notice__actions"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="transaction-details-dispute-details-body__help-link"
+      >
+        <a
+          class="components-external-link"
+          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/"
+          rel="external noreferrer noopener"
+          target="_blank"
+        >
+          <span
+            class="components-external-link__contents"
+          >
+            Learn more about Visa compliance disputes
+          </span>
+          <span
+            aria-label="(opens in a new tab)"
+            class="components-external-link__icon"
+          >
+            ↗
+          </span>
+        </a>
+      </div>
+      <div
+        class="transaction-details-dispute-details-body__visa-compliance-checkbox"
+      >
+        <div
+          class="components-base-control components-checkbox-control emotion-16 emotion-17"
+        >
+          <div
+            class="components-base-control__field emotion-18 emotion-19"
+          >
+            <div
+              class="components-flex components-h-stack emotion-20 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="HStack"
+            >
+              <span
+                class="components-checkbox-control__input-container"
+              >
+                <input
+                  class="components-checkbox-control__input"
+                  id="inspector-checkbox-control-0"
+                  type="checkbox"
+                  value="1"
+                />
+              </span>
+              <label
+                class="components-checkbox-control__label"
+                for="inspector-checkbox-control-0"
+              >
+                By checking this box, you acknowledge that challenging this Visa compliance dispute incurs a $500 USD fee, which will be refunded only if you win the case.
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="transaction-details-dispute-details-body__actions"
+      >
+        <a
+          data-link-type="wc-admin"
+          href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fchallenge&id=dp_visa_compliance_1"
+        >
+          <button
+            class="components-button is-next-40px-default-size is-primary"
+            data-testid="challenge-dispute-button"
+            disabled=""
+            type="button"
+          >
+            Challenge dispute
+          </button>
+        </a>
+        <button
+          class="components-button is-next-40px-default-size is-tertiary"
+          data-testid="open-accept-dispute-modal-button"
+          type="button"
+        >
+          Accept dispute
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-awaiting-response-details.test.tsx.snap
+++ b/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-awaiting-response-details.test.tsx.snap
@@ -210,6 +210,34 @@ exports[`DisputeAwaitingResponseDetails - Visa Compliance renders Visa complianc
                   class="woocommerce-list__item-content"
                 >
                   Non-compliant
+                  <button
+                    class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
+                    type="button"
+                  >
+                    <div
+                      class="wcpay-tooltip__content-wrapper"
+                    >
+                      <div
+                        aria-label="Learn more"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          class="gridicon gridicons-help-outline"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g>
+                            <path
+                              d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2v-1.141A3.991 3.991 0 0016 10zm-3 6h-2v2h2v-2z"
+                            />
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
                 </span>
               </div>
             </div>

--- a/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-awaiting-response-details.test.tsx.snap
+++ b/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-awaiting-response-details.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`DisputeAwaitingResponseDetails - Visa Compliance renders Visa complianc
                     >
                       <a
                         class="components-button is-secondary"
-                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -387,7 +387,7 @@ exports[`DisputeAwaitingResponseDetails - Visa Compliance renders Visa complianc
                     >
                       <a
                         class="components-button is-secondary"
-                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                        href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -464,7 +464,7 @@ exports[`DisputeAwaitingResponseDetails - Visa Compliance renders Visa complianc
       >
         <a
           class="components-external-link"
-          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/"
+          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
           rel="external noreferrer noopener"
           target="_blank"
         >

--- a/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-notice.test.tsx.snap
+++ b/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-notice.test.tsx.snap
@@ -1,0 +1,369 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DisputeNotice - Visa Compliance renders Visa compliance notice with bank name 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-error-notice dispute-notice components-notice is-error"
+  >
+    <div
+      class="components-visually-hidden emotion-0 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="VisuallyHidden"
+      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+    >
+      Error notice
+    </div>
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex emotion-2 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <svg
+            class="gridicon gridicons-notice-outline"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          Your customer’s bank, Chase Bank, claims this payment violates Visa’s rules. 
+          <strong>
+            You can challenge the dispute by 11:59 PM on September 9, 2023, or accept it.
+          </strong>
+           If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DisputeNotice - Visa Compliance renders Visa compliance notice without bank name 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-error-notice dispute-notice components-notice is-error"
+  >
+    <div
+      class="components-visually-hidden emotion-0 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="VisuallyHidden"
+      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+    >
+      Error notice
+    </div>
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex emotion-2 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <svg
+            class="gridicon gridicons-notice-outline"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          Your customer’s bank claims this payment violates Visa’s rules. 
+          <strong>
+            You can challenge the dispute by 11:59 PM on September 9, 2023, or accept it.
+          </strong>
+           If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DisputeNotice - Visa Compliance renders urgent error status for Visa compliance disputes 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-error-notice dispute-notice components-notice is-error"
+  >
+    <div
+      class="components-visually-hidden emotion-0 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="VisuallyHidden"
+      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+    >
+      Error notice
+    </div>
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex emotion-2 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <svg
+            class="gridicon gridicons-notice-outline"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          Your customer’s bank, Chase Bank, claims this payment violates Visa’s rules. 
+          <strong>
+            You can challenge the dispute by 11:59 PM on September 9, 2023, or accept it.
+          </strong>
+           If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DisputeNotice - Visa Compliance renders with warning status when not urgent 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<div>
+  <div
+    class="wcpay-inline-notice wcpay-inline-warning-notice dispute-notice components-notice is-warning"
+  >
+    <div
+      class="components-visually-hidden emotion-0 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="VisuallyHidden"
+      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+    >
+      Warning notice
+    </div>
+    <div
+      class="components-notice__content"
+    >
+      <div
+        class="components-flex emotion-2 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+      >
+        <div
+          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          <svg
+            class="gridicon gridicons-notice-outline"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-4 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
+        >
+          Your customer’s bank, Chase Bank, claims this payment violates Visa’s rules. 
+          <strong>
+            You can challenge the dispute by 11:59 PM on September 9, 2023, or accept it.
+          </strong>
+           If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.
+        </div>
+      </div>
+      <div
+        class="components-notice__actions"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-steps.test.tsx.snap
+++ b/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-steps.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`NonCompliantDisputeSteps renders the Visa compliance dispute steps 1`] 
                 >
                   <a
                     class="components-button is-secondary"
-                    href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                    href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -174,7 +174,7 @@ exports[`NonCompliantDisputeSteps renders the Visa compliance dispute steps 1`] 
                 >
                   <a
                     class="components-button is-secondary"
-                    href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                    href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-steps.test.tsx.snap
+++ b/client/payment-details/dispute-details/__tests__/__snapshots__/dispute-steps.test.tsx.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NonCompliantDisputeSteps renders the Visa compliance dispute steps 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<div>
+  <div
+    class="dispute-steps"
+  >
+    <div
+      class="wcpay-accordion"
+    >
+      <div
+        class="wcpay-accordion__body is-opened"
+      >
+        <h2
+          class="wcpay-accordion__body-title"
+        >
+          <button
+            class="components-button wcpay-accordion__body-toggle is-md is-lg"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+            >
+              <svg
+                aria-hidden="true"
+                class="wcpay-accordion__arrow"
+                focusable="false"
+                size="24"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+                />
+              </svg>
+            </span>
+            <div
+              class="wcpay-accordion__title-content"
+            >
+              Steps you can take
+              <div
+                class="wcpay-accordion__subtitle"
+              >
+                We recommend reviewing your options before responding by the deadline. 
+              </div>
+            </div>
+          </button>
+        </h2>
+        <div
+          class="wcpay-accordion__row"
+        >
+          <div
+            class="dispute-steps__content"
+          >
+            <div
+              class="dispute-steps__items"
+            >
+              <div
+                class="dispute-steps__item"
+              >
+                <div
+                  class="dispute-steps__item-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    size="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15.5 7.5h-7V9h7V7.5Zm-7 3.5h7v1.5h-7V11Zm7 3.5h-7V16h7v-1.5Z"
+                    />
+                    <path
+                      d="M17 4H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2ZM7 5.5h10a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5H7a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="dispute-steps__item-content"
+                >
+                  <div
+                    class="dispute-steps__item-name"
+                  >
+                    Accepting the dispute
+                  </div>
+                  <div
+                    class="dispute-steps__item-description"
+                  >
+                    Accepting the dispute means you’ll forfeit the funds, pay the standard dispute fee, and avoid the $500 USD Visa fee.
+                  </div>
+                </div>
+                <div
+                  class="dispute-steps__item-action"
+                >
+                  <a
+                    class="components-button is-secondary"
+                    href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more
+                  </a>
+                </div>
+              </div>
+              <div
+                class="dispute-steps__item"
+              >
+                <div
+                  class="dispute-steps__item-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    size="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M3 7c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Zm2-.5h14c.3 0 .5.2.5.5v1L12 13.5 4.5 7.9V7c0-.3.2-.5.5-.5Zm-.5 3.3V17c0 .3.2.5.5.5h14c.3 0 .5-.2.5-.5V9.8L12 15.4 4.5 9.8Z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="dispute-steps__item-content"
+                >
+                  <div
+                    class="dispute-steps__item-name"
+                  >
+                    Challenge the dispute
+                  </div>
+                  <div
+                    class="dispute-steps__item-description"
+                  >
+                    Challenging the dispute will incur a $500 USD network fee, charged by our partner Stripe when you submit evidence. This fee will be refunded if you win the dispute.
+                  </div>
+                </div>
+                <div
+                  class="dispute-steps__item-action"
+                >
+                  <a
+                    class="components-button is-secondary"
+                    href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Learn more
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div
+              class="dispute-steps__notice"
+            >
+              <div
+                class="wcpay-inline-notice wcpay-inline-info-notice dispute-steps__notice-content components-notice is-info"
+              >
+                <div
+                  class="components-visually-hidden emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="VisuallyHidden"
+                  style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                >
+                  Information notice
+                </div>
+                <div
+                  class="components-notice__content"
+                >
+                  <div
+                    class="components-flex emotion-2 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Flex"
+                  >
+                    <div
+                      class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexItem"
+                    >
+                      <svg
+                        class="gridicon gridicons-info-outline"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <g>
+                          <path
+                            d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                    <div
+                      class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="FlexItem"
+                    >
+                      <strong>
+                        The outcome of this dispute will be determined by Visa.
+                      </strong>
+                       WooPayments has no influence over the decision and is not liable for any chargebacks.
+                    </div>
+                  </div>
+                  <div
+                    class="components-notice__actions"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
@@ -1,0 +1,463 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DisputeAwaitingResponseDetails from '../dispute-awaiting-response-details';
+import { useDisputeAccept } from 'wcpay/data';
+import type { Dispute } from 'wcpay/types/disputes';
+import type { ChargeBillingDetails } from 'wcpay/types/charges';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
+
+const mockDisputeDoAccept = jest.fn();
+
+jest.mock( 'wcpay/data', () => ( {
+	useDisputeAccept: jest.fn( () => ( {
+		doAccept: mockDisputeDoAccept,
+		isLoading: false,
+	} ) ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	createRegistryControl: jest.fn(),
+	dispatch: jest.fn( () => ( {
+		setIsMatching: jest.fn(),
+		onLoad: jest.fn(),
+	} ) ),
+	registerStore: jest.fn(),
+	select: jest.fn(),
+	useDispatch: jest.fn( () => ( {
+		createErrorNotice: jest.fn(),
+	} ) ),
+	useSelect: jest.fn( () => ( { getNotices: jest.fn() } ) ),
+	withDispatch: jest.fn( () => jest.fn() ),
+	withSelect: jest.fn( () => jest.fn() ),
+} ) );
+
+jest.mock( 'tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+declare const global: {
+	wcpaySettings: {
+		zeroDecimalCurrencies: string[];
+		connect: {
+			country: string;
+		};
+	};
+};
+
+const mockUseDisputeAccept = useDisputeAccept as jest.MockedFunction<
+	typeof useDisputeAccept
+>;
+
+const getBaseDispute = (): Dispute => ( {
+	id: 'dp_visa_compliance_1',
+	amount: 5000,
+	charge: 'ch_mock',
+	order: null,
+	balance_transactions: [
+		{
+			amount: -5000,
+			currency: 'usd',
+			fee: 1500,
+			reporting_category: 'dispute',
+		},
+	],
+	created: 1693453017,
+	currency: 'usd',
+	evidence: {},
+	evidence_details: {
+		due_by: 1694303999,
+		has_evidence: false,
+		past_due: false,
+		submission_count: 0,
+	},
+	issuer_evidence: null,
+	metadata: {},
+	payment_intent: 'pi_1',
+	reason: 'noncompliant',
+	status: 'needs_response',
+	enhanced_eligibility_types: [ 'visa_compliance' ],
+} );
+
+const getBaseBillingDetails = (): ChargeBillingDetails => ( {
+	name: 'Test Customer',
+	email: 'test@example.com',
+	phone: null,
+	address: {
+		city: 'Test City',
+		country: 'US',
+		line1: '123 Test St',
+		line2: '',
+		postal_code: '12345',
+		state: 'CA',
+	},
+} );
+
+const renderWithContext = ( component: React.ReactElement ) => {
+	const settingsContext = {
+		accountStatus: {
+			country: 'US',
+		},
+		storeName: 'Test Store',
+		featureFlags: {
+			isDisputeIssuerEvidenceEnabled: false,
+		},
+	};
+	return render(
+		// @ts-expect-error: Only need a part of the settings for the test
+		<WCPaySettingsContext.Provider value={ settingsContext }>
+			{ component }
+		</WCPaySettingsContext.Provider>
+	);
+};
+
+describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
+	// eslint-disable-next-line
+	const originalWarn = console.warn;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+		};
+
+		// Suppress the List component deprecation warning
+		// eslint-disable-next-line
+		console.warn = ( ...args ) => {
+			const warningMessage = args[ 0 ];
+			if (
+				typeof warningMessage === 'string' &&
+				warningMessage.includes( 'List with items prop is deprecated' )
+			) {
+				return; // Suppress this specific warning
+			}
+			originalWarn( ...args ); // Pass through other warnings
+		};
+	} );
+
+	afterEach( () => {
+		// Restore original console.warn after each test
+		// eslint-disable-next-line
+		console.warn = originalWarn;
+	} );
+
+	test( 'renders Visa compliance dispute with NonCompliantDisputeSteps', () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		const { container } = renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Check for Visa compliance specific content
+		expect( screen.getByText( /Steps you can take/i ) ).toBeInTheDocument();
+
+		// Check for the two steps: Accept and Challenge
+		expect(
+			screen.getByText( /Accepting the dispute/i, {
+				selector: '.dispute-steps__item-name',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( /Challenge the dispute/i, {
+				selector: '.dispute-steps__item-name',
+			} )
+		).toBeInTheDocument();
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders Visa compliance checkbox', () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Check for the checkbox with the $500 fee acknowledgment
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /By checking this box, you acknowledge that challenging this Visa compliance dispute incurs a \$500 USD fee/i,
+		} );
+
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	test( 'Challenge button is disabled when checkbox is not checked and no staged evidence', () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const challengeButton = screen.getByRole( 'button', {
+			name: /Challenge dispute/i,
+		} );
+
+		expect( challengeButton ).toBeDisabled();
+	} );
+
+	test( 'Challenge button is enabled when checkbox is checked', async () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /By checking this box, you acknowledge that challenging this Visa compliance dispute incurs a \$500 USD fee/i,
+		} );
+
+		// Check the checkbox
+		await userEvent.click( checkbox );
+
+		expect( checkbox ).toBeChecked();
+
+		const challengeButton = screen.getByRole( 'button', {
+			name: /Challenge dispute/i,
+		} );
+
+		expect( challengeButton ).not.toBeDisabled();
+	} );
+
+	test( 'Challenge button is enabled when there is staged evidence (regardless of checkbox)', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			evidence_details: {
+				due_by: 1694303999,
+				has_evidence: true, // Has staged evidence
+				past_due: false,
+				submission_count: 0,
+			},
+		};
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const challengeButton = screen.getByRole( 'button', {
+			name: /Continue with challenge/i,
+		} );
+
+		// Button should be enabled even without checking the checkbox
+		expect( challengeButton ).not.toBeDisabled();
+	} );
+
+	test( 'renders correct help link for Visa compliance disputes', () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const helpLink = screen.getByRole( 'link', {
+			name: /Learn more about Visa compliance disputes/i,
+		} );
+
+		expect( helpLink ).toBeInTheDocument();
+		expect( helpLink ).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/'
+		);
+	} );
+
+	test( 'Accept dispute button works correctly for Visa compliance disputes', async () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const acceptButton = screen.getByRole( 'button', {
+			name: /Accept dispute/i,
+		} );
+
+		// Accept button should be enabled
+		expect( acceptButton ).not.toBeDisabled();
+
+		// Click to open modal
+		await userEvent.click( acceptButton );
+
+		// Check modal is displayed
+		expect(
+			screen.getByRole( 'heading', { name: /Accept the dispute\?/i } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'does not render checkbox for non-Visa compliance disputes', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'fraudulent', // Different reason
+			enhanced_eligibility_types: [],
+		};
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Checkbox should not be present
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: /By checking this box, you acknowledge that challenging this Visa compliance dispute/i,
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render checkbox when reason is noncompliant but missing visa_compliance eligibility type', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			enhanced_eligibility_types: [], // Missing visa_compliance
+		};
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Checkbox should not be present
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: /By checking this box, you acknowledge that challenging this Visa compliance dispute/i,
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'Challenge button remains disabled during accept request', () => {
+		mockUseDisputeAccept.mockReturnValueOnce( {
+			doAccept: mockDisputeDoAccept,
+			isLoading: true, // Request in progress
+		} );
+
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const challengeButton = screen.getByRole( 'button', {
+			name: /Challenge dispute/i,
+		} );
+
+		expect( challengeButton ).toBeDisabled();
+	} );
+
+	test( 'renders Visa-specific notice text in dispute notice', () => {
+		const dispute = getBaseDispute();
+		const customer = getBaseBillingDetails();
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ customer }
+				chargeCreated={ 1693453017 }
+				orderUrl="https://example.com/order/123"
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Check for Visa-specific text in the notice
+		expect(
+			screen.getByText(
+				/Your customer’s bank, Chase Bank, claims this payment violates Visa’s rules/i,
+				{ exact: false }
+			)
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByText( /Challenging adds an additional \$500 USD/i, {
+				exact: false,
+			} )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
@@ -378,7 +378,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'does not render checkbox when reason is noncompliant but missing visa_compliance eligibility type', () => {
+	test( 'render checkbox when reason is noncompliant but missing visa_compliance eligibility type', () => {
 		const dispute: Dispute = {
 			...getBaseDispute(),
 			enhanced_eligibility_types: [], // Missing visa_compliance
@@ -401,7 +401,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 			screen.queryByRole( 'checkbox', {
 				name: /By checking this box, you acknowledge that challenging this Visa compliance dispute/i,
 			} )
-		).not.toBeInTheDocument();
+		).toBeInTheDocument();
 	} );
 
 	test( 'Challenge button remains disabled during accept request', () => {

--- a/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
@@ -316,7 +316,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 		expect( helpLink ).toBeInTheDocument();
 		expect( helpLink ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/'
+			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes'
 		);
 	} );
 

--- a/client/payment-details/dispute-details/__tests__/dispute-notice.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-notice.test.tsx
@@ -1,0 +1,243 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DisputeNotice from '../dispute-notice';
+import type { Dispute } from 'wcpay/types/disputes';
+
+// Mock date formatting utility
+jest.mock( 'wcpay/utils/date-time', () => ( {
+	formatDateTimeFromTimestamp: jest.fn(
+		() => '11:59 PM on September 9, 2023'
+	),
+} ) );
+
+const getBaseDispute = (): Dispute => ( {
+	id: 'dp_1',
+	amount: 5000,
+	charge: 'ch_mock',
+	order: null,
+	balance_transactions: [
+		{
+			amount: -5000,
+			currency: 'usd',
+			fee: 1500,
+			reporting_category: 'dispute',
+		},
+	],
+	created: 1693453017,
+	currency: 'usd',
+	evidence: {},
+	evidence_details: {
+		due_by: 1694303999,
+		has_evidence: false,
+		past_due: false,
+		submission_count: 0,
+	},
+	issuer_evidence: null,
+	metadata: {},
+	payment_intent: 'pi_1',
+	reason: 'fraudulent',
+	status: 'needs_response',
+} );
+
+describe( 'DisputeNotice - Visa Compliance', () => {
+	test( 'renders Visa compliance notice with bank name', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'noncompliant',
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ true }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		// Check for Visa-specific text
+		expect( notice?.textContent ).toMatch(
+			/Your customer.s bank, Chase Bank, claims this payment violates Visa.s rules/i
+		);
+
+		// Check for the $500 fee mention
+		expect( notice?.textContent ).toMatch(
+			/Challenging adds an additional \$500 USD/i
+		);
+
+		// Check for the refund condition
+		expect( notice?.textContent ).toMatch(
+			/that is only returned to you if you win/i
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders Visa compliance notice without bank name', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'noncompliant',
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ true }
+				paymentMethod="card"
+				bankName={ null }
+			/>
+		);
+
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		// Should show generic "Your customer's bank" text
+		expect( notice?.textContent ).toMatch(
+			/Your customer.s bank claims this payment violates Visa.s rules/i
+		);
+
+		// Should not mention specific bank name
+		expect( notice?.textContent ).not.toMatch( /Chase Bank/i );
+
+		// Check for the $500 fee mention
+		expect( notice?.textContent ).toMatch(
+			/Challenging adds an additional \$500 USD/i
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders urgent error status for Visa compliance disputes', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'noncompliant',
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ true }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Check that the notice has error status (urgent)
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders deadline information correctly', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'noncompliant',
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ true }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		// Check that the deadline is mentioned
+		expect( notice?.textContent ).toMatch(
+			/11:59 PM on September 9, 2023/i
+		);
+	} );
+
+	test( 'does not render Visa compliance text for other dispute reasons', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'fraudulent', // Different reason
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ true }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		// Should not show Visa-specific text
+		expect( notice?.textContent ).not.toMatch( /violates Visa.s rules/i );
+
+		expect( notice?.textContent ).not.toMatch( /additional \$500 USD/i );
+
+		// Should show generic dispute text instead
+		expect( notice?.textContent ).toMatch(
+			/The cardholder claims this is an unauthorized transaction/i
+		);
+	} );
+
+	test( 'includes information about accepting the dispute', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'noncompliant',
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ true }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		// Check for text about accepting
+		expect( notice?.textContent ).toMatch( /or accept it/i );
+
+		expect( notice?.textContent ).toMatch(
+			/you will forfeit the funds and pay the dispute fee/i
+		);
+	} );
+
+	test( 'renders with warning status when not urgent', () => {
+		const dispute: Dispute = {
+			...getBaseDispute(),
+			reason: 'noncompliant',
+		};
+
+		const { container } = render(
+			<DisputeNotice
+				dispute={ dispute }
+				isUrgent={ false }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		// Notice should still render with warning status
+		const notice = container.querySelector( '.dispute-notice' );
+		expect( notice ).toBeInTheDocument();
+
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/payment-details/dispute-details/__tests__/dispute-steps.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-steps.test.tsx
@@ -1,0 +1,205 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { NonCompliantDisputeSteps } from '../dispute-steps';
+
+describe( 'NonCompliantDisputeSteps', () => {
+	test( 'renders the Visa compliance dispute steps', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		// Check for accordion title
+		expect(
+			screen.getByText( /Steps you can take/i, {
+				selector: '.wcpay-accordion__title-content',
+			} )
+		).toBeInTheDocument();
+
+		// Check for subtitle
+		expect(
+			screen.getByText(
+				/We recommend reviewing your options before responding by the deadline/i
+			)
+		).toBeInTheDocument();
+
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders "Accepting the dispute" step', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		// Check step title
+		expect(
+			screen.getByText( /Accepting the dispute/i, {
+				selector: '.dispute-steps__item-name',
+			} )
+		).toBeInTheDocument();
+
+		// Check step description - use container query to avoid text matching issues
+		const descriptions = container.querySelectorAll(
+			'.dispute-steps__item-description'
+		);
+		const acceptDescription = Array.from( descriptions ).find( ( el ) =>
+			el.textContent?.includes( 'forfeit the funds' )
+		);
+		expect( acceptDescription?.textContent ).toMatch(
+			/Accepting the dispute means you’ll forfeit the funds, pay the standard dispute fee, and avoid the \$500 USD Visa fee./i
+		);
+
+		// Check for Learn more link
+		const learnMoreLinks = screen.getAllByRole( 'link', {
+			name: /Learn more/i,
+		} );
+		expect( learnMoreLinks[ 0 ] ).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
+		);
+	} );
+
+	test( 'renders "Challenge the dispute" step', () => {
+		render( <NonCompliantDisputeSteps /> );
+
+		// Check step title
+		expect(
+			screen.getByText( /Challenge the dispute/i, {
+				selector: '.dispute-steps__item-name',
+			} )
+		).toBeInTheDocument();
+
+		// Check step description mentions $500 fee
+		expect(
+			screen.getByText(
+				/Challenging the dispute will incur a \$500 USD network fee/i,
+				{ exact: false }
+			)
+		).toBeInTheDocument();
+
+		// Check that it mentions the fee is charged by Stripe
+		expect(
+			screen.getByText( /charged by our partner Stripe/i, {
+				exact: false,
+			} )
+		).toBeInTheDocument();
+
+		// Check that it mentions the refund condition
+		expect(
+			screen.getByText(
+				/This fee will be refunded if you win the dispute/i,
+				{ exact: false }
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders Learn more links for both steps', () => {
+		render( <NonCompliantDisputeSteps /> );
+
+		const learnMoreLinks = screen.getAllByRole( 'link', {
+			name: /Learn more/i,
+		} );
+
+		// Should have 2 Learn more links
+		expect( learnMoreLinks ).toHaveLength( 2 );
+
+		// Both should point to the same documentation
+		learnMoreLinks.forEach( ( link ) => {
+			expect( link ).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
+			);
+			expect( link ).toHaveAttribute( 'target', '_blank' );
+			expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		} );
+	} );
+
+	test( 'renders Visa-specific notice at the bottom', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		// Check for the notice container
+		const notice = container.querySelector(
+			'.dispute-steps__notice-content'
+		);
+		expect( notice ).toBeInTheDocument();
+
+		// Check for the notice text - use container.textContent to avoid multiple element issues
+		expect( notice?.textContent ).toMatch(
+			/The outcome of this dispute will be determined by Visa/i
+		);
+
+		// Check for disclaimer
+		expect( notice?.textContent ).toMatch(
+			/WooPayments has no influence over the decision and is not liable for any chargebacks/i
+		);
+	} );
+
+	test( 'renders correct icons for each step', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		// Check that icons are rendered
+		const icons = container.querySelectorAll( '.dispute-steps__item-icon' );
+		expect( icons ).toHaveLength( 2 );
+	} );
+
+	test( 'renders two dispute steps', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		const steps = container.querySelectorAll( '.dispute-steps__item' );
+		expect( steps ).toHaveLength( 2 );
+	} );
+
+	test( 'renders info notice with correct status', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		const notice = container.querySelector(
+			'.dispute-steps__notice-content'
+		);
+		expect( notice ).toBeInTheDocument();
+	} );
+
+	test( 'does not render email customer action', () => {
+		render( <NonCompliantDisputeSteps /> );
+
+		// Should not have "Email customer" button (unlike regular DisputeSteps)
+		expect(
+			screen.queryByRole( 'button', { name: /Email customer/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render withdrawal step', () => {
+		render( <NonCompliantDisputeSteps /> );
+
+		// Should not have "Ask for the dispute to be withdrawn" step (unlike regular DisputeSteps)
+		expect(
+			screen.queryByText( /Ask for the dispute to be withdrawn/i )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders with correct structure', () => {
+		const { container } = render( <NonCompliantDisputeSteps /> );
+
+		// Check for main container
+		expect(
+			container.querySelector( '.dispute-steps' )
+		).toBeInTheDocument();
+
+		// Check for accordion
+		expect(
+			container.querySelector( '.wcpay-accordion' )
+		).toBeInTheDocument();
+
+		// Check for steps container
+		expect(
+			container.querySelector( '.dispute-steps__items' )
+		).toBeInTheDocument();
+
+		// Check for notice container
+		expect(
+			container.querySelector( '.dispute-steps__notice' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/payment-details/dispute-details/__tests__/dispute-steps.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-steps.test.tsx
@@ -58,7 +58,7 @@ describe( 'NonCompliantDisputeSteps', () => {
 		} );
 		expect( learnMoreLinks[ 0 ] ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
+			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes'
 		);
 	} );
 
@@ -110,7 +110,7 @@ describe( 'NonCompliantDisputeSteps', () => {
 		learnMoreLinks.forEach( ( link ) => {
 			expect( link ).toHaveAttribute(
 				'href',
-				'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept'
+				'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes'
 			);
 			expect( link ).toHaveAttribute( 'target', '_blank' );
 			expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -15,12 +15,13 @@ import { Link } from '@woocommerce/components';
  */
 import {
 	Button,
+	CheckboxControl,
 	ExternalLink,
 	Flex,
 	FlexItem,
+	HorizontalRule,
 	Icon,
 	Modal,
-	HorizontalRule,
 } from '@wordpress/components';
 import type { Dispute } from 'wcpay/types/disputes';
 import type { ChargeBillingDetails } from 'wcpay/types/charges';
@@ -35,6 +36,7 @@ import {
 	DisputeSteps,
 	InquirySteps,
 	NotDefendableInquirySteps,
+	NonCompliantDisputeSteps,
 } from './dispute-steps';
 import InlineNotice from 'components/inline-notice';
 import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
@@ -173,6 +175,10 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		isLoading: isDisputeAcceptRequestPending,
 	} = useDisputeAccept( dispute );
 	const [ isModalOpen, setModalOpen ] = useState( false );
+	const [
+		isVisaComplianceConditionAccepted,
+		setVisaComplianceConditionAccepted,
+	] = useState( false );
 
 	const hasStagedEvidence = dispute.evidence_details?.has_evidence;
 	const { createErrorNotice } = useDispatch( 'core/notices' );
@@ -181,6 +187,12 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		featureFlags: { isDisputeIssuerEvidenceEnabled },
 	} = useContext( WCPaySettingsContext );
 
+	const isVisaComplianceDispute =
+		dispute.reason === 'noncompliant' &&
+		( dispute?.enhanced_eligibility_types || [] ).includes(
+			'visa_compliance'
+		);
+
 	// Get the appropriate documentation URL based on dispute type
 	const getLearnMoreDocsUrl = () => {
 		if ( isInquiry( dispute.status ) ) {
@@ -188,6 +200,9 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 				return 'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#klarna-inquiries-returns';
 			}
 			return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries';
+		}
+		if ( isVisaComplianceDispute ) {
+			return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/';
 		}
 		return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding';
 	};
@@ -203,6 +218,12 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 			}
 			return __(
 				'Learn more about payment inquiries',
+				'woocommerce-payments'
+			);
+		}
+		if ( isVisaComplianceDispute ) {
+			return __(
+				'Learn more about Visa compliance disputes',
 				'woocommerce-payments'
 			);
 		}
@@ -245,10 +266,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 	 * - Visa Compliance disputes (require confirmation of a specific fee)
 	 */
 	const isDefendable = ! (
-		( paymentMethod === 'klarna' && isInquiry( dispute.status ) ) ||
-		( dispute?.enhanced_eligibility_types || [] ).includes(
-			'visa_compliance'
-		)
+		paymentMethod === 'klarna' && isInquiry( dispute.status )
 	);
 
 	const challengeButtonDefaultText = isInquiry( dispute.status )
@@ -271,9 +289,8 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		/>
 	);
 
-	// we cannot nest ternary operators, so let's build the steps in a variable
-	const steps = isInquiry( dispute.status ) ? (
-		inquirySteps
+	const disputeSteps = isVisaComplianceDispute ? (
+		<NonCompliantDisputeSteps />
 	) : (
 		<DisputeSteps
 			dispute={ dispute }
@@ -282,6 +299,9 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 			bankName={ bankName }
 		/>
 	);
+
+	// we cannot nest ternary operators, so let's build the steps in a variable
+	const steps = isInquiry( dispute.status ) ? inquirySteps : disputeSteps;
 
 	return (
 		<div className="transaction-details-dispute-details-wrapper">
@@ -330,7 +350,19 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 						{ getHelpLinkText() }
 					</ExternalLink>
 				</div>
-
+				{ /* Checkbox for the Visa Compliance dispute */ }
+				{ isVisaComplianceDispute && (
+					<div className="transaction-details-dispute-details-body__visa-compliance-checkbox">
+						<CheckboxControl
+							onChange={ setVisaComplianceConditionAccepted }
+							label={ __(
+								'By checking this box, you acknowledge that challenging this Visa compliance dispute incurs a $500 USD fee, which will be refunded only if you win the case.',
+								'woocommerce-payments'
+							) }
+							__nextHasNoMarginBottom
+						/>
+					</div>
+				) }
 				{ /* Dispute Actions */ }
 				{
 					<div className="transaction-details-dispute-details-body__actions">
@@ -351,7 +383,12 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 								<Button
 									variant="primary"
 									data-testid="challenge-dispute-button"
-									disabled={ isDisputeAcceptRequestPending }
+									disabled={
+										isDisputeAcceptRequestPending ||
+										( isVisaComplianceDispute &&
+											! hasStagedEvidence &&
+											! isVisaComplianceConditionAccepted )
+									}
 									onClick={ () => {
 										recordEvent(
 											'wcpay_dispute_challenge_clicked',

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -188,7 +188,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 	} = useContext( WCPaySettingsContext );
 
 	const isVisaComplianceDispute =
-		dispute.reason === 'noncompliant' &&
+		dispute.reason === 'noncompliant' ||
 		( dispute?.enhanced_eligibility_types || [] ).includes(
 			'visa_compliance'
 		);

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -202,7 +202,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 			return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries';
 		}
 		if ( isVisaComplianceDispute ) {
-			return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/';
+			return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes';
 		}
 		return 'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#responding';
 	};

--- a/client/payment-details/dispute-details/dispute-notice.tsx
+++ b/client/payment-details/dispute-details/dispute-notice.tsx
@@ -78,6 +78,26 @@ const DisputeNotice: React.FC< DisputeNoticeProps > = ( {
 			  );
 	}
 	// Handle specific dispute reasons
+	else if ( 'noncompliant' === dispute.reason ) {
+		/* translators: %1$s is the bank name, eg "Chase Bank". %2$s is the deadline date, eg "Aug 18, 2023 11:59 PM". */
+		noticeText = bankName
+			? sprintf(
+					__(
+						'Your customer’s bank, %1$s, claims this payment violates Visa’s rules. <strong>You can challenge the dispute by %2$s, or accept it.</strong> If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.',
+						'woocommerce-payments'
+					),
+					bankName,
+					dueByDate
+			  )
+			: sprintf(
+					__(
+						'Your customer’s bank claims this payment violates Visa’s rules. <strong>You can challenge the dispute by %1$s, or accept it.</strong> If you accept the dispute, you will forfeit the funds and pay the dispute fee. Challenging adds an additional $500 USD dispute fee that is only returned to you if you win.',
+						'woocommerce-payments'
+					),
+					dueByDate
+			  );
+	}
+	// General case for disputes
 	else {
 		/* translators: %1$s is the clients claim for the dispute, eg "The cardholder claims this is an unauthorized charge." %2$s is the bank name, eg "Chase Bank". %3$s is the deadline date, eg "Aug 18, 2023 11:59 PM". */
 		noticeText = bankName

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -246,7 +246,7 @@ export const NonCompliantDisputeSteps: React.FC = () => {
 									<div className="dispute-steps__item-action">
 										<Button
 											variant="secondary"
-											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
 											target="_blank"
 											rel="noopener noreferrer"
 										>
@@ -279,7 +279,7 @@ export const NonCompliantDisputeSteps: React.FC = () => {
 									<div className="dispute-steps__item-action">
 										<Button
 											variant="secondary"
-											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#visa-compliance-disputes"
 											target="_blank"
 											rel="noopener noreferrer"
 										>

--- a/client/payment-details/dispute-details/dispute-steps.tsx
+++ b/client/payment-details/dispute-details/dispute-steps.tsx
@@ -209,6 +209,116 @@ export const DisputeSteps: React.FC< Props > = ( {
 	);
 };
 
+export const NonCompliantDisputeSteps: React.FC = () => {
+	return (
+		<div className="dispute-steps">
+			<Accordion defaultExpanded={ true }>
+				<AccordionBody
+					lg
+					title={ __( 'Steps you can take', 'woocommerce-payments' ) }
+					subtitle={ __(
+						'We recommend reviewing your options before responding by the deadline. ',
+						'woocommerce-payments'
+					) }
+				>
+					<AccordionRow>
+						<div className="dispute-steps__content">
+							<div className="dispute-steps__items">
+								{ /* Step 1: Accept the dispute */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ page } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Accepting the dispute',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Accepting the dispute means you’ll forfeit the funds, pay the standard dispute fee, and avoid the $500 USD Visa fee.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										<Button
+											variant="secondary"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</Button>
+									</div>
+								</div>
+								{ /* Step 2: Challenge or accept the dispute */ }
+								<div className="dispute-steps__item">
+									<div className="dispute-steps__item-icon">
+										<Icon icon={ envelope } />
+									</div>
+									<div className="dispute-steps__item-content">
+										<div className="dispute-steps__item-name">
+											{ __(
+												'Challenge the dispute',
+												'woocommerce-payments'
+											) }
+										</div>
+										<div className="dispute-steps__item-description">
+											{ __(
+												'Challenging the dispute will incur a $500 USD network fee, charged by our partner Stripe when you submit evidence. This fee will be refunded if you win the dispute.',
+												'woocommerce-payments'
+											) }
+										</div>
+									</div>
+									<div className="dispute-steps__item-action">
+										<Button
+											variant="secondary"
+											href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#challenge-or-accept"
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</Button>
+									</div>
+								</div>
+							</div>
+
+							{ /* Dispute notice */ }
+							<div className="dispute-steps__notice">
+								<InlineNotice
+									icon
+									isDismissible={ false }
+									status="info"
+									className="dispute-steps__notice-content"
+								>
+									{ createInterpolateElement(
+										__(
+											'<strong>The outcome of this dispute will be determined by Visa.</strong> WooPayments has no influence over the decision and is not liable for any chargebacks.',
+											'woocommerce-payments'
+										),
+										{
+											strong: <strong />,
+										}
+									) }
+								</InlineNotice>
+							</div>
+						</div>
+					</AccordionRow>
+				</AccordionBody>
+			</Accordion>
+		</div>
+	);
+};
+
 export const InquirySteps: React.FC< Props > = ( {
 	dispute,
 	customer,

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -48,6 +48,10 @@
 			}
 		}
 
+		&__visa-compliance-checkbox {
+			margin: 0;
+		}
+
 		&__actions {
 			display: flex;
 			justify-content: start;
@@ -87,6 +91,10 @@
 			}
 		}
 	}
+}
+
+div.transaction-details-dispute-details-body__visa-compliance-checkbox + div {
+	margin-top: 16px !important;
 }
 
 .dispute-reason-tooltip {

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -183,6 +183,13 @@
 			font-weight: var( --Regular, 400 );
 			line-height: var( --s, 20px ); /* 153.846% */
 
+			@media screen and ( max-width: $break-small ) {
+				margin-bottom: 8px;
+				width: 100%;
+			}
+		}
+
+		&-content:last-child &-description {
 			width: 80%;
 
 			@media screen and ( max-width: $break-small ) {

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -190,7 +190,7 @@
 		}
 
 		&-content:last-child &-description {
-			width: 80%;
+			width: 90%;
 
 			@media screen and ( max-width: $break-small ) {
 				margin-bottom: 8px;

--- a/client/payment-details/dispute-details/style.scss
+++ b/client/payment-details/dispute-details/style.scss
@@ -93,10 +93,6 @@
 	}
 }
 
-div.transaction-details-dispute-details-body__visa-compliance-checkbox + div {
-	margin-top: 16px !important;
-}
-
 .dispute-reason-tooltip {
 	p {
 		&:first-child {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -691,13 +691,14 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 
 		// Add Visa compliance flag for noncompliant disputes.
 		if ( isset( $dispute_details['reason'] ) && 'noncompliant' === $dispute_details['reason'] ) {
-			$request['evidence_details'] = [
-				'enhanced_eligibility' => [
+			$request['evidence']['enhanced_evidence'] = array_merge(
+				$request['evidence']['enhanced_evidence'] ?? [],
+				[
 					'visa_compliance' => [
-						'status' => 'fee_acknowledged',
+						'fee_acknowledged' => 'true',
 					],
-				],
-			];
+				]
+			);
 		}
 
 		$dispute = $this->request( $request, self::DISPUTES_API . '/' . $dispute_id, self::POST );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -677,11 +677,28 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			);
 		}
 
+		// Fetch the dispute to check if it's a Visa compliance (noncompliant) dispute.
+		$dispute_details = $this->get_dispute( $dispute_id );
+		if ( is_wp_error( $dispute_details ) ) {
+			return $dispute_details;
+		}
+
 		$request = [
 			'evidence' => $evidence,
 			'submit'   => $submit,
 			'metadata' => $metadata,
 		];
+
+		// Add Visa compliance flag for noncompliant disputes.
+		if ( isset( $dispute_details['reason'] ) && 'noncompliant' === $dispute_details['reason'] ) {
+			$request['evidence_details'] = [
+				'enhanced_eligibility' => [
+					'visa_compliance' => [
+						'status' => 'fee_acknowledged',
+					],
+				],
+			];
+		}
 
 		$dispute = $this->request( $request, self::DISPUTES_API . '/' . $dispute_id, self::POST );
 		// Invalidate the dispute caches.

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1324,6 +1324,152 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Test updating a dispute with or without Visa compliance flag based on dispute reason.
+	 *
+	 * @dataProvider data_update_dispute_visa_compliance
+	 * @throws API_Exception
+	 */
+	public function test_update_dispute_visa_compliance_flag( $dispute_reason, $should_have_flag ) {
+		$dispute_id = 'dp_test123';
+		$evidence   = [
+			'product_description'    => 'Product description',
+			'customer_name'          => 'Customer Name',
+			'uncategorized_text'     => 'Additional details',
+			'customer_email_address' => 'customer@example.com',
+			'customer_purchase_ip'   => '1.2.3.4',
+			'billing_address'        => '123 Main St',
+			'receipt'                => 'file_123',
+			'customer_signature'     => 'file_456',
+			'shipping_documentation' => 'file_789',
+		];
+		$submit     = true;
+		$metadata   = [ 'order_id' => '123' ];
+
+		// Mock the dispute cache to avoid errors.
+		$mock_cache = $this->createMock( \WCPay\Database_Cache::class );
+		$mock_cache->method( 'delete_dispute_caches' )
+			->willReturn( null );
+
+		// Replace the database cache in the container.
+		wcpay_get_test_container()->replace( \WCPay\Database_Cache::class, $mock_cache );
+
+		// Mock the HTTP client to first return dispute details, then accept the update.
+		$this->mock_http_client
+			->expects( $this->exactly( 2 ) )
+			->method( 'remote_request' )
+			->willReturnCallback(
+				function ( $data, $body ) use ( $dispute_id, $evidence, $metadata, $dispute_reason, $should_have_flag ) {
+					// First call: GET dispute to check the reason.
+					if ( strpos( $data['url'], '/disputes/' . $dispute_id ) !== false && 'GET' === $data['method'] ) {
+						return [
+							'body'     => wp_json_encode(
+								[
+									'id'     => $dispute_id,
+									'charge' => 'ch_test123',
+									'reason' => $dispute_reason,
+									'status' => 'needs_response',
+								]
+							),
+							'response' => [
+								'code'    => 200,
+								'message' => 'OK',
+							],
+						];
+					}
+
+					// Second call: POST to update the dispute.
+					if ( strpos( $data['url'], '/disputes/' . $dispute_id ) !== false && 'POST' === $data['method'] ) {
+						// Validate the request parameters.
+						$this->validate_default_remote_request_params(
+							$data,
+							'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/disputes/' . $dispute_id,
+							'POST'
+						);
+
+						// Validate the body contains or doesn't contain the Visa compliance flag.
+						$decoded = json_decode( $body, true );
+
+						// Verify the standard evidence is present.
+						$this->assertArrayHasKey( 'evidence', $decoded );
+						$this->assertEquals( $evidence, $decoded['evidence'] );
+
+						// Verify the submit flag is set.
+						$this->assertArrayHasKey( 'submit', $decoded );
+						$this->assertTrue( $decoded['submit'] );
+
+						// Verify the metadata is present.
+						$this->assertArrayHasKey( 'metadata', $decoded );
+						$this->assertEquals( $metadata, $decoded['metadata'] );
+
+						// Verify the Visa compliance flag presence based on dispute reason.
+						if ( $should_have_flag ) {
+							$this->assertArrayHasKey( 'evidence_details', $decoded );
+							$this->assertArrayHasKey( 'enhanced_eligibility', $decoded['evidence_details'] );
+							$this->assertArrayHasKey( 'visa_compliance', $decoded['evidence_details']['enhanced_eligibility'] );
+							$this->assertArrayHasKey( 'status', $decoded['evidence_details']['enhanced_eligibility']['visa_compliance'] );
+							$this->assertEquals( 'fee_acknowledged', $decoded['evidence_details']['enhanced_eligibility']['visa_compliance']['status'] );
+						} else {
+							$this->assertArrayNotHasKey( 'evidence_details', $decoded );
+						}
+
+						return [
+							'body'     => wp_json_encode(
+								[
+									'id'       => $dispute_id,
+									'charge'   => 'ch_test123',
+									'reason'   => $dispute_reason,
+									'status'   => 'needs_response',
+									'evidence' => $evidence,
+								]
+							),
+							'response' => [
+								'code'    => 200,
+								'message' => 'OK',
+							],
+						];
+					}
+
+					return [
+						'body'     => wp_json_encode( [] ),
+						'response' => [
+							'code'    => 404,
+							'message' => 'Not Found',
+						],
+					];
+				}
+			);
+
+		// Call the method under test.
+		$result = $this->payments_api_client->update_dispute( $dispute_id, $evidence, $submit, $metadata );
+
+		// Assert the response is correct.
+		$this->assertEquals( $dispute_id, $result['id'] );
+
+		// Clean up.
+		wcpay_get_test_container()->reset_all_replacements();
+	}
+
+	/**
+	 * Data provider for test_update_dispute_visa_compliance_flag.
+	 */
+	public function data_update_dispute_visa_compliance() {
+		return [
+			'noncompliant_dispute_should_have_flag'   => [
+				'dispute_reason'   => 'noncompliant',
+				'should_have_flag' => true,
+			],
+			'fraudulent_dispute_should_not_have_flag' => [
+				'dispute_reason'   => 'fraudulent',
+				'should_have_flag' => false,
+			],
+			'product_unacceptable_dispute_should_not_have_flag' => [
+				'dispute_reason'   => 'product_unacceptable',
+				'should_have_flag' => false,
+			],
+		];
+	}
+
+	/**
 	 * Data provider for test_determine_suggested_product_type.
 	 */
 	public function data_determine_suggested_product_type() {

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1391,7 +1391,19 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 
 						// Verify the standard evidence is present.
 						$this->assertArrayHasKey( 'evidence', $decoded );
-						$this->assertEquals( $evidence, $decoded['evidence'] );
+						// Verify the Visa compliance flag presence based on dispute reason.
+						if ( $should_have_flag ) {
+							$this->assertArrayHasKey( 'enhanced_evidence', $decoded['evidence'] );
+							$this->assertArrayHasKey( 'visa_compliance', $decoded['evidence']['enhanced_evidence'] );
+							$this->assertArrayHasKey( 'fee_acknowledged', $decoded['evidence']['enhanced_evidence']['visa_compliance'] );
+							$this->assertEquals( 'true', $decoded['evidence']['enhanced_evidence']['visa_compliance']['fee_acknowledged'] );
+							$evidence_without_flag = $decoded['evidence'];
+							unset( $evidence_without_flag['enhanced_evidence'] );
+							$this->assertEquals( $evidence, $evidence_without_flag );
+						} else {
+							// Evidence shouldn't be modified.
+							$this->assertEquals( $evidence, $decoded['evidence'] );
+						}
 
 						// Verify the submit flag is set.
 						$this->assertArrayHasKey( 'submit', $decoded );
@@ -1400,17 +1412,6 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 						// Verify the metadata is present.
 						$this->assertArrayHasKey( 'metadata', $decoded );
 						$this->assertEquals( $metadata, $decoded['metadata'] );
-
-						// Verify the Visa compliance flag presence based on dispute reason.
-						if ( $should_have_flag ) {
-							$this->assertArrayHasKey( 'evidence_details', $decoded );
-							$this->assertArrayHasKey( 'enhanced_eligibility', $decoded['evidence_details'] );
-							$this->assertArrayHasKey( 'visa_compliance', $decoded['evidence_details']['enhanced_eligibility'] );
-							$this->assertArrayHasKey( 'status', $decoded['evidence_details']['enhanced_eligibility']['visa_compliance'] );
-							$this->assertEquals( 'fee_acknowledged', $decoded['evidence_details']['enhanced_eligibility']['visa_compliance']['status'] );
-						} else {
-							$this->assertArrayNotHasKey( 'evidence_details', $decoded );
-						}
 
 						return [
 							'body'     => wp_json_encode(


### PR DESCRIPTION
Fixes WOOPMNT-5113

#### Changes proposed in this Pull Request

 - Changes to the dispute summary screen, addressing higher fees for the dispute type and the specifics of the case.
 - Updated logic to set a `fee_acknowledged` flag when submitting evidence.
 - Changes to the evidence submission flow to indicate that the outcome is determined by Visa for this dispute type.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a WooCommerce store with WooPayments.
* Make a purchase using a card number `4000008400000779` to trigger a Visa Compliance dispute.
* As a merchant, open the payment details page for the dispute and verify that it matches the expectations in the reference design.
* Make another purchase using a different [test card number](https://docs.stripe.com/testing#disputes), e.g. `4000000000002685` which creates a "Product not received" dispute.
* Open the dispute page and verify that it remains consistent with the dispute type, i.e., there are no mentions of the special $500 fee for challenging a Visa compliance issue. The "Challenge Dispute" button should be enabled on load.


https://github.com/user-attachments/assets/f5d9890b-e3eb-42a3-bdfe-dad5b497c84a



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
