### PR TITLE
Make the WooPay button relative to contain the spinner

### DIFF
--- a/changelog/woopmnt-5398-woopay-button-spinner-and-label-is-not-visible-on-click
+++ b/changelog/woopmnt-5398-woopay-button-spinner-and-label-is-not-visible-on-click
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix styling of the WooPay button to make sure that the spinner is visible when loading.

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -18,6 +18,7 @@
 		text-transform: none;
 		list-style-type: none;
 		min-height: auto;
+		position: relative;
 
 		.button-content {
 			display: flex;


### PR DESCRIPTION
Fixes WOOPMNT-5398

#### Changes proposed in this Pull Request

Add `position:relative` so that it is a meaningful container for the spinner.

| Before | After |
|-|-|
| <img width="472" height="382" alt="image" src="https://github.com/user-attachments/assets/d1eb74ae-1805-449c-9315-052463157952" /> | <img width="468" height="378" alt="image" src="https://github.com/user-attachments/assets/3a5f7b37-31e8-415e-87ab-8bf8752de3fa" /> |

#### Testing instructions

1. Use `develop` to confirm the bug.
2. Add a `return;` after [this line](https://github.com/Automattic/woocommerce-payments/blob/c26c2fbf03ced99253cf009b6d033484eaa2f80d/client/checkout/woopay/express-button/woopay-express-checkout-button.js#L222) so you have time to inspect the bug.
3. Enable WooPay, Google Pay, and Apple Pay.
4. If working locally, start a tunnel to your site to make the Google and Apple buttons appear.
5. Add a product to the cart.
6. Navigate to the page with the checkout block.
7. Click the WooPay button.
8. Observe the _Before_ behavior from the screenshot.
9. Check out this branch, pull and `npm run build`.
10. Repeat 6-8 and observe the _After_ state.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)