### PR TITLE
fix: text color contrast of payment methods w/ dark bg

### DIFF
--- a/changelog/fix-payment-methods-logos-overflow-text-color
+++ b/changelog/fix-payment-methods-logos-overflow-text-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: text color of payment method icons on checkout page when a dark background is used

--- a/client/checkout/blocks/payment-methods-logos/style.scss
+++ b/client/checkout/blocks/payment-methods-logos/style.scss
@@ -21,7 +21,7 @@
 		width: 38px;
 		height: 24px;
 		background-color: rgba( $gray-700, 0.1 );
-		color: $gray-900;
+		color: var( --wp--preset--color--contrast, $gray-900 );
 		text-align: center;
 		line-height: 24px;
 		border-radius: 3px;


### PR DESCRIPTION
Fixes WOOPMNT-5452

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the text color of the payment methods doesn't have enough contrast when a dark background is applied.
Fixing.

Before:
<img width="818" height="452" alt="Screenshot 2025-11-05 at 11 04 48 AM" src="https://github.com/user-attachments/assets/c0268dc6-0960-43cc-97bf-c0429c63c894" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use a theme with a dark background (e.g.: TT4 with the styles below)
<img width="672" height="771" alt="Screenshot 2025-11-05 at 11 01 30 AM" src="https://github.com/user-attachments/assets/ea8f18e4-365d-412d-a257-ffc790a6b2ae" />
- Add a product to the cart
- Go to the checkout page (test both block-based and "classic" checkout)
- The text next to the payment method icons should now have enough contrast.


See a few examples below:
<img width="830" height="458" alt="Screenshot 2025-11-05 at 11 03 49 AM" src="https://github.com/user-attachments/assets/29cc5322-ab8a-4836-b044-0c45501de9f5" />
<img width="815" height="443" alt="Screenshot 2025-11-05 at 11 03 22 AM" src="https://github.com/user-attachments/assets/211f5a28-32d1-47b5-88e4-5537e0925102" />
<img width="854" height="408" alt="Screenshot 2025-11-05 at 10 54 37 AM" src="https://github.com/user-attachments/assets/b91e7210-f289-40cc-8575-995225ad4995" />
<img width="725" height="321" alt="Screenshot 2025-11-05 at 10 54 22 AM" src="https://github.com/user-attachments/assets/ae807f17-bf33-422f-aa7a-496530aa7767" />
<img width="815" height="310" alt="Screenshot 2025-11-05 at 10 54 02 AM" src="https://github.com/user-attachments/assets/52b176e2-9c81-4c77-bf35-93b0fdb69ff0" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
