### PR TITLE
Fix WooPay Direct Checkout script loading on non-cart pages

### DIFF
--- a/changelog/woopay-408-woopay-direct-checkout-causes-javascript-errors-on-wc-104
+++ b/changelog/woopay-408-woopay-direct-checkout-causes-javascript-errors-on-wc-104
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve JavaScript errors in WooPay Direct Checkout on sites with WooCommerce 10.4+

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -96,7 +96,7 @@ class WC_Payments_WooPay_Direct_Checkout {
 		// Enqueue the WCPay common config script only if it hasn't been enqueued yet.
 		// This may happen when Direct Checkout is being enqueued on pages that are not the cart page,
 		// such as the home and shop pages.
-		if ( function_exists( 'did_filter' ) && did_filter( 'wcpay_payment_fields_js_config' ) === 0 ) {
+		if ( ! $this->is_cart_page() && ! $this->is_checkout_page() && WC_Payments_Features::is_woopay_direct_checkout_enabled() ) {
 			WC_Payments::enqueue_woopay_common_config_script();
 		}
 


### PR DESCRIPTION
Fixes WOOPAY-408

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Fix WooPay Direct Checkout JavaScript errors on non-cart/checkout pages caused by WooCommerce 10.4's iAPI Mini Cart feature
- Replace unreliable `did_filter()` check with page and feature validation
- Prevent `/null/connect/` error page traffic spikes

#### Problem
WooCommerce 10.4 enables the iAPI Mini Cart by default, which [removes WooCommerce Blocks scripts from non-cart/checkout pages](https://github.com/woocommerce/woocommerce/blob/203c546b7841e54b1298e21361ef192308f3546a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php#L190). 

The WooPay Direct Checkout implementation relied on checking `did_filter('wcpay_payment_fields_js_config')` to determine when to enqueue common config scripts. However, this filter being executed didn't guarantee that Blocks scripts (specifically `blocks-checkout.js` with the `wc` global variable) were loaded on the page.

When WooPay Direct Checkout loaded on pages without the `wc` variable, [JavaScript errors occurred](https://github.com/Automattic/woocommerce-payments/blob/e1ffb6543e215431a569160ee5d30b4beacdf738/client/checkout/woopay/connect/woopay-connect.js#L37) when attempting to access `wc.wcSettings.getSetting('woocommerce_payments_data')`, causing `/null/connect/` error page requests and traffic spikes.

This issue affected sites running:
- WooCommerce 10.4+
- WooPayments with WooPay enabled
- Without WooCommerce Subscriptions installed (or any other plugin that loads Blocks scripts on every page)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure WC version is 10.4+.
* Enable WooPay.
* Disable WooCommerce Subscriptions or any other plugin that load Blocks scripts on every page.
* Access the website homepage.
* There should not have `/null/connect/` errors on the DevTools console.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
