### PR TITLE
Remove BGN (Bulgarian Lev) from available currencies

### DIFF
--- a/changelog/woopmnt-5619-remove-bgn-currency-from-wcpay-and-woocommerce
+++ b/changelog/woopmnt-5619-remove-bgn-currency-from-wcpay-and-woocommerce
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove BGN as available currency.

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -52,6 +52,10 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 				// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
 				// Only remove if not currently enabled in multi-currency.
 				$enabled_currencies = get_option( 'wcpay_multi_currency_enabled_currencies', [] );
+				// Handle edge case where option might be stored as string instead of array.
+				if ( ! is_array( $enabled_currencies ) ) {
+					return $available_currencies;
+				}
 				if ( ! in_array( 'BGN', $enabled_currencies, true ) ) {
 					$available_currencies = array_diff( $available_currencies, [ 'BGN' ] );
 				}

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -54,16 +54,6 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 			}
 		);
 
-		// Exclude deprecated currencies from WooCommerce general settings.
-		add_filter(
-			'woocommerce_currencies',
-			function ( $currencies ) {
-				// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
-				unset( $currencies['BGN'] );
-				return $currencies;
-			}
-		);
-
 		$instance->init_hooks();
 	}
 

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -50,7 +50,12 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 			'wcpay_multi_currency_available_currencies',
 			function ( $available_currencies ) {
 				// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
-				return array_diff( $available_currencies, [ 'BGN' ] );
+				// Only remove if not currently enabled in multi-currency.
+				$enabled_currencies = get_option( 'wcpay_multi_currency_enabled_currencies', [] );
+				if ( ! in_array( 'BGN', $enabled_currencies, true ) ) {
+					$available_currencies = array_diff( $available_currencies, [ 'BGN' ] );
+				}
+				return $available_currencies;
 			}
 		);
 

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -44,6 +44,26 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 			WC_Payments::get_localization_service(),
 			WC_Payments::get_database_cache()
 		);
+
+		// Exclude deprecated currencies from multi-currency.
+		add_filter(
+			'wcpay_multi_currency_available_currencies',
+			function ( $available_currencies ) {
+				// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
+				return array_diff( $available_currencies, [ 'BGN' ] );
+			}
+		);
+
+		// Exclude deprecated currencies from WooCommerce general settings.
+		add_filter(
+			'woocommerce_currencies',
+			function ( $currencies ) {
+				// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
+				unset( $currencies['BGN'] );
+				return $currencies;
+			}
+		);
+
 		$instance->init_hooks();
 	}
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -174,7 +174,11 @@ function wcpay_init() {
 		'woocommerce_currencies',
 		function ( $currencies ) {
 			// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
-			unset( $currencies['BGN'] );
+			// Only remove if not currently in use as the store's base currency.
+			$current_currency = get_option( 'woocommerce_currency' );
+			if ( 'BGN' !== $current_currency ) {
+				unset( $currencies['BGN'] );
+			}
 			return $currencies;
 		}
 	);

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -169,6 +169,16 @@ function wcpay_init() {
 	 */
 	\WCPay\WooPay\WooPay_Session::init();
 
+	// Exclude deprecated currencies from WooCommerce general settings.
+	add_filter(
+		'woocommerce_currencies',
+		function ( $currencies ) {
+			// Remove BGN (Bulgarian Lev) - Bulgaria transitioned to EUR in 2025.
+			unset( $currencies['BGN'] );
+			return $currencies;
+		}
+	);
+
 	/**
 	 * Only initialize the ECE product page session handler when needed to avoid interfering
 	 * with other payment methods like BNPL. This handler is specifically designed for


### PR DESCRIPTION
Fixes WOOPMNT-5619

#### Changes proposed in this Pull Request

Bulgaria officially transitioned from the Bulgarian Lev (BGN) to the Euro (EUR) on January 1, 2025. This PR removes BGN from the available currencies in both WooCommerce general settings and WooCommerce Payments multi-currency feature.

General settings

<img width="742" height="388" alt="image" src="https://github.com/user-attachments/assets/30016614-bc4a-43a2-97c7-4e8f48234c3e" />

Multi-currency options

<img width="1015" height="622" alt="image" src="https://github.com/user-attachments/assets/c1ff0909-6f7d-4d2f-984f-3915f6fb509b" />


#### Testing instructions

**Test 1: Verify BGN is removed from WooCommerce general settings**
  1. Go to WooCommerce → Settings → General
  2. Scroll to "Currency options"
  3. Click the "Currency" dropdown
  4. Verify that "Bulgarian lev (BGN)" is NOT in the list

**Test 2: Verify BGN is removed from multi-currency available currencies**
  1. Enable multi-currency feature in WooCommerce Payments
  2. Go to WooCommerce → Settings → Multi-currency
  3. Click "Add currencies"
  4. Verify that "Bulgarian lev (BGN)" is NOT in the available currencies list

**Test 3: Verify existing BGN configurations continue to work**
  1. If you have a test store with BGN already configured (base currency or multi-currency), verify it still displays and functions correctly
  2. Note: You won't be able to re-add it if you remove it

**Look elsewhere to ensure nothing breaks**

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
