### PR TITLE
fix: payment method title on checkout page

### DIFF
--- a/changelog/fix-payment-method-title-block-editor
+++ b/changelog/fix-payment-method-title-block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: payment method title displayed on page editor for block-based checkout page


### PR DESCRIPTION
Fixes #10515
Fixes WOOPMNT-4833

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The description of the payment methods in the block editor was janky.
Fixing their title/descriptions.

Before:
<img width="1976" height="1888" alt="420363004-81368535-2999-4f62-b2f3-f047133d9404" src="https://github.com/user-attachments/assets/0b33ef4c-ed6d-4a5c-bab7-a74ae1151b23" />

After:
<img width="910" height="970" alt="Screenshot 2026-01-14 at 2 22 20 PM" src="https://github.com/user-attachments/assets/0ee819ce-ef90-4fe1-8808-9f8f4bff9fb7" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to `wp-admin` > Pages
- Edit your block-based checkout page (or create a new page with the block-based checkout on it)
- Click on the payment methods list
- The payment methods description should no longer show duplicated descriptions that make it hard to determine which payment method each item is referring to
- Some payment methods (like giropay/amazon pay/sepa) appear in the list as "not compatible" - that's because the methods are _available_, but they might not be registered for explicit checkout usage

The ticket also mentions to perform a check for the other areas of the app - like when checking out or on the reports. I didn't find any inconsistencies to this change compared with `develop`.
<img width="419" height="357" alt="Screenshot 2026-01-14 at 2 28 38 PM" src="https://github.com/user-attachments/assets/3a7577cd-f1d3-4ba3-8d45-327c213cdbba" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
