### PR TITLE
Add QIT E2E workflows for PR, scheduled, and pre-release testing

### DIFF
--- a/.github/scripts/generate-wc-matrix.sh
+++ b/.github/scripts/generate-wc-matrix.sh
@@ -25,6 +25,14 @@ get_l1_version() {
     get_latest_stable_for_major "$l1_major"
 }
 
+# Function to get the L-2 version (two major versions back's latest stable)
+get_l2_version() {
+    local latest_version=$1
+    local major_version=$(echo "$latest_version" | cut -d. -f1)
+    local l2_major=$((major_version - 2))
+    get_latest_stable_for_major "$l2_major"
+}
+
 # Function to get specific major versions' latest stable
 get_major_versions_latest() {
     local latest_version=$1
@@ -68,6 +76,10 @@ echo "Latest WC version: $LATEST_WC_VERSION" >&2
 # Get the L-1 version
 L1_VERSION=$(get_l1_version "$LATEST_WC_VERSION")
 echo "L-1 version: $L1_VERSION" >&2
+
+# Get the L-2 version
+L2_VERSION=$(get_l2_version "$LATEST_WC_VERSION")
+echo "L-2 version: $L2_VERSION" >&2
 
 # Get major versions latest stable
 MAJOR_VERSIONS=($(get_major_versions_latest "$LATEST_WC_VERSION"))
@@ -128,6 +140,16 @@ if [[ ! "$L1_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
+if [[ -z "$L2_VERSION" || "$L2_VERSION" == "null" ]]; then
+    echo "Error: Could not extract L-2 version" >&2
+    exit 1
+fi
+
+if [[ ! "$L2_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid L-2 version: $L2_VERSION" >&2
+    exit 1
+fi
+
 # RC is optional; do not fail if not present or skipped
 
 # Only validate beta if it's available
@@ -143,12 +165,14 @@ fi
 RESULT=$(jq -n \
     --argjson versions "$(printf '%s\n' "${VERSIONS[@]}" | jq -R . | jq -s .)" \
     --arg l1_version "$L1_VERSION" \
+    --arg l2_version "$L2_VERSION" \
     --arg rc_version "${INCLUDED_RC_VERSION}" \
     --arg beta_version "${LATEST_BETA_VERSION}" \
     '{
         versions: $versions,
         metadata: {
             l1_version: $l1_version,
+            l2_version: $l2_version,
             rc_version: (if ($rc_version // "") == "" or ($rc_version == "null") then null else $rc_version end),
             beta_version: (if ($beta_version // "") == "" or ($beta_version == "null") then null else $beta_version end)
         }

--- a/.github/workflows/qit-e2e-pr.yml
+++ b/.github/workflows/qit-e2e-pr.yml
@@ -1,0 +1,60 @@
+name: QIT E2E Tests - Pull Request
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - trunk
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-matrix:
+    name: Generate test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate matrix
+        id: generate
+        run: |
+          # Get WC versions from matrix script
+          SCRIPT_RESULT=$(.github/scripts/generate-wc-matrix.sh)
+          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
+
+          echo "L-1 version: $L1_VERSION" >&2
+
+          # Build PR matrix: L-1 + latest, PHP 8.3 only, all test packages
+          MATRIX_ENTRIES=()
+          for wc_version in "$L1_VERSION" "latest"; do
+            for test_package in "shopper" "merchant" "subscriptions"; do
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$wc_version\",\"php\":\"8.3\",\"test-package\":\"$test_package\"}")
+            done
+          done
+
+          MATRIX_JSON=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s '{"include": .}' -c)
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+
+  qit-e2e:
+    name: "WC ${{ matrix.woocommerce }} | PHP ${{ matrix.php }} | ${{ matrix.test-package }}"
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    uses: ./.github/workflows/qit-e2e-run.yml
+    with:
+      woocommerce-version: ${{ matrix.woocommerce }}
+      php-version: ${{ matrix.php }}
+      test-package: ${{ matrix.test-package }}
+    secrets:
+      QIT_CI_USER: ${{ secrets.QIT_CI_USER }}
+      QIT_CI_SECRET: ${{ secrets.QIT_CI_SECRET }}
+      E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
+      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
+      E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}

--- a/.github/workflows/qit-e2e-pr.yml
+++ b/.github/workflows/qit-e2e-pr.yml
@@ -12,6 +12,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up repository
+        uses: ./.github/actions/setup-repo
+
+      - name: Build the plugin
+        uses: ./.github/actions/build
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: woocommerce-payments-${{ github.run_id }}
+          path: woocommerce-payments.zip
+          retention-days: 1
+
   generate-matrix:
     name: Generate test matrix
     runs-on: ubuntu-latest
@@ -43,7 +63,7 @@ jobs:
 
   qit-e2e:
     name: "WC ${{ matrix.woocommerce }} | PHP ${{ matrix.php }} | ${{ matrix.test-package }}"
-    needs: generate-matrix
+    needs: [build, generate-matrix]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -52,6 +72,7 @@ jobs:
       woocommerce-version: ${{ matrix.woocommerce }}
       php-version: ${{ matrix.php }}
       test-package: ${{ matrix.test-package }}
+      artifact-name: woocommerce-payments-${{ github.run_id }}
     secrets:
       QIT_CI_USER: ${{ secrets.QIT_CI_USER }}
       QIT_CI_SECRET: ${{ secrets.QIT_CI_SECRET }}

--- a/.github/workflows/qit-e2e-pr.yml
+++ b/.github/workflows/qit-e2e-pr.yml
@@ -76,6 +76,6 @@ jobs:
     secrets:
       QIT_CI_USER: ${{ secrets.QIT_CI_USER }}
       QIT_CI_SECRET: ${{ secrets.QIT_CI_SECRET }}
-      E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
-      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
-      E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
+      E2E_JP_SITE_ID: ${{ secrets.E2E_QIT_JP_SITE_ID }}
+      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}
+      E2E_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}

--- a/.github/workflows/qit-e2e-prerelease.yml
+++ b/.github/workflows/qit-e2e-prerelease.yml
@@ -1,0 +1,72 @@
+name: QIT E2E Tests - Pre-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      woocommerce-version:
+        description: 'WooCommerce version (e.g., 10.5.0-dev, 9.7.0-beta.1, 9.7.0-rc.1)'
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up repository
+        uses: ./.github/actions/setup-repo
+
+      - name: Build the plugin
+        uses: ./.github/actions/build
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: woocommerce-payments-${{ github.run_id }}
+          path: woocommerce-payments.zip
+          retention-days: 1
+
+  generate-matrix:
+    name: Generate test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Generate matrix
+        id: generate
+        run: |
+          WC_VERSION="${{ inputs.woocommerce-version }}"
+          echo "WC version: $WC_VERSION" >&2
+
+          # Build pre-release matrix: user-specified WC version, PHP 8.1 + 8.3, all test packages
+          MATRIX_ENTRIES=()
+          for php_version in "8.1" "8.3"; do
+            for test_package in "shopper" "merchant" "subscriptions"; do
+              MATRIX_ENTRIES+=("{\"woocommerce\":\"$WC_VERSION\",\"php\":\"$php_version\",\"test-package\":\"$test_package\"}")
+            done
+          done
+
+          MATRIX_JSON=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s '{"include": .}' -c)
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+
+  qit-e2e:
+    name: "WC ${{ matrix.woocommerce }} | PHP ${{ matrix.php }} | ${{ matrix.test-package }}"
+    needs: [build, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    uses: ./.github/workflows/qit-e2e-run.yml
+    with:
+      woocommerce-version: ${{ matrix.woocommerce }}
+      php-version: ${{ matrix.php }}
+      test-package: ${{ matrix.test-package }}
+      artifact-name: woocommerce-payments-${{ github.run_id }}
+    secrets:
+      QIT_CI_USER: ${{ secrets.QIT_CI_USER }}
+      QIT_CI_SECRET: ${{ secrets.QIT_CI_SECRET }}
+      E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
+      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
+      E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -49,7 +49,8 @@ jobs:
           coverage: none
 
       - name: Install QIT CLI
-        run: composer global require woocommerce/qit-cli
+        # Use dev-trunk because test packages feature is not yet in stable releases
+        run: composer global require woocommerce/qit-cli:dev-trunk
 
       - name: Authenticate QIT
         run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -36,6 +36,9 @@ jobs:
     name: "QIT E2E - ${{ inputs.test-package }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download plugin artifact
         uses: actions/download-artifact@v4
         with:
@@ -57,15 +60,13 @@ jobs:
 
       - name: Run QIT E2E Tests
         env:
-          E2E_JP_SITE_ID: ${{ secrets.E2E_QIT_JP_SITE_ID }}
-          E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}
-          E2E_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}
+          E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
+          E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
+          E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
         run: |
-          # Build the QIT command
-          # Use --plugin with explicit slug format for local zip file (run:e2e doesn't have --zip option)
+          # Build the QIT command using local config (test packages are defined locally)
           QIT_CMD="qit run:e2e woocommerce-payments"
-          QIT_CMD="$QIT_CMD --plugin=woocommerce-payments@./woocommerce-payments.zip"
-          QIT_CMD="$QIT_CMD --test-package=woocommerce-payments/${{ inputs.test-package }}:latest"
+          QIT_CMD="$QIT_CMD --config tests/qit/qit.json"
           QIT_CMD="$QIT_CMD --woo=${{ inputs.woocommerce-version }}"
           QIT_CMD="$QIT_CMD --php=${{ inputs.php-version }}"
 
@@ -81,6 +82,9 @@ jobs:
 
           # Wait for results
           QIT_CMD="$QIT_CMD --wait"
+
+          # Pass the Playwright project filter as test arguments
+          QIT_CMD="$QIT_CMD -- --project=${{ inputs.test-package }}"
 
           echo "Running: $QIT_CMD"
           eval $QIT_CMD

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -64,13 +64,13 @@ jobs:
           E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
           E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
         run: |
-          # Build command following local npm script pattern:
-          # ./vendor/bin/qit run:e2e woocommerce-payments --config tests/qit/qit.json --profile=default -- --project=<name>
+          # Use --test-package to select the specific subpackage with its own run command
+          # The :local suffix indicates it's a local package (from --config)
           QIT_ARGS=(
             "run:e2e"
             "woocommerce-payments"
             "--config" "tests/qit/qit.json"
-            "--profile=default"
+            "--test-package" "woocommerce-payments/${{ inputs.test-package }}:local"
             "--woo=${{ inputs.woocommerce-version }}"
             "--php=${{ inputs.php-version }}"
           )
@@ -87,9 +87,6 @@ jobs:
 
           # Wait for results
           QIT_ARGS+=("--wait")
-
-          # Pass the Playwright project filter as passthrough arguments
-          QIT_ARGS+=("--" "--project=${{ inputs.test-package }}")
 
           echo "Running: qit ${QIT_ARGS[*]}"
           qit "${QIT_ARGS[@]}"

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -41,10 +41,15 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+          coverage: none
+
       - name: Install QIT CLI
-        run: |
-          composer global require woocommerce/qit-cli
-          echo "$HOME/.composer/vendor/bin" >> $GITHUB_PATH
+        run: composer global require woocommerce/qit-cli
 
       - name: Authenticate QIT
         run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -61,8 +61,9 @@ jobs:
           E2E_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}
         run: |
           # Build the QIT command
+          # Use --plugin with explicit slug format for local zip file (run:e2e doesn't have --zip option)
           QIT_CMD="qit run:e2e woocommerce-payments"
-          QIT_CMD="$QIT_CMD --zip=woocommerce-payments.zip"
+          QIT_CMD="$QIT_CMD --plugin=woocommerce-payments@./woocommerce-payments.zip"
           QIT_CMD="$QIT_CMD --test-package=woocommerce-payments/${{ inputs.test-package }}"
           QIT_CMD="$QIT_CMD --woo=${{ inputs.woocommerce-version }}"
           QIT_CMD="$QIT_CMD --php=${{ inputs.php-version }}"

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -64,20 +64,20 @@ jobs:
           E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
           E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
         run: |
-          # Build command arguments array
-          # Use local config and specify the subpackage to run
+          # Build command following local npm script pattern:
+          # ./vendor/bin/qit run:e2e woocommerce-payments --config tests/qit/qit.json --profile=default -- --project=<name>
           QIT_ARGS=(
             "run:e2e"
             "woocommerce-payments"
             "--config" "tests/qit/qit.json"
-            "--test-package" "woocommerce-payments/${{ inputs.test-package }}"
+            "--profile=default"
             "--woo=${{ inputs.woocommerce-version }}"
             "--php=${{ inputs.php-version }}"
           )
 
           # Add WC Subscriptions plugin for subscriptions tests
           if [[ "${{ inputs.test-package }}" == "subscriptions" ]]; then
-            QIT_ARGS+=("--plugin=woocommerce-subscriptions")
+            QIT_ARGS+=("-p" "woocommerce-subscriptions")
           fi
 
           # Pass Jetpack secrets as environment variables
@@ -87,6 +87,9 @@ jobs:
 
           # Wait for results
           QIT_ARGS+=("--wait")
+
+          # Pass the Playwright project filter as passthrough arguments
+          QIT_ARGS+=("--" "--project=${{ inputs.test-package }}")
 
           echo "Running: qit ${QIT_ARGS[*]}"
           qit "${QIT_ARGS[@]}"

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -65,7 +65,7 @@ jobs:
           # Use --plugin with explicit slug format for local zip file (run:e2e doesn't have --zip option)
           QIT_CMD="qit run:e2e woocommerce-payments"
           QIT_CMD="$QIT_CMD --plugin=woocommerce-payments@./woocommerce-payments.zip"
-          QIT_CMD="$QIT_CMD --test-package=woocommerce-payments/${{ inputs.test-package }}"
+          QIT_CMD="$QIT_CMD --test-package=woocommerce-payments/${{ inputs.test-package }}:latest"
           QIT_CMD="$QIT_CMD --woo=${{ inputs.woocommerce-version }}"
           QIT_CMD="$QIT_CMD --php=${{ inputs.php-version }}"
 

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -1,0 +1,77 @@
+name: QIT E2E Tests - Run
+
+on:
+  workflow_call:
+    inputs:
+      woocommerce-version:
+        description: 'WooCommerce version (nightly, or specific version like 9.6.0, 10.5.0-dev)'
+        required: true
+        type: string
+      php-version:
+        description: 'PHP version'
+        required: true
+        type: string
+      test-package:
+        description: 'QIT test subpackage (shopper, merchant, subscriptions)'
+        required: true
+        type: string
+    secrets:
+      QIT_CI_USER:
+        required: true
+      QIT_CI_SECRET:
+        required: true
+      E2E_JP_SITE_ID:
+        required: true
+      E2E_JP_BLOG_TOKEN:
+        required: true
+      E2E_JP_USER_TOKEN:
+        required: true
+
+jobs:
+  qit-e2e:
+    name: "QIT E2E - ${{ inputs.test-package }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up repository
+        uses: ./.github/actions/setup-repo
+
+      - name: Build the plugin
+        uses: ./.github/actions/build
+
+      - name: Install QIT CLI
+        run: composer global require woocommerce/qit-cli
+
+      - name: Authenticate QIT
+        run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'
+
+      - name: Run QIT E2E Tests
+        env:
+          E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
+          E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
+          E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
+        run: |
+          # Build the QIT command
+          QIT_CMD="qit run:e2e woocommerce-payments"
+          QIT_CMD="$QIT_CMD --zip=woocommerce-payments.zip"
+          QIT_CMD="$QIT_CMD --test-package=woocommerce-payments/${{ inputs.test-package }}"
+          QIT_CMD="$QIT_CMD --woo=${{ inputs.woocommerce-version }}"
+          QIT_CMD="$QIT_CMD --php=${{ inputs.php-version }}"
+
+          # Add WC Subscriptions plugin for subscriptions tests
+          if [[ "${{ inputs.test-package }}" == "subscriptions" ]]; then
+            QIT_CMD="$QIT_CMD --plugin=woocommerce-subscriptions"
+          fi
+
+          # Pass Jetpack secrets as environment variables
+          QIT_CMD="$QIT_CMD --env E2E_JP_SITE_ID=$E2E_JP_SITE_ID"
+          QIT_CMD="$QIT_CMD --env E2E_JP_BLOG_TOKEN=$E2E_JP_BLOG_TOKEN"
+          QIT_CMD="$QIT_CMD --env E2E_JP_USER_TOKEN=$E2E_JP_USER_TOKEN"
+
+          # Wait for results
+          QIT_CMD="$QIT_CMD --wait"
+
+          echo "Running: $QIT_CMD"
+          eval $QIT_CMD

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Run QIT E2E Tests
         env:
-          E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
-          E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
-          E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
+          E2E_JP_SITE_ID: ${{ secrets.E2E_QIT_JP_SITE_ID }}
+          E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}
+          E2E_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}
         run: |
           # Build the QIT command
           QIT_CMD="qit run:e2e woocommerce-payments"

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -15,6 +15,10 @@ on:
         description: 'QIT test subpackage (shopper, merchant, subscriptions)'
         required: true
         type: string
