### PR TITLE
refactor: payment method definition capability duplication

### DIFF
--- a/changelog/refactor-remove-payment-method-definition-duplicate-methods
+++ b/changelog/refactor-remove-payment-method-definition-duplicate-methods
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+refactor: update payment method definition classes to delegate capabilities to PaymentMethodUtils

--- a/includes/payment-methods/Configs/Definitions/AffirmDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AffirmDefinition.php
@@ -78,42 +78,6 @@ class AffirmDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -225,15 +189,6 @@ class AffirmDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
@@ -78,42 +78,6 @@ class AlipayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -281,15 +245,6 @@ class AlipayDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/BancontactDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/BancontactDefinition.php
@@ -78,42 +78,6 @@ class BancontactDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -204,15 +168,6 @@ class BancontactDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/EpsDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/EpsDefinition.php
@@ -78,42 +78,6 @@ class EpsDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -204,15 +168,6 @@ class EpsDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/GiropayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GiropayDefinition.php
@@ -78,42 +78,6 @@ class GiropayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -205,15 +169,6 @@ class GiropayDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/IdealDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/IdealDefinition.php
@@ -78,42 +78,6 @@ class IdealDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -205,15 +169,6 @@ class IdealDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/P24Definition.php
+++ b/includes/payment-methods/Configs/Definitions/P24Definition.php
@@ -78,42 +78,6 @@ class P24Definition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -207,15 +171,6 @@ class P24Definition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/SofortDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/SofortDefinition.php
@@ -78,42 +78,6 @@ class SofortDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -210,15 +174,6 @@ class SofortDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Definitions/WechatPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/WechatPayDefinition.php
@@ -78,42 +78,6 @@ class WechatPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool {
-		return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
-	}
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool {
-		return PaymentMethodUtils::is_reusable( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool {
-		return PaymentMethodUtils::accepts_only_domestic_payments( self::get_capabilities() );
-	}
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool {
-		return PaymentMethodUtils::allows_manual_capture( self::get_capabilities() );
-	}
-
-	/**
 	 * Get the list of supported currencies
 	 *
 	 * @return string[] Array of currency codes
@@ -296,15 +260,6 @@ class WechatPayDefinition implements PaymentMethodDefinitionInterface {
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return PaymentMethodUtils::is_available_for( self::get_supported_currencies(), self::get_supported_countries(), $currency, $account_country );
-	}
-
-	/**
-	 * Whether this payment method should be enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool {
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
+++ b/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
@@ -58,34 +58,6 @@ interface PaymentMethodDefinitionInterface {
 	public static function get_description( ?string $account_country = null ): string;
 
 	/**
-	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_bnpl(): bool;
-
-	/**
-	 * Is the payment method a reusable payment method?
-	 *
-	 * @return boolean
-	 */
-	public static function is_reusable(): bool;
-
-	/**
-	 * Does the payment method accept only domestic payments?
-	 *
-	 * @return boolean
-	 */
-	public static function accepts_only_domestic_payments(): bool;
-
-	/**
-	 * Does the payment method allow manual capture?
-	 *
-	 * @return boolean
-	 */
-	public static function allows_manual_capture(): bool;
-
-	/**
 	 * Get the list of supported currencies
 	 * Empty array means all currencies are supported
 	 *
@@ -150,13 +122,6 @@ interface PaymentMethodDefinitionInterface {
 	 * @return bool
 	 */
 	public static function is_available_for( string $currency, string $account_country ): bool;
-
-	/**
-	 * Whether this payment method is enabled by default
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled_by_default(): bool;
 
 	/**
 	 * Get the currency limits for the payment method

--- a/includes/payment-methods/Configs/Utils/PaymentMethodUtils.php
+++ b/includes/payment-methods/Configs/Utils/PaymentMethodUtils.php
@@ -8,6 +8,7 @@
 namespace WCPay\PaymentMethods\Configs\Utils;
 
 use WCPay\PaymentMethods\Configs\Constants\PaymentMethodCapability;
+use WCPay\PaymentMethods\Configs\Interfaces\PaymentMethodDefinitionInterface;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 
 /**
@@ -51,41 +52,41 @@ class PaymentMethodUtils {
 	/**
 	 * Is the payment method a BNPL (Buy Now Pay Later) payment method?
 	 *
-	 * @param array<string> $capabilities The payment method capabilities.
+	 * @param string $payment_method_definition The payment method definition class name.
 	 * @return boolean
 	 */
-	public static function is_bnpl( array $capabilities ): bool {
-		return in_array( PaymentMethodCapability::BUY_NOW_PAY_LATER, $capabilities, true );
+	public static function is_bnpl( string $payment_method_definition ): bool {
+		return in_array( PaymentMethodCapability::BUY_NOW_PAY_LATER, $payment_method_definition::get_capabilities(), true );
 	}
 
 	/**
 	 * Is the payment method a reusable payment method?
 	 *
-	 * @param array<string> $capabilities The payment method capabilities.
+	 * @param string $payment_method_definition The payment method definition class name.
 	 * @return boolean
 	 */
-	public static function is_reusable( array $capabilities ): bool {
-		return in_array( PaymentMethodCapability::TOKENIZATION, $capabilities, true );
+	public static function is_reusable( string $payment_method_definition ): bool {
+		return in_array( PaymentMethodCapability::TOKENIZATION, $payment_method_definition::get_capabilities(), true );
 	}
 
 	/**
 	 * Does the payment method accept only domestic payments?
 	 *
-	 * @param array<string> $capabilities The payment method capabilities.
+	 * @param string $payment_method_definition The payment method definition class name.
 	 * @return boolean
 	 */
-	public static function accepts_only_domestic_payments( array $capabilities ): bool {
-		return in_array( PaymentMethodCapability::DOMESTIC_TRANSACTIONS_ONLY, $capabilities, true );
+	public static function accepts_only_domestic_payments( string $payment_method_definition ): bool {
+		return in_array( PaymentMethodCapability::DOMESTIC_TRANSACTIONS_ONLY, $payment_method_definition::get_capabilities(), true );
 	}
 
 	/**
 	 * Does the payment method allow manual capture?
 	 *
-	 * @param array<string> $capabilities The payment method capabilities.
+	 * @param string $payment_method_definition The payment method definition class name.
 	 * @return boolean
 	 */
-	public static function allows_manual_capture( array $capabilities ): bool {
-		return in_array( PaymentMethodCapability::CAPTURE_LATER, $capabilities, true );
+	public static function allows_manual_capture( string $payment_method_definition ): bool {
+		return in_array( PaymentMethodCapability::CAPTURE_LATER, $payment_method_definition::get_capabilities(), true );
 	}
 
 	/**
@@ -124,9 +125,9 @@ class PaymentMethodUtils {
 				'description'                   => $payment_method_definition::get_description(),
 				'settings_icon_url'             => $payment_method_definition::get_settings_icon_url(),
 				'currencies'                    => $payment_method_definition::get_supported_currencies(),
-				'allows_manual_capture'         => $payment_method_definition::allows_manual_capture(),
-				'allows_pay_later'              => $payment_method_definition::is_bnpl(),
-				'accepts_only_domestic_payment' => $payment_method_definition::accepts_only_domestic_payments(),
+				'allows_manual_capture'         => self::allows_manual_capture( $payment_method_definition ),
+				'allows_pay_later'              => self::is_bnpl( $payment_method_definition ),
+				'accepts_only_domestic_payment' => self::accepts_only_domestic_payments( $payment_method_definition ),
 			];
 		}
 

--- a/includes/payment-methods/Configs/Utils/PaymentMethodUtils.php
+++ b/includes/payment-methods/Configs/Utils/PaymentMethodUtils.php
@@ -8,7 +8,6 @@
 namespace WCPay\PaymentMethods\Configs\Utils;
 
 use WCPay\PaymentMethods\Configs\Constants\PaymentMethodCapability;
-use WCPay\PaymentMethods\Configs\Interfaces\PaymentMethodDefinitionInterface;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 
 /**

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -15,6 +15,7 @@ use WC_Payments_Token_Service;
 use WC_Payment_Token_CC;
 use WC_Payment_Token_WCPay_SEPA;
 use WC_Payments_Subscriptions_Utilities;
+use WCPay\PaymentMethods\Configs\Utils\PaymentMethodUtils;
 
 /**
  * Extendable class for payment methods.
@@ -125,11 +126,11 @@ class UPE_Payment_Method {
 		if ( null !== $this->definition ) {
 			// Cache values that don't require context.
 			$this->stripe_id                    = $this->definition::get_id();
-			$this->is_reusable                  = $this->definition::is_reusable();
+			$this->is_reusable                  = PaymentMethodUtils::is_reusable( $this->definition );
 			$this->currencies                   = $this->definition::get_supported_currencies();
-			$this->accept_only_domestic_payment = $this->definition::accepts_only_domestic_payments();
+			$this->accept_only_domestic_payment = PaymentMethodUtils::accepts_only_domestic_payments( $this->definition );
 			$this->limits_per_currency          = $this->definition::get_limits_per_currency();
-			$this->is_bnpl                      = $this->definition::is_bnpl();
+			$this->is_bnpl                      = PaymentMethodUtils::is_bnpl( $this->definition );
 			$this->countries                    = $this->definition::get_supported_countries();
 		}
 	}
@@ -434,7 +435,7 @@ class UPE_Payment_Method {
 	 */
 	public function allows_manual_capture() {
 		if ( null !== $this->definition ) {
-			return $this->definition::allows_manual_capture();
+			return PaymentMethodUtils::allows_manual_capture( $this->definition );
 		}
 
 		return false;

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
@@ -42,22 +42,6 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return 'Second mock payment method for testing';
 	}
 
-	public static function is_bnpl(): bool {
-		return false;
-	}
-
-	public static function is_reusable(): bool {
-		return true;
-	}
-
-	public static function accepts_only_domestic_payments(): bool {
-		return false;
-	}
-
-	public static function allows_manual_capture(): bool {
-		return true;
-	}
-
 	public static function get_supported_countries(): array {
 		return [ 'US' ];
 	}
@@ -89,10 +73,6 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return in_array( $currency, self::get_supported_currencies(), true ) &&
 			in_array( $account_country, self::get_supported_countries(), true );
-	}
-
-	public static function is_enabled_by_default(): bool {
-		return true;
 	}
 
 	public static function get_limits_per_currency(): array {

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
@@ -42,22 +42,6 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return 'Mock payment method for testing';
 	}
 
-	public static function is_bnpl(): bool {
-		return false;
-	}
-
-	public static function is_reusable(): bool {
-		return true;
-	}
-
-	public static function accepts_only_domestic_payments(): bool {
-		return false;
-	}
-
-	public static function allows_manual_capture(): bool {
-		return true;
-	}
-
 	public static function get_supported_currencies(): array {
 		return [ 'USD', 'CAD' ];
 	}
@@ -89,10 +73,6 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 	public static function is_available_for( string $currency, string $account_country ): bool {
 		return in_array( $currency, self::get_supported_currencies(), true ) &&
 			in_array( $account_country, self::get_supported_countries(), true );
-	}
-
-	public static function is_enabled_by_default(): bool {
-		return true;
 	}
 
 	public static function get_limits_per_currency(): array {

--- a/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
+++ b/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
@@ -302,7 +302,6 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 			$this->assertArrayHasKey( 'title', $method );
 			$this->assertArrayHasKey( 'description', $method );
 			$this->assertArrayHasKey( 'icon', $method );
-			$this->assertArrayHasKey( 'settings_icon_url', $method );
 			$this->assertArrayHasKey( 'currencies', $method );
 			$this->assertArrayHasKey( 'allows_manual_capture', $method );
 			$this->assertArrayHasKey( 'allows_pay_later', $method );

--- a/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
+++ b/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
@@ -91,21 +91,36 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	 * Test that is_bnpl() correctly identifies BNPL methods.
 	 */
 	public function test_is_bnpl() {
-		$capabilities = [ PaymentMethodCapability::BUY_NOW_PAY_LATER ];
+		// Create anonymous class with BNPL capability.
+		$bnpl_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::BUY_NOW_PAY_LATER ];
+			}
+		};
 		$this->assertTrue(
-			PaymentMethodUtils::is_bnpl( $capabilities ),
+			PaymentMethodUtils::is_bnpl( get_class( $bnpl_definition ) ),
 			'Should identify BNPL capability'
 		);
 
-		$capabilities = [ PaymentMethodCapability::TOKENIZATION ];
+		// Create anonymous class without BNPL capability.
+		$non_bnpl_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::TOKENIZATION ];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::is_bnpl( $capabilities ),
+			PaymentMethodUtils::is_bnpl( get_class( $non_bnpl_definition ) ),
 			'Should not identify non-BNPL capability as BNPL'
 		);
 
-		$capabilities = [];
+		// Create anonymous class with empty capabilities.
+		$empty_definition = new class() {
+			public static function get_capabilities(): array {
+				return [];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::is_bnpl( $capabilities ),
+			PaymentMethodUtils::is_bnpl( get_class( $empty_definition ) ),
 			'Empty capabilities should not be identified as BNPL'
 		);
 	}
@@ -114,21 +129,36 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	 * Test that is_reusable() identifies tokenizable methods.
 	 */
 	public function test_is_reusable() {
-		$capabilities = [ PaymentMethodCapability::TOKENIZATION ];
+		// Create anonymous class with tokenization capability.
+		$reusable_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::TOKENIZATION ];
+			}
+		};
 		$this->assertTrue(
-			PaymentMethodUtils::is_reusable( $capabilities ),
+			PaymentMethodUtils::is_reusable( get_class( $reusable_definition ) ),
 			'Should identify tokenizable capability'
 		);
 
