### PR TITLE
Cherry-pick: Fix Woo 10.4.0-beta compatibility (#11159)

### DIFF
--- a/changelog/fix-wc-10-4-compatibility
+++ b/changelog/fix-wc-10-4-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This change is only applicable to unit tests, and those are not distributed with the plugin, hence there are no actual changes.
+
+


### PR DESCRIPTION
## Summary

Cherry-picks commit `5f93768d0` (Fix Woo 10.4.0-beta-1 compatibility #11159) into the release/10.3.0 branch.

**Original PR:** #11159

This PR fixes unit test compatibility with WooCommerce 10.4.0-beta. Test-only changes, no production code affected.

## Test plan

- CI should pass, including WC beta compatibility checks
- No manual testing required (test-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)