### PR TITLE
Fix styling for Test Mode badge in block checkout

### DIFF
--- a/changelog/fix-missing-badge
+++ b/changelog/fix-missing-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix strict CSS selector.

--- a/changelog/fix-missing-badge
+++ b/changelog/fix-missing-badge
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fix
+Comment: Fix regression caused by PR #11085
 
-Fix strict CSS selector.
+

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -45,7 +45,7 @@ button.wcpay-stripelink-modal-trigger:hover {
 .wc-block-checkout__payment-method {
 	input:checked ~ div {
 		/* stylelint-disable-next-line selector-id-pattern */
-		.wc-block-components-radio-control__label:where( #radio-control-wc-payment-method-options-woocommerce_payments__label ) {
+		.wc-block-components-radio-control__label:where( [id^='radio-control-wc-payment-method-options-woocommerce_payments'][id$='__label'] ) {
 			> .payment-method-label {
 				.test-mode.badge {
 					// hiding the badge when the payment method is not selected
@@ -56,7 +56,7 @@ button.wcpay-stripelink-modal-trigger:hover {
 	}
 
 	/* stylelint-disable-next-line selector-id-pattern */
-	.wc-block-components-radio-control__label:where( #radio-control-wc-payment-method-options-woocommerce_payments__label ) {
+	.wc-block-components-radio-control__label:where( [id^='radio-control-wc-payment-method-options-woocommerce_payments'][id$='__label'] ) {
 		width: 100%;
 		display: block !important;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix a CSS class that was too strict [introduced here](https://github.com/Automattic/woocommerce-payments/pull/11085). Test mode badge was not appearing for other payment methods.

| Before | After |
| --- | --- |
| <img width="1219" height="428" alt="image" src="https://github.com/user-attachments/assets/7624299a-b63b-4b9f-89cc-15e47a0c895a" /> | <img width="1188" height="376" alt="image" src="https://github.com/user-attachments/assets/4cfc8c00-49a2-4974-9eda-afaba969d099" /> |


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* In test mode setup other payment methods than credit card
* On the checkout page check if they have the test mode badge.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
