### PR TITLE
Improve how we check usage tracking eligibility

### DIFF
--- a/changelog/woopmnt-4451-update-shopper-tracks-events-enablement-criteria-improvements
+++ b/changelog/woopmnt-4451-update-shopper-tracks-events-enablement-criteria-improvements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve how server-side and client-side check tracking usage eligibility.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -207,7 +207,6 @@ class WC_Payments_Checkout {
 			'isWooPayGlobalThemeSupportEnabled' => $this->gateway->is_woopay_global_theme_support_enabled(),
 			'woopayHost'                        => WooPay_Utilities::get_woopay_url(),
 			'platformTrackerNonce'              => wp_create_nonce( 'platform_tracks_nonce' ),
-			'isShopperTrackingEnabled'          => apply_filters( 'wcpay_shopper_tracking_enabled', 'no' !== get_option( 'woocommerce_allow_tracking' ) ),
 			'accountIdForIntentConfirmation'    => apply_filters( 'wc_payments_account_id_for_intent_confirmation', '' ),
 			'wcpayVersionNumber'                => WCPAY_VERSION_NUMBER,
 			'woopaySignatureNonce'              => wp_create_nonce( 'woopay_signature_nonce' ),

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -334,66 +334,6 @@ class WC_Payments_Checkout {
 	}
 
 	/**
-	 * Gets the config for a payment method.
-	 *
-	 * @param string $payment_method_id The payment method ID.
-	 * @param string $account_country The account country.
-	 * @return array
-	 */
-	private function get_config_for_payment_method( $payment_method_id, $account_country ) {
-		$payment_method = $this->gateway->wc_payments_get_payment_method_by_id( $payment_method_id );
-
-		if ( ! $payment_method ) {
-			return [];
-		}
-
-		$config = [
-			'isReusable'     => $payment_method->is_reusable(),
-			'isBnpl'         => $payment_method->is_bnpl(),
-			'title'          => $payment_method->get_title( $account_country ),
-			'icon'           => $payment_method->get_icon( $account_country ),
-			'darkIcon'       => $payment_method->get_dark_icon( $account_country ),
-			'showSaveOption' => $this->should_upe_payment_method_show_save_option( $payment_method ),
-			'countries'      => $payment_method->get_countries(),
-		];
-
-		$gateway_for_payment_method    = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
-		$config['gatewayId']           = $gateway_for_payment_method->id;
-		$config['testingInstructions'] = WC_Payments_Utils::esc_interpolated_html(
-			/* translators: link to Stripe testing page */
-			$payment_method->get_testing_instructions( $account_country ),
-			[
-				'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
-				'strong' => '<strong>',
-				'number' => '<button type="button" class="js-woopayments-copy-test-number" aria-label="' . esc_attr( __( 'Click to copy the test number to clipboard', 'woocommerce-payments' ) ) . '" title="' . esc_attr( __( 'Copy to clipboard', 'woocommerce-payments' ) ) . '"><i></i><span>',
-			]
-		);
-
-		$should_enable_network_saved_cards = Payment_Method::CARD === $payment_method_id && WC_Payments::is_network_saved_cards_enabled();
-		$config['forceNetworkSavedCards']  = $should_enable_network_saved_cards || $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
-
-		return $config;
-	}
-
-	/**
-	 * Checks if the save option for a payment method should be displayed or not.
-	 *
-	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
-	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
-	 */
-	private function should_upe_payment_method_show_save_option( $payment_method ) {
-		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
-			return false;
-		}
-
-		if ( $payment_method->is_reusable() ) {
-			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
-		}
-
-		return false;
-	}
-
-	/**
 	 * Renders the UPE input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.
@@ -467,7 +407,7 @@ class WC_Payments_Checkout {
 					?>
 				<p class="testmode-info">
 					<?php
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							echo WC_Payments_Utils::esc_interpolated_html(
 							/* translators: link to Stripe testing page */
 								$this->gateway->get_payment_method()->get_testing_instructions( $this->account->get_account_country() ),
