### PR TITLE
Fix WooPay phone field on Blocks Checkout

### DIFF
--- a/changelog/fix-woopay-blocks-field
+++ b/changelog/fix-woopay-blocks-field
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-WooPay phone field on blocks checkout.
+WooPay component spacing issues on blocks and classic checkout.

--- a/changelog/fix-woopay-blocks-field
+++ b/changelog/fix-woopay-blocks-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooPay phone field on blocks checkout.

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -16,10 +16,6 @@
 	padding: 0;
 }
 
-#contact-fields {
-	padding-bottom: 1.5em;
-}
-
 .wc-block-components-text-input button.wcpay-stripelink-modal-trigger {
 	top: 50%;
 	transform: translateY( -50% );

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -96,15 +96,6 @@ button.wcpay-stripelink-modal-trigger:hover {
 	}
 }
 
-#remember-me {
-	h2 {
-		font-size: 18px;
-		font-weight: 600;
-		line-height: 21.6px;
-		letter-spacing: -0.01em;
-	}
-}
-
 #payment-method {
 	/* stylelint-disable-next-line selector-id-pattern */
 	#radio-control-wc-payment-method-options-woocommerce_payments_affirm__label

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -92,6 +92,10 @@ button.wcpay-stripelink-modal-trigger:hover {
 	}
 }
 
+#remember-me:empty {
+	margin-bottom: 0;
+}
+
 #payment-method {
 	/* stylelint-disable-next-line selector-id-pattern */
 	#radio-control-wc-payment-method-options-woocommerce_payments_affirm__label

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -385,24 +385,25 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 								} }
 								isBlocksCheckout={ isBlocksCheckout }
 							/>
+
+							{ isBlocksCheckout && (
+								<ValidationInputError
+									elementId={ errorId }
+									propertyName={ errorId }
+								/>
+							) }
+							{ ! isBlocksCheckout && ! isPhoneValid && (
+								<p
+									id="validate-error-invalid-woopay-phone-number"
+									hidden={ isPhoneValid !== false }
+								>
+									{ __(
+										'Please enter a valid mobile phone number.',
+										'woocommerce-payments'
+									) }
+								</p>
+							) }
 						</div>
-						{ isBlocksCheckout && (
-							<ValidationInputError
-								elementId={ errorId }
-								propertyName={ errorId }
-							/>
-						) }
-						{ ! isBlocksCheckout && ! isPhoneValid && (
-							<p
-								id="validate-error-invalid-woopay-phone-number"
-								hidden={ isPhoneValid !== false }
-							>
-								{ __(
-									'Please enter a valid mobile phone number.',
-									'woocommerce-payments'
-								) }
-							</p>
-						) }
 						<AdditionalInformation />
 						<Agreement />
 					</div>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -64,33 +64,31 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
 
