### PR TITLE
fix: google pay/apple pay description wrapping

### DIFF
--- a/changelog/fix-google-pay-apple-pay-descriptions-wrap
+++ b/changelog/fix-google-pay-apple-pay-descriptions-wrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: text wrap of google pay/apple pay descriptions

--- a/client/settings/express-checkout/style.scss
+++ b/client/settings/express-checkout/style.scss
@@ -16,7 +16,7 @@
 
 			&__label-container {
 				display: flex;
-				flex-wrap: wrap;
+				flex-direction: column;
 			}
 
 			&__text-container {


### PR DESCRIPTION
Fixes WOOPMNT-5634

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The wrapping of the Google Pay/Apple Pay descriptions was... weird.
Fixing.

Before:
<img width="877" height="150" alt="Screenshot 2026-01-14 at 2 15 07 PM" src="https://github.com/user-attachments/assets/aea7b78a-e00f-4992-8b2a-e2e9aedb79e1" />

After:
<img width="875" height="166" alt="Screenshot 2026-01-14 at 2 15 25 PM" src="https://github.com/user-attachments/assets/47dc55bf-969d-4cdf-80ca-ccea9867e718" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Payments > Settings
* Scroll down to the Google Pay/Apple Pay section
* Their description should no longer be inline (you need to check google pay/apple pay to show the shorter description)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
