### PR TITLE
fix: UPE styles on block-based checkout

### DIFF
--- a/changelog/fix-upe-styles-on-new-wc-blocks
+++ b/changelog/fix-upe-styles-on-new-wc-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: redirect message styles on block-based checkout page

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -46,7 +46,7 @@ describe( 'Getting styles for automated theming', () => {
 
 	test( 'getFieldStyles returns correct styles for inputs', () => {
 		const scope = {
-			querySelectorAll: jest.fn( () => [ mockElement ] ),
+			querySelector: jest.fn( () => mockElement ),
 			defaultView: {
 				getComputedStyle: jest.fn( () => mockCSStyleDeclaration ),
 			},
@@ -71,7 +71,7 @@ describe( 'Getting styles for automated theming', () => {
 
 	test( 'getFieldStyles returns empty object if it can not find the element', () => {
 		const scope = {
-			querySelectorAll: jest.fn( () => [] ),
+			querySelector: jest.fn( () => undefined ),
 		};
 
 		const fieldStyles = upeStyles.getFieldStyles(
@@ -133,7 +133,6 @@ describe( 'Getting styles for automated theming', () => {
 	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
-			querySelectorAll: jest.fn( () => [ mockElement ] ),
 			createElement: jest.fn( ( htmlTag ) =>
 				document.createElement( htmlTag )
 			),
@@ -313,7 +312,6 @@ describe( 'Getting styles for automated theming', () => {
 			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', () => {
 				const scope = {
 					querySelector: jest.fn( () => mockElement ),
-					querySelectorAll: jest.fn( () => [ mockElement ] ),
 					createElement: jest.fn( ( htmlTag ) =>
 						document.createElement( htmlTag )
 					),

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -5,7 +5,32 @@ import * as upeStyles from '..';
 
 describe( 'Getting styles for automated theming', () => {
 	const mockElement = document.createElement( 'input' );
+	// camelCase for direct property access (styles.fontFamily)
+	const cssPropertiesCamel = {
+		fontFamily:
+			'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
+		color: 'rgb(109, 109, 109)',
+		backgroundColor: 'rgba(0, 0, 0, 0)',
+		unsuportedProperty: 'some value',
+		outlineColor: 'rgb(150, 88, 138)',
+		outlineWidth: '1px',
+		fontSize: '12px',
+		padding: '10px',
+	};
+	// dashed for getPropertyValue (styles.getPropertyValue('font-family'))
+	const cssPropertiesDashed = {
+		'font-family':
+			'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
+		color: 'rgb(109, 109, 109)',
+		'background-color': 'rgba(0, 0, 0, 0)',
+		'unsuported-property': 'some value',
+		'outline-color': 'rgb(150, 88, 138)',
+		'outline-width': '1px',
+		'font-size': '12px',
+		padding: '10px',
+	};
 	const mockCSStyleDeclaration = {
+		...cssPropertiesCamel,
 		length: 8,
 		0: 'color',
 		1: 'backgroundColor',
@@ -15,25 +40,13 @@ describe( 'Getting styles for automated theming', () => {
 		5: 'outlineWidth',
 		6: 'fontSize',
 		7: 'padding',
-		getPropertyValue: ( propertyName ) => {
-			const cssProperties = {
-				fontFamily:
-					'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
-				color: 'rgb(109, 109, 109)',
-				backgroundColor: 'rgba(0, 0, 0, 0)',
-				unsuportedProperty: 'some value',
-				outlineColor: 'rgb(150, 88, 138)',
-				outlineWidth: '1px',
-				fontSize: '12px',
-				padding: '10px',
-			};
-			return cssProperties[ propertyName ];
-		},
+		getPropertyValue: ( propertyName ) =>
+			cssPropertiesDashed[ propertyName ],
 	};
 
 	test( 'getFieldStyles returns correct styles for inputs', () => {
 		const scope = {
-			querySelector: jest.fn( () => mockElement ),
+			querySelectorAll: jest.fn( () => [ mockElement ] ),
 			defaultView: {
 				getComputedStyle: jest.fn( () => mockCSStyleDeclaration ),
 			},
@@ -58,7 +71,7 @@ describe( 'Getting styles for automated theming', () => {
 
 	test( 'getFieldStyles returns empty object if it can not find the element', () => {
 		const scope = {
-			querySelector: jest.fn( () => undefined ),
+			querySelectorAll: jest.fn( () => [] ),
 		};
 
 		const fieldStyles = upeStyles.getFieldStyles(
@@ -120,6 +133,7 @@ describe( 'Getting styles for automated theming', () => {
 	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
+			querySelectorAll: jest.fn( () => [ mockElement ] ),
 			createElement: jest.fn( ( htmlTag ) =>
 				document.createElement( htmlTag )
 			),
@@ -299,6 +313,7 @@ describe( 'Getting styles for automated theming', () => {
 			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', () => {
 				const scope = {
 					querySelector: jest.fn( () => mockElement ),
+					querySelectorAll: jest.fn( () => [ mockElement ] ),
 					createElement: jest.fn( ( htmlTag ) =>
 						document.createElement( htmlTag )
 					),

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -423,11 +423,11 @@ export const getFieldStyles = (
 	backgroundColor = null,
 	scope
 ) => {
-	// If selector is an array, get one element per selector type instead of all elements.
-	// This avoids performance issues with selectors that match many elements.
-	const elements = Array.isArray( selector )
-		? selector.map( ( s ) => scope.querySelector( s ) ).filter( Boolean )
-		: [ ...scope.querySelectorAll( selector ) ];
+	// If the selector is an array, get one element per selector type instead of all elements.
+	// This avoids performance issues with selectors that match too many elements.
+	const elements = ( Array.isArray( selector ) ? selector : [ selector ] )
+		.map( ( s ) => scope.querySelector( s ) )
+		.filter( Boolean );
 
 	if ( ! elements.length ) {
 		return {};

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -5,7 +5,6 @@ import { upeRestrictedProperties } from './upe-styles';
 import {
 	generateHoverRules,
 	generateOutlineStyle,
-	dashedToCamelCase,
 	isColorLight,
 	getBackgroundColor,
 	maybeConvertRGBAtoRGB,
@@ -56,6 +55,8 @@ export const appearanceSelectors = {
 		upeThemeTextSelectors: [
 			'.wc-block-components-checkout-step__description',
 			'.wc-block-components-text-input',
+			'.wc-block-components-radio-control__label',
+			'.wc-block-checkout__terms',
 		],
 		rowElement: 'div',
 		validClasses: [ 'wc-block-components-text-input', 'is-active' ],
@@ -413,13 +414,22 @@ const hiddenElementsForUPE = {
 	},
 };
 
+const toDashed = ( str ) =>
+	str.replace( /[A-Z]/g, ( m ) => `-${ m.toLowerCase() }` );
+
 export const getFieldStyles = (
 	selector,
 	upeElement,
 	backgroundColor = null,
 	scope
 ) => {
-	if ( ! scope.querySelector( selector ) ) {
+	// If selector is an array, get one element per selector type instead of all elements.
+	// This avoids performance issues with selectors that match many elements.
+	const elements = Array.isArray( selector )
+		? selector.map( ( s ) => scope.querySelector( s ) ).filter( Boolean )
+		: [ ...scope.querySelectorAll( selector ) ];
+
+	if ( ! elements.length ) {
 		return {};
 	}
 
@@ -427,21 +437,47 @@ export const getFieldStyles = (
 
 	const validProperties = upeRestrictedProperties[ upeElement ];
 
-	const elem = scope.querySelector( selector );
+	const elem = elements[ 0 ];
 
 	const styles = windowObject.getComputedStyle( elem );
 
 	const filteredStyles = {};
-	for ( let i = 0; i < styles.length; i++ ) {
-		const camelCase = dashedToCamelCase( styles[ i ] );
-		if ( validProperties.includes( camelCase ) ) {
-			let propertyValue = styles.getPropertyValue( styles[ i ] );
-			if ( camelCase === 'color' ) {
-				propertyValue = maybeConvertRGBAtoRGB( propertyValue );
-			}
-			filteredStyles[ camelCase ] = propertyValue;
+	validProperties.forEach( ( camelCase ) => {
+		// Convert camelCase to dashed-case
+		const dashedName = toDashed( camelCase );
+		const propertyValue = styles.getPropertyValue( dashedName );
+		if ( ! propertyValue ) {
+			return;
 		}
-	}
+
+		if ( camelCase === 'color' ) {
+			filteredStyles[ camelCase ] = maybeConvertRGBAtoRGB(
+				propertyValue
+			);
+			return;
+		}
+
+		// `line-height: 0` values are no good - try and find an alternative.
+		// Limit to the first 5 elements to avoid performance issues with large selectors.
+		if (
+			camelCase === 'lineHeight' &&
+			( propertyValue === '0' || propertyValue === '0px' )
+		) {
+			const maxElements = Math.min( elements.length, 5 );
+			for ( let i = 0; i < maxElements; i++ ) {
+				const lh = windowObject
+					.getComputedStyle( elements[ i ] )
+					.getPropertyValue( 'line-height' );
+				if ( lh !== '0' && lh !== '0px' ) {
+					filteredStyles[ camelCase ] = lh;
+					break;
+				}
+			}
+			return;
+		}
+
+		filteredStyles[ camelCase ] = propertyValue;
+	} );
 
 	if ( upeElement === '.Input' || upeElement === '.Tab--selected' ) {
 		const outline = generateOutlineStyle(

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -423,8 +423,7 @@ export const getFieldStyles = (
 	backgroundColor = null,
 	scope
 ) => {
-	// If the selector is an array, get one element per selector type instead of all elements.
-	// This avoids performance issues with selectors that match too many elements.
+	// getting one element per selector to avoid performance issues with selectors matching too many elements.
 	const elements = ( Array.isArray( selector ) ? selector : [ selector ] )
 		.map( ( s ) => scope.querySelector( s ) )
 		.filter( Boolean );
@@ -458,13 +457,11 @@ export const getFieldStyles = (
 		}
 
 		// `line-height: 0` values are no good - try and find an alternative.
-		// Limit to the first 5 elements to avoid performance issues with large selectors.
 		if (
 			camelCase === 'lineHeight' &&
 			( propertyValue === '0' || propertyValue === '0px' )
 		) {
-			const maxElements = Math.min( elements.length, 5 );
-			for ( let i = 0; i < maxElements; i++ ) {
+			for ( let i = 1; i < elements.length; i++ ) {
 				const lh = windowObject
 					.getComputedStyle( elements[ i ] )
 					.getPropertyValue( 'line-height' );

--- a/client/checkout/upe-styles/upe-styles.js
+++ b/client/checkout/upe-styles/upe-styles.js
@@ -116,7 +116,7 @@ export const upeRestrictedProperties = {
 	'.Tab': [ ...restrictedTabProperties ],
 	'.Tab--selected': [
 		...restrictedTabSelectedProperties,
-		borderOutlineBackgroundProps,
+		...borderOutlineBackgroundProps,
 	],
 	'.TabIcon': upeSupportedProperties[ '.TabIcon' ],
 	'.TabIcon--selected': [ ...restrictedTabIconSelectedProperties ],

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -91,18 +91,6 @@ export const generateOutlineStyle = (
 };
 
 /**
- * Converts CSS property from dashed format to camel case.
- *
- * @param {string} string CSS property.
- * @return {string} Camel case string.
- */
-export const dashedToCamelCase = ( string ) => {
-	return string.replace( /-([a-z])/g, function ( g ) {
-		return g[ 1 ].toUpperCase();
-	} );
-};
-
-/**
  * Searches through array of CSS selectors and returns first visible background color.
  *
  * @param {Array}  selectors List of CSS selectors to check.


### PR DESCRIPTION
Fixes #11208
Fixes WOOPMNT-5564

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Recent [WooCommerce Core block checkout styles changes](https://github.com/woocommerce/woocommerce/blob/7b78e2df7e7c64aa5d8d703d295139e80654a023/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss#L6-L7) caused a performance regression in the `getAppearance` function, which computes styles for Stripe's Payment Element theming.

The `line-height` property was being computed to `0px`.
I added a backwards-compatible change to ensure that we can compute the `line-height` from additional elements on the page.

The previous implementation of `getFieldStyles` just grabbed the first available element. In our case, it would have been the email input field.
I needed a way to have a fallback mechanism. That's why I initially moved from `scope.querySelector` to `scope.querySelectorAll`. But that was too bad for performance. So I instead just increased the number of possible elements to gather the styles from, and ensured we get at least one of each selector (instead of just the first available on the page).

Before:
<img width="632" height="202" alt="Screenshot 2025-12-16 at 12 09 49 AM" src="https://github.com/user-attachments/assets/69db5aee-ceba-40c6-93ad-8e6ec387cc1e" />

After:
<img width="634" height="196" alt="Screenshot 2025-12-16 at 12 09 27 AM" src="https://github.com/user-attachments/assets/71efb797-a011-434e-851a-588237019494" />

With these changes, I'm also introducing a 20% performance improvement on the styles computation.
Before:
<img width="285" height="52" alt="Screenshot 2025-12-15 at 11 49 22 PM" src="https://github.com/user-attachments/assets/bc972f8d-61f2-42b2-85b2-ff0eddf03bd5" />
<img width="287" height="53" alt="Screenshot 2025-12-15 at 11 49 12 PM" src="https://github.com/user-attachments/assets/1fa6f08f-3c9b-4bd2-8362-2c61e0c6c494" />
<img width="311" height="50" alt="Screenshot 2025-12-15 at 11 48 53 PM" src="https://github.com/user-attachments/assets/4364fabe-4824-4173-908d-31feeaceca7f" />
<img width="265" height="47" alt="Screenshot 2025-12-15 at 11 48 44 PM" src="https://github.com/user-attachments/assets/ee86cec5-b4dd-41dc-8222-58f66d4f07bb" />

After:
<img width="285" height="48" alt="Screenshot 2025-12-15 at 11 45 42 PM" src="https://github.com/user-attachments/assets/9a0109c7-d20a-4308-8360-9e68dc237e2b" />
<img width="280" height="49" alt="Screenshot 2025-12-15 at 11 45 35 PM" src="https://github.com/user-attachments/assets/bbcf224a-6e10-4f88-a3c1-4651f72b1e71" />

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Install one of the latest versions of WC ( e.g.: https://github.com/woocommerce/woocommerce/releases/tag/10.4.2 )
- Ensure you're using the block-based checkout
- Ensure you have at least one of the redirect-based methods enabled, like any of the BNPLs or Alipay or WeChat Pay
- As a customer, add a product to the cart
- As a merchant, navigate to the WooPayments Dev Tools and click on "Delete UPE appearance transients"
  - As an alternative, ensure that [all these returned attributes are `null`
](https://github.com/Automattic/woocommerce-payments/blob/e5aeb50deecd708e0ca706328602ae0f69ab717e/includes/class-wc-payments-checkout.php#L232-L238)
- As a customer, navigate to the block-based checkout page
- Select one of the redirect-based payment methods
- The styles shouldn't be messed up anymore


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