@@ -531,6 +471,66 @@ class WC_Payments_Checkout {
 		if ( null !== $payment_method_id ) {
 			$this->gateway = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
 		}
+	}
+
+	/**
+	 * Gets the config for a payment method.
+	 *
+	 * @param string $payment_method_id The payment method ID.
+	 * @param string $account_country The account country.
+	 * @return array
+	 */
+	private function get_config_for_payment_method( $payment_method_id, $account_country ) {
+		$payment_method = $this->gateway->wc_payments_get_payment_method_by_id( $payment_method_id );
+
+		if ( ! $payment_method ) {
+			return [];
+		}
+
+		$config = [
+			'isReusable'     => $payment_method->is_reusable(),
+			'isBnpl'         => $payment_method->is_bnpl(),
+			'title'          => $payment_method->get_title( $account_country ),
+			'icon'           => $payment_method->get_icon( $account_country ),
+			'darkIcon'       => $payment_method->get_dark_icon( $account_country ),
+			'showSaveOption' => $this->should_upe_payment_method_show_save_option( $payment_method ),
+			'countries'      => $payment_method->get_countries(),
+		];
+
+		$gateway_for_payment_method    = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
+		$config['gatewayId']           = $gateway_for_payment_method->id;
+		$config['testingInstructions'] = WC_Payments_Utils::esc_interpolated_html(
+			/* translators: link to Stripe testing page */
+			$payment_method->get_testing_instructions( $account_country ),
+			[
+				'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
+				'strong' => '<strong>',
+				'number' => '<button type="button" class="js-woopayments-copy-test-number" aria-label="' . esc_attr( __( 'Click to copy the test number to clipboard', 'woocommerce-payments' ) ) . '" title="' . esc_attr( __( 'Copy to clipboard', 'woocommerce-payments' ) ) . '"><i></i><span>',
+			]
+		);
+
+		$should_enable_network_saved_cards = Payment_Method::CARD === $payment_method_id && WC_Payments::is_network_saved_cards_enabled();
+		$config['forceNetworkSavedCards']  = $should_enable_network_saved_cards || $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
+
+		return $config;
+	}
+
+	/**
+	 * Checks if the save option for a payment method should be displayed or not.
+	 *
+	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
+	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
+	 */
+	private function should_upe_payment_method_show_save_option( $payment_method ) {
+		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
+			return false;
+		}
+
+		if ( $payment_method->is_reusable() ) {
+			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -334,6 +334,66 @@ class WC_Payments_Checkout {
 	}
 
 	/**
+	 * Gets the config for a payment method.
+	 *
+	 * @param string $payment_method_id The payment method ID.
+	 * @param string $account_country The account country.
+	 * @return array
+	 */
+	private function get_config_for_payment_method( $payment_method_id, $account_country ) {
+		$payment_method = $this->gateway->wc_payments_get_payment_method_by_id( $payment_method_id );
+
+		if ( ! $payment_method ) {
+			return [];
+		}
+
+		$config = [
+			'isReusable'     => $payment_method->is_reusable(),
+			'isBnpl'         => $payment_method->is_bnpl(),
+			'title'          => $payment_method->get_title( $account_country ),
+			'icon'           => $payment_method->get_icon( $account_country ),
+			'darkIcon'       => $payment_method->get_dark_icon( $account_country ),
+			'showSaveOption' => $this->should_upe_payment_method_show_save_option( $payment_method ),
+			'countries'      => $payment_method->get_countries(),
+		];
+
+		$gateway_for_payment_method    = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
+		$config['gatewayId']           = $gateway_for_payment_method->id;
+		$config['testingInstructions'] = WC_Payments_Utils::esc_interpolated_html(
+			/* translators: link to Stripe testing page */
+			$payment_method->get_testing_instructions( $account_country ),
+			[
+				'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
+				'strong' => '<strong>',
+				'number' => '<button type="button" class="js-woopayments-copy-test-number" aria-label="' . esc_attr( __( 'Click to copy the test number to clipboard', 'woocommerce-payments' ) ) . '" title="' . esc_attr( __( 'Copy to clipboard', 'woocommerce-payments' ) ) . '"><i></i><span>',
+			]
+		);
+
+		$should_enable_network_saved_cards = Payment_Method::CARD === $payment_method_id && WC_Payments::is_network_saved_cards_enabled();
+		$config['forceNetworkSavedCards']  = $should_enable_network_saved_cards || $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
+
+		return $config;
+	}
+
+	/**
+	 * Checks if the save option for a payment method should be displayed or not.
+	 *
+	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
+	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
+	 */
+	private function should_upe_payment_method_show_save_option( $payment_method ) {
+		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
+			return false;
+		}
+
+		if ( $payment_method->is_reusable() ) {
+			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
+		}
+
+		return false;
+	}
+
+	/**
 	 * Renders the UPE input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.
@@ -407,7 +467,7 @@ class WC_Payments_Checkout {
 					?>
 				<p class="testmode-info">
 					<?php
-                        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							echo WC_Payments_Utils::esc_interpolated_html(
 							/* translators: link to Stripe testing page */
 								$this->gateway->get_payment_method()->get_testing_instructions( $this->account->get_account_country() ),
