### PR TITLE
Update AVS Mismatch fraud filter copy

### DIFF
--- a/changelog/fix-woopmnt-5451
+++ b/changelog/fix-woopmnt-5451
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Update AVS Mismatch fraud filter copy to remove street check

--- a/client/settings/fraud-protection/advanced-settings/__tests__/__snapshots__/index.test.js.snap
+++ b/client/settings/fraud-protection/advanced-settings/__tests__/__snapshots__/index.test.js.snap
@@ -333,7 +333,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                           <span
                             class="components-toggle-control__help"
                           >
-                            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                            This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                           </span>
                         </p>
                       </div>
@@ -345,7 +345,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                         How does this filter protect me?
                       </strong>
                       <p>
-                        Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                        Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                       </p>
                     </div>
                   </div>
@@ -1517,7 +1517,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                         <span
                           class="components-toggle-control__help"
                         >
-                          This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                         </span>
                       </p>
                     </div>
@@ -1529,7 +1529,7 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
                       How does this filter protect me?
                     </strong>
                     <p>
-                      Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                     </p>
                   </div>
                 </div>
@@ -2738,7 +2738,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                           <span
                             class="components-toggle-control__help"
                           >
-                            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                            This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                           </span>
                         </p>
                       </div>
@@ -2750,7 +2750,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                         How does this filter protect me?
                       </strong>
                       <p>
-                        Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                        Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                       </p>
                     </div>
                   </div>
@@ -3722,7 +3722,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                         <span
                           class="components-toggle-control__help"
                         >
-                          This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                         </span>
                       </p>
                     </div>
@@ -3734,7 +3734,7 @@ exports[`Advanced fraud protection settings renders an error message when settin
                       How does this filter protect me?
                     </strong>
                     <p>
-                      Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                     </p>
                   </div>
                 </div>
@@ -4748,7 +4748,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                         <span
                           class="components-toggle-control__help"
                         >
-                          This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                         </span>
                       </p>
                     </div>
@@ -4760,7 +4760,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                       How does this filter protect me?
                     </strong>
                     <p>
-                      Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                     </p>
                   </div>
                 </div>
@@ -5691,7 +5691,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                       <span
                         class="components-toggle-control__help"
                       >
-                        This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                        This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                       </span>
                     </p>
                   </div>
@@ -5703,7 +5703,7 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
                     How does this filter protect me?
                   </strong>
                   <p>
-                    Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                    Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                   </p>
                 </div>
               </div>
@@ -6751,7 +6751,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                           <span
                             class="components-toggle-control__help"
                           >
-                            This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                            This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                           </span>
                         </p>
                       </div>
@@ -6763,7 +6763,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                         How does this filter protect me?
                       </strong>
                       <p>
-                        Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                        Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                       </p>
                     </div>
                   </div>
@@ -7831,7 +7831,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                         <span
                           class="components-toggle-control__help"
                         >
-                          This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
                         </span>
                       </p>
                     </div>
@@ -7843,7 +7843,7 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                       How does this filter protect me?
                     </strong>
                     <p>
-                      Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
                     </p>
                   </div>
                 </div>

--- a/client/settings/fraud-protection/advanced-settings/cards/__tests__/__snapshots__/avs-mismatch.test.js.snap
+++ b/client/settings/fraud-protection/advanced-settings/cards/__tests__/__snapshots__/avs-mismatch.test.js.snap
@@ -179,7 +179,7 @@ exports[`AVS mismatch card renders correctly when AVS check is disabled 1`] = `
               <span
                 class="components-toggle-control__help"
               >
-                This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
               </span>
             </p>
           </div>
@@ -191,7 +191,7 @@ exports[`AVS mismatch card renders correctly when AVS check is disabled 1`] = `
             How does this filter protect me?
           </strong>
           <p>
-            Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+            Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
           </p>
         </div>
       </div>
@@ -391,7 +391,7 @@ exports[`AVS mismatch card renders correctly when AVS check is enabled 1`] = `
               <span
                 class="components-toggle-control__help"
               >
-                This filter compares the street number and the post code submitted by the customer against the data on file with the card issuer. When enabled the payment will be blocked.
+                This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
               </span>
             </p>
           </div>
@@ -403,7 +403,7 @@ exports[`AVS mismatch card renders correctly when AVS check is enabled 1`] = `
             How does this filter protect me?
           </strong>
           <p>
-            Buyers who can provide the street number and post code on file with the issuing bank are more likely to be the actual account holder. AVS matches, however, are not a guarantee.
+            Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
           </p>
         </div>
       </div>

--- a/client/settings/fraud-protection/advanced-settings/cards/avs-mismatch.tsx
+++ b/client/settings/fraud-protection/advanced-settings/cards/avs-mismatch.tsx
@@ -24,16 +24,16 @@ const AVSMismatchRuleCard: React.FC = () => {
 					'woocommerce-payments'
 				) }
 				description={ __(
-					'This filter compares the street number and the post code submitted by the customer against the data on ' +
-						'file with the card issuer. When enabled the payment will be blocked.',
+					'This filter compares the post code submitted by the customer against the post code on ' +
+						'file with the card issuer. The payment will be blocked if the two post codes do not match.',
 					'woocommerce-payments'
 				) }
 			/>
 
 			<FraudProtectionRuleDescription>
 				{ __(
-					'Buyers who can provide the street number and post code on file with the issuing bank ' +
-						'are more likely to be the actual account holder. AVS matches, however, are not a guarantee.',
+					'Buyers who can provide correct post code on file with the issuing bank ' +
+						'are more likely to be the actual account holder.',
 					'woocommerce-payments'
 				) }
 			</FraudProtectionRuleDescription>


### PR DESCRIPTION
## Update AVS Mismatch fraud filter copy to remove street check

AVS checks on WooPayments transactions consist of two parts:

- Checking the customer-provided post code / ZIP against the card issuer’s data
- Checking the customer-provided billing street address against the card issuer’s data

Because of the name and description shown in the setting (see below), merchants almost certainly think this filter block transactions if they failed EITHER the post code or the street address check.

However, this is not the case! The filter in fact only blocks charges that fail the post code check.

In WOOPMNT-5451, we worked with Stripe to try to see if we could also block on address line 1 failures, but we'd need to use Radar to do that, which is not feasible here given the per-merchant fraud protection toggles. The only solution left was to change the copy.

Note: this PR is pretty minimal. I have not changed the name of the filter itself or changed anything about existing tests, etc. I'm just trying to get us to a spot where we aren't misleading users, not trying to make it "perfect." :) 

Fixes WOOPMNT-5451

**Before**

<img width="1532" height="544" alt="image" src="https://github.com/user-attachments/assets/dc11bbb7-eaca-4527-8cfc-0485a0e5b113" />

**After**

<img width="1530" height="530" alt="Screenshot taken on 2026-01-09 at 15 28 22 UTC@2x" src="https://github.com/user-attachments/assets/eab194b4-d56f-4215-953b-393db82c521f" />