### PR TITLE
Improve error logging for embedded KYC session creation  

### DIFF
--- a/changelog/add-error-logs-for-embedded-kyc
+++ b/changelog/add-error-logs-for-embedded-kyc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add error logging for embedded KYC session failures to improve debugging.

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments\Admin
  */
 
-use WCPay\Logger;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -225,19 +223,21 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 			$capabilities
 		);
 
-		if ( empty( $account_session ) ) {
-			Logger::error(
-				'Failed to create embedded KYC session: Empty response from onboarding service.',
-				[
-					'has_self_assessment' => ! empty( $self_assessment_data ),
-					'has_capabilities'    => ! empty( $capabilities ),
-				]
-			);
-		} elseif ( empty( $account_session['publishableKey'] ) ) {
-			Logger::warning(
-				'Embedded KYC session missing publishableKey.',
-				[ 'session_keys' => array_keys( $account_session ) ]
-			);
+		// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
+		if ( function_exists( 'wc_get_logger' ) ) {
+			if ( empty( $account_session ) ) {
+				$logger = wc_get_logger();
+				$logger->error(
+					'Failed to create embedded KYC session: Empty response from onboarding service.',
+					[ 'source' => 'woopayments' ]
+				);
+			} elseif ( empty( $account_session['publishableKey'] ) ) {
+				$logger = wc_get_logger();
+				$logger->warning(
+					sprintf( 'Embedded KYC session missing publishableKey. Session keys: %s.', implode( ', ', array_keys( $account_session ) ) ),
+					[ 'source' => 'woopayments' ]
+				);
+			}
 		}
 
 		if ( $account_session ) {

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -225,6 +225,21 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 			$capabilities
 		);
 
+		if ( empty( $account_session ) ) {
+			Logger::error(
+				'Failed to create embedded KYC session: Empty response from onboarding service.',
+				[
+					'has_self_assessment' => ! empty( $self_assessment_data ),
+					'has_capabilities'    => ! empty( $capabilities ),
+				]
+			);
+		} elseif ( empty( $account_session['publishableKey'] ) ) {
+			Logger::warning(
+				'Embedded KYC session missing publishableKey.',
+				[ 'session_keys' => array_keys( $account_session ) ]
+			);
+		}
+
 		if ( $account_session ) {
 			$account_session['locale'] = get_user_locale();
 		}

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -223,21 +223,13 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 			$capabilities
 		);
 