+      artifact-name:
+        description: 'Name of the artifact containing the built plugin zip'
+        required: true
+        type: string
     secrets:
       QIT_CI_USER:
         required: true
@@ -32,14 +36,10 @@ jobs:
     name: "QIT E2E - ${{ inputs.test-package }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up repository
-        uses: ./.github/actions/setup-repo
-
-      - name: Build the plugin
-        uses: ./.github/actions/build
+      - name: Download plugin artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
 
       - name: Install QIT CLI
         run: composer global require woocommerce/qit-cli

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -42,7 +42,9 @@ jobs:
           name: ${{ inputs.artifact-name }}
 
       - name: Install QIT CLI
-        run: composer global require woocommerce/qit-cli
+        run: |
+          composer global require woocommerce/qit-cli
+          echo "$HOME/.composer/vendor/bin" >> $GITHUB_PATH
 
       - name: Authenticate QIT
         run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -64,13 +64,13 @@ jobs:
           E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
           E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
         run: |
-          # Use --test-package to select the specific subpackage with its own run command
-          # The :local suffix indicates it's a local package (from --config)
+          # Match local npm script: ./vendor/bin/qit run:e2e woocommerce-payments --config tests/qit/qit.json --profile=default
+          # Pass --project via passthrough args to filter Playwright tests
           QIT_ARGS=(
             "run:e2e"
             "woocommerce-payments"
             "--config" "tests/qit/qit.json"
-            "--test-package" "woocommerce-payments/${{ inputs.test-package }}:local"
+            "--profile=default"
             "--woo=${{ inputs.woocommerce-version }}"
             "--php=${{ inputs.php-version }}"
           )
