### PR TITLE
fix: VAT error messages localization

### DIFF
--- a/changelog/fix-vat-error-messages-localization
+++ b/changelog/fix-vat-error-messages-localization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: VAT error messages localization

--- a/client/vat/form/style.scss
+++ b/client/vat/form/style.scss
@@ -1,6 +1,6 @@
 .components-notice.vat-number-error {
 	margin: 0;
-	margin-top: 15px;
+	margin-bottom: 15px;
 }
 
 // This matches the styling of the VatNumberTask component before __nextHasNoMarginBottom was added in a few internal components.


### PR DESCRIPTION
Fixes #9144

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Ensuring error messages for invalid tax IDs use the correct terminology for each country (e.g., "Corporate Number" for Japan, "ABN" for Australia) instead of always saying "VAT number".

The server returns symbolic error codes (`wcpay_invalid_tax_number` / `wcpay_unsupported_tax_docs_country`), but the client was displaying the raw server message, which always mentioned "VAT". 
In Japan the "VAT" is called "Corporate Number". This PR fixes the issue by mapping the error code to an error message.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Onboard with a JP-based account
- Add a new tax document on your local server: `wp wcpay add_document_for_account {account_id} vat_invoice --mode=test --period_from="2024-04-01 00:00:00" --period_to="2024-04-30 23:59:59"`
- As a merchant, navigate to Payments > Documents
- Click Download for a tax doc row
- You should see a dialog
- Enter something invalid, like "baba"
- Click "Continue"
- The error message should say "Corporate number"
- The error message should be displayed below the text field

Before:
<img width="669" height="506" alt="Screenshot 2025-12-12 at 5 05 26 PM" src="https://github.com/user-attachments/assets/024ef2f6-55d7-4a46-b43f-a3d818e33556" />

After:
<img width="676" height="509" alt="Screenshot 2025-12-12 at 5 07 11 PM" src="https://github.com/user-attachments/assets/914dee51-22d0-4529-aefb-414b96292d77" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
