### PR TITLE
chore: remove inline script from blocks checkout

### DIFF
--- a/changelog/chore-remove-wcblockscheckoutdata-inline-script
+++ b/changelog/chore-remove-wcblockscheckoutdata-inline-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+chore: remove unused `wcBlocksCheckoutData` constant

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -75,19 +75,6 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 
 		wp_set_script_translations( 'WCPAY_BLOCKS_CHECKOUT', 'woocommerce-payments' );
 
-		wp_add_inline_script(
-			'WCPAY_BLOCKS_CHECKOUT',
-			'var wcBlocksCheckoutData = ' . wp_json_encode(
-				[
-					'amount'         => WC()->cart ? WC()->cart->get_total( '' ) : 0,
-					'currency'       => get_woocommerce_currency(),
-					'storeCountry'   => WC()->countries->get_base_country(),
-					'billingCountry' => WC()->customer ? WC()->customer->get_billing_country() : 'US',
-				]
-			) . ';',
-			'before'
-		);
-
 		Fraud_Prevention_Service::maybe_append_fraud_prevention_token();
 
 		return [ 'WCPAY_BLOCKS_CHECKOUT' ];


### PR DESCRIPTION
Fixes WOOPMNT-5535

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The `wcBlocksCheckoutData` constant is not used in the codebase. It was introduced here ( https://github.com/Automattic/woocommerce-payments/pull/8452 ) as part of a payment method label refactoring on the blocks checkout. But it's no longer needed.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Look for `wcBlocksCheckoutData` in the codebase. It should not be present.
Accessing the block-based checkout page should not trigger any console errors regarding `wcBlocksCheckoutData`.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