-	const woopayComponent = isBlocksCheckout
-		? document.querySelector( '#remember-me' )
-		: document.querySelector( '.woopay-save-new-user-container' );
-
 	useEffect( () => {
 		if ( ! isBlocksCheckout ) {
 			return;
 		}
 
-		if ( ! woopayComponent ) {
+		const rememberMe = document.querySelector( '#remember-me' );
+
+		if ( ! rememberMe ) {
 			return;
 		}
 
 		if ( checkoutIsProcessing ) {
-			woopayComponent.classList.add(
+			rememberMe.classList.add(
 				'wc-block-components-checkout-step--disabled'
 			);
-			woopayComponent.setAttribute( 'disabled', 'disabled' );
+			rememberMe.setAttribute( 'disabled', 'disabled' );
 
 			return;
 		}
 
-		woopayComponent.classList.remove(
+		rememberMe.classList.remove(
 			'wc-block-components-checkout-step--disabled'
 		);
-		woopayComponent.removeAttribute( 'disabled', 'disabled' );
-	}, [ woopayComponent, checkoutIsProcessing, isBlocksCheckout ] );
+		rememberMe.removeAttribute( 'disabled', 'disabled' );
+	}, [ checkoutIsProcessing, isBlocksCheckout ] );
 
 	const getPhoneFieldValue = useCallback( () => {
 		let phoneFieldValue = '';
@@ -305,12 +303,8 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		! isWCPayWithNewTokenChosen ||
 		isRegisteredUser
 	) {
-		woopayComponent.style.display = 'none';
-
 		return null;
 	}
-
-	woopayComponent.style.display = 'block';
 
 	return (
 		<Container isBlocksCheckout={ isBlocksCheckout }>

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -64,31 +64,33 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 	const viewportWidth = window.document.documentElement.clientWidth;
 	const viewportHeight = window.document.documentElement.clientHeight;
 
+	const woopayComponent = isBlocksCheckout
+		? document.querySelector( '#remember-me' )
+		: document.querySelector( '.woopay-save-new-user-container' );
+
 	useEffect( () => {
 		if ( ! isBlocksCheckout ) {
 			return;
 		}
 
-		const rememberMe = document.querySelector( '#remember-me' );
-
-		if ( ! rememberMe ) {
+		if ( ! woopayComponent ) {
 			return;
 		}
 
 		if ( checkoutIsProcessing ) {
-			rememberMe.classList.add(
+			woopayComponent.classList.add(
 				'wc-block-components-checkout-step--disabled'
 			);
-			rememberMe.setAttribute( 'disabled', 'disabled' );
+			woopayComponent.setAttribute( 'disabled', 'disabled' );
 
 			return;
 		}
 
-		rememberMe.classList.remove(
+		woopayComponent.classList.remove(
 			'wc-block-components-checkout-step--disabled'
 		);
-		rememberMe.removeAttribute( 'disabled', 'disabled' );
-	}, [ checkoutIsProcessing, isBlocksCheckout ] );
+		woopayComponent.removeAttribute( 'disabled', 'disabled' );
+	}, [ woopayComponent, checkoutIsProcessing, isBlocksCheckout ] );
 
 	const getPhoneFieldValue = useCallback( () => {
 		let phoneFieldValue = '';
@@ -303,8 +305,12 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 		! isWCPayWithNewTokenChosen ||
 		isRegisteredUser
 	) {
+		woopayComponent.style.display = 'none';
+
 		return null;
 	}
+
+	woopayComponent.style.display = 'block';
 
 	return (
 		<Container isBlocksCheckout={ isBlocksCheckout }>

--- a/client/components/woopay/save-user/container.js
+++ b/client/components/woopay/save-user/container.js
@@ -8,7 +8,13 @@ const Container = ( { children, isBlocksCheckout } ) => {
 	return (
 		<>
 			<div className="woopay-save-new-user-container">
-				<h2>{ __( 'Save my info' ) }</h2>
+				<div className="wc-block-components-checkout-step__heading-container">
+					<div className="wc-block-components-checkout-step__heading">
+						<h2 className="wc-block-components-title wc-block-components-checkout-step__title">
+							{ __( 'Save my info' ) }
+						</h2>
+					</div>
+				</div>
 				{ children }
 			</div>
 		</>

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -37,7 +37,6 @@
 			flex: 1;
 
 			label {
-				gap: unset;
 				display: flex !important;
 				align-items: flex-start;
 				padding: 0;

--- a/client/components/woopay/save-user/style.scss
+++ b/client/components/woopay/save-user/style.scss
@@ -1,9 +1,3 @@
-.woocommerce-checkout-payment {
-	.woopay-save-new-user-container {
-		padding: 1.41575em;
-	}
-}
-
 .woopay-save-new-user-container {
 	.save-details {
 		.wc-block-components-text-input input:-webkit-autofill {

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -1,10 +1,6 @@
 @import '/node_modules/intl-tel-input/build/css/intlTelInput.css';
 
 .woopay-save-new-user-container {
-	display: flex;
-	flex-direction: column;
-	gap: $gap;
-
 	&:not( :empty ) {
 		#payment .wc_payment_methods.payment_methods.methods + & {
 			margin-top: $gap-large;
@@ -91,7 +87,6 @@
 			box-shadow: none;
 			border: 1px solid $gray-300;
 			border-radius: 5px;
-			margin-left: 0.1rem;
 			width: calc( 100% - 0.25rem );
 
 			&::placeholder {

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -59,20 +59,19 @@
 		}
 
 		.additional-information {
-			font-size: 14px;
-			font-weight: 400;
+			font-size: var( --wp--preset--font-size--small, 14px );
 			line-height: 21px;
 			text-align: left;
 		}
 
 		.tos {
-			font-size: 12px;
+			font-size: 13px;
 		}
 
 		#validate-error-invalid-woopay-phone-number {
 			// Using rems to base this on the theme styles.
-			font-size: 0.875rem;
-			line-height: 1.5rem;
+			font-size: 13px;
+			line-height: 1;
 			margin-bottom: 0;
 			color: $alert-red;
 		}


### PR DESCRIPTION
Closes WOOPAY-395

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
This PR fixes spacing issues in the WooPay component on blocks and classic checkout.

| Before | After |
|-|-|
| <img width="626" height="747" alt="Screenshot 2025-11-05 at 9 25 52 PM" src="https://github.com/user-attachments/assets/411a1ed0-e415-493b-93a4-be8a5c30cf5f" /> | <img width="626" height="691" alt="Screenshot 2025-11-05 at 9 22 16 PM" src="https://github.com/user-attachments/assets/67f6892d-c653-45d5-966f-5bcf6e2adb70" /> |
| <img width="460" height="953" alt="Screenshot 2025-11-06 at 10 19 52 AM" src="https://github.com/user-attachments/assets/d1da7c8e-4d0d-417d-a538-272a9fdef1c6" /> | <img width="454" height="890" alt="Screenshot 2025-11-06 at 10 20 25 AM" src="https://github.com/user-attachments/assets/267e1bf7-a282-4006-bc0a-abd947ba19a0" /> |

It also fixes the extra spacing when the user email exists, that was rendering an extra spacing even though the WooPay component was not rendered.

| Before | After |
|-|-|
| <img width="622" height="514" alt="Screenshot 2025-11-06 at 10 05 23 AM" src="https://github.com/user-attachments/assets/12bf27e5-38b0-46dd-97d2-9f4889db3ae5" /> | <img width="626" height="489" alt="Screenshot 2025-11-06 at 10 03 46 AM" src="https://github.com/user-attachments/assets/ea336a48-2869-47f8-9cad-74849bebcdfb" /> |
| <img width="459" height="841" alt="Screenshot 2025-11-06 at 10 05 43 AM" src="https://github.com/user-attachments/assets/40347ced-8f95-4c4e-9513-e72f878f8779" /> | <img width="483" height="787" alt="Screenshot 2025-11-06 at 10 04 13 AM" src="https://github.com/user-attachments/assets/bfec267d-b806-4ba8-8ddc-ca7b1b719be0" /> |

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For better matching, checkout to the WooCommerce trunk branch, which includes woocommerce/woocommerce#59787.
* Add a product to the cart.
* Access the blocks checkout page.
* The WooPay `Save my info` component should have better styling.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
