### PR TITLE
Release 10.5.0: Bump `WC tested up to`

### DIFF
--- a/changelog/bump-10.5.0-versions
+++ b/changelog/bump-10.5.0-versions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Tested up to WooCommerce 10.5.0

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 10.4.0
+ * WC tested up to: 10.5.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
  * Version: 10.4.0


### PR DESCRIPTION
In preparation for the WooPayments `10.5.0` release, bump up the `WC tested up to:` tag to `10.5.0`.

They will finally match! 🎉 