### PR TITLE
Bump WordPress tested up to 6.9

### DIFF
--- a/changelog/fix-bump-wp-version
+++ b/changelog/fix-bump-wp-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump the version of WP in tested up to readme

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.3
 Stable tag: 10.4.0
 License: GPLv2 or later


### PR DESCRIPTION
This bumps the WP tested version up to 6.9