-		$capabilities = [ PaymentMethodCapability::BUY_NOW_PAY_LATER ];
+		// Create anonymous class without tokenization capability.
+		$non_reusable_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::BUY_NOW_PAY_LATER ];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::is_reusable( $capabilities ),
+			PaymentMethodUtils::is_reusable( get_class( $non_reusable_definition ) ),
 			'Should not identify non-tokenizable capability as reusable'
 		);
 
-		$capabilities = [];
+		// Create anonymous class with empty capabilities.
+		$empty_definition = new class() {
+			public static function get_capabilities(): array {
+				return [];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::is_reusable( $capabilities ),
+			PaymentMethodUtils::is_reusable( get_class( $empty_definition ) ),
 			'Empty capabilities should not be identified as reusable'
 		);
 	}
@@ -137,21 +167,36 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	 * Test that accepts_only_domestic_payments() identifies domestic-only methods.
 	 */
 	public function test_accepts_only_domestic_payments() {
-		$capabilities = [ PaymentMethodCapability::DOMESTIC_TRANSACTIONS_ONLY ];
+		// Create anonymous class with domestic-only capability.
+		$domestic_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::DOMESTIC_TRANSACTIONS_ONLY ];
+			}
+		};
 		$this->assertTrue(
-			PaymentMethodUtils::accepts_only_domestic_payments( $capabilities ),
+			PaymentMethodUtils::accepts_only_domestic_payments( get_class( $domestic_definition ) ),
 			'Should identify domestic-only capability'
 		);
 