@@ -87,6 +87,9 @@ jobs:
 
           # Wait for results
           QIT_ARGS+=("--wait")
+
+          # Pass Playwright project filter as passthrough arguments
+          QIT_ARGS+=("--" "--project=${{ inputs.test-package }}")
 
           echo "Running: qit ${QIT_ARGS[*]}"
           qit "${QIT_ARGS[@]}"

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -65,10 +65,12 @@ jobs:
           E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
         run: |
           # Build command arguments array
+          # Use local config and specify the subpackage to run
           QIT_ARGS=(
             "run:e2e"
             "woocommerce-payments"
             "--config" "tests/qit/qit.json"
+            "--test-package" "woocommerce-payments/${{ inputs.test-package }}"
             "--woo=${{ inputs.woocommerce-version }}"
             "--php=${{ inputs.php-version }}"
           )
@@ -85,9 +87,6 @@ jobs:
 
           # Wait for results
           QIT_ARGS+=("--wait")
-
-          # Pass the Playwright project filter as test arguments
-          QIT_ARGS+=("--" "--project=${{ inputs.test-package }}")
 
           echo "Running: qit ${QIT_ARGS[*]}"
           qit "${QIT_ARGS[@]}"

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -64,27 +64,30 @@ jobs:
           E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
           E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
         run: |