-		// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
-		if ( function_exists( 'wc_get_logger' ) ) {
-			if ( empty( $account_session ) ) {
-				$logger = wc_get_logger();
-				$logger->error(
-					'Failed to create embedded KYC session: Empty response from onboarding service.',
-					[ 'source' => 'woopayments' ]
-				);
-			} elseif ( empty( $account_session['publishableKey'] ) ) {
-				$logger = wc_get_logger();
-				$logger->warning(
-					sprintf( 'Embedded KYC session missing publishableKey. Session keys: %s.', implode( ', ', array_keys( $account_session ) ) ),
-					[ 'source' => 'woopayments' ]
-				);
-			}
+		if ( empty( $account_session ) ) {
+			WC_Payments_Utils::log_to_wc( 'Failed to create embedded KYC session: Empty response from onboarding service.' );
+		} elseif ( empty( $account_session['publishableKey'] ) ) {
+			WC_Payments_Utils::log_to_wc(
+				sprintf( 'Embedded KYC session missing publishableKey. Session keys: %s.', implode( ', ', array_keys( $account_session ) ) ),
+				'warning'
+			);
 		}
 
 		if ( $account_session ) {

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -735,11 +735,8 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		foreach ( $enabled_payment_methods as $payment_method_id ) {
 			$gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
 			if ( ! $gateway ) {
-				if ( function_exists( 'wc_get_logger' ) ) {
-					$logger = wc_get_logger();
-					/* translators: 1: Payment method ID, 2: Error message */
-					$logger->warning( sprintf( 'Failed to enable payment method %1$s: %2$s', $payment_method_id, 'payment gateway instance not available' ), [ 'source' => 'woopayments' ] );
-				}
+				/* translators: 1: Payment method ID, 2: Error message */
+				WC_Payments_Utils::log_to_wc( sprintf( 'Failed to enable payment method %1$s: %2$s', $payment_method_id, 'payment gateway instance not available' ), 'warning' );
 				continue;
 			}
 
@@ -754,11 +751,8 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		foreach ( $disabled_payment_methods as $payment_method_id ) {
 			$gateway = WC_Payments::get_payment_gateway_by_id( $payment_method_id );
 			if ( ! $gateway ) {
-				if ( function_exists( 'wc_get_logger' ) ) {
-					$logger = wc_get_logger();
-					/* translators: 1: Payment method ID, 2: Error message */
-					$logger->warning( sprintf( 'Failed to disable payment method %1$s: %2$s', $payment_method_id, 'payment gateway instance not available' ), [ 'source' => 'woopayments' ] );
-				}
+				/* translators: 1: Payment method ID, 2: Error message */
+				WC_Payments_Utils::log_to_wc( sprintf( 'Failed to disable payment method %1$s: %2$s', $payment_method_id, 'payment gateway instance not available' ), 'warning' );
 				continue;
 			}
 			$gateway->disable();

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -286,14 +286,7 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function create_embedded_kyc_session( array $self_assessment_data, array $capabilities = [] ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->error(
-					'Failed to create embedded KYC session: Jetpack connection not available.',
-					[ 'source' => 'woopayments' ]
-				);
-			}
+			WC_Payments_Utils::log_to_wc( 'Failed to create embedded KYC session: Jetpack connection not available.' );
 			return [];
 		}
 
@@ -349,14 +342,7 @@ class WC_Payments_Onboarding_Service {
 		} catch ( API_Exception $e ) {
 			$this->clear_onboarding_init_in_progress();
 
-			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->error(
-					'Failed to create embedded KYC session: ' . $e->getMessage(),
-					[ 'source' => 'woopayments' ]
-				);
-			}
+			WC_Payments_Utils::log_to_wc( 'Failed to create embedded KYC session: ' . $e->getMessage() );
 
 			// If we fail to create the session, return an empty array.
 			return [];
@@ -402,14 +388,7 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function finalize_embedded_kyc( string $locale, string $source, array $actioned_notes ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->error(
-					'Failed to finalize embedded KYC: Jetpack connection not available.',
-					[ 'source' => 'woopayments' ]
-				);
-			}
+			WC_Payments_Utils::log_to_wc( 'Failed to finalize embedded KYC: Jetpack connection not available.' );
 			return [
 				'success' => false,
 			];

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -286,7 +286,14 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function create_embedded_kyc_session( array $self_assessment_data, array $capabilities = [] ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			Logger::error( 'Failed to create embedded KYC session: Jetpack connection not available.' );
+			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
+			if ( function_exists( 'wc_get_logger' ) ) {
+				$logger = wc_get_logger();
+				$logger->error(
+					'Failed to create embedded KYC session: Jetpack connection not available.',
+					[ 'source' => 'woopayments' ]
+				);
+			}
 			return [];
 		}
 
@@ -342,7 +349,14 @@ class WC_Payments_Onboarding_Service {
 		} catch ( API_Exception $e ) {
 			$this->clear_onboarding_init_in_progress();
 
-			Logger::error( 'Failed to create embedded KYC session: ' . $e->getMessage() );
+			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
+			if ( function_exists( 'wc_get_logger' ) ) {
+				$logger = wc_get_logger();
+				$logger->error(
+					'Failed to create embedded KYC session: ' . $e->getMessage(),
+					[ 'source' => 'woopayments' ]
+				);
+			}
 
 			// If we fail to create the session, return an empty array.
 			return [];
@@ -388,7 +402,14 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function finalize_embedded_kyc( string $locale, string $source, array $actioned_notes ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
-			Logger::error( 'Failed to finalize embedded KYC: Jetpack connection not available.' );
+			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
+			if ( function_exists( 'wc_get_logger' ) ) {
+				$logger = wc_get_logger();
+				$logger->error(
+					'Failed to finalize embedded KYC: Jetpack connection not available.',
+					[ 'source' => 'woopayments' ]
+				);
+			}
 			return [
 				'success' => false,
 			];

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -286,6 +286,7 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function create_embedded_kyc_session( array $self_assessment_data, array $capabilities = [] ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
+			Logger::error( 'Failed to create embedded KYC session: Jetpack connection not available.' );
 			return [];
 		}
 
@@ -341,6 +342,8 @@ class WC_Payments_Onboarding_Service {
 		} catch ( API_Exception $e ) {
 			$this->clear_onboarding_init_in_progress();
 
+			Logger::error( 'Failed to create embedded KYC session: ' . $e->getMessage() );
+
 			// If we fail to create the session, return an empty array.
 			return [];
 		}
@@ -385,6 +388,7 @@ class WC_Payments_Onboarding_Service {
 	 */
 	public function finalize_embedded_kyc( string $locale, string $source, array $actioned_notes ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
+			Logger::error( 'Failed to finalize embedded KYC: Jetpack connection not available.' );
 			return [
 				'success' => false,
 			];

--- a/includes/class-wc-payments-pm-promotions-service.php
+++ b/includes/class-wc-payments-pm-promotions-service.php
@@ -425,18 +425,11 @@ class WC_Payments_PM_Promotions_Service {
 	 * @param string $error_message     The error message.
 	 */
 	private function log_gateway_error( string $payment_method_id, string $error_message ): void {
-		if ( function_exists( 'wc_get_logger' ) ) {
-			$logger = wc_get_logger();
-			$logger->warning(
-				sprintf(
-					/* translators: 1: Payment method ID, 2: Error message */
-					'Failed to enable payment method %1$s: %2$s',
-					$payment_method_id,
-					$error_message
-				),
-				[ 'source' => 'woopayments' ]
-			);
-		}
+		/* translators: 1: Payment method ID, 2: Error message */
+		WC_Payments_Utils::log_to_wc(
+			sprintf( 'Failed to enable payment method %1$s: %2$s', $payment_method_id, $error_message ),
+			'warning'
+		);
 	}
 
 	/**
@@ -461,15 +454,10 @@ class WC_Payments_PM_Promotions_Service {
 			$enabled_pm_ids[] = $payment_method_id;
 			$result           = $payment_gateway->update_option( 'upe_enabled_payment_method_ids', $enabled_pm_ids );
 
-			if ( false === $result && function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->warning(
-					sprintf(
-						'Failed to sync payment method %s to gateway %s',
-						$payment_method_id,
-						get_class( $payment_gateway )
-					),
-					[ 'source' => 'woopayments' ]
+			if ( false === $result ) {
+				WC_Payments_Utils::log_to_wc(
+					sprintf( 'Failed to sync payment method %s to gateway %s', $payment_method_id, get_class( $payment_gateway ) ),
+					'warning'
 				);
 			}
 		}
@@ -543,12 +531,10 @@ class WC_Payments_PM_Promotions_Service {
 	 * @return bool Always returns false.
 	 */
 	private function handle_promotion_activation_failure( string $payment_method_id, array $promotion, string $error_message ): bool {
-		// Log the error.
-		if ( function_exists( 'wc_get_logger' ) ) {
-			$logger = wc_get_logger();
-			/* translators: 1: Payment method ID, 2: Error message */
-			$logger->error( sprintf( 'Failed to activate promotion for payment method %1$s: %2$s', $payment_method_id, $error_message ), [ 'source' => 'woopayments' ] );
-		}
+		/* translators: 1: Payment method ID, 2: Error message */
+		WC_Payments_Utils::log_to_wc(
+			sprintf( 'Failed to activate promotion for payment method %1$s: %2$s', $payment_method_id, $error_message )
+		);
 
 		// Track the failure.
 		$this->tracks_event(

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1452,4 +1452,23 @@ class WC_Payments_Utils {
 			Country_Code::SWEDEN,
 		];
 	}
+
+	/**
+	 * Log directly to WC logger, bypassing WCPay's logging settings.
+	 *
+	 * Use for critical errors that should always be captured, or errors that can occur
+	 * before WCPay settings are initialized (e.g., onboarding errors).
+	 *
+	 * @param string $message Log message.
+	 * @param string $level   Log level: 'emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'.
+	 */
+	public static function log_to_wc( string $message, string $level = 'error' ): void {
+		if ( function_exists( 'wc_get_logger' ) ) {
+			$valid_levels = [ 'emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug' ];
+			$level        = in_array( $level, $valid_levels, true ) ? $level : 'error';
+
+			$logger = wc_get_logger();
+			$logger->$level( $message, [ 'source' => 'woopayments' ] );
+		}
+	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -949,10 +949,7 @@ class WC_Payments {
 
 			return $new_ordering;
 		} catch ( Exception $e ) {
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->warning( 'Failed to order gateways: ' . $e->getMessage(), [ 'source' => 'woopayments' ] );
-			}
+			WC_Payments_Utils::log_to_wc( 'Failed to order gateways: ' . $e->getMessage(), 'warning' );
 			return $ordering;
 		}
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1139,22 +1139,31 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		$session = $this->request( $request_args, self::ONBOARDING_API . '/embedded', self::POST, true, true );
 
 		if ( ! is_array( $session ) ) {
-			Logger::error(
-				'Failed to initialize embedded KYC: Invalid API response.',
-				[ 'response_type' => gettype( $session ) ]
-			);
+			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
+			if ( function_exists( 'wc_get_logger' ) ) {
+				$logger = wc_get_logger();
+				$logger->error(
+					sprintf( 'Failed to initialize embedded KYC: Invalid API response type %s.', gettype( $session ) ),
+					[ 'source' => 'woopayments' ]
+				);
+			}
 			return [];
 		}
 
 		// Log a warning if the session is missing critical fields that indicate a server-side issue.
 		if ( empty( $session['publishable_key'] ) || empty( $session['client_secret'] ) ) {
-			Logger::warning(
-				'Embedded KYC session missing required fields.',
-				[
-					'has_publishable_key' => ! empty( $session['publishable_key'] ),
-					'has_client_secret'   => ! empty( $session['client_secret'] ),
-				]
-			);
+			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
+			if ( function_exists( 'wc_get_logger' ) ) {
+				$logger = wc_get_logger();
+				$logger->warning(
+					sprintf(
+						'Embedded KYC session missing required fields: publishable_key=%s, client_secret=%s.',
+						empty( $session['publishable_key'] ) ? 'missing' : 'set',
+						empty( $session['client_secret'] ) ? 'missing' : 'set'
+					),
+					[ 'source' => 'woopayments' ]
+				);
+			}
 		}
 
 		return $session;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1139,7 +1139,22 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		$session = $this->request( $request_args, self::ONBOARDING_API . '/embedded', self::POST, true, true );
 
 		if ( ! is_array( $session ) ) {
+			Logger::error(
+				'Failed to initialize embedded KYC: Invalid API response.',
+				[ 'response_type' => gettype( $session ) ]
+			);
 			return [];
+		}
+
+		// Log a warning if the session is missing critical fields that indicate a server-side issue.
+		if ( empty( $session['publishable_key'] ) || empty( $session['client_secret'] ) ) {
+			Logger::warning(
+				'Embedded KYC session missing required fields.',
+				[
+					'has_publishable_key' => ! empty( $session['publishable_key'] ),
+					'has_client_secret'   => ! empty( $session['client_secret'] ),
+				]
+			);
 		}
 
 		return $session;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1139,31 +1139,20 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		$session = $this->request( $request_args, self::ONBOARDING_API . '/embedded', self::POST, true, true );
 
 		if ( ! is_array( $session ) ) {
-			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->error(
-					sprintf( 'Failed to initialize embedded KYC: Invalid API response type %s.', gettype( $session ) ),
-					[ 'source' => 'woopayments' ]
-				);
-			}
+			WC_Payments_Utils::log_to_wc( sprintf( 'Failed to initialize embedded KYC: Invalid API response type %s.', gettype( $session ) ) );
 			return [];
 		}
 
 		// Log a warning if the session is missing critical fields that indicate a server-side issue.
 		if ( empty( $session['publishable_key'] ) || empty( $session['client_secret'] ) ) {
-			// Log directly to WC logger to ensure this is captured even when WCPay logging is disabled.
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$logger = wc_get_logger();
-				$logger->warning(
-					sprintf(
-						'Embedded KYC session missing required fields: publishable_key=%s, client_secret=%s.',
-						empty( $session['publishable_key'] ) ? 'missing' : 'set',
-						empty( $session['client_secret'] ) ? 'missing' : 'set'
-					),
-					[ 'source' => 'woopayments' ]
-				);
-			}
+			WC_Payments_Utils::log_to_wc(
+				sprintf(
+					'Embedded KYC session missing required fields: publishable_key=%s, client_secret=%s.',
+					empty( $session['publishable_key'] ) ? 'missing' : 'set',
+					empty( $session['client_secret'] ) ? 'missing' : 'set'
+				),
+				'warning'
+			);
 		}
 
 		return $session;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the error logging in the embedded KYC session creation flow to help debug issues when onboarding fails silently.

**Problem:** When the embedded KYC session creation fails (e.g., due to a broken Jetpack connection), the API returns `{"success":true,"session":{"locale":"en_US"}}` without the required `publishableKey` and other critical fields. Without logging, it's difficult to diagnose why the session is incomplete.

**Solution:** Add error and warning logs at key failure points:

- **`WC_Payments_Onboarding_Service`:**
  - Log error when Jetpack connection is not available during session creation.
  - Log error when API exception is caught during session initialization.
  - Log error when Jetpack connection is not available during finalization.

- **`WC_Payments_API_Client`:**
  - Log error when API response is not an array.
  - Log a warning when a session is missing `publishable_key` or `client_secret`.

- **`WC_REST_Payments_Onboarding_Controller`:**
  - Log error when the session is empty.
  - Log a warning when the session is missing `publishableKey.`

All logs use structured context arrays for easier parsing and follow existing codebase logging patterns.

#### Testing instructions

1. Enable WooPayments logging in WooCommerce > Settings > Payments > WooPayments > Advanced settings
2. Simulate a broken Jetpack connection scenario (e.g., disconnect the site from WordPress.com)
3. Attempt to start the embedded KYC onboarding flow
4. Check WooCommerce logs for the new error messages:
   - `Failed to create embedded KYC session: Jetpack connection not available.`
   - `Failed to create embedded KYC session: Empty response from onboarding service.`

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) - These are logging-only changes that don't affect functionality; testing would require mocking complex Jetpack connection states
- [x] Tested on mobile (or does not apply) - Backend-only changes, does not apply

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
