### PR TITLE
Add feature flag and backend support for additional dispute evidence types

### DIFF
--- a/changelog/woopmnt-5447-backend-update-backend-for-new-challenge-forms
+++ b/changelog/woopmnt-5447-backend-update-backend-for-new-challenge-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add backend support for additional dispute evidence types (event, booking, other) behind feature flag.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -27,6 +27,7 @@ class WC_Payments_Features {
 	const WOOPAY_FIRST_PARTY_AUTH_FLAG_NAME                   = '_wcpay_feature_woopay_first_party_auth';
 	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME                    = '_wcpay_feature_woopay_direct_checkout';
 	const DISPUTE_ISSUER_EVIDENCE                             = '_wcpay_feature_dispute_issuer_evidence';
+	const DISPUTE_ADDITIONAL_EVIDENCE_TYPES                   = '_wcpay_feature_dispute_additional_evidence_types';
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME               = '_wcpay_feature_woopay_global_theme_support';
 	const WCPAY_DYNAMIC_CHECKOUT_PLACE_ORDER_BUTTON_FLAG_NAME = '_wcpay_feature_dynamic_checkout_place_order_button';
 	const ACCOUNT_DETAILS_FLAG_NAME                           = '_wcpay_feature_account_details';
@@ -324,6 +325,17 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Dispute Additional Evidence Types feature should be enabled. Disabled by default.
+	 *
+	 * This gates the new evidence form types (event, booking_reservation, other) for dispute challenges.
+	 *
+	 * @return bool
+	 */
+	public static function is_dispute_additional_evidence_types_enabled(): bool {
+		return '1' === get_option( self::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, '0' );
+	}
+
+	/**
 	 * Checks whether the next deposit notice on the deposits list screen has been dismissed.
 	 *
 	 * @return bool
@@ -363,6 +375,7 @@ class WC_Payments_Features {
 				'documents'                                => self::is_documents_section_enabled(),
 				'woopayExpressCheckout'                    => self::is_woopay_express_checkout_enabled(),
 				'isDisputeIssuerEvidenceEnabled'           => self::is_dispute_issuer_evidence_enabled(),
+				'isDisputeAdditionalEvidenceTypesEnabled'  => self::is_dispute_additional_evidence_types_enabled(),
 				'isFRTReviewFeatureActive'                 => self::is_frt_review_feature_active(),
 				'isDynamicCheckoutPlaceOrderButtonEnabled' => self::is_dynamic_checkout_place_order_button_enabled(),
 				'isAccountDetailsEnabled'                  => self::is_account_details_enabled(),

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -3000,8 +3000,8 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		}
 
 		// At this point, we know there's exactly one product.
-		// Check for specific product types.
-		if ( 'booking' === $product_type ) {
+		// Check for specific product types (gated by feature flag).
+		if ( WC_Payments_Features::is_dispute_additional_evidence_types_enabled() && 'booking' === $product_type ) {
 			return 'booking_reservation';
 		}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2962,9 +2962,9 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			return 'physical_product';
 		}
 
-		$virtual_products  = 0;
-		$physical_products = 0;
-		$product_count     = 0;
+		$virtual_products = 0;
+		$product_count    = 0;
+		$product_type     = null;
 
 		foreach ( $items as $item ) {
 			// Only process product items.
@@ -2979,11 +2979,19 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 
 			++$product_count;
 
+			// Capture first product's type (only used for single-product orders).
+			if ( null === $product_type ) {
+				$product_type = $product->get_type();
+			}
+
 			if ( $product->is_virtual() ) {
 				++$virtual_products;
-			} else {
-				++$physical_products;
 			}
+		}
+
+		// If no valid products found, default to physical.
+		if ( 0 === $product_count ) {
+			return 'physical_product';
 		}
 
 		// If more than one product, suggest multiple.
@@ -2991,8 +2999,14 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			return 'multiple';
 		}
 
-		// If only one product and it's virtual, suggest digital.
-		if ( 1 === $product_count && 1 === $virtual_products ) {
+		// At this point, we know there's exactly one product.
+		// Check for specific product types.
+		if ( 'booking' === $product_type ) {
+			return 'booking_reservation';
+		}
+
+		// Check if it's virtual (digital product or service).
+		if ( 1 === $virtual_products ) {
 			return 'digital_product_or_service';
 		}
 

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1304,7 +1304,10 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @dataProvider data_determine_suggested_product_type
 	 */
-	public function test_determine_suggested_product_type( $order_items, $expected_product_type ) {
+	public function test_determine_suggested_product_type( $order_items, $expected_product_type, $feature_flag_enabled = true ) {
+		// Set the feature flag option.
+		update_option( WC_Payments_Features::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, $feature_flag_enabled ? '1' : '0' );
+
 		// Create a mock order.
 		$mock_order = $this->getMockBuilder( 'WC_Order' )
 			->disableOriginalConstructor()
@@ -1328,75 +1331,92 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	 */
 	public function data_determine_suggested_product_type() {
 		return [
-			'empty_order'                  => [
+			'empty_order'                              => [
 				'order_items'           => [],
 				'expected_product_type' => 'physical_product',
 			],
-			'single_physical_product'      => [
+			'single_physical_product'                  => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( false ), // not virtual.
 				],
 				'expected_product_type' => 'physical_product',
 			],
-			'single_virtual_product'       => [
+			'single_virtual_product'                   => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true ), // virtual.
 				],
 				'expected_product_type' => 'digital_product_or_service',
 			],
-			'multiple_products_mixed'      => [
+			'multiple_products_mixed'                  => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( false ), // physical.
 					$this->create_mock_order_item_product( true ),  // virtual.
 				],
 				'expected_product_type' => 'multiple',
 			],
-			'multiple_physical_products'   => [
+			'multiple_physical_products'               => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( false ), // physical.
 					$this->create_mock_order_item_product( false ), // physical.
 				],
 				'expected_product_type' => 'multiple',
 			],
-			'multiple_virtual_products'    => [
+			'multiple_virtual_products'                => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true ), // virtual.
 					$this->create_mock_order_item_product( true ), // virtual.
 				],
 				'expected_product_type' => 'multiple',
 			],
