### PR TITLE
chore: add non-interactive changelog command for automation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,7 +105,8 @@ npm run psalm                       # PHP static analysis
 
 ### Other
 ```bash
-npm run changelog                   # Add changelog entry
+npm run changelog                   # Add changelog entry (interactive)
+npm run changelog:add               # Add changelog entry (non-interactive, for automation)
 npm run i18n:pot                    # Generate translations
 ```
 
@@ -128,7 +129,9 @@ npm run i18n:pot                    # Generate translations
 - Release branch: `trunk`
 - Husky manages git hooks
 - **Before creating a PR:**
-  - Must run `npm run changelog add` and commit the changelog entry (choose 'patch' if change is not significant)
+  - Must add and commit a changelog entry (use 'patch' significance if change is not significant)
+  - For Claude/automation: `npm run changelog:add -- --type=<type> --entry="<description>"`
+  - For interactive use: `npm run changelog`
   - Changelog must be committed and pushed before creating the PR
 - Use PR template from `.github/PULL_REQUEST_TEMPLATE.md` when creating pull requests
   - Include testing instructions
@@ -148,8 +151,15 @@ npm run i18n:pot                    # Generate translations
 - Use npm for JavaScript dependencies
 
 ### Changelog
-- Use `npm run changelog` to add entries
-- Types: Add, Fix, Update, Dev
+- Use `npm run changelog` for interactive changelog entry creation
+- Use `npm run changelog:add` for non-interactive (automation/Claude) usage:
+  ```bash
+  npm run changelog:add -- --type=fix --entry="Fixed a bug"
+  npm run changelog:add -- --type=add --entry="Added feature" --significance=minor
+  # Or with positional args: npm run changelog:add -- patch fix "Fixed a bug"
+  ```
+- Types: add, fix, update, dev
+- Significances: patch (default), minor, major
 - Entries go in `changelog/` directory
 
 ## Important Configuration Files

--- a/bin/changelog-add.sh
+++ b/bin/changelog-add.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Non-interactive wrapper for the Jetpack Changelogger add command.
+# Makes it easy for automation (including Claude) to add changelog entries.
+#
+# Usage:
+#   ./bin/changelog-add.sh --type=fix --entry="Fixed a bug"
+#   ./bin/changelog-add.sh -t add -e "Added new feature" -s minor
+#   ./bin/changelog-add.sh patch fix "Fixed a bug"  # positional: significance type entry
+#
+# Options:
+#   -t, --type         Type of change: add, fix, update, dev (required)
+#   -s, --significance Significance: patch, minor, major (default: patch)
+#   -e, --entry        Changelog entry text (required)
+#   -f, --filename     Custom filename (default: auto-generated from branch)
+#   -c, --comment      Optional comment
+#   -h, --help         Show this help message
+#
+
+set -e
+
+# Default values
+SIGNIFICANCE="patch"
+TYPE=""
+ENTRY=""
+FILENAME=""
+COMMENT=""
+
+show_help() {
+    cat << EOF
+Usage: $0 [OPTIONS] or $0 <significance> <type> <entry>
+
+Non-interactive changelog entry creation.
+
+Options:
+  -t, --type         Type of change: add, fix, update, dev (required)
+  -s, --significance Significance: patch, minor, major (default: patch)
+  -e, --entry        Changelog entry text (required)
+  -f, --filename     Custom filename (default: auto-generated from branch)
+  -c, --comment      Optional comment
+  -h, --help         Show this help message
+
+Positional Arguments (alternative to options):
+  $0 <significance> <type> <entry>
+
+Examples:
+  $0 --type=fix --entry="Fixed payment processing bug"
+  $0 -t add -e "Added new payment method" -s minor
+  $0 patch fix "Fixed a bug"
+  $0 minor add "Added new feature"
+
+Valid types: add, fix, update, dev
+Valid significances: patch, minor, major
+EOF
+    exit 0
+}
+
+# Check if positional arguments are provided (significance type entry)
+if [[ $# -ge 3 && ! "$1" =~ ^- ]]; then
+    SIGNIFICANCE="$1"
+    TYPE="$2"
+    ENTRY="$3"
+else
+    # Parse named arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -t|--type)
+                TYPE="$2"
+                shift 2
+                ;;
+            --type=*)
+                TYPE="${1#*=}"
+                shift
+                ;;
+            -s|--significance)
+                SIGNIFICANCE="$2"
+                shift 2
+                ;;
+            --significance=*)
+                SIGNIFICANCE="${1#*=}"
+                shift
+                ;;
+            -e|--entry)
+                ENTRY="$2"
+                shift 2
+                ;;
+            --entry=*)
+                ENTRY="${1#*=}"
+                shift
+                ;;
+            -f|--filename)
+                FILENAME="$2"
+                shift 2
+                ;;
+            --filename=*)
+                FILENAME="${1#*=}"
+                shift
+                ;;
+            -c|--comment)
+                COMMENT="$2"
+                shift 2
+                ;;
+            --comment=*)
+                COMMENT="${1#*=}"
+                shift
+                ;;
+            -h|--help)
+                show_help
+                ;;
+            *)
+                echo "Error: Unknown option: $1" >&2
+                echo "Use --help for usage information" >&2
+                exit 1
+                ;;
+        esac
+    done
+fi
+
+# Validate required arguments
+if [[ -z "$TYPE" ]]; then
+    echo "Error: --type is required (add, fix, update, dev)" >&2
+    exit 1
+fi
+
+if [[ -z "$ENTRY" ]]; then
+    echo "Error: --entry is required" >&2
+    exit 1
+fi
+
+# Validate type
+if [[ ! "$TYPE" =~ ^(add|fix|update|dev)$ ]]; then
+    echo "Error: Invalid type '$TYPE'. Must be one of: add, fix, update, dev" >&2
+    exit 1
+fi
+
+# Validate significance
+if [[ ! "$SIGNIFICANCE" =~ ^(patch|minor|major)$ ]]; then
+    echo "Error: Invalid significance '$SIGNIFICANCE'. Must be one of: patch, minor, major" >&2
+    exit 1
+fi
+
+# Build the command arguments array for proper escaping
+ARGS=(
+    "./vendor/bin/changelogger" "add"
+    "--no-interaction"
+    "--filename-auto-suffix"
+    "--significance=$SIGNIFICANCE"
+    "--type=$TYPE"
+    "--entry=$ENTRY"
+)
+
+if [[ -n "$FILENAME" ]]; then
+    ARGS+=("--filename=$FILENAME")
+fi
+
+if [[ -n "$COMMENT" ]]; then
+    ARGS+=("--comment=$COMMENT")
+fi
+
+# Run the command
+"${ARGS[@]}"

