### PR TITLE
fix: blocks checkout logos with WC beta

### DIFF
--- a/changelog/fix-blocks-checkout-logos-in-wc-beta
+++ b/changelog/fix-blocks-checkout-logos-in-wc-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: payment method logos compatibility with WooCommerce Blocks in WC>=10.4

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -72,6 +72,7 @@ button.wcpay-stripelink-modal-trigger:hover {
 
 			> .payment-methods--logos {
 				grid-area: logos;
+				height: 24px;
 				justify-self: end;
 			}
 


### PR DESCRIPTION
Fixes WOOPMNT-5520

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Some changes were introduced in WC 10.4 beta to the block-based checkout.
We relied on the logo height set by WC Core for the payment method logos displayed on the block-based checkout.
That height got removed.

Fixing it in our codebase.

Before, with WC 10.3:
<img width="852" height="755" alt="Screenshot 2025-11-25 at 5 20 08 PM" src="https://github.com/user-attachments/assets/ede493b0-d9ec-42b4-9f12-bd43e774edce" />

With WC 10.4.0-beta.1:
<img width="840" height="952" alt="Screenshot 2025-11-25 at 5 20 49 PM" src="https://github.com/user-attachments/assets/dfb6932c-1f39-490c-8aaf-6aa8aebd9a05" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Install Jetpack Beta tester or WC Beta tester
- Install [the WC 10.4.0-beta.1 version](https://github.com/woocommerce/woocommerce/releases/tag/10.4.0-beta.1)
- Go to the block-based checkout
- The logos should be fixed
<img width="878" height="630" alt="Screenshot 2025-11-25 at 5 20 16 PM" src="https://github.com/user-attachments/assets/2e6b90e9-32ed-4b48-93c6-9feda7ad2540" />



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