-          # Build the QIT command using local config (test packages are defined locally)
-          QIT_CMD="qit run:e2e woocommerce-payments"
-          QIT_CMD="$QIT_CMD --config tests/qit/qit.json"
-          QIT_CMD="$QIT_CMD --woo=${{ inputs.woocommerce-version }}"
-          QIT_CMD="$QIT_CMD --php=${{ inputs.php-version }}"
+          # Build command arguments array
+          QIT_ARGS=(
+            "run:e2e"
+            "woocommerce-payments"
+            "--config" "tests/qit/qit.json"
+            "--woo=${{ inputs.woocommerce-version }}"
+            "--php=${{ inputs.php-version }}"
+          )
 
           # Add WC Subscriptions plugin for subscriptions tests
           if [[ "${{ inputs.test-package }}" == "subscriptions" ]]; then
-            QIT_CMD="$QIT_CMD --plugin=woocommerce-subscriptions"
+            QIT_ARGS+=("--plugin=woocommerce-subscriptions")
           fi
 
           # Pass Jetpack secrets as environment variables
-          QIT_CMD="$QIT_CMD --env E2E_JP_SITE_ID=$E2E_JP_SITE_ID"
-          QIT_CMD="$QIT_CMD --env E2E_JP_BLOG_TOKEN=$E2E_JP_BLOG_TOKEN"
-          QIT_CMD="$QIT_CMD --env E2E_JP_USER_TOKEN=$E2E_JP_USER_TOKEN"
+          QIT_ARGS+=("--env" "E2E_JP_SITE_ID=$E2E_JP_SITE_ID")
+          QIT_ARGS+=("--env" "E2E_JP_BLOG_TOKEN=$E2E_JP_BLOG_TOKEN")
+          QIT_ARGS+=("--env" "E2E_JP_USER_TOKEN=$E2E_JP_USER_TOKEN")
 
           # Wait for results