-		$capabilities = [ PaymentMethodCapability::TOKENIZATION ];
+		// Create anonymous class without domestic-only capability.
+		$non_domestic_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::TOKENIZATION ];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::accepts_only_domestic_payments( $capabilities ),
+			PaymentMethodUtils::accepts_only_domestic_payments( get_class( $non_domestic_definition ) ),
 			'Should not identify non-domestic-only capability as domestic-only'
 		);
 
-		$capabilities = [];
+		// Create anonymous class with empty capabilities.
+		$empty_definition = new class() {
+			public static function get_capabilities(): array {
+				return [];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::accepts_only_domestic_payments( $capabilities ),
+			PaymentMethodUtils::accepts_only_domestic_payments( get_class( $empty_definition ) ),
 			'Empty capabilities should not be identified as domestic-only'
 		);
 	}
@@ -160,21 +205,36 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	 * Test that allows_manual_capture() identifies manual capture support.
 	 */
 	public function test_allows_manual_capture() {
-		$capabilities = [ PaymentMethodCapability::CAPTURE_LATER ];
+		// Create anonymous class with manual capture capability.
+		$manual_capture_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::CAPTURE_LATER ];
+			}
+		};
 		$this->assertTrue(
-			PaymentMethodUtils::allows_manual_capture( $capabilities ),
+			PaymentMethodUtils::allows_manual_capture( get_class( $manual_capture_definition ) ),
 			'Should identify manual capture capability'
 		);
 
