### PR TITLE
Update titles for the subscription evidence and suggestions based on product type

### DIFF
--- a/changelog/woopmnt-5444-other-subscription-cancelled-purchase-info-page-update-copy
+++ b/changelog/woopmnt-5444-other-subscription-cancelled-purchase-info-page-update-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update suggested evidence for the Subscription Cancelled dispute reason.

--- a/client/disputes/new-evidence/__tests__/recommended-document-fields.test.ts
+++ b/client/disputes/new-evidence/__tests__/recommended-document-fields.test.ts
@@ -50,10 +50,11 @@ describe( 'Recommended Documents', () => {
 			const result = getRecommendedDocumentFields(
 				'subscription_canceled'
 			);
-			expect( result ).toHaveLength( 6 ); // Default fields + 2 specific fields
+			expect( result ).toHaveLength( 6 ); // Default fields + 3 specific fields
 			expect( result[ 0 ].key ).toBe( 'receipt' );
 			expect( result[ 1 ].key ).toBe( 'customer_communication' );
 			expect( result[ 2 ].key ).toBe( 'access_activity_log' );
+			expect( result[ 2 ].label ).toBe( 'Subscription logs' );
 			expect( result[ 3 ].key ).toBe( 'refund_policy' );
 			expect( result[ 4 ].key ).toBe( 'cancellation_policy' );
 			expect( result[ 5 ].key ).toBe( 'uncategorized_file' );
@@ -211,6 +212,85 @@ describe( 'Recommended Documents', () => {
 				'refund_policy',
 				'uncategorized_file',
 			] );
+		} );
+
+		describe( 'subscription_canceled with productType variations', () => {
+			it( 'should return fields with subscription logs for subscription_canceled with single product type', () => {
+				const result = getRecommendedDocumentFields(
+					'subscription_canceled',
+					undefined,
+					undefined,
+					'physical_product'
+				);
+				expect( result ).toHaveLength( 6 ); // Default fields + 3 specific fields
+				expect( result[ 0 ].key ).toBe( 'receipt' );
+				expect( result[ 1 ].key ).toBe( 'customer_communication' );
+				expect( result[ 2 ].key ).toBe( 'access_activity_log' );
+				expect( result[ 2 ].label ).toBe( 'Subscription logs' );
+				expect( result[ 2 ].description ).toBe(
+					'Order notes or the history of related orders. This should clearly show successful renewals before the dispute.'
+				);
+				expect( result[ 3 ].key ).toBe( 'refund_policy' );
+				expect( result[ 4 ].key ).toBe( 'cancellation_policy' );
+				expect( result[ 5 ].key ).toBe( 'uncategorized_file' );
+			} );
+
+			it( 'should return fields with subscription logs for subscription_canceled with digital product', () => {
+				const result = getRecommendedDocumentFields(
+					'subscription_canceled',
+					undefined,
+					undefined,
+					'digital_product_or_service'
+				);
+				expect( result ).toHaveLength( 6 );
+				expect( result[ 2 ].key ).toBe( 'access_activity_log' );
+				expect( result[ 2 ].label ).toBe( 'Subscription logs' );
+			} );
+
+			it( 'should return fields without subscription logs for subscription_canceled with multiple product types', () => {
+				const result = getRecommendedDocumentFields(
+					'subscription_canceled',
+					undefined,
+					undefined,
+					'multiple'
+				);
+				expect( result ).toHaveLength( 5 ); // Default fields + 2 specific fields (no subscription logs)
+				expect( result[ 0 ].key ).toBe( 'receipt' );
+				expect( result[ 1 ].key ).toBe( 'customer_communication' );
+				expect( result[ 2 ].key ).toBe( 'refund_policy' );
+				expect( result[ 3 ].key ).toBe( 'cancellation_policy' );
+				expect( result[ 4 ].key ).toBe( 'uncategorized_file' );
+
+				// Verify subscription logs are NOT included
+				const hasSubscriptionLogs = result.some(
+					( field ) => field.key === 'access_activity_log'
+				);
+				expect( hasSubscriptionLogs ).toBe( false );
+			} );
+
+			it( 'should return fields with subscription logs for subscription_canceled with booking_reservation type', () => {
+				const result = getRecommendedDocumentFields(
+					'subscription_canceled',
+					undefined,
+					undefined,
+					'booking_reservation'
+				);
+				expect( result ).toHaveLength( 6 );
+				expect( result[ 2 ].key ).toBe( 'access_activity_log' );
+				expect( result[ 2 ].label ).toBe( 'Subscription logs' );
+			} );
+
+			it( 'should return fields with subscription logs for subscription_canceled with offline_service type', () => {
+				const result = getRecommendedDocumentFields(
+					'subscription_canceled',
+					undefined,
+					undefined,
+					'offline_service'
+				);
+				expect( result ).toHaveLength( 6 );
+				expect( result[ 2 ].key ).toBe( 'access_activity_log' );
+				expect( result[ 2 ].label ).toBe( 'Subscription logs' );
+			} );
 		} );
 	} );
 } );

