### PR TITLE
Update to the tooltip shown on active promos.

### DIFF
--- a/changelog/dev-update-discount-tooltip
+++ b/changelog/dev-update-discount-tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update wording on promo rate information tooltip

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -505,9 +505,7 @@ describe( 'Account fees utility functions', () => {
 
 			const result = getDiscountTooltipText( discountFee );
 
-			expect( result ).toBe(
-				'You are getting 15% off on processing fees.'
-			);
+			expect( result ).toBe( 'You are saving 15% on processing fees.' );
 		} );
 
 		it( 'uses volume_currency when available, falls back to currency', () => {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -397,7 +397,7 @@ export const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
 		return sprintf(
 			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires, %3$s: End date of the promotion */
 			__(
-				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume or through %3$s.',
+				'You are saving %1$s%% on processing fees for the first %2$s of total payment volume or through %3$s.',
 				'woocommerce-payments'
 			),
 			discountPercentage,
@@ -408,7 +408,7 @@ export const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
 		return sprintf(
 			/* translators: %1$s: discount percentage, %2$s: total payment volume until this promotion expires */
 			__(
-				'You are getting %1$s%% off on processing fees for the first %2$s of total payment volume.',
+				'You are saving %1$s%% on processing fees for the first %2$s of total payment volume.',
 				'woocommerce-payments'
 			),
 			discountPercentage,
@@ -418,7 +418,7 @@ export const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
 		return sprintf(
 			/* translators: %1$s: discount percentage, %2$s: End date of the promotion */
 			__(
-				'You are getting %1$s%% off on processing fees through %2$s.',
+				'You are saving %1$s%% on processing fees through %2$s.',
 				'woocommerce-payments'
 			),
 			discountPercentage,

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -428,10 +428,7 @@ export const getDiscountTooltipText = ( discountFee: DiscountFee ): string => {
 
 	return sprintf(
 		/* translators: %s: discount percentage */
-		__(
-			'You are getting %s%% off on processing fees.',
-			'woocommerce-payments'
-		),
+		__( 'You are saving %s%% on processing fees.', 'woocommerce-payments' ),
 		discountPercentage
 	);
 };


### PR DESCRIPTION
Fixes WOOPMNT-5610

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Update the display string wording when a promotional rate is applied to an account.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code changes make sense.
* Apply this change to `client/settings/payment-methods-list/payment-method.tsx` and confirm you see the tooltip and the text looks correct.

  ```diff
        const { chip, chipType = 'warning' } = usePaymentMethodAvailability( id );

  -     const discountFee = accountFees?.[ id ]?.discount?.[ 0 ];
  +     // TODO: Remove this mock data - for PR testing only
  +     const mockDiscountFee = {
  +             discount: 50, // 50% discount
  +             volume_allowance: 250000, // $2,500 volume allowance
  +             volume_currency: 'usd',
  +             currency: 'usd',
  +             end_time: '2025-03-31 23:59:59',
  +     };
  +
  +     const discountFee = mockDiscountFee; // accountFees?.[ id ]?.discount?.[ 0 ];
        const hasDiscount = discountFee?.discount;
  ```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