-		$capabilities = [ PaymentMethodCapability::TOKENIZATION ];
+		// Create anonymous class without manual capture capability.
+		$non_manual_capture_definition = new class() {
+			public static function get_capabilities(): array {
+				return [ PaymentMethodCapability::TOKENIZATION ];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::allows_manual_capture( $capabilities ),
+			PaymentMethodUtils::allows_manual_capture( get_class( $non_manual_capture_definition ) ),
 			'Should not identify non-manual-capture capability as supporting manual capture'
 		);
 
-		$capabilities = [];
+		// Create anonymous class with empty capabilities.
+		$empty_definition = new class() {
+			public static function get_capabilities(): array {
+				return [];
+			}
+		};
 		$this->assertFalse(
-			PaymentMethodUtils::allows_manual_capture( $capabilities ),
+			PaymentMethodUtils::allows_manual_capture( get_class( $empty_definition ) ),
 			'Empty capabilities should not be identified as supporting manual capture'
 		);
 	}
@@ -239,9 +299,10 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 		// Verify required fields are present.
 		foreach ( $decoded as $method ) {
 			$this->assertArrayHasKey( 'id', $method );
+			$this->assertArrayHasKey( 'stripe_key', $method );
 			$this->assertArrayHasKey( 'title', $method );
 			$this->assertArrayHasKey( 'description', $method );
-			$this->assertArrayHasKey( 'icon', $method );
+			$this->assertArrayHasKey( 'settings_icon_url', $method );
 			$this->assertArrayHasKey( 'currencies', $method );
 			$this->assertArrayHasKey( 'allows_manual_capture', $method );
 			$this->assertArrayHasKey( 'allows_pay_later', $method );
@@ -250,15 +311,15 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_payment_method_definitions_json() returns empty string for empty registry.
+	 * Test that get_payment_method_definitions_json() returns valid JSON structure.
 	 */
-	public function test_get_payment_method_definitions_json_empty_registry() {
-		$registry = PaymentMethodDefinitionRegistry::instance();
-		$json     = PaymentMethodUtils::get_payment_method_definitions_json();
+	public function test_get_payment_method_definitions_json_structure() {
+		$json = PaymentMethodUtils::get_payment_method_definitions_json();
 
 		$this->assertJson( $json );
 		$decoded = json_decode( $json, true );
 		$this->assertIsArray( $decoded );
-		$this->assertEmpty( $decoded );
+		// Registry is a singleton, so it may have entries from previous tests.
+		// We just verify it returns valid JSON structure.
 	}
 }

--- a/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
+++ b/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
@@ -13,11 +13,69 @@ use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 use WCPay\Tests\PaymentMethods\Configs\MockPaymentMethodDefinition;
 use WCPay\Tests\PaymentMethods\Configs\SecondMockPaymentMethodDefinition;
 use WCPAY_UnitTestCase;
+use ReflectionClass;
 
 /**
  * PaymentMethodUtils unit tests.
  */
 class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
+
+	/**
+	 * PaymentMethodDefinitionRegistry is a singleton that maintains state.
+	 * But we need to ensure each test starts with a clean slate by resetting the registry.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// on each test, reset the global definition registry class.
+		$reflection = new ReflectionClass( PaymentMethodDefinitionRegistry::class );
+
+		// Reset the static instance property to null.
+		$instance_property = $reflection->getProperty( 'instance' );
+		$instance_property->setAccessible( true );
+		$instance_property->setValue( null, null );
+		$instance_property->setAccessible( false );
+
+		// Create a new instance.
+		$registry = PaymentMethodDefinitionRegistry::instance();
+
+		// Reset available definitions.
+		$available_definitions = $reflection->getProperty( 'available_definitions' );
+		$available_definitions->setAccessible( true );
+		$available_definitions->setValue( $registry, [] );
+		$available_definitions->setAccessible( false );
+
+		// Reset payment methods.
+		$payment_methods = $reflection->getProperty( 'payment_methods' );
+		$payment_methods->setAccessible( true );
+		$payment_methods->setValue( $registry, [] );
+		$payment_methods->setAccessible( false );
+	}
+
+	/**
+	 * Helper method to create a mock payment method definition with given capabilities.
+	 *
+	 * @param array $capabilities Array of capabilities.
+	 * @return string The class name of the created definition.
+	 */
+	private function create_mock_definition( array $capabilities ): string {
+		$definition = new class( $capabilities ) {
+			/**
+			 * @var array The capabilities (injected) for the mocked payment definition.
+			 */
+			private static $static_capabilities;
+
+			public function __construct( array $capabilities ) {
+				self::$static_capabilities = $capabilities;
+			}
+
+			public static function get_capabilities(): array {
+				return self::$static_capabilities ?? [];
+			}
+		};
+
+		return get_class( $definition );
+	}
 
 	/**
 	 * Test that get_stripe_id() correctly appends '_payments'.
@@ -88,155 +146,159 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test that is_bnpl() correctly identifies BNPL methods.
+	 * Data provider for test_is_bnpl.
+	 *
+	 * @return array
 	 */
-	public function test_is_bnpl() {
-		// Create anonymous class with BNPL capability.
-		$bnpl_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::BUY_NOW_PAY_LATER ];
-			}
-		};
-		$this->assertTrue(
-			PaymentMethodUtils::is_bnpl( get_class( $bnpl_definition ) ),
-			'Should identify BNPL capability'
-		);
+	public function is_bnpl_provider(): array {
+		return [
+			'with BNPL capability'    => [
+				[ PaymentMethodCapability::BUY_NOW_PAY_LATER ],
+				true,
+				'Should identify BNPL capability',
+			],
+			'without BNPL capability' => [
+				[ PaymentMethodCapability::TOKENIZATION ],
+				false,
+				'Should not identify non-BNPL capability as BNPL',
+			],
+			'with empty capabilities' => [
+				[],
+				false,
+				'Empty capabilities should not be identified as BNPL',
+			],
+		];
+	}
 