--- a/client/disputes/new-evidence/cover-letter-generator.ts
+++ b/client/disputes/new-evidence/cover-letter-generator.ts
@@ -134,7 +134,7 @@ export const generateAttachments = (
 		},
 		{
 			key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
-			label: __( 'Proof of active subscription', 'woocommerce-payments' ),
+			label: __( 'Subscription logs', 'woocommerce-payments' ),
 		},
 		{
 			key: DOCUMENT_FIELD_KEYS.UNCATEGORIZED_FILE,

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -862,7 +862,8 @@ export default ( { query }: { query: { id: string } } ) => {
 	const recommendedDocumentFields = getRecommendedDocumentFields(
 		disputeReason,
 		disputeReason === 'credit_not_processed' ? refundStatus : undefined,
-		disputeReason === 'duplicate' ? duplicateStatus : undefined
+		disputeReason === 'duplicate' ? duplicateStatus : undefined,
+		productType
 	);
 
 	const recommendedShippingDocumentFields = getRecommendedShippingDocumentFields();

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -57,18 +57,20 @@ const getRecommendedDocumentFieldsForSubscriptionCanceled = (
 		},
 	];
 
-	// Add subscription logs for single product types
-	if ( 'multiple' !== productType ) {
-		fields.push( {
-			key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
-			label: __( 'Subscription logs', 'woocommerce-payments' ),
-			description: __(
-				'Order notes or the history of related orders. This should clearly show successful renewals before the dispute.',
-				'woocommerce-payments'
-			),
-			order: 30,
-		} );
+	// For the multiple product type only core fields are needed.
+	if ( 'multiple' === productType ) {
+		return fields;
 	}
+
+	fields.push( {
+		key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
+		label: __( 'Subscription logs', 'woocommerce-payments' ),
+		description: __(
+			'Order notes or the history of related orders. This should clearly show successful renewals before the dispute.',
+			'woocommerce-payments'
+		),
+		order: 30,
+	} );
 
 	return fields;
 };

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -35,39 +35,8 @@ export const DOCUMENT_FIELD_KEYS = {
 const getRecommendedDocumentFieldsForSubscriptionCanceled = (
 	productType?: string
 ): Array< RecommendedDocument > => {
-	if ( 'multiple' === productType ) {
-		return [
-			{
-				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
-				label: __( 'Store refund policy', 'woocommerce-payments' ),
-				description: __(
-					"A screenshot of your store's refund policy.",
-					'woocommerce-payments'
-				),
-				order: 40,
-			},
-			{
-				key: DOCUMENT_FIELD_KEYS.CANCELLATION_POLICY,
-				label: __( 'Terms of service', 'woocommerce-payments' ),
-				description: __(
-					"A screenshot of your store's terms of service.",
-					'woocommerce-payments'
-				),
-				order: 50,
-			},
-		];
-	}
-
-	return [
-		{
-			key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
-			label: __( 'Subscription logs', 'woocommerce-payments' ),
-			description: __(
-				'Order notes or the history of related orders. This should clearly show successful renewals before the dispute.',
-				'woocommerce-payments'
-			),
-			order: 30,
-		},
+	// Common fields for all subscription cancellation disputes
+	const fields: Array< RecommendedDocument > = [
 		{
 			key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
 			label: __( 'Store refund policy', 'woocommerce-payments' ),
@@ -87,6 +56,21 @@ const getRecommendedDocumentFieldsForSubscriptionCanceled = (
 			order: 50,
 		},
 	];
+
+	// Add subscription logs for single product types
+	if ( 'multiple' !== productType ) {
+		fields.push( {
+			key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
+			label: __( 'Subscription logs', 'woocommerce-payments' ),
+			description: __(
+				'Order notes or the history of related orders. This should clearly show successful renewals before the dispute.',
+				'woocommerce-payments'
+			),
+			order: 30,
+		} );
+	}
+
+	return fields;
 };
 
 /**

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -26,6 +26,12 @@ export const DOCUMENT_FIELD_KEYS = {
 	SHIPPING_DOCUMENTATION: 'shipping_documentation',
 } as const;
 
+/**
+ * Get recommended document fields for the subscription_canceled dispute reason
+ *
+ * @param {string} productType - The product type (for subscription_canceled disputes)
+ * @return {Array<{key: string, label: string}>} Array of recommended document fields
+ */
 const getRecommendedDocumentFieldsForSubscriptionCanceled = (
 	productType?: string
 ): Array< RecommendedDocument > => {
@@ -89,6 +95,7 @@ const getRecommendedDocumentFieldsForSubscriptionCanceled = (
  * @param {string} reason - The dispute reason
  * @param {string} refundStatus - The refund status (for credit_not_processed disputes)
  * @param {string} duplicateStatus - The duplicate status (for duplicate disputes)
+ * @param {string} productType - The product type (for subscription_canceled disputes)
  * @return {Array<{key: string, label: string}>} Array of recommended document fields
  */
 const getRecommendedDocumentFields = (

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -26,6 +26,63 @@ export const DOCUMENT_FIELD_KEYS = {
 	SHIPPING_DOCUMENTATION: 'shipping_documentation',
 } as const;
 
+const getRecommendedDocumentFieldsForSubscriptionCanceled = (
+	productType?: string
+): Array< RecommendedDocument > => {
+	if ( 'multiple' === productType ) {
+		return [
+			{
+				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
+				label: __( 'Store refund policy', 'woocommerce-payments' ),
+				description: __(
+					"A screenshot of your store's refund policy.",
+					'woocommerce-payments'
+				),
+				order: 40,
+			},
+			{
+				key: DOCUMENT_FIELD_KEYS.CANCELLATION_POLICY,
+				label: __( 'Terms of service', 'woocommerce-payments' ),
+				description: __(
+					"A screenshot of your store's terms of service.",
+					'woocommerce-payments'
+				),
+				order: 50,
+			},
+		];
+	}
+
+	return [
+		{
+			key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
+			label: __( 'Subscription logs', 'woocommerce-payments' ),
+			description: __(
+				'Order notes or the history of related orders. This should clearly show successful renewals before the dispute.',
+				'woocommerce-payments'
+			),
+			order: 30,
+		},
+		{
+			key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
+			label: __( 'Store refund policy', 'woocommerce-payments' ),
+			description: __(
+				"A screenshot of your store's refund policy.",
+				'woocommerce-payments'
+			),
+			order: 40,
+		},
+		{
+			key: DOCUMENT_FIELD_KEYS.CANCELLATION_POLICY,
+			label: __( 'Terms of service', 'woocommerce-payments' ),
+			description: __(
+				"A screenshot of your store's terms of service.",
+				'woocommerce-payments'
+			),
+			order: 50,
+		},
+	];
+};
+
 /**
  * Get recommended document fields based on dispute reason
  *
@@ -37,7 +94,8 @@ export const DOCUMENT_FIELD_KEYS = {
 const getRecommendedDocumentFields = (
 	reason: string,
 	refundStatus?: string,
-	duplicateStatus?: string
+	duplicateStatus?: string,
+	productType?: string
 ): Array< RecommendedDocument > => {
 	// Define fields with their order
 	const orderedFields = [
@@ -202,38 +260,9 @@ const getRecommendedDocumentFields = (
 							order: 25,
 						},
 				  ],
-		subscription_canceled: [
-			{
-				key: DOCUMENT_FIELD_KEYS.ACCESS_ACTIVITY_LOG,
-				label: __(
-					'Proof of active subscription',
-					'woocommerce-payments'
-				),
-				description: __(
-					'Any documents showing the billing history, subscription status, or cancellation logs, for example.',
-					'woocommerce-payments'
-				),
-				order: 30,
-			},
-			{
-				key: DOCUMENT_FIELD_KEYS.REFUND_POLICY,
-				label: __( 'Store refund policy', 'woocommerce-payments' ),
-				description: __(
-					"A screenshot of your store's refund policy.",
-					'woocommerce-payments'
-				),
-				order: 40,
-			},
-			{
-				key: DOCUMENT_FIELD_KEYS.CANCELLATION_POLICY,
-				label: __( 'Terms of service', 'woocommerce-payments' ),
-				description: __(
-					"A screenshot of your store's terms of service.",
-					'woocommerce-payments'
-				),
-				order: 50,
-			},
-		],
+		subscription_canceled: getRecommendedDocumentFieldsForSubscriptionCanceled(
+			productType
+		),
 		fraudulent: [
 			{
 				key: DOCUMENT_FIELD_KEYS.CUSTOMER_SIGNATURE,


### PR DESCRIPTION
Fixes WOOPMNT-5444

#### Changes proposed in this Pull Request

For the "Subscription cancelled" dispute reason:
 - Change the "Proof of active subscription" to "Subscription logs"
 - Suggest evidence based on the product type
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable additional evidence types for disputes and set a dispute reason override to `subscription_cancelled` in the Dev Tools.
* Make an order with the card to trigger a dispute.
* Go to the challenge form and verify it looks as expected.


https://github.com/user-attachments/assets/6dd1830a-36f7-475f-b17c-15fe772cd746



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
