### PR TITLE
Prevent Stripe Billing migrator instantiation on older Subscriptions versions

### DIFF
--- a/changelog/woopmnt-4711-subscriptions-fatals-on-atomic-hosted-sites
+++ b/changelog/woopmnt-4711-subscriptions-fatals-on-atomic-hosted-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error on sites running WooCommerce Subscriptions < 5.0.0 by not instantiating the Stripe Billing migrator when required functions are unavailable.

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -98,7 +98,7 @@ class WC_Payments_Subscriptions {
 			( new WC_Payments_Subscriptions_Disabler() )->init_hooks();
 		}
 
-		if ( class_exists( 'WCS_Background_Repairer' ) ) {
+		if ( class_exists( 'WCS_Background_Repairer' ) && function_exists( 'wcs_get_orders_with_meta_query' ) ) {
 			include_once __DIR__ . '/class-wc-payments-subscriptions-migrator.php';
 			self::$stripe_billing_migrator = new WC_Payments_Subscriptions_Migrator( $api_client, $token_service );
 		}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -137,6 +137,7 @@ if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID >= 70400 ) {
  */
 function wcpay_init_subscriptions_core() {
 	require_once __DIR__ . '/helpers/class-wcs-helper-background-repairer.php';
+	require_once __DIR__ . '/helpers/class-wc-helper-subscriptions.php';
 }
 
 // Placeholder for the test container.


### PR DESCRIPTION
Fixes #10221

#### Changes proposed in this Pull Request

This PR prevents a PHP fatal error on sites running WooCommerce Subscriptions < 5.0.0:

```
PHP Fatal error: Uncaught Error: Call to undefined function wcs_get_orders_with_meta_query()
in includes/subscriptions/class-wc-payments-subscriptions-migrator.php
```

The Stripe Billing migrator depends on `wcs_get_orders_with_meta_query()` which was introduced in WooCommerce Subscriptions 5.0.0. Rather than adding defensive `function_exists()` checks to individual methods (which would silently return incorrect data), this PR prevents the migrator from being instantiated at all when the required function is unavailable.

**How can this code break?**
- If someone on WooCommerce Subscriptions < 5.0.0 needs the migrator, it won't be available. However, WooCommerce Subscriptions 5.0.0 was released in 2022, and the migrator wouldn't work anyway without the required function.

#### Testing instructions

This is a simple one-line conditional change that adds `&& function_exists('wcs_get_orders_with_meta_query')` to an existing condition. The edge case (Subscriptions < 5.0.0) is impractical to test manually, so code review verification is sufficient.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.