-		// Create anonymous class without BNPL capability.
-		$non_bnpl_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::TOKENIZATION ];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::is_bnpl( get_class( $non_bnpl_definition ) ),
-			'Should not identify non-BNPL capability as BNPL'
-		);
+	/**
+	 * Test that is_bnpl() correctly identifies BNPL methods.
+	 *
+	 * @dataProvider is_bnpl_provider
+	 *
+	 * @param array  $capabilities Array of capabilities.
+	 * @param bool   $expected Expected result.
+	 * @param string $message Assertion message.
+	 */
+	public function test_is_bnpl( array $capabilities, bool $expected, string $message ) {
+		$definition_class = $this->create_mock_definition( $capabilities );
+		$this->assertEquals( $expected, PaymentMethodUtils::is_bnpl( $definition_class ), $message );
+	}
 
-		// Create anonymous class with empty capabilities.
-		$empty_definition = new class() {
-			public static function get_capabilities(): array {
-				return [];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::is_bnpl( get_class( $empty_definition ) ),
-			'Empty capabilities should not be identified as BNPL'
-		);
+	/**
+	 * Data provider for test_is_reusable.
+	 *
+	 * @return array
+	 */
+	public function is_reusable_provider(): array {
+		return [
+			'with tokenization capability'    => [
+				[ PaymentMethodCapability::TOKENIZATION ],
+				true,
+				'Should identify tokenizable capability',
+			],
+			'without tokenization capability' => [
+				[ PaymentMethodCapability::BUY_NOW_PAY_LATER ],
+				false,
+				'Should not identify non-tokenizable capability as reusable',
+			],
+			'with empty capabilities'         => [
+				[],
+				false,
+				'Empty capabilities should not be identified as reusable',
+			],
+		];
 	}
 
 	/**
 	 * Test that is_reusable() identifies tokenizable methods.
+	 *
+	 * @dataProvider is_reusable_provider
+	 *
+	 * @param array  $capabilities Array of capabilities.
+	 * @param bool   $expected Expected result.
+	 * @param string $message Assertion message.
 	 */
-	public function test_is_reusable() {
-		// Create anonymous class with tokenization capability.
-		$reusable_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::TOKENIZATION ];
-			}
-		};
-		$this->assertTrue(
-			PaymentMethodUtils::is_reusable( get_class( $reusable_definition ) ),
-			'Should identify tokenizable capability'
-		);
+	public function test_is_reusable( array $capabilities, bool $expected, string $message ) {
+		$definition_class = $this->create_mock_definition( $capabilities );
+		$this->assertEquals( $expected, PaymentMethodUtils::is_reusable( $definition_class ), $message );
+	}
 
