### PR TITLE
Add promotional discount badges to payment methods in settings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -186,3 +186,5 @@ npm run i18n:pot                    # Generate translations
 - Test files mirror source structure
 - PHP tests require Docker - ensure it's running before executing tests
 - Use `npm run test:php` to run all tests or edit the command to pass PHPUnit filters
+- When pushing, always push only the current branch: `git push origin HEAD` (not `git push` which tries to push all configured branches)
+- When pulling, always pull only the current branch: `git pull origin $(git branch --show-current)` or `git pull --rebase origin HEAD`

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ project.properties
 .sublimelinterrc
 .cursor/
 **/.claude/**/*.local.*
+.claude/local/
 .zed/
 .phpactor.json
 

--- a/changelog/add-WOOPMNT-5460-discount-badges-to-payment-methods
+++ b/changelog/add-WOOPMNT-5460-discount-badges-to-payment-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add discount badges to payment methods with active promotions in settings.

--- a/client/components/promotional-badge/__tests__/__snapshots__/index.test.tsx.snap
+++ b/client/components/promotional-badge/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromotionalBadge renders correctly with all props 1`] = `
+<div>
+  <span
+    class="chip chip-primary wcpay-promotional-badge"
+  >
+    30% off fees through Dec 31, 2026
+    <button
+      class="wcpay-tooltip__content-wrapper wcpay-tooltip--click__content-wrapper"
+      type="button"
+    >
+      <div
+        class="wcpay-tooltip__content-wrapper"
+      >
+        <div
+          aria-label="View promotion details"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            class="gridicon gridicons-info-outline"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </button>
+  </span>
+</div>
+`;

--- a/client/components/promotional-badge/__tests__/index.test.tsx
+++ b/client/components/promotional-badge/__tests__/index.test.tsx
@@ -1,0 +1,120 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PromotionalBadge from '../';
+
+describe( 'PromotionalBadge', () => {
+	test( 'renders the badge with message', () => {
+		render(
+			<PromotionalBadge
+				message="50% off fees"
+				tooltip="You are getting 50% off on processing fees."
+			/>
+		);
+
+		expect( screen.getByText( '50% off fees' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders with success type by default', () => {
+		const { container } = render(
+			<PromotionalBadge
+				message="25% off fees"
+				tooltip="Discount details"
+			/>
+		);
+
+		const badge = container.querySelector( '.wcpay-promotional-badge' );
+		expect( badge ).toHaveClass( 'chip-success' );
+	} );
+
+	test( 'renders with custom chip type', () => {
+		const { container } = render(
+			<PromotionalBadge
+				message="Limited offer"
+				tooltip="Discount details"
+				type="warning"
+			/>
+		);
+
+		const badge = container.querySelector( '.wcpay-promotional-badge' );
+		expect( badge ).toHaveClass( 'chip-warning' );
+	} );
+
+	test( 'renders the info icon button', () => {
+		render(
+			<PromotionalBadge
+				message="50% off fees"
+				tooltip="Tooltip content"
+				tooltipLabel="Discount details"
+			/>
+		);
+
+		const tooltipButton = screen.getByRole( 'button', {
+			name: /discount details/i,
+		} );
+		expect( tooltipButton ).toBeInTheDocument();
+	} );
+
+	test( 'shows tooltip content when clicking the info icon', () => {
+		render(
+			<PromotionalBadge
+				message="50% off fees"
+				tooltip="You are getting 50% off on processing fees."
+				tooltipLabel="Discount details"
+			/>
+		);
+
+		const tooltipButton = screen.getByRole( 'button', {
+			name: /discount details/i,
+		} );
+		fireEvent.click( tooltipButton );
+
+		expect(
+			screen.getByText( 'You are getting 50% off on processing fees.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'uses default tooltip label when not provided', () => {
+		render(
+			<PromotionalBadge
+				message="50% off fees"
+				tooltip="Tooltip content"
+			/>
+		);
+
+		const tooltipButton = screen.getByRole( 'button', {
+			name: /more information/i,
+		} );
+		expect( tooltipButton ).toBeInTheDocument();
+	} );
+
+	test( 'applies chip base class', () => {
+		const { container } = render(
+			<PromotionalBadge message="Test badge" tooltip="Test tooltip" />
+		);
+
+		const badge = container.querySelector( '.wcpay-promotional-badge' );
+		expect( badge ).toHaveClass( 'chip' );
+	} );
+
+	test( 'renders correctly with all props', () => {
+		const { container } = render(
+			<PromotionalBadge
+				message="30% off fees through Dec 31, 2026"
+				tooltip="You are getting 30% off on processing fees for the first $1,000 of total payment volume or through Dec 31, 2026."
+				type="primary"
+				tooltipLabel="View promotion details"
+			/>
+		);
+
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/components/promotional-badge/index.tsx
+++ b/client/components/promotional-badge/index.tsx
@@ -4,13 +4,14 @@
  * External dependencies
  */
 import React from 'react';
+import clsx from 'clsx';
 import InfoOutlineIcon from 'gridicons/dist/info-outline';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import Chip, { ChipType } from 'wcpay/components/chip';
+import { ChipType } from 'wcpay/components/chip';
 import { ClickTooltip } from 'wcpay/components/tooltip';
 import './style.scss';
 
@@ -31,9 +32,15 @@ const PromotionalBadge: React.FC< PromotionalBadgeProps > = ( {
 	type = 'success',
 	tooltipLabel = __( 'More information', 'woocommerce-payments' ),
 } ) => {
+	const classNames = clsx(
+		'chip',
+		`chip-${ type }`,
+		'wcpay-promotional-badge'
+	);
+
 	return (
-		<span className="wcpay-promotional-badge">
-			<Chip message={ message } type={ type } />
+		<span className={ classNames }>
+			{ message }
 			<ClickTooltip
 				buttonIcon={ <InfoOutlineIcon /> }
 				buttonLabel={ tooltipLabel }

--- a/client/components/promotional-badge/index.tsx
+++ b/client/components/promotional-badge/index.tsx
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import InfoOutlineIcon from 'gridicons/dist/info-outline';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Chip, { ChipType } from 'wcpay/components/chip';
+import { ClickTooltip } from 'wcpay/components/tooltip';
+import './style.scss';
+
+interface PromotionalBadgeProps {
+	/** The badge text displayed in the chip */
+	message: string;
+	/** The tooltip content shown when clicking the info icon */
+	tooltip: string;
+	/** The chip type/color (defaults to "success") */
+	type?: ChipType;
+	/** Accessible label for the tooltip button */
+	tooltipLabel?: string;
+}
+
+const PromotionalBadge: React.FC< PromotionalBadgeProps > = ( {
+	message,
+	tooltip,
+	type = 'success',
+	tooltipLabel = __( 'More information', 'woocommerce-payments' ),
+} ) => {
+	return (
+		<span className="wcpay-promotional-badge">
+			<Chip message={ message } type={ type } />
+			<ClickTooltip
+				buttonIcon={ <InfoOutlineIcon /> }
+				buttonLabel={ tooltipLabel }
+				content={ tooltip }
+			/>
+		</span>
+	);
+};
+
+export default PromotionalBadge;

--- a/client/components/promotional-badge/style.scss
+++ b/client/components/promotional-badge/style.scss
@@ -1,0 +1,7 @@
+/** @format */
+
+.wcpay-promotional-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}

--- a/client/components/promotional-badge/style.scss
+++ b/client/components/promotional-badge/style.scss
@@ -4,4 +4,18 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
+
+	.wcpay-tooltip__content-wrapper {
+		display: inline-flex;
+		align-items: center;
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		cursor: pointer;
+
+		> div {
+			margin-right: 0;
+		}
+	}
 }

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -5,17 +5,21 @@
 import clsx from 'clsx';
 import React, { useContext } from 'react';
 import { CheckboxControl } from '@wordpress/components';
+import InfoOutlineIcon from 'gridicons/dist/info-outline';
 
 /**
  * Internal dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { HoverTooltip } from 'components/tooltip';
-import { FeeStructure } from 'wcpay/types/fees';
+import { ClickTooltip, HoverTooltip } from 'components/tooltip';
+import { DiscountFee, FeeStructure } from 'wcpay/types/fees';
 import {
 	formatMethodFeesDescription,
 	formatMethodFeesTooltip,
 } from 'wcpay/utils/account-fees';
+import { formatFee } from 'wcpay/utils/fees';
+import { formatDateTimeFromString } from 'wcpay/utils/date-time';
+import { formatCurrency } from 'multi-currency/interface/functions';
 import WCPaySettingsContext from '../wcpay-settings-context';
 import Chip from 'wcpay/components/chip';
 import Pill from 'wcpay/components/pill';
@@ -48,14 +52,88 @@ interface PaymentMethodProps {
 	locked: boolean;
 }
 
+const getDiscountBadgeText = ( discountFee: DiscountFee ): string => {
+	const discountPercentage = formatFee( discountFee.discount ?? 0 );
+
+	if ( discountFee.end_time ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: expiration date */
+			__( '%1$s%% off fees through %2$s', 'woocommerce-payments' ),
+			discountPercentage,
+			formatDateTimeFromString( discountFee.end_time )
+		);
+	}
+
+	return sprintf(
+		/* translators: %s: discount percentage */
+		__( '%s%% off fees', 'woocommerce-payments' ),
+		discountPercentage
+	);
+};
+
+const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
+	const discountPercentage = formatFee( discountFee.discount ?? 0 );
+	const currencyCode = discountFee.volume_currency ?? discountFee.currency;
+
+	if ( discountFee.volume_allowance && discountFee.end_time ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires, %3$s: End date of the promotion */
+			__(
+				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume or through %3$s.',
+				'woocommerce-payments'
+			),
+			discountPercentage,
+			formatCurrency( discountFee.volume_allowance, currencyCode ),
+			formatDateTimeFromString( discountFee.end_time )
+		);
+	} else if ( discountFee.volume_allowance ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires */
+			__(
+				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume.',
+				'woocommerce-payments'
+			),
+			discountPercentage,
+			formatCurrency( discountFee.volume_allowance, currencyCode )
+		);
+	} else if ( discountFee.end_time ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: End date of the promotion */
+			__(
+				'You are getting %1$s%% off on processing fees through %2$s.',
+				'woocommerce-payments'
+			),
+			discountPercentage,
+			formatDateTimeFromString( discountFee.end_time )
+		);
+	}
+
+	return sprintf(
+		/* translators: %s: discount percentage */
+		__(
+			'You are getting %s%% off on processing fees.',
+			'woocommerce-payments'
+		),
+		discountPercentage
+	);
+};
+
 const PaymentMethodLabel = ( {
 	id,
 	label,
+	accountFees,
 }: {
 	id: string;
 	label: string;
+	accountFees?: Record< string, FeeStructure >;
 } ): React.ReactElement => {
 	const { chip, chipType = 'warning' } = usePaymentMethodAvailability( id );
+
+	const discountFee =
+		accountFees?.[ id ]?.discount && accountFees[ id ].discount.length > 0
+			? accountFees[ id ].discount[ 0 ]
+			: null;
+	const hasDiscount = discountFee && discountFee.discount;
 
 	return (
 		<>
@@ -66,6 +144,22 @@ const PaymentMethodLabel = ( {
 				</span>
 			) }
 			{ chip && <Chip message={ chip } type={ chipType } /> }
+			{ hasDiscount && (
+				<>
+					<Chip
+						message={ getDiscountBadgeText( discountFee ) }
+						type="success"
+					/>
+					<ClickTooltip
+						buttonIcon={ <InfoOutlineIcon /> }
+						buttonLabel={ __(
+							'Discount details',
+							'woocommerce-payments'
+						) }
+						content={ getDiscountTooltipText( discountFee ) }
+					/>
+				</>
+			) }
 		</>
 	);
 };
@@ -142,12 +236,20 @@ const PaymentMethod = ( {
 						<Icon />
 					</div>
 					<div className="payment-method__label payment-method__label-mobile">
-						<PaymentMethodLabel label={ label } id={ id } />
+						<PaymentMethodLabel
+							label={ label }
+							id={ id }
+							accountFees={ accountFees }
+						/>
 					</div>
 					<div className="payment-method__text">
 						<div className="payment-method__label-container">
 							<div className="payment-method__label payment-method__label-desktop">
-								<PaymentMethodLabel label={ label } id={ id } />
+								<PaymentMethodLabel
+									label={ label }
+									id={ id }
+									accountFees={ accountFees }
+								/>
 							</div>
 							<div className="payment-method__description">
 								{ description }

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -62,11 +62,8 @@ const PaymentMethodLabel = ( {
 } ): React.ReactElement => {
 	const { chip, chipType = 'warning' } = usePaymentMethodAvailability( id );
 
-	const discountFee =
-		accountFees?.[ id ]?.discount && accountFees[ id ].discount.length > 0
-			? accountFees[ id ].discount[ 0 ]
-			: null;
-	const hasDiscount = discountFee && discountFee.discount;
+	const discountFee = accountFees?.[ id ]?.discount?.[ 0 ];
+	const hasDiscount = discountFee?.discount;
 
 	return (
 		<>

--- a/client/settings/payment-methods-list/payment-method.tsx
+++ b/client/settings/payment-methods-list/payment-method.tsx
@@ -5,23 +5,22 @@
 import clsx from 'clsx';
 import React, { useContext } from 'react';
 import { CheckboxControl } from '@wordpress/components';
-import InfoOutlineIcon from 'gridicons/dist/info-outline';
 
 /**
  * Internal dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { ClickTooltip, HoverTooltip } from 'components/tooltip';
-import { DiscountFee, FeeStructure } from 'wcpay/types/fees';
+import { HoverTooltip } from 'components/tooltip';
+import { FeeStructure } from 'wcpay/types/fees';
 import {
 	formatMethodFeesDescription,
 	formatMethodFeesTooltip,
+	getDiscountBadgeText,
+	getDiscountTooltipText,
 } from 'wcpay/utils/account-fees';
-import { formatFee } from 'wcpay/utils/fees';
-import { formatDateTimeFromString } from 'wcpay/utils/date-time';
-import { formatCurrency } from 'multi-currency/interface/functions';
 import WCPaySettingsContext from '../wcpay-settings-context';
 import Chip from 'wcpay/components/chip';
+import PromotionalBadge from 'wcpay/components/promotional-badge';
 import Pill from 'wcpay/components/pill';
 import './payment-method.scss';
 import DuplicateNotice from 'wcpay/components/duplicate-notice';
@@ -52,72 +51,6 @@ interface PaymentMethodProps {
 	locked: boolean;
 }
 
-const getDiscountBadgeText = ( discountFee: DiscountFee ): string => {
-	const discountPercentage = formatFee( discountFee.discount ?? 0 );
-
-	if ( discountFee.end_time ) {
-		return sprintf(
-			/* translators: %1$s: discount percentage, %2$s: expiration date */
-			__( '%1$s%% off fees through %2$s', 'woocommerce-payments' ),
-			discountPercentage,
-			formatDateTimeFromString( discountFee.end_time )
-		);
-	}
-
-	return sprintf(
-		/* translators: %s: discount percentage */
-		__( '%s%% off fees', 'woocommerce-payments' ),
-		discountPercentage
-	);
-};
-
-const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
-	const discountPercentage = formatFee( discountFee.discount ?? 0 );
-	const currencyCode = discountFee.volume_currency ?? discountFee.currency;
-
-	if ( discountFee.volume_allowance && discountFee.end_time ) {
-		return sprintf(
-			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires, %3$s: End date of the promotion */
-			__(
-				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume or through %3$s.',
-				'woocommerce-payments'
-			),
-			discountPercentage,
-			formatCurrency( discountFee.volume_allowance, currencyCode ),
-			formatDateTimeFromString( discountFee.end_time )
-		);
-	} else if ( discountFee.volume_allowance ) {
-		return sprintf(
-			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires */
-			__(
-				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume.',
-				'woocommerce-payments'
-			),
-			discountPercentage,
-			formatCurrency( discountFee.volume_allowance, currencyCode )
-		);
-	} else if ( discountFee.end_time ) {
-		return sprintf(
-			/* translators: %1$s: discount percentage, %2$s: End date of the promotion */
-			__(
-				'You are getting %1$s%% off on processing fees through %2$s.',
-				'woocommerce-payments'
-			),
-			discountPercentage,
-			formatDateTimeFromString( discountFee.end_time )
-		);
-	}
-
-	return sprintf(
-		/* translators: %s: discount percentage */
-		__(
-			'You are getting %s%% off on processing fees.',
-			'woocommerce-payments'
-		),
-		discountPercentage
-	);
-};
-
 const PaymentMethodLabel = ( {
 	id,
 	label,
@@ -145,20 +78,14 @@ const PaymentMethodLabel = ( {
 			) }
 			{ chip && <Chip message={ chip } type={ chipType } /> }
 			{ hasDiscount && (
-				<>
-					<Chip
-						message={ getDiscountBadgeText( discountFee ) }
-						type="success"
-					/>
-					<ClickTooltip
-						buttonIcon={ <InfoOutlineIcon /> }
-						buttonLabel={ __(
-							'Discount details',
-							'woocommerce-payments'
-						) }
-						content={ getDiscountTooltipText( discountFee ) }
-					/>
-				</>
+				<PromotionalBadge
+					message={ getDiscountBadgeText( discountFee ) }
+					tooltip={ getDiscountTooltipText( discountFee ) }
+					tooltipLabel={ __(
+						'Discount details',
+						'woocommerce-payments'
+					) }
+				/>
 			) }
 		</>
 	);

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -388,7 +388,7 @@ describe( 'Account fees utility functions', () => {
 			expect( result ).toBe( '25% off fees' );
 		} );
 
-		it( 'handles zero discount gracefully', () => {
+		it( 'returns empty string for zero discount', () => {
 			const discountFee: DiscountFee = {
 				discount: 0,
 				end_time: null,
@@ -402,10 +402,10 @@ describe( 'Account fees utility functions', () => {
 
 			const result = getDiscountBadgeText( discountFee );
 
-			expect( result ).toBe( '0% off fees' );
+			expect( result ).toBe( '' );
 		} );
 
-		it( 'handles undefined discount gracefully', () => {
+		it( 'returns empty string for undefined discount', () => {
 			const discountFee: DiscountFee = {
 				end_time: null,
 				volume_allowance: null,
@@ -418,7 +418,7 @@ describe( 'Account fees utility functions', () => {
 
 			const result = getDiscountBadgeText( discountFee );
 
-			expect( result ).toBe( '0% off fees' );
+			expect( result ).toBe( '' );
 		} );
 	} );
 

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -13,6 +13,8 @@ import {
 	formatMethodFeesDescription,
 	formatMethodFeesTooltip,
 	getCurrentBaseFee,
+	getDiscountBadgeText,
+	getDiscountTooltipText,
 } from '../account-fees';
 import { formatCurrency } from 'multi-currency/interface/functions';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
@@ -28,6 +30,8 @@ declare const global: {
 		connect: {
 			country: string;
 		};
+		dateFormat?: string;
+		timeFormat?: string;
 	};
 };
 
@@ -337,6 +341,205 @@ describe( 'Account fees utility functions', () => {
 			);
 
 			expect( container ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'getDiscountBadgeText()', () => {
+		beforeAll( () => {
+			global.wcpaySettings = {
+				...global.wcpaySettings,
+				dateFormat: 'M j, Y',
+				timeFormat: 'g:i a',
+			};
+		} );
+
+		it( 'returns discount percentage with end date when end_time is provided', () => {
+			const discountFee: DiscountFee = {
+				discount: 0.5,
+				end_time: '2026-02-27 04:20:49',
+				volume_allowance: null,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountBadgeText( discountFee );
+
+			expect( result ).toContain( '50%' );
+			expect( result ).toContain( 'off fees through' );
+		} );
+
+		it( 'returns discount percentage without date when end_time is null', () => {
+			const discountFee: DiscountFee = {
+				discount: 0.25,
+				end_time: null,
+				volume_allowance: null,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountBadgeText( discountFee );
+
+			expect( result ).toBe( '25% off fees' );
+		} );
+
+		it( 'handles zero discount gracefully', () => {
+			const discountFee: DiscountFee = {
+				discount: 0,
+				end_time: null,
+				volume_allowance: null,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountBadgeText( discountFee );
+
+			expect( result ).toBe( '0% off fees' );
+		} );
+
+		it( 'handles undefined discount gracefully', () => {
+			const discountFee: DiscountFee = {
+				end_time: null,
+				volume_allowance: null,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountBadgeText( discountFee );
+
+			expect( result ).toBe( '0% off fees' );
+		} );
+	} );
+
+	describe( 'getDiscountTooltipText()', () => {
+		beforeAll( () => {
+			global.wcpaySettings = {
+				...global.wcpaySettings,
+				dateFormat: 'M j, Y',
+				timeFormat: 'g:i a',
+			};
+		} );
+
+		it( 'returns text with volume allowance and end time', () => {
+			const discountFee: DiscountFee = {
+				discount: 0.5,
+				end_time: '2026-02-27 04:20:49',
+				volume_allowance: 100000,
+				volume_currency: 'usd',
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountTooltipText( discountFee );
+
+			expect( result ).toContain( '50%' );
+			expect( result ).toContain( 'first' );
+			expect( result ).toContain( 'total payment volume' );
+			expect( result ).toContain( 'or through' );
+		} );
+
+		it( 'returns text with only volume allowance when end_time is null', () => {
+			const discountFee: DiscountFee = {
+				discount: 0.3,
+				end_time: null,
+				volume_allowance: 50000,
+				volume_currency: 'usd',
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountTooltipText( discountFee );
+
+			expect( result ).toContain( '30%' );
+			expect( result ).toContain( 'first' );
+			expect( result ).toContain( 'total payment volume' );
+			expect( result ).not.toContain( 'through' );
+		} );
+
+		it( 'returns text with only end time when volume_allowance is null', () => {
+			const discountFee: DiscountFee = {
+				discount: 0.2,
+				end_time: '2026-02-27 04:20:49',
+				volume_allowance: null,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountTooltipText( discountFee );
+
+			expect( result ).toContain( '20%' );
+			expect( result ).toContain( 'through' );
+			expect( result ).not.toContain( 'first' );
+			expect( result ).not.toContain( 'total payment volume' );
+		} );
+
+		it( 'returns basic text when neither volume_allowance nor end_time are provided', () => {
+			const discountFee: DiscountFee = {
+				discount: 0.15,
+				end_time: null,
+				volume_allowance: null,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			const result = getDiscountTooltipText( discountFee );
+
+			expect( result ).toBe(
+				'You are getting 15% off on processing fees.'
+			);
+		} );
+
+		it( 'uses volume_currency when available, falls back to currency', () => {
+			const discountFeeWithVolumeCurrency: DiscountFee = {
+				discount: 0.1,
+				end_time: null,
+				volume_allowance: 10000,
+				volume_currency: 'eur',
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			getDiscountTooltipText( discountFeeWithVolumeCurrency );
+
+			expect( formatCurrency ).toHaveBeenCalledWith( 10000, 'eur' );
+
+			const discountFeeWithoutVolumeCurrency: DiscountFee = {
+				discount: 0.1,
+				end_time: null,
+				volume_allowance: 10000,
+				volume_currency: null,
+				current_volume: null,
+				currency: 'USD',
+				percentage_rate: 0,
+				fixed_rate: 0,
+			};
+
+			getDiscountTooltipText( discountFeeWithoutVolumeCurrency );
+
+			expect( formatCurrency ).toHaveBeenCalledWith( 10000, 'USD' );
 		} );
 	} );
 } );

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -363,7 +363,11 @@ export const getTransactionsPaymentMethodName = (
 };
 
 export const getDiscountBadgeText = ( discountFee: DiscountFee ): string => {
-	const discountPercentage = formatFee( discountFee.discount ?? 0 );
+	if ( ! discountFee.discount ) {
+		return '';
+	}
+
+	const discountPercentage = formatFee( discountFee.discount );
 
 	if ( discountFee.end_time ) {
 		return sprintf(
@@ -382,7 +386,11 @@ export const getDiscountBadgeText = ( discountFee: DiscountFee ): string => {
 };
 
 export const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
-	const discountPercentage = formatFee( discountFee.discount ?? 0 );
+	if ( ! discountFee.discount ) {
+		return '';
+	}
+
+	const discountPercentage = formatFee( discountFee.discount );
 	const currencyCode = discountFee.volume_currency ?? discountFee.currency;
 
 	if ( discountFee.volume_allowance && discountFee.end_time ) {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -13,6 +13,7 @@ import './account-fees.scss';
  */
 import { formatCurrency } from 'multi-currency/interface/functions';
 import { formatFee } from 'utils/fees';
+import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 import React from 'react';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
 import { createInterpolateElement } from '@wordpress/element';
@@ -359,4 +360,70 @@ export const getTransactionsPaymentMethodName = (
 
 	// Fallback for unknown payment methods
 	return __( 'Unknown transactions', 'woocommerce-payments' );
+};
+
+export const getDiscountBadgeText = ( discountFee: DiscountFee ): string => {
+	const discountPercentage = formatFee( discountFee.discount ?? 0 );
+
+	if ( discountFee.end_time ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: expiration date */
+			__( '%1$s%% off fees through %2$s', 'woocommerce-payments' ),
+			discountPercentage,
+			formatDateTimeFromString( discountFee.end_time )
+		);
+	}
+
+	return sprintf(
+		/* translators: %s: discount percentage */
+		__( '%s%% off fees', 'woocommerce-payments' ),
+		discountPercentage
+	);
+};
+
+export const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
+	const discountPercentage = formatFee( discountFee.discount ?? 0 );
+	const currencyCode = discountFee.volume_currency ?? discountFee.currency;
+
+	if ( discountFee.volume_allowance && discountFee.end_time ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires, %3$s: End date of the promotion */
+			__(
+				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume or through %3$s.',
+				'woocommerce-payments'
+			),
+			discountPercentage,
+			formatCurrency( discountFee.volume_allowance, currencyCode ),
+			formatDateTimeFromString( discountFee.end_time )
+		);
+	} else if ( discountFee.volume_allowance ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires */
+			__(
+				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume.',
+				'woocommerce-payments'
+			),
+			discountPercentage,
+			formatCurrency( discountFee.volume_allowance, currencyCode )
+		);
+	} else if ( discountFee.end_time ) {
+		return sprintf(
+			/* translators: %1$s: discount percentage, %2$s: End date of the promotion */
+			__(
+				'You are getting %1$s%% off on processing fees through %2$s.',
+				'woocommerce-payments'
+			),
+			discountPercentage,
+			formatDateTimeFromString( discountFee.end_time )
+		);
+	}
+
+	return sprintf(
+		/* translators: %s: discount percentage */
+		__(
+			'You are getting %s%% off on processing fees.',
+			'woocommerce-payments'
+		),
+		discountPercentage
+	);
 };

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -48,6 +48,12 @@ module.exports = {
 		'<rootDir>/tests/e2e',
 		'<rootDir>/tests/qit/e2e',
 	],
+	modulePathIgnorePatterns: [
+		'<rootDir>/docker/',
+		'<rootDir>/vendor/',
+		'<rootDir>/.*/build/',
+		'<rootDir>/.*/build-module/',
+	],
 	watchPathIgnorePatterns: [
 		'/node_modules/',
 		'/vendor/',


### PR DESCRIPTION
Fixes WOOPMNT-5461
Fixes WOOPMNT-5460

#### Changes proposed in this Pull Request
This PR introduces promotional discount badges for payment methods in the WooPayments settings screen. These badges highlight active promotions and provide additional details via a tooltip retrieved from the account cache.

<img width="887" height="192" alt="Screenshot 2025-11-27 at 21 59 30" src="https://github.com/user-attachments/assets/41bf0cd3-47b8-46c2-8ce3-2c1c32fc287d" />


#### Testing instructions
- Connect a US account to your local environment.
- On your local server, open the file: `/server/wp-content/rest-api-plugins/endpoints/wcpay/service/class-fee-service.php`
- Insert the following snippet at line 382:
```
// For testing purposes only.
if ( Payment_Method::KLARNA === $method ) {
$fee_info[ $method ]['discount'] = [
	[
		'start_time'       => '2025-11-27 16:20:49',
		'end_time'         => '2026-02-27 04:20:49',
		'volume_allowance' => null,
		'volume_currency'  => 'usd',
		'current_volume'   => null,
		'discount'         => 0.5,
	],
];
}
```
- Clear the account cache in WCPay Dev to ensure the discount is refreshed.
- Navigate to Payments → Settings and scroll to the Klarna payment method.
- Verify that the badge appears and that the tooltip is shown when clicking the info icon.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
