### PR TITLE
E2E tests: Change expected text from 'Complete' to 'Connected' after onboarding

### DIFF
--- a/tests/e2e/specs/wcpay/merchant/non-admin-wp-admin-access.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/non-admin-wp-admin-access.spec.ts
@@ -70,7 +70,7 @@ test.describe( 'Non-admin WP-Admin access', { tag: '@critical' }, () => {
 		await expect(
 			merchantPage.getByText( 'Account details' )
 		).toBeVisible();
-		await expect( merchantPage.getByText( 'Complete' ) ).toBeVisible();
+		await expect( merchantPage.getByText( 'Connected' ) ).toBeVisible();
 
 		// Ensure that the editor can access wp-admin pages screen.
 		await checkEditorAccess(


### PR DESCRIPTION
Fixes [WOOPMNT-5623](https://linear.app/a8c/issue/WOOPMNT-5623/update-expected-text-in-e2e-tests-from-complete-to-connected) 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Current merchant tests fail after 198877-ghe-Automattic/wpcom is merged on the server side. Since then, WooPayments ver >= 10.4 will use the new AccountDetails component, which is "Connected" rather than "Complete" for the good status after onboarding.

```
 1) [chromium] › tests/e2e/specs/wcpay/merchant/non-admin-wp-admin-access.spec.ts:47:6 › Non-admin WP-Admin access › should be able to access wp-admin before and after onboarding @critical 

    Error: Timed out 20000ms waiting for expect(locator).toBeVisible()

    Locator: getByText('Complete')
    Expected: visible
    Received: <element(s) not found>
    Call log:
      - expect.toBeVisible with timeout 20000ms
      - waiting for getByText('Complete')


      71 | 			merchantPage.getByText( 'Account details' )
      72 | 		).toBeVisible();
    > 73 | 		await expect( merchantPage.getByText( 'Complete' ) ).toBeVisible();
         | 		                                                     ^
      74 |
      75 | 		// Ensure that the editor can access wp-admin pages screen.
      76 | 		await checkEditorAccess(
        at /home/runner/work/woocommerce-payments/woocommerce-payments/tests/e2e/specs/wcpay/merchant/non-admin-wp-admin-access.spec.ts:73:56
``` 


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure tests work properly. 

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.