-		// Create anonymous class without tokenization capability.
-		$non_reusable_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::BUY_NOW_PAY_LATER ];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::is_reusable( get_class( $non_reusable_definition ) ),
-			'Should not identify non-tokenizable capability as reusable'
-		);
-
-		// Create anonymous class with empty capabilities.
-		$empty_definition = new class() {
-			public static function get_capabilities(): array {
-				return [];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::is_reusable( get_class( $empty_definition ) ),
-			'Empty capabilities should not be identified as reusable'
-		);
+	/**
+	 * Data provider for test_accepts_only_domestic_payments.
+	 *
+	 * @return array
+	 */
+	public function accepts_only_domestic_payments_provider(): array {
+		return [
+			'with domestic-only capability'    => [
+				[ PaymentMethodCapability::DOMESTIC_TRANSACTIONS_ONLY ],
+				true,
+				'Should identify domestic-only capability',
+			],
+			'without domestic-only capability' => [
+				[ PaymentMethodCapability::TOKENIZATION ],
+				false,
+				'Should not identify non-domestic-only capability as domestic-only',
+			],
+			'with empty capabilities'          => [
+				[],
+				false,
+				'Empty capabilities should not be identified as domestic-only',
+			],
+		];
 	}
 
 	/**
 	 * Test that accepts_only_domestic_payments() identifies domestic-only methods.
+	 *
+	 * @dataProvider accepts_only_domestic_payments_provider
+	 *
+	 * @param array  $capabilities Array of capabilities.
+	 * @param bool   $expected Expected result.
+	 * @param string $message Assertion message.
 	 */
-	public function test_accepts_only_domestic_payments() {
-		// Create anonymous class with domestic-only capability.
-		$domestic_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::DOMESTIC_TRANSACTIONS_ONLY ];
-			}
-		};
-		$this->assertTrue(
-			PaymentMethodUtils::accepts_only_domestic_payments( get_class( $domestic_definition ) ),
-			'Should identify domestic-only capability'
-		);
+	public function test_accepts_only_domestic_payments( array $capabilities, bool $expected, string $message ) {
+		$definition_class = $this->create_mock_definition( $capabilities );
+		$this->assertEquals( $expected, PaymentMethodUtils::accepts_only_domestic_payments( $definition_class ), $message );
+	}
 
