### PR TITLE
feat: add amazon pay settings storage

### DIFF
--- a/changelog/feat-amazon-pay-settings-storage
+++ b/changelog/feat-amazon-pay-settings-storage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+feat: add Amazon Pay settings storage

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -223,6 +223,10 @@ export function updateIsWooPayEnabled( isEnabled ) {
 	return updateSettingsValues( { is_woopay_enabled: isEnabled } );
 }
 
+export function updateIsAmazonPayEnabled( isEnabled ) {
+	return updateSettingsValues( { is_amazon_pay_enabled: isEnabled } );
+}
+
 export function updateIsWooPayGlobalThemeSupportEnabled( isEnabled ) {
 	return updateSettingsValues( {
 		is_woopay_global_theme_support_enabled: isEnabled,

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -570,6 +570,26 @@ export const useWooPayStoreLogo = () => {
 export const useWooPayLocations = makeExpressCheckoutLocationHook( 'woopay' );
 
 /**
+ * @return {import('wcpay/types/wcpay-data-settings-hooks').GenericSettingsHook<boolean>}
+ */
+export const useAmazonPayEnabledSettings = () => {
+	const { updateIsAmazonPayEnabled } = useDispatch( STORE_NAME );
+
+	const isAmazonPayEnabled = useSelect( ( select ) =>
+		select( STORE_NAME ).getIsAmazonPayEnabled()
+	);
+
+	return [ isAmazonPayEnabled, updateIsAmazonPayEnabled ];
+};
+
+/**
+ * @return {import('wcpay/types/wcpay-data-settings-hooks').GenericSettingsHook<string[]>}
+ */
+export const useAmazonPayLocations = makeExpressCheckoutLocationHook(
+	'amazon_pay'
+);
+
+/**
  * @return {import('wcpay/types/wcpay-data-settings-hooks').GenericSettingsHook<string>}
  */
 export const useCurrentProtectionLevel = () => {

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -186,6 +186,10 @@ export const getIsWooPayEnabled = ( state ) => {
 	return getSettings( state ).is_woopay_enabled || false;
 };
 
+export const getIsAmazonPayEnabled = ( state ) => {
+	return getSettings( state ).is_amazon_pay_enabled || false;
+};
+
 export const getIsWooPayGlobalThemeSupportEnabled = ( state ) => {
 	return getSettings( state ).is_woopay_global_theme_support_enabled || false;
 };

--- a/client/disable-confirmation-modal/__tests__/disable-confirmation-modal.test.js
+++ b/client/disable-confirmation-modal/__tests__/disable-confirmation-modal.test.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -10,6 +11,7 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import DisableConfirmationModal from '..';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
 
 jest.mock( '../../data', () => ( {
 	useEnabledPaymentMethodIds: jest
@@ -17,12 +19,24 @@ jest.mock( '../../data', () => ( {
 		.mockReturnValue( [ [ 'card', 'giropay', 'link' ] ] ),
 	useWooPayEnabledSettings: jest.fn().mockReturnValue( [ true ] ),
 	usePaymentRequestEnabledSettings: jest.fn().mockReturnValue( [ true ] ),
+	useAmazonPayEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
 } ) );
+
+const renderWithSettingsProvider = ( ui ) =>
+	render(
+		<WCPaySettingsContext.Provider
+			value={ { featureFlags: { amazonPay: false } } }
+		>
+			{ ui }
+		</WCPaySettingsContext.Provider>
+	);
 
 describe( 'DisableConfirmationModal', () => {
 	it( 'calls the onClose handler on cancel', async () => {
 		const handleCloseMock = jest.fn();
-		render( <DisableConfirmationModal onClose={ handleCloseMock } /> );
+		renderWithSettingsProvider(
+			<DisableConfirmationModal onClose={ handleCloseMock } />
+		);
 
 		expect( handleCloseMock ).not.toHaveBeenCalled();
 
@@ -33,7 +47,9 @@ describe( 'DisableConfirmationModal', () => {
 
 	it( 'calls the onConfirm handler on cancel', async () => {
 		const handleConfirmMock = jest.fn();
-		render( <DisableConfirmationModal onConfirm={ handleConfirmMock } /> );
+		renderWithSettingsProvider(
+			<DisableConfirmationModal onConfirm={ handleConfirmMock } />
+		);
 
 		expect( handleConfirmMock ).not.toHaveBeenCalled();
 

--- a/client/disable-confirmation-modal/index.js
+++ b/client/disable-confirmation-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
@@ -11,6 +11,7 @@ import interpolateComponents from '@automattic/interpolate-components';
  */
 import './styles.scss';
 import {
+	useAmazonPayEnabledSettings,
 	useEnabledPaymentMethodIds,
 	usePaymentRequestEnabledSettings,
 	useWooPayEnabledSettings,
@@ -21,14 +22,19 @@ import WooCardIcon from 'assets/images/cards/woo-card.svg?asset';
 import ConfirmationModal from '../components/confirmation-modal';
 import paymentMethodsMap from 'wcpay/payment-methods-map';
 import { WooIconShort } from 'wcpay/payment-methods-icons';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
 
 const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 	const [ enabledMethodIds ] = useEnabledPaymentMethodIds();
 	const [ isWooPayEnabled ] = useWooPayEnabledSettings();
 	const [ isPaymentRequestEnabled ] = usePaymentRequestEnabledSettings();
+	const [ isAmazonPayEnabled ] = useAmazonPayEnabledSettings();
 	const isStripeLinkEnabled = Boolean(
 		enabledMethodIds.find( ( id ) => id === 'link' )
 	);
+	const {
+		featureFlags: { amazonPay: isAmazonPayFeatureFlagEnabled },
+	} = useContext( WCPaySettingsContext );
 
 	return (
 		<ConfirmationModal
@@ -115,6 +121,14 @@ const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 							/>
 						</li>
 					</>
+				) }
+				{ isAmazonPayEnabled && isAmazonPayFeatureFlagEnabled && (
+					<li>
+						<PaymentMethodIcon
+							Icon={ paymentMethodsMap.amazon_pay.icon }
+							label={ paymentMethodsMap.amazon_pay.label }
+						/>
+					</li>
 				) }
 				{ isStripeLinkEnabled && (
 					<li>

--- a/client/settings/express-checkout-settings/__tests__/amazon-pay-settings.test.js
+++ b/client/settings/express-checkout-settings/__tests__/amazon-pay-settings.test.js
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import AmazonPaySettings from '../amazon-pay-settings';
+import { useAmazonPayEnabledSettings, useAmazonPayLocations } from 'wcpay/data';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
+
+jest.mock( 'wcpay/data', () => ( {
+	useAmazonPayEnabledSettings: jest.fn(),
+	useAmazonPayLocations: jest.fn(),
+	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'medium' ] ),
+	useWooPayEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
+	usePaymentRequestEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
+} ) );
+
+const renderWithSettingsProvider = ( ui ) =>
+	render(
+		<WCPaySettingsContext.Provider
+			value={ { featureFlags: { woopay: false, amazonPay: false } } }
+		>
+			{ ui }
+		</WCPaySettingsContext.Provider>
+	);
+
+describe( 'AmazonPaySettings', () => {
+	beforeEach( () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+		useAmazonPayLocations.mockReturnValue( [
+			[ 'product', 'cart', 'checkout' ],
+			jest.fn(),
+		] );
+	} );
+
+	it( 'triggers the update handler when the enable checkbox is clicked', async () => {
+		const updateIsAmazonPayEnabledHandler = jest.fn();
+		useAmazonPayEnabledSettings.mockReturnValue( [
+			true,
+			updateIsAmazonPayEnabledHandler,
+		] );
+
+		renderWithSettingsProvider( <AmazonPaySettings section="enable" /> );
+
+		expect( updateIsAmazonPayEnabledHandler ).not.toHaveBeenCalled();
+
+		expect(
+			screen.getByLabelText(
+				'Enable Amazon Pay as an express payment button'
+			)
+		).toBeChecked();
+
+		userEvent.click(
+			screen.getByLabelText(
+				'Enable Amazon Pay as an express payment button'
+			)
+		);
+
+		expect( updateIsAmazonPayEnabledHandler ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'renders location checkboxes as checked when locations are enabled', () => {
+		useAmazonPayLocations.mockReturnValue( [
+			[ 'product', 'cart', 'checkout' ],
+			jest.fn(),
+		] );
+
+		renderWithSettingsProvider( <AmazonPaySettings section="enable" /> );
+
+		expect(
+			screen.getByLabelText( 'Show on checkout page' )
+		).toBeChecked();
+		expect( screen.getByLabelText( 'Show on product page' ) ).toBeChecked();
+		expect( screen.getByLabelText( 'Show on cart page' ) ).toBeChecked();
+	} );
+
+	it( 'renders location checkboxes as unchecked when locations are disabled', () => {
+		useAmazonPayLocations.mockReturnValue( [ [], jest.fn() ] );
+
+		renderWithSettingsProvider( <AmazonPaySettings section="enable" /> );
+
+		expect(
+			screen.getByLabelText( 'Show on checkout page' )
+		).not.toBeChecked();
+		expect(
+			screen.getByLabelText( 'Show on product page' )
+		).not.toBeChecked();
+		expect(
+			screen.getByLabelText( 'Show on cart page' )
+		).not.toBeChecked();
+	} );
+
+	it( 'disables location checkboxes when Amazon Pay is disabled', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ false, jest.fn() ] );
+
+		renderWithSettingsProvider( <AmazonPaySettings section="enable" /> );
+
+		expect(
+			screen.getByLabelText(
+				'Enable Amazon Pay as an express payment button'
+			)
+		).not.toBeChecked();
+		expect(
+			screen.getByLabelText( 'Show on checkout page' )
+		).toBeDisabled();
+		expect(
+			screen.getByLabelText( 'Show on product page' )
+		).toBeDisabled();
+		expect( screen.getByLabelText( 'Show on cart page' ) ).toBeDisabled();
+	} );
+
+	it( 'triggers the location update handler when location checkboxes are clicked', async () => {
+		const updateAmazonPayLocationsHandler = jest.fn();
+		useAmazonPayLocations.mockReturnValue( [
+			[ 'product' ],
+			updateAmazonPayLocationsHandler,
+		] );
+
+		renderWithSettingsProvider( <AmazonPaySettings section="enable" /> );
+
+		expect( updateAmazonPayLocationsHandler ).not.toHaveBeenCalled();
+
+		userEvent.click( screen.getByLabelText( 'Show on checkout page' ) );
+		expect( updateAmazonPayLocationsHandler ).toHaveBeenLastCalledWith(
+			'checkout',
+			true
+		);
+
+		userEvent.click( screen.getByLabelText( 'Show on product page' ) );
+		expect( updateAmazonPayLocationsHandler ).toHaveBeenLastCalledWith(
+			'product',
+			false
+		);
+
+		userEvent.click( screen.getByLabelText( 'Show on cart page' ) );
+		expect( updateAmazonPayLocationsHandler ).toHaveBeenLastCalledWith(
+			'cart',
+			true
+		);
+	} );
+
+	it( 'renders general settings section with button size options', () => {
+		renderWithSettingsProvider( <AmazonPaySettings section="general" /> );
+
+		expect( screen.queryByText( 'Button size' ) ).toBeInTheDocument();
+
+		const radioButtons = screen.queryAllByRole( 'radio' );
+		expect( radioButtons ).toHaveLength( 3 );
+	} );
+} );

--- a/client/settings/express-checkout-settings/__tests__/express-checkout-settings-notices.test.js
+++ b/client/settings/express-checkout-settings/__tests__/express-checkout-settings-notices.test.js
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ExpressCheckoutSettingsNotices from '../express-checkout-settings-notices';
+import {
+	useWooPayEnabledSettings,
+	usePaymentRequestEnabledSettings,
+	useAmazonPayEnabledSettings,
+} from 'wcpay/data';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
+
+jest.mock( 'wcpay/data', () => ( {
+	useWooPayEnabledSettings: jest.fn(),
+	usePaymentRequestEnabledSettings: jest.fn(),
+	useAmazonPayEnabledSettings: jest.fn(),
+} ) );
+
+const renderWithSettingsProvider = (
+	ui,
+	featureFlags = { woopay: true, amazonPay: true }
+) =>
+	render(
+		<WCPaySettingsContext.Provider value={ { featureFlags } }>
+			{ ui }
+		</WCPaySettingsContext.Provider>
+	);
+
+describe( 'ExpressCheckoutSettingsNotices', () => {
+	beforeEach( () => {
+		useWooPayEnabledSettings.mockReturnValue( [ false ] );
+		usePaymentRequestEnabledSettings.mockReturnValue( [ false ] );
+		useAmazonPayEnabledSettings.mockReturnValue( [ false ] );
+	} );
+
+	it( 'renders nothing when no other methods are enabled', () => {
+		const { container } = renderWithSettingsProvider(
+			<ExpressCheckoutSettingsNotices currentMethod="woopay" />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders notices when one other method is enabled (singular button)', () => {
+		usePaymentRequestEnabledSettings.mockReturnValue( [ true ] );
+
+		renderWithSettingsProvider(
+			<ExpressCheckoutSettingsNotices currentMethod="woopay" />
+		);
+
+		expect(
+			screen.getByText(
+				'These settings will also apply to the Apple Pay / Google Pay button on your store.'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Some appearance settings may be overridden in the express payment section of the Cart & Checkout blocks.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders notices when two other methods are enabled (plural buttons with "and")', () => {
+		useWooPayEnabledSettings.mockReturnValue( [ true ] );
+		usePaymentRequestEnabledSettings.mockReturnValue( [ true ] );
+
+		renderWithSettingsProvider(
+			<ExpressCheckoutSettingsNotices currentMethod="amazon_pay" />
+		);
+
+		expect(
+			screen.getByText(
+				'These settings will also apply to the WooPay and Apple Pay / Google Pay buttons on your store.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders notices when all other methods are enabled', () => {
+		useWooPayEnabledSettings.mockReturnValue( [ true ] );
+		usePaymentRequestEnabledSettings.mockReturnValue( [ true ] );
+		useAmazonPayEnabledSettings.mockReturnValue( [ true ] );
+
+		renderWithSettingsProvider(
+			<ExpressCheckoutSettingsNotices currentMethod="woopay" />
+		);
+
+		expect(
+			screen.getByText(
+				'These settings will also apply to the Apple Pay / Google Pay and Amazon Pay buttons on your store.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'respects WooPay feature flag when disabled', () => {
+		useWooPayEnabledSettings.mockReturnValue( [ true ] );
+		usePaymentRequestEnabledSettings.mockReturnValue( [ true ] );
+
+		renderWithSettingsProvider(
+			<ExpressCheckoutSettingsNotices currentMethod="amazon_pay" />,
+			{ woopay: false, amazonPay: true }
+		);
+
+		expect(
+			screen.getByText(
+				'These settings will also apply to the Apple Pay / Google Pay button on your store.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'respects Amazon Pay feature flag when disabled', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true ] );
+		usePaymentRequestEnabledSettings.mockReturnValue( [ true ] );
+
+		renderWithSettingsProvider(
+			<ExpressCheckoutSettingsNotices currentMethod="woopay" />,
+			{ woopay: true, amazonPay: false }
+		);
+
+		expect(
+			screen.getByText(
+				'These settings will also apply to the Apple Pay / Google Pay button on your store.'
+			)
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/settings/express-checkout-settings/__tests__/index.test.js
+++ b/client/settings/express-checkout-settings/__tests__/index.test.js
@@ -39,6 +39,10 @@ jest.mock( '../../../data', () => ( {
 		.fn()
 		.mockReturnValue( [ [ true, true, true ], jest.fn() ] ),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
+	useAmazonPayEnabledSettings: jest
+		.fn()
+		.mockReturnValue( [ false, jest.fn() ] ),
+	useAmazonPayLocations: jest.fn().mockReturnValue( [ [], jest.fn() ] ),
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {

--- a/client/settings/express-checkout-settings/__tests__/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/__tests__/payment-request-settings.test.js
@@ -33,6 +33,9 @@ jest.mock( '../../../data', () => ( {
 	useWooPayEnabledSettings: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
 	useAppleGooglePayInPaymentMethodsOptionsEnabledSettings: jest.fn(),
+	useAmazonPayEnabledSettings: jest
+		.fn()
+		.mockReturnValue( [ false, jest.fn() ] ),
 } ) );
 
 jest.mock( '../payment-request-button-preview' );

--- a/client/settings/express-checkout-settings/amazon-pay-settings.js
+++ b/client/settings/express-checkout-settings/amazon-pay-settings.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,8 +14,13 @@ import {
 	BaseControl,
 	RadioControl,
 } from '@wordpress/components';
-import { usePaymentRequestButtonSize } from 'wcpay/data';
+import {
+	usePaymentRequestButtonSize,
+	useAmazonPayEnabledSettings,
+	useAmazonPayLocations,
+} from 'wcpay/data';
 import interpolateComponents from '@automattic/interpolate-components';
+import ExpressCheckoutSettingsNotices from './express-checkout-settings-notices';
 
 const makeButtonSizeText = ( string ) =>
 	interpolateComponents( {
@@ -62,6 +67,7 @@ const GeneralSettings = () => {
 
 	return (
 		<CardBody className="wcpay-card-body">
+			<ExpressCheckoutSettingsNotices currentMethod="amazon_pay" />
 			<RadioControl
 				label={ __( 'Button size', 'woocommerce-payments' ) }
 				selected={ size }
@@ -73,21 +79,17 @@ const GeneralSettings = () => {
 };
 
 const AmazonPaySettings = ( { section } ) => {
-	const [ isAmazonPayEnabled, setIsAmazonPayEnabled ] = useState( false );
-	const [ amazonPayLocations, setAmazonPayLocations ] = useState( [
-		'product',
-		'cart',
-		'checkout',
-	] );
+	const [
+		isAmazonPayEnabled,
+		updateIsAmazonPayEnabled,
+	] = useAmazonPayEnabledSettings();
+	const [
+		amazonPayLocations,
+		updateAmazonPayLocations,
+	] = useAmazonPayLocations();
 
 	const makeLocationChangeHandler = ( location ) => ( isChecked ) => {
-		if ( isChecked ) {
-			setAmazonPayLocations( [ ...amazonPayLocations, location ] );
-		} else {
-			setAmazonPayLocations(
-				amazonPayLocations.filter( ( name ) => name !== location )
-			);
-		}
+		updateAmazonPayLocations( location, isChecked );
 	};
 
 	return (
@@ -98,7 +100,7 @@ const AmazonPaySettings = ( { section } ) => {
 						<CheckboxControl
 							className="wcpay-payment-request-settings__enable__checkbox"
 							checked={ isAmazonPayEnabled }
-							onChange={ setIsAmazonPayEnabled }
+							onChange={ updateIsAmazonPayEnabled }
 							label={ __(
 								'Enable Amazon Pay as an express payment button',
 								'woocommerce-payments'

--- a/client/settings/express-checkout-settings/express-checkout-settings-notices.tsx
+++ b/client/settings/express-checkout-settings/express-checkout-settings-notices.tsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -58,10 +57,6 @@ const formatButtonList = ( buttonNames: string[] ) => {
 	);
 };
 
-/**
- * Notices displayed when settings are shared with other express checkout methods.
- * This component fetches enablement status internally using hooks.
- */
 const ExpressCheckoutSettingsNotices: React.FC< ExpressCheckoutSettingsNoticesProps > = ( {
 	currentMethod,
 } ) => {

--- a/client/settings/express-checkout-settings/express-checkout-settings-notices.tsx
+++ b/client/settings/express-checkout-settings/express-checkout-settings-notices.tsx
@@ -1,0 +1,132 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { useContext } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InlineNotice from 'wcpay/components/inline-notice';
+import WCPaySettingsContext from '../wcpay-settings-context';
+import {
+	useWooPayEnabledSettings,
+	usePaymentRequestEnabledSettings,
+	useAmazonPayEnabledSettings,
+} from 'wcpay/data';
+
+type ExpressCheckoutMethod = 'woopay' | 'google/apple' | 'amazon_pay';
+
+interface ExpressCheckoutSettingsNoticesProps {
+	currentMethod: ExpressCheckoutMethod;
+}
+
+/**
+ * Builds a human-readable list of button names.
+ * E.g., ["WooPay"] => "WooPay button"
+ * E.g., ["WooPay", "Apple Pay / Google Pay"] => "WooPay and Apple Pay / Google Pay buttons"
+ * E.g., ["WooPay", "Apple Pay / Google Pay", "Amazon Pay"] => "WooPay, Apple Pay / Google Pay, and Amazon Pay buttons"
+ */
+const formatButtonList = ( buttonNames: string[] ) => {
+	if ( buttonNames.length === 1 ) {
+		return sprintf(
+			/* translators: %s: name of a button type (e.g., "WooPay") */
+			__( '%s button', 'woocommerce-payments' ),
+			buttonNames[ 0 ]
+		);
+	}
+
+	if ( buttonNames.length === 2 ) {
+		return sprintf(
+			/* translators: %1$s and %2$s: names of button types */
+			__( '%1$s and %2$s buttons', 'woocommerce-payments' ),
+			buttonNames[ 0 ],
+			buttonNames[ 1 ]
+		);
+	}
+
+	// For 3+ items, use Oxford comma style
+	const lastItem = buttonNames[ buttonNames.length - 1 ];
+	const otherItems = buttonNames.slice( 0, -1 ).join( ', ' );
+
+	return sprintf(
+		/* translators: %1$s: comma-separated list of button types, %2$s: last button type in the list */
+		__( '%1$s, and %2$s buttons', 'woocommerce-payments' ),
+		otherItems,
+		lastItem
+	);
+};
+
+/**
+ * Notices displayed when settings are shared with other express checkout methods.
+ * This component fetches enablement status internally using hooks.
+ */
+const ExpressCheckoutSettingsNotices: React.FC< ExpressCheckoutSettingsNoticesProps > = ( {
+	currentMethod,
+} ) => {
+	const [ isWooPayEnabled ] = useWooPayEnabledSettings();
+	const [ isPaymentRequestEnabled ] = usePaymentRequestEnabledSettings();
+	const [ isAmazonPayEnabled ] = useAmazonPayEnabledSettings();
+	const {
+		featureFlags: {
+			woopay: isWooPayFeatureFlagEnabled,
+			amazonPay: isAmazonPayFeatureFlagEnabled,
+		},
+	} = useContext( WCPaySettingsContext );
+
+	// need to ensure that if the feature flag is disabled, we ignore the button's state.
+	const isWooPayEffectivelyEnabled =
+		isWooPayEnabled && isWooPayFeatureFlagEnabled;
+	const isAmazonPayEffectivelyEnabled =
+		isAmazonPayEnabled && isAmazonPayFeatureFlagEnabled;
+
+	const otherButtons = [
+		currentMethod !== 'woopay' &&
+			isWooPayEffectivelyEnabled &&
+			__( 'WooPay', 'woocommerce-payments' ),
+		currentMethod !== 'google/apple' &&
+			isPaymentRequestEnabled &&
+			__( 'Apple Pay / Google Pay', 'woocommerce-payments' ),
+		currentMethod !== 'amazon_pay' &&
+			isAmazonPayEffectivelyEnabled &&
+			__( 'Amazon Pay', 'woocommerce-payments' ),
+	].filter( Boolean );
+
+	if ( otherButtons.length === 0 ) {
+		return null;
+	}
+
+	const formattedList = formatButtonList( otherButtons as string[] );
+
+	return (
+		<>
+			<InlineNotice
+				status="warning"
+				icon={ true }
+				isDismissible={ false }
+			>
+				{ sprintf(
+					/* translators: %s: formatted list of button types that share these settings */
+					__(
+						'These settings will also apply to the %s on your store.',
+						'woocommerce-payments'
+					),
+					formattedList
+				) }
+			</InlineNotice>
+			<InlineNotice
+				status="warning"
+				icon={ true }
+				isDismissible={ false }
+			>
+				{ __(
+					'Some appearance settings may be overridden in the express payment section of the Cart & Checkout blocks.',
+					'woocommerce-payments'
+				) }
+			</InlineNotice>
+		</>
+	);
+};
+
+export default ExpressCheckoutSettingsNotices;

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -3,10 +3,9 @@
  * External dependencies
  */
 import React, { useMemo } from 'react';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,15 +22,12 @@ import CardBody from '../card-body';
 import PaymentRequestButtonPreview from './payment-request-button-preview';
 import interpolateComponents from '@automattic/interpolate-components';
 import { getExpressCheckoutConfig } from 'utils/express-checkout';
-import WCPaySettingsContext from '../wcpay-settings-context';
-import InlineNotice from 'wcpay/components/inline-notice';
+import ExpressCheckoutSettingsNotices from './express-checkout-settings-notices';
 import {
 	usePaymentRequestButtonType,
 	usePaymentRequestButtonSize,
 	usePaymentRequestButtonTheme,
 	usePaymentRequestButtonBorderRadius,
-	usePaymentRequestEnabledSettings,
-	useWooPayEnabledSettings,
 } from 'wcpay/data';
 
 const makeButtonSizeText = ( string ) =>
@@ -125,11 +121,6 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 	const [ size, setSize ] = usePaymentRequestButtonSize();
 	const [ theme, setTheme ] = usePaymentRequestButtonTheme();
 	const [ radius, setRadius ] = usePaymentRequestButtonBorderRadius();
-	const [ isWooPayEnabled ] = useWooPayEnabledSettings();
-	const [ isPaymentRequestEnabled ] = usePaymentRequestEnabledSettings();
-	const {
-		featureFlags: { woopay: isWooPayFeatureFlagEnabled },
-	} = useContext( WCPaySettingsContext );
 
 	const stripePromise = useMemo( () => {
 		const stripeSettings = getExpressCheckoutConfig( 'stripe' );
@@ -139,45 +130,9 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 		} );
 	}, [] );
 
-	const otherButtons =
-		type === 'woopay'
-			? __( 'Apple Pay / Google Pay buttons', 'woocommerce-payments' )
-			: __( 'WooPay button', 'woocommerce-payments' );
-
-	const showWarning =
-		isWooPayEnabled &&
-		isPaymentRequestEnabled &&
-		isWooPayFeatureFlagEnabled;
-
 	return (
 		<CardBody className="wcpay-card-body">
-			{ showWarning && (
-				<>
-					<InlineNotice
-						status="warning"
-						icon={ true }
-						isDismissible={ false }
-					>
-						{ sprintf(
-							/* translators: %s type of button to which the settings will be applied */
-							__(
-								'These settings will also apply to the %s on your store.',
-								'woocommerce-payments'
-							),
-							otherButtons
-						) }
-					</InlineNotice>
-					<InlineNotice
-						status="warning"
-						icon={ true }
-						isDismissible={ false }
-					>
-						{ __(
-							'Some appearance settings may be overridden in the express payment section of the Cart & Checkout blocks.'
-						) }
-					</InlineNotice>
-				</>
-			) }
+			<ExpressCheckoutSettingsNotices currentMethod={ type } />
 			<SelectControl
 				className="payment-method-settings__cta-selection"
 				label={ __( 'Call to action', 'woocommerce-payments' ) }

--- a/client/settings/express-checkout/__tests__/index.test.js
+++ b/client/settings/express-checkout/__tests__/index.test.js
@@ -17,6 +17,7 @@ import {
 	useWooPayEnabledSettings,
 	useWooPayShowIncompatibilityNotice,
 	useGetDuplicatedPaymentMethodIds,
+	useAmazonPayEnabledSettings,
 } from 'wcpay/data';
 import WCPaySettingsContext from '../../wcpay-settings-context';
 
@@ -28,6 +29,7 @@ jest.mock( 'wcpay/data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
 	useWooPayShowIncompatibilityNotice: jest.fn(),
 	useGetDuplicatedPaymentMethodIds: jest.fn(),
+	useAmazonPayEnabledSettings: jest.fn(),
 } ) );
 
 const getMockPaymentRequestEnabledSettings = (
@@ -48,6 +50,7 @@ describe( 'ExpressCheckout', () => {
 		useWooPayEnabledSettings.mockReturnValue(
 			getMockWooPayEnabledSettings( false, jest.fn() )
 		);
+		useAmazonPayEnabledSettings.mockReturnValue( [ false, jest.fn() ] );
 
 		useWooPayShowIncompatibilityNotice.mockReturnValue( false );
 

--- a/client/settings/express-checkout/amazon-pay-item.tsx
+++ b/client/settings/express-checkout/amazon-pay-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { getPaymentMethodSettingsUrl } from '../../utils';
 
@@ -11,9 +11,13 @@ import { getPaymentMethodSettingsUrl } from '../../utils';
 import { Button, CheckboxControl } from '@wordpress/components';
 import interpolateComponents from '@automattic/interpolate-components';
 import methodsConfiguration from '../../payment-methods-map';
+import { useAmazonPayEnabledSettings } from 'wcpay/data';
 
 const AmazonPayExpressCheckoutItem = (): React.ReactElement => {
-	const [ isAmazonPayEnabled, setIsAmazonPayEnabled ] = useState( false );
+	const [
+		isAmazonPayEnabled,
+		updateIsAmazonPayEnabled,
+	] = useAmazonPayEnabledSettings();
 
 	const {
 		icon: AmazonPayIcon,
@@ -28,7 +32,7 @@ const AmazonPayExpressCheckoutItem = (): React.ReactElement => {
 					<CheckboxControl
 						label={ label }
 						checked={ isAmazonPayEnabled }
-						onChange={ setIsAmazonPayEnabled }
+						onChange={ updateIsAmazonPayEnabled }
 						data-testid="amazon-pay-toggle"
 						__nextHasNoMarginBottom
 					/>

--- a/client/settings/general-settings/__tests__/general-settings.test.js
+++ b/client/settings/general-settings/__tests__/general-settings.test.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { fireEvent, render, screen, act } from '@testing-library/react';
 
 /**
@@ -13,6 +14,7 @@ import {
 	useTestMode,
 	useTestModeOnboarding,
 } from 'wcpay/data';
+import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
 
 jest.mock( 'wcpay/data', () => ( {
 	useDevMode: jest.fn(),
@@ -22,7 +24,17 @@ jest.mock( 'wcpay/data', () => ( {
 	useEnabledPaymentMethodIds: jest.fn().mockReturnValue( [ [ 'card' ] ] ),
 	useWooPayEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
 	usePaymentRequestEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
+	useAmazonPayEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
 } ) );
+
+const renderWithSettingsProvider = ( ui ) =>
+	render(
+		<WCPaySettingsContext.Provider
+			value={ { featureFlags: { amazonPay: false } } }
+		>
+			{ ui }
+		</WCPaySettingsContext.Provider>
+	);
 
 describe( 'GeneralSettings', () => {
 	beforeEach( () => {
@@ -33,7 +45,7 @@ describe( 'GeneralSettings', () => {
 	} );
 
 	it( 'renders', () => {
-		render( <GeneralSettings /> );
+		renderWithSettingsProvider( <GeneralSettings /> );
 
 		expect(
 			screen.queryByText( 'Enable WooPayments' )
@@ -46,7 +58,7 @@ describe( 'GeneralSettings', () => {
 		( isEnabled ) => {
 			useIsWCPayEnabled.mockReturnValue( [ isEnabled ] );
 
-			render( <GeneralSettings /> );
+			renderWithSettingsProvider( <GeneralSettings /> );
 
 			const enableWCPayCheckbox = screen.getByLabelText(
 				'Enable WooPayments'
@@ -67,7 +79,7 @@ describe( 'GeneralSettings', () => {
 			updateIsWCPayEnabledMock,
 		] );
 
-		render( <GeneralSettings /> );
+		renderWithSettingsProvider( <GeneralSettings /> );
 
 		fireEvent.click( screen.getByLabelText( 'Enable WooPayments' ) );
 
@@ -83,7 +95,7 @@ describe( 'GeneralSettings', () => {
 		const updateIsWCPayEnabledMock = jest.fn();
 		useIsWCPayEnabled.mockReturnValue( [ true, updateIsWCPayEnabledMock ] );
 
-		render( <GeneralSettings /> );
+		renderWithSettingsProvider( <GeneralSettings /> );
 
 		fireEvent.click( screen.getByLabelText( 'Enable WooPayments' ) );
 
@@ -108,7 +120,7 @@ describe( 'GeneralSettings', () => {
 		'display of CheckBox when initial Test Mode = %s',
 		( isEnabled ) => {
 			useTestMode.mockReturnValue( [ isEnabled, jest.fn() ] );
-			render( <GeneralSettings /> );
+			renderWithSettingsProvider( <GeneralSettings /> );
 			const enableTestModeCheckbox = screen.getByLabelText(
 				'Enable test mode'
 			);
@@ -125,7 +137,7 @@ describe( 'GeneralSettings', () => {
 		'Checks Confirmation Modal display when initial Test Mode = %s',
 		( isEnabled ) => {
 			useTestMode.mockReturnValue( [ isEnabled, jest.fn() ] );
-			render( <GeneralSettings /> );
+			renderWithSettingsProvider( <GeneralSettings /> );
 			const enableTestModeCheckbox = screen.getByLabelText(
 				'Enable test mode'
 			);
@@ -144,7 +156,7 @@ describe( 'GeneralSettings', () => {
 	);
 
 	it( 'show the modal when the appropriate event is dispatched', () => {
-		render( <GeneralSettings /> );
+		renderWithSettingsProvider( <GeneralSettings /> );
 
 		act( () => {
 			document.dispatchEvent(

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -1197,4 +1197,77 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		$this->assertFalse( $data['is_payment_request_enabled'] );
 	}
+
+	public function test_update_settings_enables_amazon_pay() {
+		$amazon_pay_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$amazon_pay_gateway->expects( $this->once() )->method( 'enable' );
+
+		$this->set_payment_gateway_map( [ 'amazon_pay' => $amazon_pay_gateway ] );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_amazon_pay_enabled', true );
+
+		$this->controller->update_settings( $request );
+	}
+
+	public function test_update_settings_disables_amazon_pay() {
+		$amazon_pay_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$amazon_pay_gateway->expects( $this->once() )->method( 'disable' );
+
+		$this->set_payment_gateway_map( [ 'amazon_pay' => $amazon_pay_gateway ] );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_amazon_pay_enabled', false );
+
+		$this->controller->update_settings( $request );
+	}
+
+	public function test_update_settings_does_not_toggle_amazon_pay_if_not_supplied() {
+		$amazon_pay_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$amazon_pay_gateway->expects( $this->never() )->method( 'enable' );
+		$amazon_pay_gateway->expects( $this->never() )->method( 'disable' );
+
+		$this->set_payment_gateway_map( [ 'amazon_pay' => $amazon_pay_gateway ] );
+
+		$request = new WP_REST_Request();
+
+		$this->controller->update_settings( $request );
+	}
+
+	public function test_get_settings_returns_is_amazon_pay_enabled_true(): void {
+		$amazon_pay_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$amazon_pay_gateway->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( true );
+
+		$this->set_payment_gateway_map( [ 'amazon_pay' => $amazon_pay_gateway ] );
+
+		$response = $this->controller->get_settings();
+
+		$this->assertArrayHasKey( 'is_amazon_pay_enabled', $response->get_data() );
+		$this->assertTrue( $response->get_data()['is_amazon_pay_enabled'] );
+	}
+
+	public function test_get_settings_returns_is_amazon_pay_enabled_false(): void {
+		$amazon_pay_gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$amazon_pay_gateway->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( false );
+
+		$this->set_payment_gateway_map( [ 'amazon_pay' => $amazon_pay_gateway ] );
+
+		$response = $this->controller->get_settings();
+
+		$this->assertArrayHasKey( 'is_amazon_pay_enabled', $response->get_data() );
+		$this->assertFalse( $response->get_data()['is_amazon_pay_enabled'] );
+	}
+
+	public function test_get_settings_returns_is_amazon_pay_enabled_false_when_gateway_unavailable(): void {
+		$this->set_payment_gateway_map( [] );
+
+		$response = $this->controller->get_settings();
+
+		$this->assertArrayHasKey( 'is_amazon_pay_enabled', $response->get_data() );
+		$this->assertFalse( $response->get_data()['is_amazon_pay_enabled'] );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5609

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding settings storage (enablement status and location preferences) for Amazon Pay.
While testing, I noticed there was a notice in Google Pay/Apple Pay and Amazon Pay alerting the merchant that changing the setting would have affected other payment methods.
I extracted that notice and adopted it for Amazon Pay.

The settings are only persisted in the DB. Amazon Pay is not yet implemented in customer-facing pages, so you can't test it or preview it, yet.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With the Amazon Pay feature flag disabled ( `wp option update _wcpay_feature_amazon_pay 0` )
  - Navigate to Payments > Settings
  - Ensure you have Google Pay/Apple Pay and WooPay enabled
  - Click "Customize" on Google Pay/Apple Pay
  - There should be a notice that says "These settings will also apply to the WooPay button on your store"
<img width="1218" height="191" alt="Screenshot 2025-12-23 at 11 35 50 PM" src="https://github.com/user-attachments/assets/14315f11-6b43-42fe-b6f1-265fbf689613" />

- With the Amazon Pay feature flag enabled ( `wp option update _wcpay_feature_amazon_pay 1` )
  - Navigate to Payments > Settings
  - Ensure you have Google Pay/Apple Pay, WooPay and Amazon Pay enabled
  - Click "Customize" on Amazon Pay
  - There should be a notice that says "These settings will also apply to the WooPay and Apple Pay / Google Pay buttons on your store."
  - Enable/Disable the Amazon Pay payment method
  - Change its location preferences
  - The preferences should be persisted after you refresh the page
  - The locations preferences should be independent than Google Pay/Apple Pay and WooPay (i.e.: if Amazon Pay is enabled in Cart/Checkout, Google Pay can be enabled on only checkout, for example)
<img width="1238" height="170" alt="Screenshot 2025-12-23 at 11 37 33 PM" src="https://github.com/user-attachments/assets/5b451873-8ecb-4ad1-bd51-d43b84adebc3" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
