### PR TITLE
Fix number format when converting order price

### DIFF
--- a/changelog/fix-multi-currency-order-total-type
+++ b/changelog/fix-multi-currency-order-total-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix number format when converting order prices.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -212,7 +212,7 @@ class Compatibility extends BaseCompatibility {
 			}
 
 			$exchange_rate = $order->get_meta( '_wcpay_multi_currency_order_exchange_rate', true );
-			$order->set_total( number_format( $order->get_total() * ( 1 / $exchange_rate ), wc_get_price_decimals() ) );
+			$order->set_total( wc_format_decimal( $order->get_total() * ( 1 / $exchange_rate ), wc_get_price_decimals() ) );
 		}
 
 		remove_filter( 'woocommerce_order_query', [ $this, 'convert_order_prices' ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

```
There was 1 failure:

1) WCPay_Multi_Currency_Compatibility_Tests::test_filter_woocommerce_order_query
Failed asserting that '2.00' matches expected 2000.

/home/runner/work/woocommerce-payments/woocommerce-payments/tests/unit/multi-currency/test-class-compatibility.php:201
phpvfscomposer:///home/runner/work/woocommerce-payments/woocommerce-payments/vendor/phpunit/phpunit/phpunit:97
```

`number_format()` was returning a formatted string with thousands separators (e.g., "2,000.00"), which when parsed back to a number would be truncated at the comma, resulting in 2.00. Replace `number_format()` with `wc_format_decimal()`, which is the standard function for formatting prices. 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Tests passing

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