--- a/changelog/improve-changelog-command
+++ b/changelog/improve-changelog-command
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add non-interactive changelog command for automation

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "psalm": "./bin/run-psalm.sh",
     "xdebug:toggle": "docker compose exec -u root wordpress /var/www/html/wp-content/plugins/woocommerce-payments/bin/xdebug-toggle.sh",
     "changelog": "./vendor/bin/changelogger add",
+    "changelog:add": "./bin/changelog-add.sh",
     "cli": "./bin/cli.sh"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Adds a non-interactive wrapper script (`bin/changelog-add.sh`) for the Jetpack Changelogger that enables automation tools (including Claude) to create changelog entries without interactive prompts.

**Why is this change needed?**
The current `npm run changelog` command requires interactive input, which doesn't work well for automation or AI assistants that need to add changelog entries programmatically.

**What does this change do?**
- Adds `bin/changelog-add.sh` - a bash wrapper that accepts CLI arguments
- Adds `npm run changelog:add` script for non-interactive usage
- Updates CLAUDE.md documentation with the new command

**Usage examples:**
```bash
# Named arguments
npm run changelog:add -- --type=fix --entry="Fixed a bug"
npm run changelog:add -- --type=add --entry="Added feature" --significance=minor

# Positional arguments
npm run changelog:add -- patch fix "Fixed a bug"
```

**Options:**
- `--type` / `-t` (required): add, fix, update, dev
- `--significance` / `-s` (default: patch): patch, minor, major
- `--entry` / `-e` (required): changelog text
- `--filename` / `-f` (optional): custom filename
- `--comment` / `-c` (optional): comment

#### Testing instructions

1. Run `npm run changelog:add -- --help` to see usage information
2. Test creating a changelog entry:
   ```bash
   npm run changelog:add -- --type=dev --entry="Test entry" --filename=test-entry
   ```
3. Verify the file was created in `changelog/test-entry`
4. Clean up: `rm changelog/test-entry`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
  - This is a simple bash wrapper script; manual testing is sufficient
- [x] Tested on mobile (or does not apply)
  - N/A - CLI tool only

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)