### PR TITLE
Enforce strict user capability checks when deleting test orders

### DIFF
--- a/changelog/update-verify-user-access-when-deleting-test-orders
+++ b/changelog/update-verify-user-access-when-deleting-test-orders
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Enforce strict capability checks when deleting test orders.
+
+

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -131,7 +131,7 @@ class WC_Payments_Status {
 			$deleted_count = 0;
 			foreach ( $test_orders as $order ) {
 				// Permanently delete the order (skip trash).
-				if ( $order->delete() ) {
+				if ( $order->delete( true ) ) {
 					++$deleted_count;
 				}
 			}

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -106,6 +106,11 @@ class WC_Payments_Status {
 	 * @return string Success or error message.
 	 */
 	public function delete_test_orders() {
+		// Add explicit capability check.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return __( 'You do not have permission to delete orders.', 'woocommerce-payments' );
+		}
+
 		try {
 			// Get all orders with test mode meta.
 			$test_orders = wc_get_orders(

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -43,6 +43,9 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Set up an admin user with proper capabilities.
+		wp_set_current_user( 1 );
+
 		$this->mock_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
 		$this->mock_http    = $this->createMock( WC_Payments_Http_Interface::class );
 		$this->mock_account = $this->createMock( WC_Payments_Account::class );
@@ -148,14 +151,12 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		// Verify result message.
 		$this->assertStringContainsString( '2 test orders have been permanently deleted.', $result );
 
-		// Verify test orders were moved to trash.
-		$trashed_order1 = wc_get_order( $order1->get_id() );
-		$this->assertInstanceOf( WC_Order::class, $trashed_order1 );
-		$this->assertEquals( 'trash', $trashed_order1->get_status() );
+		// Verify test orders were permanently deleted (no longer exist).
+		$deleted_order1 = wc_get_order( $order1->get_id() );
+		$this->assertFalse( $deleted_order1, 'Test order 1 should be permanently deleted' );
 
-		$trashed_order2 = wc_get_order( $order2->get_id() );
-		$this->assertInstanceOf( WC_Order::class, $trashed_order2 );
-		$this->assertEquals( 'trash', $trashed_order2->get_status() );
+		$deleted_order2 = wc_get_order( $order2->get_id() );
+		$this->assertFalse( $deleted_order2, 'Test order 2 should be permanently deleted' );
 
 		// Verify non-test order was not deleted.
 		$order3_check = wc_get_order( $order3->get_id() );
@@ -176,10 +177,9 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$this->assertStringContainsString( '1 test order has been permanently deleted.', $result );
 
-		// Verify order was moved to trash.
-		$trashed_order = wc_get_order( $order->get_id() );
-		$this->assertInstanceOf( WC_Order::class, $trashed_order );
-		$this->assertEquals( 'trash', $trashed_order->get_status() );
+		// Verify order was permanently deleted (no longer exists).
+		$deleted_order = wc_get_order( $order->get_id() );
+		$this->assertFalse( $deleted_order, 'Test order should be permanently deleted' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -214,7 +214,11 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$order2->save();
 
 		// Mock that the current user is missing the manage_woocommerce capability.
-		$filter_callback = fn( $caps ) => [ 'manage_woocommerce' => false ];
+		$filter_callback = function ( $allcaps ) {
+			$allcaps['manage_woocommerce'] = false;
+
+			return $allcaps;
+		};
 		add_filter( 'user_has_cap', $filter_callback );
 
 		$result = $this->status->delete_test_orders();

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -111,21 +111,20 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_delete_test_orders_with_no_orders() {
 		// Mock wc_get_orders to return empty array.
-		add_filter(
-			'woocommerce_order_data_store_cpt_get_orders_query',
-			function ( $query, $query_vars ) {
-				if ( isset( $query_vars['meta_key'] ) && '_wcpay_mode' === $query_vars['meta_key'] ) {
-					$query['post__in'] = [ 0 ]; // Force no results.
-				}
-				return $query;
-			},
-			10,
-			2
-		);
+		$filter_callback = function ( $query, $query_vars ) {
+			if ( isset( $query_vars['meta_key'] ) && '_wcpay_mode' === $query_vars['meta_key'] ) {
+				$query['post__in'] = [ 0 ]; // Force no results.
+			}
+			return $query;
+		};
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $filter_callback, 10, 2 );
 
 		$result = $this->status->delete_test_orders();
 
 		$this->assertEquals( 'No test orders found.', $result );
+
+		// Clean up filter.
+		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $filter_callback, 10 );
 	}
 
 	/**
@@ -187,18 +186,17 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_delete_test_orders_handles_exception() {
 		// Mock wc_get_orders to throw an exception.
-		add_filter(
-			'woocommerce_order_data_store_cpt_get_orders_query',
-			function ( $query, $query_vars ) {
-				throw new Exception( 'Database error' );
-			},
-			10,
-			2
-		);
+		$filter_callback = function () {
+			throw new Exception( 'Database error' );
+		};
+		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $filter_callback, 10, 2 );
 
 		$result = $this->status->delete_test_orders();
 
 		$this->assertStringContainsString( 'Error deleting test orders:', $result );
 		$this->assertStringContainsString( 'Database error', $result );
+
+		// Clean up filter.
+		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $filter_callback, 10 );
 	}
 }

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -199,4 +199,37 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		// Clean up filter.
 		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $filter_callback, 10 );
 	}
+
+	/**
+	 * Test delete_test_orders denies access for users without manage_woocommerce capability.
+	 */
+	public function test_delete_test_orders_requires_manage_woocommerce_capability() {
+		// Create test orders with _wcpay_mode meta.
+		$order1 = wc_create_order();
+		$order1->update_meta_data( '_wcpay_mode', 'test' );
+		$order1->save();
+
+		$order2 = wc_create_order();
+		$order2->update_meta_data( '_wcpay_mode', 'test' );
+		$order2->save();
+
+		// Mock that the current user is missing the manage_woocommerce capability.
+		$filter_callback = fn( $caps ) => [ 'manage_woocommerce' => false ];
+		add_filter( 'user_has_cap', $filter_callback );
+
+		$result = $this->status->delete_test_orders();
+
+		// Verify permission denied message.
+		$this->assertEquals( 'You do not have permission to delete orders.', $result );
+
+		// Verify orders were NOT deleted.
+		$order1_check = wc_get_order( $order1->get_id() );
+		$this->assertInstanceOf( WC_Order::class, $order1_check );
+
+		$order2_check = wc_get_order( $order2->get_id() );
+		$this->assertInstanceOf( WC_Order::class, $order2_check );
+
+		// Clean up filter.
+		remove_filter( 'user_has_cap', $filter_callback );
+	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-payments/pull/11103

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Better safe than sorry: even if the WooCommerce Debug Tools have access checks, we should make sure we have backstops in place. When deleting test orders we add an explicit check for the `manage_woocommerce` capability.

Also, we were missing the right parameter to force delete test orders and skip trash.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions of the original PR: https://github.com/Automattic/woocommerce-payments/pull/11103

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
