### PR TITLE
Add analytics tracking for payment method promotions

### DIFF
--- a/client/components/spotlight/__tests__/index.test.tsx
+++ b/client/components/spotlight/__tests__/index.test.tsx
@@ -230,4 +230,45 @@ describe( 'Spotlight Component', () => {
 			container.querySelector( '.wcpay-spotlight__card' )
 		).toBeInTheDocument();
 	} );
+
+	it( 'calls onView when spotlight becomes visible with showImmediately', () => {
+		const onView = jest.fn();
+
+		render( <Spotlight { ...defaultProps } onView={ onView } /> );
+
+		expect( onView ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls onView after delay when showImmediately is false', async () => {
+		jest.useFakeTimers();
+		const onView = jest.fn();
+
+		render(
+			<Spotlight
+				{ ...defaultProps }
+				showImmediately={ false }
+				onView={ onView }
+			/>
+		);
+
+		// onView should not be called initially
+		expect( onView ).not.toHaveBeenCalled();
+
+		// Fast forward time by 4 seconds
+		act( () => {
+			jest.advanceTimersByTime( 4000 );
+		} );
+
+		// Flush requestAnimationFrame calls
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		// onView should now be called
+		await waitFor( () => {
+			expect( onView ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		jest.useRealTimers();
+	} );
 } );

--- a/client/components/spotlight/index.tsx
+++ b/client/components/spotlight/index.tsx
@@ -35,6 +35,7 @@ const Spotlight: React.FC< SpotlightProps > = ( {
 	secondaryButtonLabel,
 	onSecondaryClick,
 	onDismiss,
+	onView,
 	showImmediately = false,
 } ) => {
 	const [ isVisible, setIsVisible ] = useState( false );
@@ -60,6 +61,14 @@ const Spotlight: React.FC< SpotlightProps > = ( {
 
 		return () => clearTimeout( timer );
 	}, [ showImmediately ] );
+
+	// Call onView when spotlight becomes visible
+	useEffect( () => {
+		if ( isAnimatingIn && onView ) {
+			onView();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isAnimatingIn ] );
 
 	const handleClose = () => {
 		setIsAnimatingIn( false );

--- a/client/components/spotlight/types.ts
+++ b/client/components/spotlight/types.ts
@@ -55,6 +55,12 @@ export interface SpotlightProps {
 	onDismiss: () => void;
 
 	/**
+	 * Callback when the spotlight becomes visible (after delay and animation starts).
+	 * Useful for tracking view events.
+	 */
+	onView?: () => void;
+
+	/**
 	 * Whether to show the spotlight immediately without delay (for testing).
 	 *
 	 * @default false

--- a/client/data/promotions/types.d.ts
+++ b/client/data/promotions/types.d.ts
@@ -30,6 +30,7 @@ export interface PromotionConfig {
 
 export interface Promotion {
 	promo_id: string;
+	payment_method: string;
 	discount_rate: string;
 	duration_days: number;
 	config?: PromotionConfig;

--- a/client/promotions/spotlight/__tests__/index.test.tsx
+++ b/client/promotions/spotlight/__tests__/index.test.tsx
@@ -314,7 +314,7 @@ describe( 'SpotlightPromotion', () => {
 			payment_method: 'klarna',
 			variation_id: 'promo_123__spotlight_1',
 			display_context: 'spotlight',
-			page: 'http://localhost/',
+			source: 'unknown',
 		};
 
 		beforeEach( () => {

--- a/client/promotions/spotlight/__tests__/index.test.tsx
+++ b/client/promotions/spotlight/__tests__/index.test.tsx
@@ -337,18 +337,15 @@ describe( 'SpotlightPromotion', () => {
 			);
 		} );
 
-		it( 'records cta_click event when primary button is clicked', () => {
+		it( 'records activate_click event when primary button is clicked', () => {
 			render( <SpotlightPromotion /> );
 
 			const activateButton = screen.getByText( 'Activate now' );
 			activateButton.click();
 
 			expect( recordEvent ).toHaveBeenCalledWith(
-				'wcpay_payment_method_promotion_cta_click',
-				{
-					...expectedBaseProperties,
-					cta_label: 'Activate now',
-				}
+				'wcpay_payment_method_promotion_activate_click',
+				expectedBaseProperties
 			);
 		} );
 

--- a/client/promotions/spotlight/__tests__/index.test.tsx
+++ b/client/promotions/spotlight/__tests__/index.test.tsx
@@ -11,11 +11,16 @@ import { render, screen } from '@testing-library/react';
  */
 import SpotlightPromotion from '../index';
 import { usePromotions, usePromotionActions } from 'data';
+import { recordEvent } from 'tracks';
 
 // Mock the dependencies
 jest.mock( 'data', () => ( {
 	usePromotions: jest.fn(),
 	usePromotionActions: jest.fn(),
+} ) );
+
+jest.mock( 'tracks', () => ( {
+	recordEvent: jest.fn(),
 } ) );
 
 jest.mock( 'components/spotlight', () => ( {
@@ -37,6 +42,7 @@ jest.mock( 'components/spotlight', () => ( {
 				{ props.secondaryButtonLabel }
 			</button>
 			<button onClick={ props.onDismiss }>Close</button>
+			<button onClick={ props.onView }>View</button>
 		</div>
 	),
 } ) );
@@ -63,6 +69,7 @@ describe( 'SpotlightPromotion', () => {
 	const mockPromotionData = [
 		{
 			promo_id: 'promo_123',
+			payment_method: 'klarna',
 			discount_rate: '100%',
 			duration_days: 90,
 			variations: [
@@ -299,5 +306,90 @@ describe( 'SpotlightPromotion', () => {
 
 		// Reset to original
 		( global as any ).wcpaySettings = mockWcpaySettings;
+	} );
+
+	describe( 'tracks events', () => {
+		const expectedBaseProperties = {
+			promotion_id: 'promo_123',
+			payment_method: 'klarna',
+			variation_id: 'promo_123__spotlight_1',
+			display_context: 'spotlight',
+			page: 'http://localhost/',
+		};
+
+		beforeEach( () => {
+			( usePromotions as jest.Mock ).mockReturnValue( {
+				promotions: mockPromotionData,
+				isLoading: false,
+			} );
+		} );
+
+		it( 'records view event when spotlight becomes visible', () => {
+			render( <SpotlightPromotion /> );
+
+			const viewButton = screen.getByText( 'View' );
+			viewButton.click();
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'wcpay_payment_method_promotion_view',
+				expectedBaseProperties
+			);
+		} );
+
+		it( 'records cta_click event when primary button is clicked', () => {
+			render( <SpotlightPromotion /> );
+
+			const activateButton = screen.getByText( 'Activate now' );
+			activateButton.click();
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'wcpay_payment_method_promotion_cta_click',
+				{
+					...expectedBaseProperties,
+					cta_label: 'Activate now',
+				}
+			);
+		} );
+
+		it( 'records secondary_click event when secondary button is clicked', () => {
+			jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+			render( <SpotlightPromotion /> );
+
+			const learnMoreButton = screen.getByText( 'Learn more' );
+			learnMoreButton.click();
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'wcpay_payment_method_promotion_secondary_click',
+				expectedBaseProperties
+			);
+		} );
+
+		it( 'records dismiss event when close button is clicked', () => {
+			render( <SpotlightPromotion /> );
+
+			const closeButton = screen.getByText( 'Close' );
+			closeButton.click();
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'wcpay_payment_method_promotion_dismiss',
+				expectedBaseProperties
+			);
+		} );
+
+		it( 'records link_click event when terms link is clicked', () => {
+			render( <SpotlightPromotion /> );
+
+			const termsLink = screen.getByText( 'Terms and conditions' );
+			termsLink.click();
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'wcpay_payment_method_promotion_link_click',
+				{
+					...expectedBaseProperties,
+					link_type: 'terms',
+				}
+			);
+		} );
 	} );
 } );

--- a/client/promotions/spotlight/__tests__/index.test.tsx
+++ b/client/promotions/spotlight/__tests__/index.test.tsx
@@ -315,6 +315,7 @@ describe( 'SpotlightPromotion', () => {
 			variation_id: 'promo_123__spotlight_1',
 			display_context: 'spotlight',
 			source: 'unknown',
+			path: '/',
 		};
 
 		beforeEach( () => {

--- a/client/promotions/spotlight/index.tsx
+++ b/client/promotions/spotlight/index.tsx
@@ -100,7 +100,6 @@ const SpotlightPromotion: React.FC = () => {
 	const promotionId = activePromotion.promo_id;
 	const paymentMethod = activePromotion.payment_method;
 	const variationId = spotlightVariation.id;
-	const ctaLabel = spotlightVariation.cta_label;
 	const ctaUrl = spotlightVariation.cta_url;
 
 	/**
@@ -123,10 +122,10 @@ const SpotlightPromotion: React.FC = () => {
 	};
 
 	const handlePrimaryClick = () => {
-		recordEvent( 'wcpay_payment_method_promotion_cta_click', {
-			...getEventProperties(),
-			cta_label: ctaLabel,
-		} );
+		recordEvent(
+			'wcpay_payment_method_promotion_activate_click',
+			getEventProperties()
+		);
 		activatePromotion( promotionId );
 	};
 

--- a/client/promotions/spotlight/index.tsx
+++ b/client/promotions/spotlight/index.tsx
@@ -112,6 +112,7 @@ const SpotlightPromotion: React.FC = () => {
 		variation_id: variationId,
 		display_context: 'spotlight',
 		source: getPageSource(),
+		path: window.location.pathname + window.location.search,
 	} );
 
 	const handleView = () => {

--- a/client/promotions/spotlight/index.tsx
+++ b/client/promotions/spotlight/index.tsx
@@ -25,6 +25,30 @@ const spotlightImages: Record< string, string > = {
 };
 
 /**
+ * Determine a human-readable source identifier based on the current page.
+ *
+ * @return {string} Source identifier for tracking.
+ */
+const getPageSource = (): string => {
+	const path = window.location.pathname + window.location.search;
+
+	if ( path.includes( 'path=%2Fpayments%2Foverview' ) ) {
+		return 'wcpay-overview';
+	}
+	if ( path.includes( 'path=%2Fpayments%2Fsettings' ) ) {
+		return 'wcpay-settings';
+	}
+	if (
+		path.includes( 'page=wc-settings' ) &&
+		path.includes( 'tab=checkout' )
+	) {
+		return 'wc-settings-payments';
+	}
+
+	return 'unknown';
+};
+
+/**
  * Container component that fetches promotions and renders the Spotlight component.
  *
  * This component:
@@ -87,7 +111,7 @@ const SpotlightPromotion: React.FC = () => {
 		payment_method: paymentMethod,
 		variation_id: variationId,
 		display_context: 'spotlight',
-		page: window.location.href,
+		source: getPageSource(),
 	} );
 
 	const handleView = () => {

--- a/client/promotions/spotlight/index.tsx
+++ b/client/promotions/spotlight/index.tsx
@@ -10,7 +10,8 @@ import React from 'react';
  */
 import Spotlight from 'components/spotlight';
 import { usePromotions, usePromotionActions } from 'data';
-import { PromotionVariation } from 'data/promotions/types';
+import { Promotion, PromotionVariation } from 'data/promotions/types';
+import { recordEvent } from 'tracks';
 import KlarnaIllustration from 'assets/images/illustrations/klarna-promotion-spotlight.svg?asset';
 
 /**
@@ -53,7 +54,7 @@ const SpotlightPromotion: React.FC = () => {
 
 	// Find the first available promotion with a 'spotlight' variation
 	let spotlightVariation: PromotionVariation | null = null;
-	let promotionId: string | null = null;
+	let activePromotion: Promotion | null = null;
 
 	for ( const promotion of promotions ) {
 		const variation = promotion.variations.find(
@@ -61,15 +62,73 @@ const SpotlightPromotion: React.FC = () => {
 		);
 		if ( variation ) {
 			spotlightVariation = variation;
-			promotionId = promotion.promo_id;
+			activePromotion = promotion;
 			break;
 		}
 	}
 
 	// No spotlight promotion available
-	if ( ! spotlightVariation || ! promotionId ) {
+	if ( ! spotlightVariation || ! activePromotion ) {
 		return null;
 	}
+
+	// Extract values after null check for TypeScript
+	const promotionId = activePromotion.promo_id;
+	const paymentMethod = activePromotion.payment_method;
+	const variationId = spotlightVariation.id;
+	const ctaLabel = spotlightVariation.cta_label;
+	const ctaUrl = spotlightVariation.cta_url;
+
+	/**
+	 * Get common event properties for tracking.
+	 */
+	const getEventProperties = () => ( {
+		promotion_id: promotionId,
+		payment_method: paymentMethod,
+		variation_id: variationId,
+		display_context: 'spotlight',
+		page: window.location.href,
+	} );
+
+	const handleView = () => {
+		recordEvent(
+			'wcpay_payment_method_promotion_view',
+			getEventProperties()
+		);
+	};
+
+	const handlePrimaryClick = () => {
+		recordEvent( 'wcpay_payment_method_promotion_cta_click', {
+			...getEventProperties(),
+			cta_label: ctaLabel,
+		} );
+		activatePromotion( promotionId );
+	};
+
+	const handleSecondaryClick = () => {
+		recordEvent(
+			'wcpay_payment_method_promotion_secondary_click',
+			getEventProperties()
+		);
+		if ( ctaUrl ) {
+			window.open( ctaUrl, '_blank' );
+		}
+	};
+
+	const handleDismiss = () => {
+		recordEvent(
+			'wcpay_payment_method_promotion_dismiss',
+			getEventProperties()
+		);
+		dismissPromotion( promotionId, variationId as string );
+	};
+
+	const handleTermsClick = () => {
+		recordEvent( 'wcpay_payment_method_promotion_link_click', {
+			...getEventProperties(),
+			link_type: 'terms',
+		} );
+	};
 
 	// Build disclaimer content if footnote and tc_url exist
 	let disclaimer: React.ReactNode | undefined;
@@ -81,6 +140,7 @@ const SpotlightPromotion: React.FC = () => {
 					href={ spotlightVariation.tc_url }
 					target="_blank"
 					rel="noopener noreferrer"
+					onClick={ handleTermsClick }
 				>
 					Terms and conditions
 				</a>
@@ -89,23 +149,6 @@ const SpotlightPromotion: React.FC = () => {
 	} else if ( spotlightVariation.footnote ) {
 		disclaimer = spotlightVariation.footnote;
 	}
-
-	const handlePrimaryClick = () => {
-		activatePromotion( promotionId as string );
-	};
-
-	const handleSecondaryClick = () => {
-		if ( spotlightVariation?.cta_url ) {
-			window.open( spotlightVariation.cta_url, '_blank' );
-		}
-	};
-
-	const handleDismiss = () => {
-		if ( ! promotionId || ! spotlightVariation ) {
-			return;
-		}
-		dismissPromotion( promotionId, spotlightVariation.id as string );
-	};
 
 	// Get the image for this promotion (undefined if not mapped)
 	const image = spotlightImages[ promotionId ];
@@ -122,6 +165,7 @@ const SpotlightPromotion: React.FC = () => {
 			secondaryButtonLabel="Learn more"
 			onSecondaryClick={ handleSecondaryClick }
 			onDismiss={ handleDismiss }
+			onView={ handleView }
 		/>
 	);
 };

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -127,4 +127,9 @@ export type MerchantEvent =
 	| 'payments_transactions_details_refund_full'
 	| 'payments_transactions_risk_review_list_review_button_click'
 	| 'payments_transactions_uncaptured_list_capture_charge_button_click'
+	| 'wcpay_payment_method_promotion_view'
+	| 'wcpay_payment_method_promotion_dismiss'
+	| 'wcpay_payment_method_promotion_cta_click'
+	| 'wcpay_payment_method_promotion_secondary_click'
+	| 'wcpay_payment_method_promotion_link_click'
 	| string;

--- a/client/tracks/event.d.ts
+++ b/client/tracks/event.d.ts
@@ -129,7 +129,7 @@ export type MerchantEvent =
 	| 'payments_transactions_uncaptured_list_capture_charge_button_click'
 	| 'wcpay_payment_method_promotion_view'
 	| 'wcpay_payment_method_promotion_dismiss'
-	| 'wcpay_payment_method_promotion_cta_click'
+	| 'wcpay_payment_method_promotion_activate_click'
 	| 'wcpay_payment_method_promotion_secondary_click'
 	| 'wcpay_payment_method_promotion_link_click'
 	| string;

--- a/includes/admin/class-wc-rest-payments-promotions-controller.php
+++ b/includes/admin/class-wc-rest-payments-promotions-controller.php
@@ -294,16 +294,17 @@ class WC_REST_Payments_Promotions_Controller extends WC_Payments_REST_Controller
 		// Mock available promotions with variations.
 		$promotions = [
 			[
-				'promo_id'      => 'klarna-2026-promo',
-				'discount_rate' => '100%',
-				'duration_days' => 90,
-				'config'        => [
+				'promo_id'       => 'klarna-2026-promo',
+				'payment_method' => 'klarna',
+				'discount_rate'  => '100%',
+				'duration_days'  => 90,
+				'config'         => [
 					'spotlight' => [
 						'reshow_delay_days' => 7,   // Days to wait before showing next variation.
 						'max_dismissals'    => 2,   // Total dismissals before permanent hide.
 					],
 				],
-				'variations'    => [
+				'variations'     => [
 					[
 						'id'          => 'klarna-2026-promo__spotlight_primary',
 						'type'        => 'spotlight',
@@ -331,10 +332,11 @@ class WC_REST_Payments_Promotions_Controller extends WC_Payments_REST_Controller
 				],
 			],
 			[
-				'promo_id'      => 'promo-affirm-cashback-2024',
-				'discount_rate' => '2%',
-				'duration_days' => 60,
-				'variations'    => [
+				'promo_id'       => 'promo-affirm-cashback-2024',
+				'payment_method' => 'affirm',
+				'discount_rate'  => '2%',
+				'duration_days'  => 60,
+				'variations'     => [
 					[
 						'id'          => 'promo-affirm-cashback-2024__banner_primary',
 						'type'        => 'banner',


### PR DESCRIPTION
Fixes WOOPMNT-5457

#### Changes proposed in this Pull Request

Implements analytics tracking for payment method promotion UI components. This adds five tracking events that fire when merchants interact with spotlight promotions:

- `wcpay_payment_method_promotion_view` - Promotion displayed
- `wcpay_payment_method_promotion_dismiss` - Promotion dismissed  
- `wcpay_payment_method_promotion_activate_click` - Activate button clicked
- `wcpay_payment_method_promotion_secondary_click` - Secondary action clicked
- `wcpay_payment_method_promotion_link_click` - Terms link clicked

All events include these properties:
- `promotion_id` - e.g., `klarna-2026-promo`
- `payment_method` - e.g., `klarna`
- `variation_id` - e.g., `klarna-2026-promo__spotlight_primary`
- `display_context` - e.g., `spotlight`
- `source` - Human-readable page identifier: `wcpay-overview`, `wcpay-settings`, `wc-settings-payments`
- `path` - Full URL path (pathname + search params)

#### Testing instructions

**Unit tests:**
```bash
npm run test:js -- --testPathPattern="client/promotions/spotlight"
npm run test:js -- --testPathPattern="client/components/spotlight"
```

**Manual testing:**
1. Navigate to WooPayments > Overview (ensure account is onboarded)
2. Open browser dev tools Network tab, filter by `t.gif`
3. Wait for spotlight promotion to appear (4 second delay)
4. For each interaction, verify a request to `pixel.wp.com/t.gif` fires with the correct `_en` parameter:
   - Spotlight appears → `_en=wcadmin_wcpay_payment_method_promotion_view`
   - Click "Activate Now" → `_en=wcadmin_wcpay_payment_method_promotion_activate_click`
   - Click "Learn more" → `_en=wcadmin_wcpay_payment_method_promotion_secondary_click`
   - Click "Terms and conditions" link → `_en=wcadmin_wcpay_payment_method_promotion_link_click`
   - Click X to dismiss → `_en=wcadmin_wcpay_payment_method_promotion_dismiss`
5. Verify each request includes these properties in the query string:
   - `promotion_id=klarna-2026-promo`
   - `payment_method=klarna`
   - `variation_id=klarna-2026-promo__spotlight_primary`
   - `display_context=spotlight`
   - `source=wcpay-overview` (or `wcpay-settings` / `wc-settings-payments` depending on page)
   - `path=/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview` (URL-encoded path)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_ (analytics only, no user-facing changes)
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)