### PR TITLE
Fix Incorrect Reference to “WooPayments Mobile Application” on Card Readers Page

### DIFF
--- a/changelog/fix-WOOPMNT-5517-mobile-app-reference
+++ b/changelog/fix-WOOPMNT-5517-mobile-app-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update “WooPayments” to “WooCommerce” mobile application in the Card Readers page.

--- a/client/card-readers/list/index.tsx
+++ b/client/card-readers/list/index.tsx
@@ -26,7 +26,7 @@ const ReadersListDescription = () => (
 						'To connect or disconnect card readers, use the %s mobile application.',
 					'woocommerce-payments'
 				),
-				'WooPayments'
+				'WooCommerce'
 			) }
 		</p>
 	</>


### PR DESCRIPTION
Fixes WOOPMNT-5517

#### Changes proposed in this Pull Request

This PR updates the Card Readers page to reference the correct mobile application. The existing text incorrectly instructs users to use the “WooPayments mobile application,” which does not exist. The correct app for managing card readers is the WooCommerce Mobile application.

| Before | After |
| ------ | ----- |
| <img width="439" height="161" alt="Screenshot 2025-11-25 at 17 01 12" src="https://github.com/user-attachments/assets/63942c3c-4af7-419f-abbf-964de672fc02" /> | <img width="436" height="161" alt="Screenshot 2025-11-25 at 16 58 13" src="https://github.com/user-attachments/assets/62197ac0-e86e-44c2-a7e8-2e20ca7930f8" />  |

#### Testing instructions
- Check out the branch locally.
- Apply the [patch](https://github.com/user-attachments/files/23750345/card-readers-eligible.patch) to fake the presence of card readers and enable the Card Readers page.
- Connect a test account.
- Go to Payments > Card Readers.
- Verify that the Card Readers description now references the WooCommerce mobile application instead of the WooPayments mobile application.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
