### PR TITLE
Fix exit survey option persistence by introducing type-based REST settings validation

### DIFF
--- a/changelog/fix-WOOPMNT-5551-exit-survey-option-not-preserved
+++ b/changelog/fix-WOOPMNT-5551-exit-survey-option-not-preserved
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix exit survey option not being preserved due to string type validation failure.

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -302,7 +302,7 @@ export function* submitStripeBillingSubscriptionMigration() {
 }
 
 export function saveOption( optionName, value ) {
-	directApiFetch( {
+	return directApiFetch( {
 		path: `${ NAMESPACE }/settings/${ optionName }`,
 		method: 'post',
 		data: { value },

--- a/client/plugins-page/index.js
+++ b/client/plugins-page/index.js
@@ -39,7 +39,7 @@ const PluginsPage = () => {
 		const currentDate = new Date();
 
 		// Update modal dismissed option.
-		saveOption( 'wcpay_exit_survey_last_shown', currentDate );
+		await saveOption( 'wcpay_exit_survey_last_shown', currentDate );
 
 		window.wcpayPluginsSettings.exitSurveyLastShown = currentDate;
 

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -13,21 +13,23 @@ defined( 'ABSPATH' ) || exit;
 class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Controller {
 
 	/**
-	 * List of allowed option names that can be updated via the REST API.
+	 * Map of allowed option names to their accepted value types.
+	 * Types: 'bool', 'array', 'string'.
 	 *
 	 * @var array
 	 */
 	private const ALLOWED_OPTIONS = [
-		'wcpay_multi_currency_setup_completed',
-		'woocommerce_dismissed_todo_tasks',
-		'woocommerce_remind_me_later_todo_tasks',
-		'woocommerce_deleted_todo_tasks',
-		'wcpay_fraud_protection_welcome_tour_dismissed',
-		'wcpay_onboarding_eligibility_modal_dismissed',
-		'wcpay_connection_success_modal_dismissed',
-		'wcpay_next_deposit_notice_dismissed',
-		'wcpay_duplicate_payment_method_notices_dismissed',
-		'wcpay_instant_deposit_notice_dismissed',
+		'wcpay_multi_currency_setup_completed'             => 'bool',
+		'woocommerce_dismissed_todo_tasks'                 => 'array',
+		'woocommerce_remind_me_later_todo_tasks'           => 'array',
+		'woocommerce_deleted_todo_tasks'                   => 'array',
+		'wcpay_fraud_protection_welcome_tour_dismissed'    => 'bool',
+		'wcpay_onboarding_eligibility_modal_dismissed'     => 'bool',
+		'wcpay_connection_success_modal_dismissed'         => 'bool',
+		'wcpay_next_deposit_notice_dismissed'              => 'bool',
+		'wcpay_duplicate_payment_method_notices_dismissed' => 'bool',
+		'wcpay_instant_deposit_notice_dismissed'           => 'bool',
+		'wcpay_exit_survey_last_shown'                     => 'string',
 	];
 
 	/**
@@ -69,22 +71,41 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 	 * @return bool
 	 */
 	public function validate_option_name( string $option_name ): bool {
-		return in_array( $option_name, self::ALLOWED_OPTIONS, true );
+		return array_key_exists( $option_name, self::ALLOWED_OPTIONS );
 	}
 
 	/**
-	 * Validate the value parameter.
+	 * Validate the value parameter based on the option's expected type.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed           $value   The value to validate.
+	 * @param WP_REST_Request $request The request object.
 	 * @return bool|WP_Error True if valid, WP_Error if invalid.
 	 */
-	public function validate_value( $value ) {
-		if ( is_bool( $value ) || is_array( $value ) ) {
+	public function validate_value( $value, WP_REST_Request $request ) {
+		$option_name   = $request->get_param( 'option_name' );
+		$expected_type = self::ALLOWED_OPTIONS[ $option_name ] ?? null;
+
+		$is_valid = false;
+		switch ( $expected_type ) {
+			case 'bool':
+				$is_valid = is_bool( $value );
+				break;
+			case 'array':
+				$is_valid = is_array( $value );
+				break;
+			case 'string':
+				$is_valid = is_string( $value );
+				break;
+		}
+
+		if ( $is_valid ) {
 			return true;
 		}
+
 		return new WP_Error(
 			'rest_invalid_param',
-			__( 'Invalid value type; must be either boolean or array', 'woocommerce-payments' ),
+			/* translators: %s: expected type (bool, array, or string) */
+			sprintf( __( 'Invalid value type; expected %s', 'woocommerce-payments' ), $expected_type ),
 			[ 'status' => 400 ]
 		);
 	}

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
@@ -72,34 +72,51 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 		$this->assertSame( $expected_result, $this->controller->validate_option_name( $option ) );
 	}
 
-	public function test_validate_value_with_valid_values() {
-		$valid_values = [
-			true,
-			false,
-			[],
-			[ 'key' => 'value' ],
-			[ 'key' => [ 'nested_key' => 'nested_value' ] ],
+	public function provider_valid_values(): array {
+		return [
+			'bool option with true'          => [ 'wcpay_multi_currency_setup_completed', true ],
+			'bool option with false'         => [ 'wcpay_multi_currency_setup_completed', false ],
+			'array option with empty array'  => [ 'woocommerce_dismissed_todo_tasks', [] ],
+			'array option with array'        => [ 'woocommerce_dismissed_todo_tasks', [ 'key' => 'value' ] ],
+			'array option with nested array' => [ 'woocommerce_dismissed_todo_tasks', [ 'key' => [ 'nested' => 'value' ] ] ],
+			'string option with string'      => [ 'wcpay_exit_survey_last_shown', '2026-01-09T09:23:30.444Z' ],
 		];
-
-		foreach ( $valid_values as $value ) {
-			$result = $this->controller->validate_value( $value );
-			$this->assertTrue( $result );
-		}
 	}
 
-	public function test_validate_value_with_invalid_values() {
-		$invalid_values = [
-			'string',
-			123,
-			null,
-			(object) [],
-		];
+	/**
+	 * @dataProvider provider_valid_values
+	 */
+	public function test_validate_value_with_valid_values( string $option_name, $value ) {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'option_name', $option_name );
 
-		foreach ( $invalid_values as $value ) {
-			$result = $this->controller->validate_value( $value );
-			$this->assertInstanceOf( WP_Error::class, $result );
-			$this->assertEquals( 'rest_invalid_param', $result->get_error_code() );
-			$this->assertEquals( 400, $result->get_error_data()['status'] );
-		}
+		$result = $this->controller->validate_value( $value, $request );
+		$this->assertTrue( $result );
+	}
+
+	public function provider_invalid_values(): array {
+		return [
+			'bool option with string'  => [ 'wcpay_multi_currency_setup_completed', 'string' ],
+			'bool option with array'   => [ 'wcpay_multi_currency_setup_completed', [] ],
+			'bool option with int'     => [ 'wcpay_multi_currency_setup_completed', 123 ],
+			'array option with bool'   => [ 'woocommerce_dismissed_todo_tasks', true ],
+			'array option with string' => [ 'woocommerce_dismissed_todo_tasks', 'string' ],
+			'string option with bool'  => [ 'wcpay_exit_survey_last_shown', true ],
+			'string option with array' => [ 'wcpay_exit_survey_last_shown', [] ],
+			'string option with int'   => [ 'wcpay_exit_survey_last_shown', 123 ],
+		];
+	}
+
+	/**
+	 * @dataProvider provider_invalid_values
+	 */
+	public function test_validate_value_with_invalid_values( string $option_name, $value ) {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'option_name', $option_name );
+
+		$result = $this->controller->validate_value( $value, $request );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'rest_invalid_param', $result->get_error_code() );
+		$this->assertEquals( 400, $result->get_error_data()['status'] );
 	}
 }

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
@@ -54,11 +54,15 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 				'wcpay_fraud_protection_welcome_tour_dismissed',
 				true,
 			],
-			'invalid option: invalid_option'       => [
+			'valid option: wcpay_exit_survey_last_shown' => [
+				'wcpay_exit_survey_last_shown',
+				true,
+			],
+			'invalid option: invalid_option'             => [
 				'invalid_option',
 				false,
 			],
-			'invalid option: wcpay_invalid_option' => [
+			'invalid option: wcpay_invalid_option'       => [
 				'wcpay_invalid_option',
 				false,
 			],
@@ -72,6 +76,11 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 		$this->assertSame( $expected_result, $this->controller->validate_option_name( $option ) );
 	}
 
+	/**
+	 * Data provider for valid option values.
+	 *
+	 * @return array<string, array>
+	 */
 	public function provider_valid_values(): array {
 		return [
 			'bool option with true'          => [ 'wcpay_multi_currency_setup_completed', true ],
@@ -94,6 +103,11 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * Data provider for invalid option values.
+	 *
+	 * @return array<string, array>
+	 */
 	public function provider_invalid_values(): array {
 		return [
 			'bool option with string'  => [ 'wcpay_multi_currency_setup_completed', 'string' ],


### PR DESCRIPTION
Fixes #WOOPMNT-5551

#### Changes proposed in this Pull Request

This PR fixes the exit survey option not being preserved by adding type-based validation for REST API settings options.

**Problem:** The `wcpay_exit_survey_last_shown` option (a string timestamp) was being rejected by the settings option controller because the `validate_value()` method only accepted boolean or array types.

**Solution:**
- Changed `ALLOWED_OPTIONS` from a simple list to a map that specifies the expected type for each option (`bool`, `array`, or `string`)
- Updated `validate_value()` to validate against the specific expected type for each option
- Added `wcpay_exit_survey_last_shown` as a string-type option

This approach is more explicit and extensible - each option now declares its expected type, making validation stricter and clearer.

#### Testing instructions

1. Navigate to WooCommerce > Settings > Payments > WooPayments.
2. Trigger the exit survey (e.g., by attempting to disable the payment method).
3. Dismiss or interact with the survey.
4. Verify that the `wcpay_exit_survey_last_shown` option is saved correctly in the database.
5. Refresh the page and confirm the survey behavior respects the saved timestamp.

**Alternative testing via REST API:**
```bash
# This should now succeed (was failing before)
curl -X POST '/wp-json/wc/v3/payments/settings/option' \
  -d '{"option_name": "wcpay_exit_survey_last_shown", "value": "2026-01-09T09:23:30.444Z"}'
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_ (internal fix, no user-facing change)
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.