### PR TITLE
chore: Add WooCommerce core reference instructions to Claude config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,29 @@ WooCommerce Payments (WCPay) is a WordPress plugin that provides payment process
 - See `woocommerce-payments.php` header for current version and WordPress/WooCommerce/PHP requirements
 - See `package.json` for Node.js version requirements (engines field)
 
+## WooCommerce Core Reference
+
+WooPayments is a separate plugin that integrates with WooCommerce core, leveraging its hooks, filters, and APIs. Having the WooCommerce codebase available locally provides useful context when working on WooPayments.
+
+**Location:** `../woocommerce` (or set `WOOCOMMERCE_DIR` env var to override)
+
+**Key paths within WooCommerce:**
+- `plugins/woocommerce/includes/` - Core WooCommerce PHP classes
+- `plugins/woocommerce/src/` - Modern PSR-4 WooCommerce code
+- `plugins/woocommerce-blocks/` - Checkout and cart blocks
+
+**When to reference WooCommerce core:**
+- When working with WC hooks/filters - check the core implementation to understand parameters, timing, and context
+- When using WC base classes (e.g., `WC_Payment_Gateway`) - understand the parent class behavior
+- When debugging issues that may involve core behavior
+- When implementing features that interact with WC APIs (orders, products, customers, etc.)
+
+**Auto-reference triggers:** Proactively check WooCommerce core when you encounter:
+- Classes using `WC_*` base classes
+- Hooks starting with `woocommerce_` or `wc_`
+- Usage of `WC()` singleton or WC helper functions
+- Order, product, or customer manipulation code
+
 ## Directory Structure
 
 ### PHP Code

--- a/changelog/add-claude-woocommerce-reference
+++ b/changelog/add-claude-woocommerce-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add WooCommerce core reference instructions to Claude Code configuration


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a "WooCommerce Core Reference" section to the Claude Code configuration (`.claude/CLAUDE.md`) to improve AI-assisted development workflows.

**What this change does:**
- Documents the location of the WooCommerce monorepo relative to this project (`../woocommerce`)
- Provides key paths within WooCommerce that are useful for context (includes, src, blocks)
- Lists scenarios when Claude should proactively reference WooCommerce core code
- Defines auto-reference triggers (WC hooks, base classes, WC() singleton usage)

**Why this is needed:**
WooPayments integrates closely with WooCommerce core via hooks, filters, and APIs. When using Claude Code for development, having explicit instructions to reference the WooCommerce codebase provides better context for code suggestions, debugging, and understanding how WooPayments interacts with core functionality.

This is a developer tooling improvement that helps team members using Claude Code get more accurate and context-aware assistance.

#### Testing instructions

* This is a documentation-only change to Claude Code configuration
* No runtime behavior is affected
* Open a new `claude` session in the root directory of this project, and ask it if it is able to look at the WooCommerce codebase.


<img width="1051" height="367" alt="Screenshot 2026-01-20 at 11 45 52" src="https://github.com/user-attachments/assets/546e012f-6d88-4040-86cc-14e6640aed23" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) - Documentation only, no tests needed
- [x] Tested on mobile (or does not apply) - Does not apply

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.