-			'order_with_non_product_items' => [
+			'order_with_non_product_items'             => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true ), // virtual product.
 					$this->create_mock_order_item_shipping(), // shipping item (not a product).
 				],
 				'expected_product_type' => 'digital_product_or_service',
 			],
-			'order_with_invalid_product'   => [
+			'order_with_invalid_product'               => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true, false ), // virtual but invalid product.
 				],
 				'expected_product_type' => 'physical_product',
 			],
-			'single_booking_product'       => [
+			'single_booking_product'                   => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking product.
 				],
 				'expected_product_type' => 'booking_reservation',
+				'feature_flag_enabled'  => true,
 			],
-			'multiple_booking_products'    => [
+			'single_booking_product_flag_off'          => [
+				'order_items'           => [
+					$this->create_mock_order_item_product( true, true, 'booking' ), // booking product (virtual).
+				],
+				'expected_product_type' => 'digital_product_or_service', // Falls back to virtual detection.
+				'feature_flag_enabled'  => false,
+			],
+			'single_booking_product_physical_flag_off' => [
+				'order_items'           => [
+					$this->create_mock_order_item_product( false, true, 'booking' ), // booking product (not virtual).
+				],
+				'expected_product_type' => 'physical_product', // Falls back to physical detection.
+				'feature_flag_enabled'  => false,
+			],
+			'multiple_booking_products'                => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
 				],
 				'expected_product_type' => 'multiple',
+				'feature_flag_enabled'  => true,
 			],
-			'booking_physical_mixed'       => [
+			'booking_physical_mixed'                   => [
 				'order_items'           => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
 					$this->create_mock_order_item_product( false, true, 'simple' ), // physical.
 				],
 				'expected_product_type' => 'multiple',
+				'feature_flag_enabled'  => true,
 			],
 		];
 	}

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1304,9 +1304,9 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @dataProvider data_determine_suggested_product_type
 	 */
-	public function test_determine_suggested_product_type( $order_items, $expected_product_type, $feature_flag_enabled = true ) {
+	public function test_determine_suggested_product_type( $order_items, $expected_product_type, $evidence_types_flag_enabled = true ) {
 		// Set the feature flag option.
-		update_option( WC_Payments_Features::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, $feature_flag_enabled ? '1' : '0' );
+		update_option( WC_Payments_Features::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, $evidence_types_flag_enabled ? '1' : '0' );
 
 		// Create a mock order.
 		$mock_order = $this->getMockBuilder( 'WC_Order' )
@@ -1382,41 +1382,41 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 				'expected_product_type' => 'physical_product',
 			],
 			'single_booking_product'                   => [
-				'order_items'           => [
+				'order_items'                 => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking product.
 				],
-				'expected_product_type' => 'booking_reservation',
-				'feature_flag_enabled'  => true,
+				'expected_product_type'       => 'booking_reservation',
+				'evidence_types_flag_enabled' => true,
 			],
 			'single_booking_product_flag_off'          => [
-				'order_items'           => [
+				'order_items'                 => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking product (virtual).
 				],
-				'expected_product_type' => 'digital_product_or_service', // Falls back to virtual detection.
-				'feature_flag_enabled'  => false,
+				'expected_product_type'       => 'digital_product_or_service', // Falls back to virtual detection.
+				'evidence_types_flag_enabled' => false,
 			],
 			'single_booking_product_physical_flag_off' => [
-				'order_items'           => [
+				'order_items'                 => [
 					$this->create_mock_order_item_product( false, true, 'booking' ), // booking product (not virtual).
 				],
-				'expected_product_type' => 'physical_product', // Falls back to physical detection.
-				'feature_flag_enabled'  => false,
+				'expected_product_type'       => 'physical_product', // Falls back to physical detection.
+				'evidence_types_flag_enabled' => false,
 			],
 			'multiple_booking_products'                => [
-				'order_items'           => [
+				'order_items'                 => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
 				],
-				'expected_product_type' => 'multiple',
-				'feature_flag_enabled'  => true,
+				'expected_product_type'       => 'multiple',
+				'evidence_types_flag_enabled' => true,
 			],
 			'booking_physical_mixed'                   => [
-				'order_items'           => [
+				'order_items'                 => [
 					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
 					$this->create_mock_order_item_product( false, true, 'simple' ), // physical.
 				],
-				'expected_product_type' => 'multiple',
-				'feature_flag_enabled'  => true,
+				'expected_product_type'       => 'multiple',
+				'evidence_types_flag_enabled' => true,
 			],
 		];
 	}

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1378,23 +1378,45 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 				],
 				'expected_product_type' => 'physical_product',
 			],