@@ -471,66 +531,6 @@ class WC_Payments_Checkout {
 		if ( null !== $payment_method_id ) {
 			$this->gateway = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
 		}
-	}
-
-	/**
-	 * Gets the config for a payment method.
-	 *
-	 * @param string $payment_method_id The payment method ID.
-	 * @param string $account_country The account country.
-	 * @return array
-	 */
-	private function get_config_for_payment_method( $payment_method_id, $account_country ) {
-		$payment_method = $this->gateway->wc_payments_get_payment_method_by_id( $payment_method_id );
-
-		if ( ! $payment_method ) {
-			return [];
-		}
-
-		$config = [
-			'isReusable'     => $payment_method->is_reusable(),
-			'isBnpl'         => $payment_method->is_bnpl(),
-			'title'          => $payment_method->get_title( $account_country ),
-			'icon'           => $payment_method->get_icon( $account_country ),
-			'darkIcon'       => $payment_method->get_dark_icon( $account_country ),
-			'showSaveOption' => $this->should_upe_payment_method_show_save_option( $payment_method ),
-			'countries'      => $payment_method->get_countries(),
-		];
-
-		$gateway_for_payment_method    = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
-		$config['gatewayId']           = $gateway_for_payment_method->id;
-		$config['testingInstructions'] = WC_Payments_Utils::esc_interpolated_html(
-			/* translators: link to Stripe testing page */
-			$payment_method->get_testing_instructions( $account_country ),
-			[
-				'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
-				'strong' => '<strong>',
-				'number' => '<button type="button" class="js-woopayments-copy-test-number" aria-label="' . esc_attr( __( 'Click to copy the test number to clipboard', 'woocommerce-payments' ) ) . '" title="' . esc_attr( __( 'Copy to clipboard', 'woocommerce-payments' ) ) . '"><i></i><span>',
-			]
-		);
-
-		$should_enable_network_saved_cards = Payment_Method::CARD === $payment_method_id && WC_Payments::is_network_saved_cards_enabled();
-		$config['forceNetworkSavedCards']  = $should_enable_network_saved_cards || $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
-
-		return $config;
-	}
-
-	/**
-	 * Checks if the save option for a payment method should be displayed or not.
-	 *
-	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
-	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
-	 */
-	private function should_upe_payment_method_show_save_option( $payment_method ) {
-		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
-			return false;
-		}
-
-		if ( $payment_method->is_reusable() ) {
-			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
-		}
-
-		return false;
 	}
 
 	/**

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -153,7 +153,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 */
 	public function maybe_record_wcpay_shopper_event( $event, $data = [], $record_on_frontend = true ) {
 		$is_admin_event      = false;
-		$track_on_all_stores = false;
+		$track_on_all_stores = true;
 
 		// Record the event immediately.
 		if ( ! $record_on_frontend ) {

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -141,8 +141,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			$event = self::$user_prefix . '_' . $event;
 		}
 
-		// Track on all stores regardless of WooPay status for general shopper events.
-		return $this->tracks_record_event( $event, $data, false, true );
+		return $this->tracks_record_event( $event, $data, false, false );
 	}
 
 	/**
@@ -154,7 +153,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 */
 	public function maybe_record_wcpay_shopper_event( $event, $data = [], $record_on_frontend = true ) {
 		$is_admin_event      = false;
-		$track_on_all_stores = true;
+		$track_on_all_stores = false;
 
 		// Record the event immediately.
 		if ( ! $record_on_frontend ) {
@@ -258,8 +257,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		// For all other events ensure:
 		// 1. Only site pages are tracked.
 		// 2. Site Admin activity in site pages are not tracked.
-		// 3. If track_on_all_stores is enabled, track all events regardless of WooPay eligibility.
-		// 4. Otherwise, track only when WooPay is active.
+		// 3. If track_on_all_stores is true, tracking is enabled regardless of WooPay eligibility.
+		// 4. Otherwise, tracking requires WooPay to be eligible and enabled.
 
 		// Track only site pages.
 		if ( is_admin() && ! wp_doing_ajax() ) {
@@ -527,7 +526,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 */
 	public function bump_stats( $group, $stat_name ) {
 		$is_admin_event      = false;
-		$track_on_all_stores = true;
+		$track_on_all_stores = false;
 
 		if ( ! $this->should_enable_tracking( $is_admin_event, $track_on_all_stores ) ) {
 			return false;
@@ -641,9 +640,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @return array The modified config.
 	 */
 	public function add_tracking_config_to_payment_fields( $config ) {
-		// Pass track_on_all_stores = true to enable tracking for general shopper events
-		// regardless of WooPay eligibility.
-		$config['isShopperTrackingEnabled'] = $this->should_enable_tracking( false, true );
+		$config['isShopperTrackingEnabled'] = $this->should_enable_tracking( false, false );
 		return $config;
 	}
 
@@ -654,9 +651,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @return array The modified params.
 	 */
 	public function add_tracking_config_to_express_checkout( $params ) {
-		// Pass track_on_all_stores = true to enable tracking for general shopper events
-		// regardless of WooPay eligibility.
-		$params['is_shopper_tracking_enabled'] = $this->should_enable_tracking( false, true );
+		$params['is_shopper_tracking_enabled'] = $this->should_enable_tracking( false, false );
 		return $params;
 	}
 

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -338,59 +338,6 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	}
 
 	/**
-	 * Procedurally build a Tracks Event Object.
-	 *
-	 * @param \WP_User $user                  WP_user object.
-	 * @param string   $event_name            The name of the event.
-	 * @param array    $properties            Custom properties to send with the event.
-	 *
-	 * @return \Jetpack_Tracks_Event|\WP_Error
-	 */
-	private function tracks_build_event_obj( $user, $event_name, $properties = [] ) {
-		$identity = $this->tracks_get_identity();
-		$site_url = get_option( 'siteurl' );
-
-		$properties['_lg']       = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
-		$properties['blog_url']  = $site_url;
-		$properties['blog_id']   = \Jetpack_Options::get_option( 'id' );
-		$properties['user_lang'] = $user->get( 'WPLANG' );
-		$properties['store_id']  = $this->get_wc_store_id();
-
-		// Add event property for test mode vs. live mode events.
-		$properties['test_mode']     = WC_Payments::mode()->is_test() ? 1 : 0;
-		$properties['wcpay_version'] = WCPAY_VERSION_NUMBER;
-
-		// Add client's user agent to the event properties.
-		if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$properties['_via_ua'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
-		}
-
-		$blog_details = [
-			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
-		];
-
-		$timestamp        = round( microtime( true ) * 1000 );
-		$timestamp_string = is_string( $timestamp ) ? $timestamp : number_format( $timestamp, 0, '', '' );
-
-		/**
-		 * Ignore incorrect argument definition in Jetpack_Tracks_Event.
-		 *
-		 * @psalm-suppress InvalidArgument
-		 */
-		return new \Jetpack_Tracks_Event(
-			array_merge(
-				$blog_details,
-				(array) $properties,
-				$identity,
-				[
-					'_en' => $event_name,
-					'_ts' => $timestamp_string,
-				]
-			)
-		);
-	}
-
-	/**
 	 * Returns WC store_id value, if available.
 	 * store_id introduced in WC 8.4.
 	 *
@@ -679,8 +626,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		wp_add_inline_script(
 			'wcpay-frontend-tracks',
 			"
-			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
-			",
+            var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
+            ",
 			'before'
 		);
 
@@ -691,5 +638,58 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		);
 
 		wp_enqueue_script( 'wcpay-frontend-tracks' );
+	}
+
+	/**
+	 * Procedurally build a Tracks Event Object.
+	 *
+	 * @param \WP_User $user                  WP_user object.
+	 * @param string   $event_name            The name of the event.
+	 * @param array    $properties            Custom properties to send with the event.
+	 *
+	 * @return \Jetpack_Tracks_Event|\WP_Error
+	 */
+	private function tracks_build_event_obj( $user, $event_name, $properties = [] ) {
+		$identity = $this->tracks_get_identity();
+		$site_url = get_option( 'siteurl' );
+
+		$properties['_lg']       = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
+		$properties['blog_url']  = $site_url;
+		$properties['blog_id']   = \Jetpack_Options::get_option( 'id' );
+		$properties['user_lang'] = $user->get( 'WPLANG' );
+		$properties['store_id']  = $this->get_wc_store_id();
+
+		// Add event property for test mode vs. live mode events.
+		$properties['test_mode']     = WC_Payments::mode()->is_test() ? 1 : 0;
+		$properties['wcpay_version'] = WCPAY_VERSION_NUMBER;
+
+		// Add client's user agent to the event properties.
+		if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$properties['_via_ua'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+		}
+
+		$blog_details = [
+			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
+		];
+
+		$timestamp        = round( microtime( true ) * 1000 );
+		$timestamp_string = is_string( $timestamp ) ? $timestamp : number_format( $timestamp, 0, '', '' );
+
+		/**
+		 * Ignore incorrect argument definition in Jetpack_Tracks_Event.
+		 *
+		 * @psalm-suppress InvalidArgument
+		 */
+		return new \Jetpack_Tracks_Event(
+			array_merge(
+				$blog_details,
+				(array) $properties,
+				$identity,
+				[
+					'_en' => $event_name,
+					'_ts' => $timestamp_string,
+				]
+			)
+		);
 	}
 }

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -338,6 +338,59 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	}
 
 	/**
+	 * Procedurally build a Tracks Event Object.
+	 *
+	 * @param \WP_User $user                  WP_user object.
+	 * @param string   $event_name            The name of the event.
+	 * @param array    $properties            Custom properties to send with the event.
+	 *
+	 * @return \Jetpack_Tracks_Event|\WP_Error
+	 */
+	private function tracks_build_event_obj( $user, $event_name, $properties = [] ) {
+		$identity = $this->tracks_get_identity();
+		$site_url = get_option( 'siteurl' );
+
+		$properties['_lg']       = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
+		$properties['blog_url']  = $site_url;
+		$properties['blog_id']   = \Jetpack_Options::get_option( 'id' );
+		$properties['user_lang'] = $user->get( 'WPLANG' );
+		$properties['store_id']  = $this->get_wc_store_id();
+
+		// Add event property for test mode vs. live mode events.
+		$properties['test_mode']     = WC_Payments::mode()->is_test() ? 1 : 0;
+		$properties['wcpay_version'] = WCPAY_VERSION_NUMBER;
+
+		// Add client's user agent to the event properties.
+		if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			$properties['_via_ua'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+		}
+
+		$blog_details = [
+			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
+		];
+
+		$timestamp        = round( microtime( true ) * 1000 );
+		$timestamp_string = is_string( $timestamp ) ? $timestamp : number_format( $timestamp, 0, '', '' );
+
+		/**
+		 * Ignore incorrect argument definition in Jetpack_Tracks_Event.
+		 *
+		 * @psalm-suppress InvalidArgument
+		 */
+		return new \Jetpack_Tracks_Event(
+			array_merge(
+				$blog_details,
+				(array) $properties,
+				$identity,
+				[
+					'_en' => $event_name,
+					'_ts' => $timestamp_string,
+				]
+			)
+		);
+	}
+
+	/**
 	 * Returns WC store_id value, if available.
 	 * store_id introduced in WC 8.4.
 	 *
@@ -626,8 +679,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		wp_add_inline_script(
 			'wcpay-frontend-tracks',
 			"
-            var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
-            ",
+			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
+			",
 			'before'
 		);
 
@@ -638,58 +691,5 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		);
 
 		wp_enqueue_script( 'wcpay-frontend-tracks' );
-	}
-
-	/**
-	 * Procedurally build a Tracks Event Object.
-	 *
-	 * @param \WP_User $user                  WP_user object.
-	 * @param string   $event_name            The name of the event.
-	 * @param array    $properties            Custom properties to send with the event.
-	 *
-	 * @return \Jetpack_Tracks_Event|\WP_Error
-	 */
-	private function tracks_build_event_obj( $user, $event_name, $properties = [] ) {
-		$identity = $this->tracks_get_identity();
-		$site_url = get_option( 'siteurl' );
-
-		$properties['_lg']       = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
-		$properties['blog_url']  = $site_url;
-		$properties['blog_id']   = \Jetpack_Options::get_option( 'id' );
-		$properties['user_lang'] = $user->get( 'WPLANG' );
-		$properties['store_id']  = $this->get_wc_store_id();
-
-		// Add event property for test mode vs. live mode events.
-		$properties['test_mode']     = WC_Payments::mode()->is_test() ? 1 : 0;
-		$properties['wcpay_version'] = WCPAY_VERSION_NUMBER;
-
-		// Add client's user agent to the event properties.
-		if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			$properties['_via_ua'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
-		}
-
-		$blog_details = [
-			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
-		];
-
-		$timestamp        = round( microtime( true ) * 1000 );
-		$timestamp_string = is_string( $timestamp ) ? $timestamp : number_format( $timestamp, 0, '', '' );
-
-		/**
-		 * Ignore incorrect argument definition in Jetpack_Tracks_Event.
-		 *
-		 * @psalm-suppress InvalidArgument
-		 */
-		return new \Jetpack_Tracks_Event(
-			array_merge(
-				$blog_details,
-				(array) $properties,
-				$identity,
-				[
-					'_en' => $event_name,
-					'_ts' => $timestamp_string,
-				]
-			)
-		);
 	}
 }

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -141,7 +141,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			$event = self::$user_prefix . '_' . $event;
 		}
 
