### PR TITLE
 Fix WooPay express button text clipping

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -15,6 +15,15 @@
 		"media-feature-parentheses-space-inside": "always",
 		"no-descending-specificity": null,
 		"no-duplicate-selectors": null,
+		"property-no-unknown": [
+			true,
+			{
+				"ignoreProperties": [
+					"container-type",
+					"container-name"
+				]
+			}
+		],
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
 		"selector-pseudo-class-parentheses-space-inside": "always",

--- a/changelog/woopmnt-5396-woopay-pill-shaped-button-is-cutoff-on-checkout-alt
+++ b/changelog/woopmnt-5396-woopay-pill-shaped-button-is-cutoff-on-checkout-alt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay express button text clipping

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -1,4 +1,8 @@
 #wcpay-woopay-button {
+	// Enable container queries on the button wrapper
+	container-type: inline-size;
+	container-name: woopay-button;
+
 	.woopay-express-button {
 		font-size: 18px;
 		font-weight: 500;
@@ -58,10 +62,41 @@
 		&[data-type='buy'],
 		&[data-type='book'],
 		&[data-type='donate'] {
-			min-width: 200px;
+			min-width: 150px;
 
 			svg {
 				margin-left: 5px;
+			}
+
+			// Container queries for small buttons (40px height)
+			@container woopay-button (max-width: 280px) {
+				font-size: 14px;
+				letter-spacing: 0.5px;
+
+				svg {
+					width: 88px;
+					margin-left: 4px;
+				}
+			}
+
+			@container woopay-button (max-width: 240px) {
+				font-size: 12px;
+				letter-spacing: 0.3px;
+
+				svg {
+					width: 84px;
+					margin-left: 3px;
+				}
+			}
+
+			@container woopay-button (max-width: 200px) {
+				font-size: 10px;
+				letter-spacing: 0.2px;
+
+				svg {
+					width: 80px;
+					margin-left: 2px;
+				}
 			}
 		}
 
@@ -92,57 +127,44 @@
 			&[data-type='buy'],
 			&[data-type='book'],
 			&[data-type='donate'] {
-				min-width: 229px;
+				min-width: 150px;
 
-				// Reduce font-size progressively as viewport narrows to prevent clipping
-				// Keep logo size larger to maintain visual balance with other payment buttons
-				@media screen and ( max-width: 1709px ) {
-					font-size: 16px;
-					letter-spacing: 0.6px;
-					min-width: 200px;
+				// Container queries: respond to actual button container width
+				// These trigger based on the button's actual width in the layout
+
+				// Default state for wide containers (> 280px)
+				// Uses default 18px font, 99px logo from parent
+
+				// When container is moderately constrained
+				@container woopay-button (max-width: 280px) {
+					font-size: 15px;
+					letter-spacing: 0.5px;
 
 					svg {
-						width: 95px;
+						width: 90px;
 						margin-left: 4px;
 					}
 				}
 
-				@media screen and ( max-width: 1350px ) {
-					font-size: 14px;
-					letter-spacing: 0.4px;
-					min-width: 180px;
+				// When container is squeezed (common in 3-button horizontal layouts)
+				@container woopay-button (max-width: 240px) {
+					font-size: 13px;
+					letter-spacing: 0.3px;
 
 					svg {
-						width: 95px;
+						width: 86px;
 						margin-left: 3px;
 					}
 				}
 
-				@media screen and ( max-width: 1118px ) {
-					font-size: 13px;
-					letter-spacing: 0.3px;
-					min-width: 150px;
-
-					svg {
-						width: 92px;
-					}
-				}
-
-				@media screen and ( max-width: 720px ) {
-					font-size: 12px;
-					letter-spacing: 0.2px;
-
-					svg {
-						width: 90px;
-					}
-				}
-
-				@media screen and ( max-width: 550px ) {
+				// When container is very tight
+				@container woopay-button (max-width: 200px) {
 					font-size: 11px;
 					letter-spacing: 0.2px;
 
 					svg {
-						width: 87px;
+						width: 82px;
+						margin-left: 2px;
 					}
 				}
 			}
@@ -158,63 +180,50 @@
 			&[data-type='buy'],
 			&[data-type='book'],
 			&[data-type='donate'] {
-				min-width: 229px;
+				min-width: 150px;
 
-				// Reduce font-size progressively as viewport narrows to prevent clipping
-				// Keep logo size larger to maintain visual balance with other payment buttons
-				@media screen and ( max-width: 1709px ) {
-					font-size: 17px;
-					letter-spacing: 0.7px;
-					min-width: 200px;
+				// Container queries for large buttons
+				// Slightly larger than medium buttons at each breakpoint
+
+				@container woopay-button (max-width: 280px) {
+					font-size: 16px;
+					letter-spacing: 0.6px;
 
 					svg {
-						width: 98px;
+						width: 93px;
 						margin-left: 4px;
 					}
 				}
 
-				@media screen and ( max-width: 1350px ) {
-					font-size: 15px;
-					letter-spacing: 0.5px;
-					min-width: 180px;
+				@container woopay-button (max-width: 240px) {
+					font-size: 14px;
+					letter-spacing: 0.4px;
 
 					svg {
-						width: 98px;
+						width: 89px;
 						margin-left: 3px;
 					}
 				}
 
-				@media screen and ( max-width: 1118px ) {
-					font-size: 14px;
-					letter-spacing: 0.4px;
-					min-width: 150px;
-
-					svg {
-						width: 95px;
-					}
-				}
-
-				@media screen and ( max-width: 720px ) {
-					font-size: 13px;
+				@container woopay-button (max-width: 200px) {
+					font-size: 12px;
 					letter-spacing: 0.3px;
 
 					svg {
-						width: 93px;
-					}
-				}
-
-				@media screen and ( max-width: 550px ) {
-					font-size: 12px;
-					letter-spacing: 0.2px;
-
-					svg {
-						width: 90px;
+						width: 85px;
+						margin-left: 2px;
 					}
 				}
 			}
 
 			.button-content {
-				transform: scale( 1 );
+				transform: scale( 1.1 );
+			}
+
+			// For this width range, the button's text is too large to fit
+			// in the button. The text is reduced to 22px to fit.
+			@media screen and ( min-width: 785px ) and ( max-width: 850px ) {
+				font-size: 22px;
 			}
 		}
 	}

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -88,30 +88,47 @@
 
 		&[data-size='medium'] {
 			height: 48px;
-			// Scale down font and spacing to fit in constrained horizontal layouts
-			font-size: 14px;
-			letter-spacing: 0.3px;
 
 			&[data-type='buy'],
 			&[data-type='book'],
 			&[data-type='donate'] {
-				// Reduce min-width to allow flexibility in horizontal layouts
-				min-width: 150px;
+				min-width: 229px;
 
-				svg {
-					// Reduce left margin to save space
-					margin-left: 3px;
+				// Reduce font-size progressively as viewport narrows to prevent clipping
+				@media screen and ( max-width: 1563px ) {
+					font-size: 15px;
+					letter-spacing: 0.5px;
+					min-width: 180px;
+
+					svg {
+						width: 88px;
+						margin-left: 4px;
+					}
+				}
+
+				@media screen and ( max-width: 1118px ) {
+					font-size: 13px;
+					letter-spacing: 0.3px;
+					min-width: 150px;
+
+					svg {
+						width: 83px;
+						margin-left: 3px;
+					}
+				}
+
+				@media screen and ( max-width: 550px ) {
+					font-size: 12px;
+					letter-spacing: 0.2px;
+
+					svg {
+						width: 80px;
+					}
 				}
 			}
 
 			.button-content {
-				// Scale down the entire content to fit in constrained spaces
-				transform: scale( 0.88 );
-			}
-
-			svg {
-				// Scale down SVG for medium buttons to fit better
-				width: 75px;
+				transform: scale( 1 );
 			}
 		}
 

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -18,12 +18,14 @@
 		text-transform: none;
 		list-style-type: none;
 		min-height: auto;
+		overflow: hidden;
 
 		.button-content {
 			display: flex;
-			align-content: center;
+			align-items: center;
 			justify-content: center;
 			transform: scale( 0.9 );
+			max-width: 100%;
 		}
 
 		&:not( :disabled ) {
@@ -86,15 +88,30 @@
 
 		&[data-size='medium'] {
 			height: 48px;
+			// Scale down font and spacing to fit in constrained horizontal layouts
+			font-size: 14px;
+			letter-spacing: 0.3px;
 
 			&[data-type='buy'],
 			&[data-type='book'],
 			&[data-type='donate'] {
-				min-width: 229px;
+				// Reduce min-width to allow flexibility in horizontal layouts
+				min-width: 150px;
+
+				svg {
+					// Reduce left margin to save space
+					margin-left: 3px;
+				}
 			}
 
 			.button-content {
-				transform: scale( 1 );
+				// Scale down the entire content to fit in constrained spaces
+				transform: scale( 0.88 );
+			}
+
+			svg {
+				// Scale down SVG for medium buttons to fit better
+				width: 75px;
 			}
 		}
 

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -139,16 +139,42 @@
 			&[data-type='book'],
 			&[data-type='donate'] {
 				min-width: 229px;
+
+				// Reduce font-size progressively as viewport narrows to prevent clipping
+				@media screen and ( max-width: 1563px ) {
+					font-size: 16px;
+					letter-spacing: 0.6px;
+					min-width: 180px;
+
+					svg {
+						width: 92px;
+						margin-left: 4px;
+					}
+				}
+
+				@media screen and ( max-width: 1118px ) {
+					font-size: 14px;
+					letter-spacing: 0.4px;
+					min-width: 150px;
+
+					svg {
+						width: 88px;
+						margin-left: 3px;
+					}
+				}
+
+				@media screen and ( max-width: 550px ) {
+					font-size: 13px;
+					letter-spacing: 0.3px;
+
+					svg {
+						width: 85px;
+					}
+				}
 			}
 
 			.button-content {
-				transform: scale( 1.1 );
-			}
-
-			// For this width range, the button's text is too large to fit
-			// in the button. The text is reduced to 22px to fit.
-			@media screen and ( min-width: 785px ) and ( max-width: 850px ) {
-				font-size: 22px;
+				transform: scale( 1 );
 			}
 		}
 	}

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -95,14 +95,26 @@
 				min-width: 229px;
 
 				// Reduce font-size progressively as viewport narrows to prevent clipping
-				@media screen and ( max-width: 1563px ) {
-					font-size: 15px;
-					letter-spacing: 0.5px;
+				// Keep logo size larger to maintain visual balance with other payment buttons
+				@media screen and ( max-width: 1709px ) {
+					font-size: 16px;
+					letter-spacing: 0.6px;
+					min-width: 200px;
+
+					svg {
+						width: 95px;
+						margin-left: 4px;
+					}
+				}
+
+				@media screen and ( max-width: 1350px ) {
+					font-size: 14px;
+					letter-spacing: 0.4px;
 					min-width: 180px;
 
 					svg {
-						width: 88px;
-						margin-left: 4px;
+						width: 95px;
+						margin-left: 3px;
 					}
 				}
 
@@ -112,17 +124,25 @@
 					min-width: 150px;
 
 					svg {
-						width: 83px;
-						margin-left: 3px;
+						width: 92px;
 					}
 				}
 
-				@media screen and ( max-width: 550px ) {
+				@media screen and ( max-width: 720px ) {
 					font-size: 12px;
 					letter-spacing: 0.2px;
 
 					svg {
-						width: 80px;
+						width: 90px;
+					}
+				}
+
+				@media screen and ( max-width: 550px ) {
+					font-size: 11px;
+					letter-spacing: 0.2px;
+
+					svg {
+						width: 87px;
 					}
 				}
 			}
@@ -141,14 +161,26 @@
 				min-width: 229px;
 
 				// Reduce font-size progressively as viewport narrows to prevent clipping
-				@media screen and ( max-width: 1563px ) {
-					font-size: 16px;
-					letter-spacing: 0.6px;
+				// Keep logo size larger to maintain visual balance with other payment buttons
+				@media screen and ( max-width: 1709px ) {
+					font-size: 17px;
+					letter-spacing: 0.7px;
+					min-width: 200px;
+
+					svg {
+						width: 98px;
+						margin-left: 4px;
+					}
+				}
+
+				@media screen and ( max-width: 1350px ) {
+					font-size: 15px;
+					letter-spacing: 0.5px;
 					min-width: 180px;
 
 					svg {
-						width: 92px;
-						margin-left: 4px;
+						width: 98px;
+						margin-left: 3px;
 					}
 				}
 
@@ -158,17 +190,25 @@
 					min-width: 150px;
 
 					svg {
-						width: 88px;
-						margin-left: 3px;
+						width: 95px;
 					}
 				}
 
-				@media screen and ( max-width: 550px ) {
+				@media screen and ( max-width: 720px ) {
 					font-size: 13px;
 					letter-spacing: 0.3px;
 
 					svg {
-						width: 85px;
+						width: 93px;
+					}
+				}
+
+				@media screen and ( max-width: 550px ) {
+					font-size: 12px;
+					letter-spacing: 0.2px;
+
+					svg {
+						width: 90px;
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #WOOPMNT-5396

 This PR fixes the WooPay express checkout button text clipping issue that occurred when buttons were displayed horizontally in constrained layouts (e.g., checkout block with multiple payment buttons).

#### Changes proposed in this Pull Request

*  Implements CSS container queries to dynamically scale button content based on actual container width (not viewport)
* Adds 3 container query breakpoints per button size (small/medium/large):
* Reduces min-width from 229px to 150px for better flexibility
* Updates stylelint configuration to support container query CSS properties

 **Solutions considered:**

  1. **Media queries** (initial attempt) - ❌ Required many viewport-specific breakpoints, brittle and hard to maintain
  2. **Scale** - ❌ Made button unnecessarily small on wide screens
  3. **Container queries** (chosen) - ✅ Responds to actual button space, cleaner code, future-proof

 **Trade-offs:**

  - Container queries are a modern CSS feature, but all target browsers (Chrome 131+, Firefox 137+, Safari 18+) support them
  - Older browsers will show default styles (may clip) but won't break
  - WooCommerce Blocks already uses container queries, so we're following their established pattern

**Screenshots**

Before

<img width="759" height="212" alt="Screenshot 2025-11-07 at 17 11 39" src="https://github.com/user-attachments/assets/7b5f6590-46ef-446d-87df-28050f2e2faf" />

After

<img width="746" height="152" alt="Screenshot 2025-11-07 at 17 12 07" src="https://github.com/user-attachments/assets/c8698080-78d2-4d46-a5a9-c6d23a20b1cd" />


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Tested the button size and call to action variations on Chrome, Safari and Firefox and Mobile Safari.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Prerequisites:**
  - Enable WooPay, Apple Pay, and Google Pay express checkout buttons

1. Resize browser viewport from wide (1600px+) to narrow (400px)
2. Verify at all viewport sizes:
    - WooPay button text is never clipped
    - Logo remains proportionally sized compared to Apple Pay/Google Pay
    - Content scales smoothly as viewport changes
  3. Test on mobile device (or mobile emulation) to verify no clipping when buttons stack vertically

Expected result:
No text or logo clipping at any viewport size or button configuration.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