+			'single_booking_product'       => [
+				'order_items'           => [
+					$this->create_mock_order_item_product( true, true, 'booking' ), // booking product.
+				],
+				'expected_product_type' => 'booking_reservation',
+			],
+			'multiple_booking_products'    => [
+				'order_items'           => [
+					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
+					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
+				],
+				'expected_product_type' => 'multiple',
+			],
+			'booking_physical_mixed'       => [
+				'order_items'           => [
+					$this->create_mock_order_item_product( true, true, 'booking' ), // booking.
+					$this->create_mock_order_item_product( false, true, 'simple' ), // physical.
+				],
+				'expected_product_type' => 'multiple',
+			],
 		];
 	}
 
 	/**
 	 * Create a mock order item product for testing.
 	 *
-	 * @param bool $is_virtual Whether the product is virtual.
-	 * @param bool $is_valid Whether the product is valid (can be retrieved).
+	 * @param bool   $is_virtual Whether the product is virtual.
+	 * @param bool   $is_valid Whether the product is valid (can be retrieved).
+	 * @param string $product_type The product type (e.g., 'simple', 'booking', 'variable').
 	 * @return MockObject
 	 */
-	private function create_mock_order_item_product( $is_virtual = false, $is_valid = true ) {
+	private function create_mock_order_item_product( $is_virtual = false, $is_valid = true, $product_type = 'simple' ) {
 		$mock_product = $this->getMockBuilder( 'WC_Product' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'is_virtual' ] )
+			->setMethods( [ 'is_virtual', 'get_type' ] )
 			->getMock();
 
 		$mock_product->method( 'is_virtual' )->willReturn( $is_virtual );
+		$mock_product->method( 'get_type' )->willReturn( $product_type );
 
 		$mock_order_item = $this->getMockBuilder( 'WC_Order_Item_Product' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Fixes #WOOPMNT-5447

Adds backend support for new dispute evidence form types (Event, Booking/Reservation, Other) as part of the "Improve the WooPayments Dispute Experience" initiative.

This PR introduces a new feature flag `DISPUTE_ADDITIONAL_EVIDENCE_TYPES` and implements booking product type auto-detection, enabling merchants to submit more specific evidence based on their product type.

## Product Types Supported
After this change, the backend will support 7 product types for dispute challenges:
  - `physical_product` (existing)
  - `digital_product_or_service` (existing)
  - `offline_service` (existing)
  - `multiple` (existing)
  - `event` (new - manual selection only)
  - `booking_reservation` (new - auto-detected for booking products when flag is ON)
  - `other` (new - manual selection only)

#### Changes proposed in this Pull Request
- Added new feature flag `DISPUTE_ADDITIONAL_EVIDENCE_TYPES` (disabled by default)
- Implemented booking product type detection in `determine_suggested_product_type()`
- When flag is enabled and order contains a booking product, suggests `booking_reservation` type
- When flag is disabled, booking products fall back to existing types (`digital_product_or_service` or `physical_product`)

### Key Decisions
1. **Conservative detection**: Only auto-detects WooCommerce Bookings products (proven to exist). Event types require manual selection
2. **Backend-only changes**: No frontend modifications in this PR, we have dedicated tasks for that part.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
Prerequisites
  - WooCommerce Payments installed
  - WooCommerce Bookings plugin installed

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Manual Testing (Optional - can be properly tested after frontend is ready)
Test Case 1: Booking Product → booking_reservation
Enable the feature flag via: `wp option update _wcpay_feature_dispute_additional_evidence_types 1`
  1. Create a bookable product (requires WooCommerce Bookings plugin):
    - Go to Products → Add New
    - Product name: "Hotel Room Booking"
    - Product type: Select "Bookable product"
    - Set price: $100
    - Configure booking settings (duration, availability, etc.)
    - Publish
  2. Complete a purchase:
    - Add the bookable product to cart
    - Proceed to checkout
    - Use Stripe test card: 4000000000000259 (dispute-able card)
    - Complete the order
   3. Check the Dispute
    - Go to Payments → Disputes
    - Locate the payment you just created and click Respond
    - Click Challenge Dispute
    - In the browser dev tools check the dispute request: wc/v3/payments/disputes/du_12345
    - In the response, verify `order.suggested_product_type` is `booking_reservation`

  Test Case 2: Flag OFF → fallback behavior

  1. Disable the feature flag:
  wp option update _wcpay_feature_dispute_additional_evidence_types 0
  2. Create another order with the same bookable product (follow step 2 above)
  3. Create a dispute (follow step 3 above)
  4. Verify: `order.suggested_product_type` is `physical_product` (previous default)
 
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