-		return $this->tracks_record_event( $event, $data, false, false );
+		return $this->tracks_record_event( $event, $data, false );
 	}
 
 	/**

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -526,7 +526,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 */
 	public function bump_stats( $group, $stat_name ) {
 		$is_admin_event      = false;
-		$track_on_all_stores = false;
+		$track_on_all_stores = true;
 
 		if ( ! $this->should_enable_tracking( $is_admin_event, $track_on_all_stores ) ) {
 			return false;

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -76,6 +76,10 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'wp_footer', [ $this, 'add_frontend_tracks_scripts' ] );
 		add_action( 'before_woocommerce_pay_form', [ $this, 'pay_for_order_page_view' ] );
 		add_action( 'woocommerce_thankyou', [ $this, 'thank_you_page_view' ] );
+
+		// Inject tracking configuration into JS configs.
+		add_filter( 'wcpay_payment_fields_js_config', [ $this, 'add_tracking_config_to_payment_fields' ] );
+		add_filter( 'wcpay_express_checkout_js_params', [ $this, 'add_tracking_config_to_express_checkout' ] );
 	}
 
 	/**
@@ -137,7 +141,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			$event = self::$user_prefix . '_' . $event;
 		}
 
-		return $this->tracks_record_event( $event, $data );
+		// Track on all stores regardless of WooPay status for general shopper events.
+		return $this->tracks_record_event( $event, $data, false, true );
 	}
 
 	/**
@@ -218,14 +223,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 */
 	public function should_enable_tracking( $is_admin_event = false, $track_on_all_stores = false ) {
 		// Allow merchants to disable all shopper tracking via filter.
-		if ( ! apply_filters( 'wcpay_shopper_tracking_enabled', true ) ) {
-			return false;
-		}
-
-		// Respect WooCommerce global tracking opt-out setting.
-		// Only disable if explicitly set to 'no' (not false, null, or empty).
-		$allow_tracking = get_option( 'woocommerce_allow_tracking', '' );
-		if ( 'no' === $allow_tracking ) {
+		// The filter defaults to the WooCommerce global tracking setting.
+		if ( ! apply_filters( 'wcpay_shopper_tracking_enabled', 'no' !== get_option( 'woocommerce_allow_tracking', '' ) ) ) {
 			return false;
 		}
 
@@ -633,6 +632,32 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		}
 
 		$this->maybe_record_admin_event( 'woopay_express_button_locations_updated', $props );
+	}
+
+	/**
+	 * Add tracking configuration to payment fields JS config.
+	 *
+	 * @param array $config The payment fields JS config.
+	 * @return array The modified config.
+	 */
+	public function add_tracking_config_to_payment_fields( $config ) {
+		// Pass track_on_all_stores = true to enable tracking for general shopper events
+		// regardless of WooPay eligibility.
+		$config['isShopperTrackingEnabled'] = $this->should_enable_tracking( false, true );
+		return $config;
+	}
+
+	/**
+	 * Add tracking configuration to express checkout JS params.
+	 *
+	 * @param array $params The express checkout JS params.
+	 * @return array The modified params.
+	 */
+	public function add_tracking_config_to_express_checkout( $params ) {
+		// Pass track_on_all_stores = true to enable tracking for general shopper events
+		// regardless of WooPay eligibility.
+		$params['is_shopper_tracking_enabled'] = $this->should_enable_tracking( false, true );
+		return $params;
 	}
 
 	/**

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -141,7 +141,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			$event = self::$user_prefix . '_' . $event;
 		}
 
-		return $this->tracks_record_event( $event, $data, false );
+		return $this->tracks_record_event( $event, $data );
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -226,17 +226,16 @@ class WC_Payments_Express_Checkout_Button_Handler {
 			apply_filters(
 				'wcpay_express_checkout_js_params',
 				[
-					'ajax_url'                    => admin_url( 'admin-ajax.php' ),
-					'wc_ajax_url'                 => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-					'is_shopper_tracking_enabled' => apply_filters( 'wcpay_shopper_tracking_enabled', 'no' !== get_option( 'woocommerce_allow_tracking' ) ),
-					'nonce'                       => [
+					'ajax_url'           => admin_url( 'admin-ajax.php' ),
+					'wc_ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+					'nonce'              => [
 						'platform_tracker'             => wp_create_nonce( 'platform_tracks_nonce' ),
 						// needed to communicate via the Store API.
 						'tokenized_cart_nonce'         => wp_create_nonce( 'woopayments_tokenized_cart_nonce' ),
 						'tokenized_cart_session_nonce' => wp_create_nonce( 'woopayments_tokenized_cart_session_nonce' ),
 						'store_api_nonce'              => wp_create_nonce( 'wc_store_api' ),
 					],
-					'checkout'                    => [
+					'checkout'           => [
 						'currency_code'              => strtolower( get_woocommerce_currency() ),
 						'currency_decimals'          => WC_Payments::get_localization_service()->get_currency_format( get_woocommerce_currency() )['num_decimals'],
 						'country_code'               => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
@@ -246,12 +245,12 @@ class WC_Payments_Express_Checkout_Button_Handler {
 						'allowed_shipping_countries' => array_keys( WC()->countries->get_shipping_countries() ?? [] ),
 						'display_prices_with_tax'    => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
 					],
-					'button'                      => $this->get_button_settings(),
-					'login_confirmation'          => $this->get_login_confirmation_settings(),
-					'button_context'              => $this->express_checkout_helper->get_button_context(),
-					'has_block'                   => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
-					'product'                     => $this->express_checkout_helper->get_product_data(),
-					'store_name'                  => get_bloginfo( 'name' ),
+					'button'             => $this->get_button_settings(),
+					'login_confirmation' => $this->get_login_confirmation_settings(),
+					'button_context'     => $this->express_checkout_helper->get_button_context(),
+					'has_block'          => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
+					'product'            => $this->express_checkout_helper->get_product_data(),
+					'store_name'         => get_bloginfo( 'name' ),
 				]
 			),
 			[

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -80,6 +80,9 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_account_connected = true;
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
 
+		// Enable WooPay in gateway settings.
+		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
+
 		global $wp_roles;
 		$all_roles = array_diff( $wp_roles->get_names(), [ 'administrator' ] );
 

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -80,9 +80,6 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$is_account_connected = true;
 		$this->setup_woopay_environment( $is_woopay_eligible, $is_account_connected );
 
-		// Enable WooPay in gateway settings.
-		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
-
 		global $wp_roles;
 		$all_roles = array_diff( $wp_roles->get_names(), [ 'administrator' ] );
 


### PR DESCRIPTION
See #11188 

#### Changes proposed in this Pull Request

Addresses https://github.com/Automattic/woocommerce-payments/pull/11188#discussion_r2605728484 by consolidating tracking enablement logic into `WooPay_Tracker`. The tracker now injects tracking configuration via filters, using `should_enable_tracking()` for checks. Removes duplicate config from checkout classes and ensures tracking works independently of WooPay status.

#### Testing instructions

**Test 1: Respect WooCommerce global opt-out**
1. Go to WooCommerce → Settings → Advanced → WooCommerce.com
2. Uncheck "Allow usage tracking"
3. Visit a product page, cart, and checkout as a shopper (non-admin)
4. Verify no tracking requests to `/wp-admin/admin-ajax.php`. In browser network tab, check the payload and look for `action platform_tracks`
5. Re-enable tracking and verify events are sent again

**Test 2: Respect wcpay_enable_shopper_tracking filter**
1. Add to your theme's functions.php:
   ```php
   add_filter( 'wcpay_enable_shopper_tracking', '__return_false' );
   ```
2. Visit product page, cart, checkout as shopper
3. Verify no tracking requests are made
4. Remove the filter and verify tracking resumes

**Test 3: Filter takes priority**
1. Enable WooCommerce global tracking
2. Add filter to disable: `add_filter( 'wcpay_enable_shopper_tracking', '__return_false' );`
3. Verify tracking is disabled (filter wins)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
