### PR TITLE
chore: tweak wcpay_payment_fields_js_config calls and content

### DIFF
--- a/changelog/chore-remove-unused-payment-methods-js-config
+++ b/changelog/chore-remove-unused-payment-methods-js-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+chore: removed unused entries from the `wcpay_payment_fields_js_config` filter; ensured single call of the `wcpay_payment_fields_js_config` filter;

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -236,7 +236,6 @@ class WC_Payments_Checkout {
 
 		$enabled_billing_fields = [];
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
-			$payment_fields['isChangingPayment'] = true;
 			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
 				$enabled_billing_fields[ $billing_field ] = [
 					'required' => $billing_field_options['required'] ?? false,
@@ -247,6 +246,7 @@ class WC_Payments_Checkout {
 
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
 			if ( $this->gateway->is_subscriptions_enabled() && $this->gateway->is_changing_payment_method_for_subscription() ) {
+				$payment_fields['isChangingPayment'] = true;
 				return $payment_fields; // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 			}
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -216,15 +216,8 @@ class WC_Payments_Checkout {
 			'woopayMinimumSessionData'          => WooPay_Session::get_woopay_minimum_session_data(),
 		];
 
-		/**
-		 * Allows filtering of the JS config for the payment fields.
-		 *
-		 * @param array $js_config The JS config for the payment fields.
-		 */
-		$payment_fields = apply_filters( 'wcpay_payment_fields_js_config', $js_config );
+		$payment_fields = $js_config;
 
-		$payment_fields['accountDescriptor']             = $this->gateway->get_account_statement_descriptor();
-		$payment_fields['addPaymentReturnURL']           = wc_get_account_endpoint_url( 'payment-methods' );
 		$payment_fields['gatewayId']                     = WC_Payment_Gateway_WCPay::GATEWAY_ID;
 		$payment_fields['isCheckout']                    = is_checkout();
 		$payment_fields['paymentMethodsConfig']          = $this->get_enabled_payment_method_config();
@@ -243,6 +236,7 @@ class WC_Payments_Checkout {
 
 		$enabled_billing_fields = [];
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
+			$payment_fields['isChangingPayment'] = true;
 			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
 				$enabled_billing_fields[ $billing_field ] = [
 					'required' => $billing_field_options['required'] ?? false,
@@ -253,16 +247,6 @@ class WC_Payments_Checkout {
 
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
 			if ( $this->gateway->is_subscriptions_enabled() && $this->gateway->is_changing_payment_method_for_subscription() ) {
-				$payment_fields['isChangingPayment']   = true;
-				$payment_fields['addPaymentReturnURL'] = esc_url_raw( home_url( add_query_arg( [] ) ) );
-
-				if ( $this->gateway->is_setup_intent_success_creation_redirection() && isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) ) ) {
-					$setup_intent_id = isset( $_GET['setup_intent'] ) ? wc_clean( wp_unslash( $_GET['setup_intent'] ) ) : '';
-					$token           = $this->gateway->create_token_from_setup_intent( $setup_intent_id, wp_get_current_user() );
-					if ( null !== $token ) {
-						$payment_fields['newTokenFormId'] = '#wc-' . $token->get_gateway_id() . '-payment-token-' . $token->get_id();
-					}
-				}
 				return $payment_fields; // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 			}
 
@@ -281,13 +265,10 @@ class WC_Payments_Checkout {
 		// Get the store base country.
 		$payment_fields['storeCountry'] = WC()->countries->get_base_country();
 
-		// Get the WooCommerce Store API endpoint.
-		$payment_fields['storeApiURL'] = get_rest_url( null, 'wc/store' );
-
 		/**
-		 * Allows filtering for the payment fields.
+		 * Allows filtering of the JS config for the payment fields.
 		 *
-		 * @param array $payment_fields The payment fields.
+		 * @param array $js_config The JS config for the payment fields.
 		 */
 		return apply_filters( 'wcpay_payment_fields_js_config', $payment_fields ); // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 	}


### PR DESCRIPTION
Fixes WOOPMNT-5644

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the `wcpay_payment_fields_js_config` filter was being called twice.
One time is sufficient - it looks like it was a copy-pasta mistake.

While I was there, I also removed a few unused entries from the config:
- `accountDescriptor`
- `addPaymentReturnURL`
- `newTokenFormId`
- `storeApiURL`

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Search for the configuration entries I removed (mentioned above) in the codebase - there should be no usage
- E2E tests should have no new failures

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