-          QIT_CMD="$QIT_CMD --wait"
+          QIT_ARGS+=("--wait")
 
           # Pass the Playwright project filter as test arguments
-          QIT_CMD="$QIT_CMD -- --project=${{ inputs.test-package }}"
+          QIT_ARGS+=("--" "--project=${{ inputs.test-package }}")
 
-          echo "Running: $QIT_CMD"
-          eval $QIT_CMD
+          echo "Running: qit ${QIT_ARGS[*]}"
+          qit "${QIT_ARGS[@]}"

--- a/.github/workflows/qit-e2e-scheduled.yml
+++ b/.github/workflows/qit-e2e-scheduled.yml
@@ -1,0 +1,84 @@
+name: QIT E2E Tests - Scheduled
+
+on:
+  schedule:
+    # Daily at midnight UTC
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - develop
+      - trunk
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up repository
+        uses: ./.github/actions/setup-repo
+
+      - name: Build the plugin
+        uses: ./.github/actions/build
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: woocommerce-payments-${{ github.run_id }}
+          path: woocommerce-payments.zip
+          retention-days: 1
+
+  generate-matrix:
+    name: Generate test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate matrix
+        id: generate
+        run: |
+          # Get WC versions from matrix script
+          SCRIPT_RESULT=$(.github/scripts/generate-wc-matrix.sh)
+          L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
+          L2_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l2_version')
+
+          echo "L-1 version: $L1_VERSION" >&2
+          echo "L-2 version: $L2_VERSION" >&2
+
+          # Build scheduled matrix: L-2 + L-1 + latest + nightly, PHP 8.1 + 8.3, all test packages
+          MATRIX_ENTRIES=()
+          for wc_version in "$L2_VERSION" "$L1_VERSION" "latest" "nightly"; do
+            for php_version in "8.1" "8.3"; do
+              for test_package in "shopper" "merchant" "subscriptions"; do
+                MATRIX_ENTRIES+=("{\"woocommerce\":\"$wc_version\",\"php\":\"$php_version\",\"test-package\":\"$test_package\"}")
+              done
+            done
+          done
+
+          MATRIX_JSON=$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s '{"include": .}' -c)
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+
+  qit-e2e:
+    name: "WC ${{ matrix.woocommerce }} | PHP ${{ matrix.php }} | ${{ matrix.test-package }}"
+    needs: [build, generate-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    uses: ./.github/workflows/qit-e2e-run.yml
+    with:
+      woocommerce-version: ${{ matrix.woocommerce }}
+      php-version: ${{ matrix.php }}
+      test-package: ${{ matrix.test-package }}
+      artifact-name: woocommerce-payments-${{ github.run_id }}
+    secrets:
+      QIT_CI_USER: ${{ secrets.QIT_CI_USER }}
+      QIT_CI_SECRET: ${{ secrets.QIT_CI_SECRET }}
+      E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
+      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
+      E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}