-		// Create anonymous class without domestic-only capability.
-		$non_domestic_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::TOKENIZATION ];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::accepts_only_domestic_payments( get_class( $non_domestic_definition ) ),
-			'Should not identify non-domestic-only capability as domestic-only'
-		);
-
-		// Create anonymous class with empty capabilities.
-		$empty_definition = new class() {
-			public static function get_capabilities(): array {
-				return [];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::accepts_only_domestic_payments( get_class( $empty_definition ) ),
-			'Empty capabilities should not be identified as domestic-only'
-		);
+	/**
+	 * Data provider for test_allows_manual_capture.
+	 *
+	 * @return array
+	 */
+	public function allows_manual_capture_provider(): array {
+		return [
+			'with manual capture capability'    => [
+				[ PaymentMethodCapability::CAPTURE_LATER ],
+				true,
+				'Should identify manual capture capability',
+			],
+			'without manual capture capability' => [
+				[ PaymentMethodCapability::TOKENIZATION ],
+				false,
+				'Should not identify non-manual-capture capability as supporting manual capture',
+			],
+			'with empty capabilities'           => [
+				[],
+				false,
+				'Empty capabilities should not be identified as supporting manual capture',
+			],
+		];
 	}
 
 	/**
 	 * Test that allows_manual_capture() identifies manual capture support.
+	 *
+	 * @dataProvider allows_manual_capture_provider
+	 *
+	 * @param array  $capabilities Array of capabilities.
+	 * @param bool   $expected Expected result.
+	 * @param string $message Assertion message.
 	 */
-	public function test_allows_manual_capture() {
-		// Create anonymous class with manual capture capability.
-		$manual_capture_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::CAPTURE_LATER ];
-			}
-		};
-		$this->assertTrue(
-			PaymentMethodUtils::allows_manual_capture( get_class( $manual_capture_definition ) ),
-			'Should identify manual capture capability'
-		);
-
-		// Create anonymous class without manual capture capability.
-		$non_manual_capture_definition = new class() {
-			public static function get_capabilities(): array {
-				return [ PaymentMethodCapability::TOKENIZATION ];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::allows_manual_capture( get_class( $non_manual_capture_definition ) ),
-			'Should not identify non-manual-capture capability as supporting manual capture'
-		);
-
-		// Create anonymous class with empty capabilities.
-		$empty_definition = new class() {
-			public static function get_capabilities(): array {
-				return [];
-			}
-		};
-		$this->assertFalse(
-			PaymentMethodUtils::allows_manual_capture( get_class( $empty_definition ) ),
-			'Empty capabilities should not be identified as supporting manual capture'
-		);
+	public function test_allows_manual_capture( array $capabilities, bool $expected, string $message ) {
+		$definition_class = $this->create_mock_definition( $capabilities );
+		$this->assertEquals( $expected, PaymentMethodUtils::allows_manual_capture( $definition_class ), $message );
 	}
 
 	/**
@@ -313,8 +375,7 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	 * Test that get_payment_method_definitions_json() returns empty string for empty registry.
 	 */
 	public function test_get_payment_method_definitions_json_empty_registry() {
-		$registry = PaymentMethodDefinitionRegistry::instance();
-		$json     = PaymentMethodUtils::get_payment_method_definitions_json();
+		$json = PaymentMethodUtils::get_payment_method_definitions_json();
 
 		$this->assertJson( $json );
 		$decoded = json_decode( $json, true );

--- a/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
+++ b/tests/unit/payment-methods/Configs/test-class-payment-method-utils.php
@@ -299,9 +299,9 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 		// Verify required fields are present.
 		foreach ( $decoded as $method ) {
 			$this->assertArrayHasKey( 'id', $method );
-			$this->assertArrayHasKey( 'stripe_key', $method );
 			$this->assertArrayHasKey( 'title', $method );
 			$this->assertArrayHasKey( 'description', $method );
+			$this->assertArrayHasKey( 'icon', $method );
 			$this->assertArrayHasKey( 'settings_icon_url', $method );
 			$this->assertArrayHasKey( 'currencies', $method );
 			$this->assertArrayHasKey( 'allows_manual_capture', $method );
@@ -311,15 +311,15 @@ class PaymentMethodUtilsTest extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_payment_method_definitions_json() returns valid JSON structure.
+	 * Test that get_payment_method_definitions_json() returns empty string for empty registry.
 	 */
-	public function test_get_payment_method_definitions_json_structure() {
-		$json = PaymentMethodUtils::get_payment_method_definitions_json();
+	public function test_get_payment_method_definitions_json_empty_registry() {
+		$registry = PaymentMethodDefinitionRegistry::instance();
+		$json     = PaymentMethodUtils::get_payment_method_definitions_json();
 
 		$this->assertJson( $json );
 		$decoded = json_decode( $json, true );
 		$this->assertIsArray( $decoded );
-		// Registry is a singleton, so it may have entries from previous tests.
-		// We just verify it returns valid JSON structure.
+		$this->assertEmpty( $decoded );
 	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5515

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed here: https://github.com/Automattic/woocommerce-payments/pull/11138#discussion_r2542623808

Refactoring the `PaymentMethodDefinitionInterface` (and related code) to reduce boilerplate across payment method definitions. In this PR, I:
1. Removed capability-derived methods from the interface,
2. Used `PaymentMethodUtils` helpers, instead
3. Removed the unused `is_enabled_by_default()` method

The `PaymentMethodDefinitionInterface` required four methods that were all derived from `get_capabilities()`:
- `is_bnpl()`
- `is_reusable()`
- `accepts_only_domestic_payments()`
- `allows_manual_capture()`

Every payment method definition (9 definitions) had identical boilerplate implementations:
```
  public static function is_bnpl(): bool {
      return PaymentMethodUtils::is_bnpl( self::get_capabilities() );
  }
  // ... repeated for all 4 methods in all 9 definitions
```

To maintain the explicitness, I kept the `get_capabilities()` method in the interface. I just removed the derived convenience methods.

The original design requirements wanted to avoid composition or traits - I kept these requirements.

I considered to also remove the `is_bnpl()`/`is_reusable()`/etc. checks from the `PaymentMethodUtils`.
However, I felt that it was becoming too verbose and didn't offer good autocomplete suggestions. 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- BNPL methods should appear in the BNPL section on the settings page (i.e.: the `is_bnpl()` categorizes the payment methods correctly)
<img width="1231" height="298" alt="Screenshot 2025-11-21 at 4 08 32 PM" src="https://github.com/user-attachments/assets/16ba59f8-896a-437f-877d-1e3cbbeb6708" />
- Checkout flow is unaffected

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
