### PR TITLE
chore: add Amazon Pay feature flag

### DIFF
--- a/changelog/chore-add-amazon-pay-feature-flag
+++ b/changelog/chore-add-amazon-pay-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+chore: add amazon pay feature flag.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -30,6 +30,7 @@ class WC_Payments_Features {
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME               = '_wcpay_feature_woopay_global_theme_support';
 	const WCPAY_DYNAMIC_CHECKOUT_PLACE_ORDER_BUTTON_FLAG_NAME = '_wcpay_feature_dynamic_checkout_place_order_button';
 	const ACCOUNT_DETAILS_FLAG_NAME                           = '_wcpay_feature_account_details';
+	const AMAZON_PAY_FLAG_NAME                                = '_wcpay_feature_amazon_pay';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -348,6 +349,15 @@ class WC_Payments_Features {
 	 */
 	public static function is_account_details_enabled(): bool {
 		return '1' === get_option( self::ACCOUNT_DETAILS_FLAG_NAME, '0' );
+	}
+
+	/**
+	 * Checks whether Amazon Pay is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_amazon_pay_enabled(): bool {
+		return '1' === get_option( self::AMAZON_PAY_FLAG_NAME, '0' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -348,4 +348,26 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'isAccountDetailsEnabled', $result );
 		$this->assertTrue( $result['isAccountDetailsEnabled'] );
 	}
+
+	public function test_is_amazon_pay_enabled_returns_false_when_disabled() {
+		$this->set_feature_flag_option( WC_Payments_Features::AMAZON_PAY_FLAG_NAME, '0' );
+
+		$result = WC_Payments_Features::is_amazon_pay_enabled();
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_is_amazon_pay_enabled_returns_true_when_enabled() {
+		$this->set_feature_flag_option( WC_Payments_Features::AMAZON_PAY_FLAG_NAME, '1' );
+
+		$result = WC_Payments_Features::is_amazon_pay_enabled();
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_is_amazon_pay_enabled_returns_false_by_default() {
+		$result = WC_Payments_Features::is_amazon_pay_enabled();
+
+		$this->assertFalse( $result );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5485

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As part of the Amazon Pay ECE implementation ( pcreKM-3Ic-p2 ), let's start by the first building block: implement a feature flag.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No changes/side effects - this is just a simple feature flag implementation.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.