### PR TITLE
Add ineligibility notice for instant payouts

### DIFF
--- a/changelog/woopmnt-3121-instant-deposit-button-disappears-without-warning-or-details
+++ b/changelog/woopmnt-3121-instant-deposit-button-disappears-without-warning-or-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show an informative notice when a previously eligible merchant loses instant payout eligibility, instead of silently hiding the button.

--- a/client/components/account-balances/__tests__/index.test.tsx
+++ b/client/components/account-balances/__tests__/index.test.tsx
@@ -396,7 +396,7 @@ describe( 'AccountBalances', () => {
 			screen.getByRole( 'button', { name: 'Get $300.00 now' } )
 		).toBeInTheDocument();
 		expect(
-			screen.queryByText( /Instant payouts are temporarily unavailable/ )
+			screen.queryByText( /Instant payouts are currently unavailable/ )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/account-balances/__tests__/index.test.tsx
+++ b/client/components/account-balances/__tests__/index.test.tsx
@@ -34,6 +34,7 @@ declare const global: {
 		connect: {
 			country: string;
 		};
+		instantDepositsPreviouslyEligible: boolean;
 	};
 };
 const mockWcPaySettings = {
@@ -52,6 +53,7 @@ const mockWcPaySettings = {
 			precision: 2,
 		},
 	},
+	instantDepositsPreviouslyEligible: false,
 };
 
 jest.mock( 'wcpay/data', () => ( {
@@ -323,6 +325,78 @@ describe( 'AccountBalances', () => {
 
 		expect(
 			screen.queryByRole( 'button', { name: 'Deposit available funds' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render ineligibility notice when not previously eligible', () => {
+		global.wcpaySettings = {
+			...mockWcPaySettings,
+			instantDepositsPreviouslyEligible: false,
+		};
+		const mockOverview = createMockOverview( 'usd', 10000, 20000, 0 );
+		mockOverview.instant = undefined;
+		mockOverviews( [ mockOverview ] );
+		render( <AccountBalances /> );
+
+		expect(
+			screen.queryByText( /Instant payouts are temporarily unavailable/ )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders ineligibility notice when previously eligible and instant balance is undefined', () => {
+		global.wcpaySettings = {
+			...mockWcPaySettings,
+			instantDepositsPreviouslyEligible: true,
+		};
+		const mockOverview = createMockOverview( 'usd', 10000, 20000, 0 );
+		mockOverview.instant = undefined;
+		mockOverviews( [ mockOverview ] );
+		const { container } = render( <AccountBalances /> );
+
+		expect(
+			container.querySelector(
+				'.wcpay-account-balances__instant-deposit-unavailable'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', {
+				name: /Learn about eligibility requirements/,
+			} )
+		).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/woopayments/payouts/instant-payouts/'
+		);
+	} );
+
+	test( 'renders ineligibility notice when previously eligible and instant balance amount is 0', () => {
+		global.wcpaySettings = {
+			...mockWcPaySettings,
+			instantDepositsPreviouslyEligible: true,
+		};
+		mockOverviews( [ createMockOverview( 'usd', 10000, 20000, 0 ) ] );
+		const { container } = render( <AccountBalances /> );
+
+		expect(
+			container.querySelector(
+				'.wcpay-account-balances__instant-deposit-unavailable'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'does not render ineligibility notice when eligible with funds', () => {
+		global.wcpaySettings = {
+			...mockWcPaySettings,
+			instantDepositsPreviouslyEligible: true,
+		};
+		mockOverviews( [ createMockOverview( 'usd', 10000, 20000, 30000 ) ] );
+		render( <AccountBalances /> );
+
+		// The button should be shown, not the ineligibility notice.
+		expect(
+			screen.getByRole( 'button', { name: 'Get $300.00 now' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText( /Instant payouts are temporarily unavailable/ )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/components/account-balances/__tests__/index.test.tsx
+++ b/client/components/account-balances/__tests__/index.test.tsx
@@ -339,7 +339,7 @@ describe( 'AccountBalances', () => {
 		render( <AccountBalances /> );
 
 		expect(
-			screen.queryByText( /Instant payouts are temporarily unavailable/ )
+			screen.queryByText( /Instant payouts are currently unavailable/ )
 		).not.toBeInTheDocument();
 	} );
 

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -238,7 +238,7 @@ const AccountBalances: React.FC = () => {
 					>
 						{ interpolateComponents( {
 							mixedString: __(
-								'Instant payouts are temporarily unavailable for your account. {{learnMoreLink}}Learn about eligibility requirements{{/learnMoreLink}}',
+								'Instant payouts are currently unavailable for your account. {{learnMoreLink}}Learn about eligibility requirements{{/learnMoreLink}}',
 								'woocommerce-payments'
 							),
 							components: {

--- a/client/components/account-balances/index.tsx
+++ b/client/components/account-balances/index.tsx
@@ -228,6 +228,32 @@ const AccountBalances: React.FC = () => {
 						</Flex>
 					</Flex>
 				) }
+			{ wcpaySettings.instantDepositsPreviouslyEligible &&
+				( ! selectedOverview.instantBalance ||
+					selectedOverview.instantBalance.amount === 0 ) && (
+					<InlineNotice
+						className="wcpay-account-balances__instant-deposit-unavailable"
+						status="warning"
+						isDismissible={ false }
+					>
+						{ interpolateComponents( {
+							mixedString: __(
+								'Instant payouts are temporarily unavailable for your account. {{learnMoreLink}}Learn about eligibility requirements{{/learnMoreLink}}',
+								'woocommerce-payments'
+							),
+							components: {
+								learnMoreLink: (
+									// @ts-expect-error: children is provided when interpolating the component
+									<ExternalLink
+										href={
+											'https://woocommerce.com/document/woopayments/payouts/instant-payouts/'
+										}
+									/>
+								),
+							},
+						} ) }
+					</InlineNotice>
+				) }
 		</>
 	);
 };

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -141,6 +141,7 @@ declare global {
 		storeName: string;
 		isNextDepositNoticeDismissed: boolean;
 		isInstantDepositNoticeDismissed: boolean;
+		instantDepositsPreviouslyEligible: boolean;
 		isConnectionSuccessModalDismissed: boolean;
 		trackingInfo?: {
 			hosting_provider: string;

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1006,6 +1006,7 @@ class WC_Payments_Admin {
 			'storeName'                          => get_bloginfo( 'name' ),
 			'isNextDepositNoticeDismissed'       => WC_Payments_Features::is_next_deposit_notice_dismissed(),
 			'isInstantDepositNoticeDismissed'    => get_option( 'wcpay_instant_deposit_notice_dismissed', false ),
+			'instantDepositsPreviouslyEligible'  => get_option( 'wcpay_instant_deposits_previously_eligible', false ),
 			'dismissedDuplicateNotices'          => get_option( 'wcpay_duplicate_payment_method_notices_dismissed', [] ),
 			'isConnectionSuccessModalDismissed'  => get_option( WC_Payments_Onboarding_Service::ONBOARDING_CONNECTION_SUCCESS_MODAL_OPTION, false ),
 			'isOverviewSurveySubmitted'          => get_option( 'wcpay_survey_payment_overview_submitted', false ),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2555,6 +2555,10 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			return;
 		}
 
+		// Track that this merchant has been eligible for instant deposits.
+		// Used to show an informative notice if they later become ineligible.
+		update_option( 'wcpay_instant_deposits_previously_eligible', true );
+
 		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-instant-deposits-eligible.php';
 		WC_Payments_Notes_Instant_Deposits_Eligible::possibly_add_note();
 		$this->maybe_add_instant_deposit_note_reminder();

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3091,6 +3091,9 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 			'instant_deposits_eligible' => true,
 		];
 
+		// Ensure option is not set before.
+		delete_option( 'wcpay_instant_deposits_previously_eligible' );
+
 		$this->wcpay_account->handle_instant_deposits_inbox_note( $account );
 
 		$note_id = WC_Payments_Notes_Instant_Deposits_Eligible::NOTE_NAME;
@@ -3098,6 +3101,9 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 
 		// Test to see if scheduled action was created.
 		$this->assertTrue( $this->mock_action_scheduler_service->pending_action_exists( $action_hook ) );
+
+		// Test that the previously eligible option is set.
+		$this->assertTrue( get_option( 'wcpay_instant_deposits_previously_eligible', false ) );
 	}
 
 	public function test_handle_instant_deposits_inbox_note_not_eligible() {
@@ -3111,10 +3117,16 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 			'instant_deposits_eligible' => false,
 		];
 
+		// Ensure option is not set before.
+		delete_option( 'wcpay_instant_deposits_previously_eligible' );
+
 		$this->wcpay_account->handle_instant_deposits_inbox_note( $account );
 
 		$note_id = WC_Payments_Notes_Instant_Deposits_Eligible::NOTE_NAME;
 		$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+
+		// Test that the previously eligible option is NOT set when ineligible.
+		$this->assertFalse( get_option( 'wcpay_instant_deposits_previously_eligible', false ) );
 	}
 
 	public function test_handle_instant_deposits_inbox_reminder_will_not_schedule_job_if_pending_action_exist() {


### PR DESCRIPTION
Fixes WOOPMNT-3121

#### Changes proposed in this Pull Request

When a merchant who was previously eligible for instant payouts becomes ineligible (e.g., due to dispute ratio changes), the instant payout button would silently disappear with no explanation.

This PR adds an informative warning notice that appears when:
- The merchant was previously eligible for instant payouts
- They are currently ineligible (no instant balance available)

The notice includes a link to the eligibility requirements documentation.

**Implementation:**
- Track previous eligibility via `wcpay_instant_deposits_previously_eligible` WordPress option
- Pass this flag to the frontend via `wcpaySettings`
- Show a non-dismissible warning notice when previously eligible but currently ineligible

#### Testing instructions

1. Set up a test store eligible for instant deposits (USD currency, US location, debit card payout method, >$1000 processed)
2. Verify the instant payout button appears on Payments → Overview
3. In the database, set `wcpay_instant_deposits_previously_eligible` option to `true`
4. Simulate ineligibility by clearing the instant balance data (or use a test account that becomes ineligible)
5. Verify the warning notice appears: "Instant payouts are temporarily unavailable for your account. Learn about eligibility requirements"
6. Verify the link goes to the instant payouts documentation

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)