### PR TITLE
Fix fatal error caused by missing hook in Get_PM_Promotions request class

### DIFF
--- a/changelog/fix-missing-hook-pm-promotions
+++ b/changelog/fix-missing-hook-pm-promotions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error on WooCommerce Settings Payments tab caused by missing hook in Get_PM_Promotions request class

--- a/includes/core/server/request/class-get-pm-promotions.php
+++ b/includes/core/server/request/class-get-pm-promotions.php
@@ -16,6 +16,13 @@ use WCPay\Core\Server\Request;
 class Get_PM_Promotions extends Request {
 
 	/**
+	 * Specifies the WordPress hook name that will be triggered upon calling the send() method.
+	 *
+	 * @var string
+	 */
+	protected $hook = 'wcpay_get_pm_promotions_request';
+
+	/**
 	 * Get API route.
 	 *
 	 * @return string


### PR DESCRIPTION
## Summary

Fixes a fatal error on the WooCommerce Settings Payments tab affecting PHP 8.0+ users.

**The Problem:**
The `Get_PM_Promotions` request class was missing the required `$hook` property that all other request classes define. This caused `apply_filters()` to be called with an empty string hook name, which in certain conditions could result in `get_class()` receiving `null` - throwing a `TypeError` on PHP 8.0+.

**Error seen by users:**
```
TypeError: get_class(): Argument #1 ($object) must be of type object, null given 
in .../includes/core/server/class-request.php:516
```

**The Fix:**
Adds the missing `$hook` property to `Get_PM_Promotions`, following the pattern used by all other request classes.

## Testing instructions

1. Use PHP 8.0+  (you can spin up a new JN site with 8.4, for example)
2. Using the Code Snippets plugin (or by editing your `functions.php`, add the following code:
```php
add_filter( '', function( $value ) {
    return null;
} );
```
4. Onboard a store
5. Navigate to WooCommerce → Settings → Payments tab
6. Verify no fatal error occurs