--- a/.github/workflows/qit-e2e-scheduled.yml
+++ b/.github/workflows/qit-e2e-scheduled.yml
@@ -79,6 +79,6 @@ jobs:
     secrets:
       QIT_CI_USER: ${{ secrets.QIT_CI_USER }}
       QIT_CI_SECRET: ${{ secrets.QIT_CI_SECRET }}
-      E2E_JP_SITE_ID: ${{ secrets.E2E_JP_SITE_ID }}
-      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_JP_BLOG_TOKEN }}
-      E2E_JP_USER_TOKEN: ${{ secrets.E2E_JP_USER_TOKEN }}
+      E2E_JP_SITE_ID: ${{ secrets.E2E_QIT_JP_SITE_ID }}
+      E2E_JP_BLOG_TOKEN: ${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}
+      E2E_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}

--- a/changelog/add-qit-e2e-workflows
+++ b/changelog/add-qit-e2e-workflows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add QIT E2E workflows for PR, scheduled, and pre-release testing with L-2 WooCommerce version support.

--- a/tests/qit/test-package/qit-test.json
+++ b/tests/qit/test-package/qit-test.json
@@ -23,7 +23,7 @@
                 "npx playwright install chromium --with-deps"
             ],
             "run": [
-                "npx playwright test --project=default --project=shopper --project=merchant"
+                "npx playwright test"
             ],
             "teardown": [],
             "globalTeardown": []


### PR DESCRIPTION
## Summary
- Add L-2 WooCommerce version support to matrix generation script
- Create reusable QIT E2E workflow (`qit-e2e-run.yml`) that builds once and shares artifact
- Add PR trigger workflow (L-1 + latest WC, PHP 8.3, 6 jobs)
- Add scheduled trigger workflow (L-2 + L-1 + latest + nightly WC, PHP 8.1 + 8.3, 24 jobs)
- Add pre-release trigger workflow for manual testing against dev/beta/rc versions

## Test plan
- [ ] Verify YAML syntax is valid (done locally)
- [ ] Verify matrix script outputs `l2_version` correctly (done locally)
- [ ] Trigger PR workflow manually via `workflow_dispatch` to verify it runs
- [ ] Verify artifact sharing works (plugin built once, downloaded by matrix jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)