### PR TITLE
Fix Tampermonkey script to display more options for creating Jurrasis sites right in Github PRs

### DIFF
--- a/bin/wcpay-live-branches/wcpay-live-branches.user.js
+++ b/bin/wcpay-live-branches/wcpay-live-branches.user.js
@@ -1,10 +1,10 @@
 // ==UserScript==
-// @name         WCPay Live Branches
+// @name         WooPayments Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.2
+// @version      1.3
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
-// @connect      jurassic.ninja
+// @connect      betadownload.jetpack.me
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/woocommerce-payments/pull/*
 // ==/UserScript==
@@ -99,18 +99,18 @@
 			);
 		} else {
 			if ( ! pluginsList ) {
-				pluginsList = dofetch( `${ host }/wp-json/jurassic.ninja/jetpack-beta/plugins` );
+				pluginsList = dofetch(`https://betadownload.jetpack.me/query-branch.php?repo=${ encodeURIComponent( repo ) }&branch=${ encodeURIComponent( currentBranch ) }` );
 			}
 			pluginsList
 				.then( body => {
 					const plugins = [];
 
-					if ( body.status === 'ok' ) {
+					if ( body.hasOwnProperty( 'plugins' ) ) {
 						const labels = new Set(
 							$.map( $( '.js-issue-labels a.IssueLabel' ), e => $( e ).data( 'name' ) )
 						);
-						Object.keys( body.data ).forEach( k => {
-							const data = body.data[ k ];
+						Object.keys( body.plugins ).forEach( k => {
+							const data = body.plugins[ k ];
 							if ( data.repo === repo ) {
 								plugins.push( {
 									name: `branches.${ k }`,
@@ -125,14 +125,6 @@
 							throw new Error( `No plugins are configured for ${ repo }` );
 						}
 						plugins.sort( ( a, b ) => a.label.localeCompare( b.label ) );
-					} else if ( body.code === 'rest_no_route' ) {
-						plugins.push( {
-							name: 'branch',
-							value: currentBranch,
-							label: 'Jetpack',
-							checked: true,
-							disabled: true,
-						} );
 					} else {
 						throw new Error( 'Invalid response from server' );
 					}

--- a/bin/wcpay-live-branches/wcpay-live-branches.user.js
+++ b/bin/wcpay-live-branches/wcpay-live-branches.user.js
@@ -393,7 +393,7 @@
 			`);
 			const liveBranches = $( '<div id="wcpay-live-branches" />' ).append(
 				styles,
-				`<h2>🚀 WCPay Live Branches 🚀</h2>${ contents }`
+				`<h2>🚀 WooPayments Live Branches 🚀</h2>${ contents }`
 			);
 			$( '#wcpay-live-branches' ).remove();
 			$el.append( liveBranches );

--- a/changelog/fix-wcpay-live-branches-script
+++ b/changelog/fix-wcpay-live-branches-script
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix Tampermonkey script to display more options for creating Jurrasic sites right in Github PRs
+
+


### PR DESCRIPTION
Fixes [WOOPMNT-5614](https://linear.app/a8c/issue/WOOPMNT-5614/display-more-options-for-creating-jurrasis-sites-in-github-prs)

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Literally, apply this diff from Jetpack repo https://github.com/Automattic/jetpack/commit/41494e01a9eda9b2dfdd146a0159e2bbd33b815b 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Before this PR, for existing open PRs (not draft, not merged PRs), there is no section like this. But with this PR and following up https://github.com/Automattic/woocommerce-payments/tree/develop/bin/wcpay-live-branches, it should display the correct info. 

<img width="1894" height="814" alt="CleanShot 2025-12-30 at 10 28 24@2x" src="https://github.com/user-attachments/assets/477e9a36-87bd-4b11-9695-2623a7ef45d8" />
