### PR TITLE
Update fees doc links

### DIFF
--- a/changelog/fix-update-fees-doc-links
+++ b/changelog/fix-update-fees-doc-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Comment: Update links to the WooPayments fees documentation.

--- a/client/components/account-balances/__tests__/index.test.tsx
+++ b/client/components/account-balances/__tests__/index.test.tsx
@@ -254,7 +254,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getAllByRole( 'link' )[ 1 ] ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/'
+			'https://woocommerce.com/document/woopayments/fees/account-showing-negative-balance/'
 		);
 	} );
 
@@ -273,7 +273,7 @@ describe( 'AccountBalances', () => {
 		} );
 		expect( within( tooltip ).getAllByRole( 'link' )[ 1 ] ).toHaveAttribute(
 			'href',
-			'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/'
+			'https://woocommerce.com/document/woopayments/fees/account-showing-negative-balance/'
 		);
 	} );
 

--- a/client/components/account-balances/strings.ts
+++ b/client/components/account-balances/strings.ts
@@ -12,5 +12,5 @@ export const documentationUrls = {
 	depositSchedule:
 		'https://woocommerce.com/document/woopayments/payouts/payout-schedule/',
 	negativeBalance:
-		'https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/',
+		'https://woocommerce.com/document/woopayments/fees/account-showing-negative-balance/',
 };

--- a/client/components/deposits-overview/deposit-notices.tsx
+++ b/client/components/deposits-overview/deposit-notices.tsx
@@ -102,7 +102,7 @@ export const NegativeBalanceDepositsPausedNotice: React.FC = () => (
 					<a
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://woocommerce.com/document/woopayments/fees-and-debits/account-showing-negative-balance/"
+						href="https://woocommerce.com/document/woopayments/fees/account-showing-negative-balance/"
 					/>
 				),
 			},

--- a/client/utils/__tests__/__snapshots__/account-fees.test.tsx.snap
+++ b/client/utils/__tests__/__snapshots__/account-fees.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
       <span>
         <a
           class="components-external-link"
-          href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
+          href="https://woocommerce.com/document/woopayments/fees/#united-states"
           rel="external noreferrer noopener"
           target="_blank"
         >
@@ -113,7 +113,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
       <span>
         <a
           class="components-external-link"
-          href="https://woocommerce.com/document/woopayments/fees-and-debits/fees/#united-states"
+          href="https://woocommerce.com/document/woopayments/fees/#united-states"
           rel="external noreferrer noopener"
           target="_blank"
         >

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -19,9 +19,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import PAYMENT_METHOD_IDS from 'constants/payment-method';
 
 const countryFeeStripeDocsBaseLink =
-	'https://woocommerce.com/document/woopayments/fees-and-debits/fees/#';
+	'https://woocommerce.com/document/woopayments/fees/#';
 const countryFeeStripeDocsBaseLinkNoCountry =
-	'https://woocommerce.com/document/woopayments/fees-and-debits/fees/';
+	'https://woocommerce.com/document/woopayments/fees/';
 const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	AE: 'united-arab-emirates',
 	AU: 'australia',

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -2409,7 +2409,7 @@ class WC_Payments_Order_Service {
 	 * @return string
 	 */
 	private function get_frod_support_note( $formatted_amount ) {
-		$learn_more_url = 'https://woocommerce.com/document/woopayments/fees-and-debits/preventing-negative-balances/#adding-funds';
+		$learn_more_url = 'https://woocommerce.com/document/woopayments/fees/preventing-negative-balances/#adding-funds';
 		return sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %s: Formatted refund amount */

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ Features previously only available on your payment provider’s website are now 
 
 **Pay as you go**
 
-WooPayments is **free to install**, with **no setup fees or monthly fees**. Our pay-as-you-go pricing model means we're incentivized to help you succeed! [Read more about transaction fees](https://woocommerce.com/document/woopayments/fees-and-debits/fees/).
+WooPayments is **free to install**, with **no setup fees or monthly fees**. Our pay-as-you-go pricing model means we're incentivized to help you succeed! [Read more about transaction fees](https://woocommerce.com/document/woopayments/fees/).
 
 **Supported by the WooCommerce team**
 


### PR DESCRIPTION
Fixes #11150 

In PAYOPS-1170, I updated and consolidated the fees documentation for WooPayments. The new documentation lives [here](https://woocommerce.com/document/woopayments/fees/) now.

Old fees docs URLs (such as `https://woocommerce.com/document/woopayments/fees-and-debits/fees/`) will redirect to the new page.

While the existing fees docs URLs in the plugin should work fine given this redirect, it's probably best to avoid the redirect where we can, so I'm filing this issue to update the URLs.

Testing should be fairly straightforward: visit any WooPayments plugin pages that link out to our fees page and test the links. They should immediately go to the new URL:

`https://woocommerce.com/document/woopayments/fees/`

