### PR TITLE
Fix E2E test for non-admin WP-Admin access

### DIFF
--- a/changelog/woopmnt-5622-investigate-failed-e2e-test-for-non-admin-wp-admin-access
+++ b/changelog/woopmnt-5622-investigate-failed-e2e-test-for-non-admin-wp-admin-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix E2E test for non-admin WP-Admin access to expect 'Connected' instead of 'Complete' account status.

--- a/tests/e2e/specs/wcpay/merchant/non-admin-wp-admin-access.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/non-admin-wp-admin-access.spec.ts
@@ -70,7 +70,7 @@ test.describe( 'Non-admin WP-Admin access', { tag: '@critical' }, () => {
 		await expect(
 			merchantPage.getByText( 'Account details' )
 		).toBeVisible();
-		await expect( merchantPage.getByText( 'Complete' ) ).toBeVisible();
+		await expect( merchantPage.getByText( 'Connected' ) ).toBeVisible();
 
 		// Ensure that the editor can access wp-admin pages screen.
 		await checkEditorAccess(


### PR DESCRIPTION
Fixes WOOPMNT-5622

## Summary
- Updates E2E test to expect 'Connected' instead of 'Complete' account status text

## Root Cause
The WooPayments server API now returns "Connected" as the account status text instead of "Complete". This change happened as part of the AccountDetails component refactor (#11039, #11048) that fetches status text dynamically from the server rather than hardcoding it in the frontend.

## Test plan
- Run the E2E test `non-admin-wp-admin-access.spec.ts` locally or in CI (i.e. https://github.com/Automattic/woocommerce-payments/actions/runs/20822666686)
- Verify the test passes with the updated assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)