### PR TITLE
Fix subscription cancellation when payment method is removed

### DIFF
--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -508,6 +508,14 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return;
 		}
 
+		// Skip validation for subscriptions in terminal statuses.
+		// These subscriptions don't require a valid payment method since they won't have future automatic renewals.
+		$terminal_statuses = [ 'cancelled', 'expired', 'trash', 'pending-cancel' ];
+		if ( $subscription && is_callable( [ $subscription, 'get_status' ] )
+			&& in_array( $subscription->get_status(), $terminal_statuses, true ) ) {
+			return;
+		}
+
 		if ( empty( $payment_meta[ self::$payment_method_meta_table ][ self::$payment_method_meta_key ]['value'] ) ) {
 			throw new Invalid_Payment_Method_Exception(
 				__( 'A customer saved payment method was not selected for this order.', 'woocommerce-payments' ),

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -773,6 +773,57 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Test that validation is skipped for cancelled subscriptions.
+	 *
+	 * @dataProvider terminal_status_provider
+	 */
+	public function test_validate_subscription_payment_meta_skips_terminal_statuses( $status ) {
+		$subscription         = new WC_Subscription();
+		$subscription->status = $status;
+
+		// The validate method should return without throwing an exception for terminal statuses,
+		// even when no payment method is provided.
+		$this->assertNull(
+			$this->wcpay_gateway->validate_subscription_payment_meta(
+				$this->wcpay_gateway->id,
+				[ 'wc_order_tokens' => [ 'token' => [ 'value' => '' ] ] ],
+				$subscription
+			)
+		);
+	}
+
+	/**
+	 * Data provider for terminal subscription statuses.
+	 *
+	 * @return array
+	 */
+	public function terminal_status_provider() {
+		return [
+			'cancelled status'      => [ 'cancelled' ],
+			'expired status'        => [ 'expired' ],
+			'trash status'          => [ 'trash' ],
+			'pending-cancel status' => [ 'pending-cancel' ],
+		];
+	}
+
+	/**
+	 * Test that validation still works for active subscriptions.
+	 */
+	public function test_validate_subscription_payment_meta_validates_active_subscription() {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'A customer saved payment method was not selected for this order.' );
+
+		$subscription         = new WC_Subscription();
+		$subscription->status = 'active';
+
+		$this->wcpay_gateway->validate_subscription_payment_meta(
+			$this->wcpay_gateway->id,
+			[ 'wc_order_tokens' => [ 'token' => [ 'value' => '' ] ] ],
+			$subscription
+		);
+	}
+
 	public function test_save_meta_in_order_tokens_adds_token_to_order() {
 		$subscription = WC_Helper_Order::create_order( self::USER_ID );
 		$token        = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPMNT-3229/unable-to-cancel-subscription-if-the-saved-payment-method-has-been

#### Changes proposed in this Pull Request

When a customer removes their saved payment method and a store manager tries to cancel their subscription, the system was throwing an error: "A customer saved payment method was not selected for this order."

This PR fixes the issue by skipping payment method validation for subscriptions in terminal statuses (`cancelled`, `expired`, `trash`, `pending-cancel`). These subscriptions don't require a valid payment method since they won't have future automatic renewals.

**How can this code break?**
- The validation could be incorrectly skipped for active subscriptions if the status check fails

**What are we doing to make sure this code doesn't break?**
- Added unit tests for all 4 terminal statuses to ensure validation is skipped
- Added a test to verify validation still works for active subscriptions
- Using `is_callable()` check to ensure the method exists before calling it

#### Testing instructions

1. Purchase a subscription using WooCommerce Subscriptions extension
2. In the account page, go to payment methods and add a new payment method (do not select to have it update existing subscriptions)
3. Delete the existing/original payment method
4. In the admin, attempt to change the subscription's status to "cancelled"
5. **Before:** Error message "A customer saved payment method was not selected for this order"
6. **After:** Subscription can be cancelled without error

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.