### PR TITLE
Fix PHP8 deprecation warning about callables

### DIFF
--- a/changelog/woopmnt-5500-php-deprecations-in-the-request-classes
+++ b/changelog/woopmnt-5500-php-deprecations-in-the-request-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix deprecation warning about usage of `parent` in callables.

--- a/includes/admin/tasks/class-wc-payments-task-disputes.php
+++ b/includes/admin/tasks/class-wc-payments-task-disputes.php
@@ -157,7 +157,7 @@ class WC_Payments_Task_Disputes extends Task {
 	 */
 	public function get_parent_id() {
 		// WC 6.4.0 compatibility.
-		if ( is_callable( 'parent::get_parent_id' ) ) {
+		if ( is_callable( [ parent::class, 'get_parent_id' ] ) ) {
 			return parent::get_parent_id();
 		}
 


### PR DESCRIPTION
Fixes WOOPMNT-5500

#### Changes proposed in this Pull Request


Fix the following deprecation warning:

```
Use of "parent" in callables is deprecated in /wordpress/plugins/woocommerce-payments/10.2.0/includes/admin/tasks/class-wc-payments-task-disputes.php on line 160Errors can be seen in this dashboard.
```
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Automated tests shall pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
