### PR TITLE
fix: gutenberg version in PHP GH actions

### DIFF
--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -7,7 +7,6 @@ on:
 env:
   WP_VERSION:        latest
   WC_MIN_SUPPORTED_VERSION: '7.6.0'
-  GUTENBERG_VERSION: latest
   PHP_MIN_SUPPORTED_VERSION: '7.3'
 
 concurrency:
@@ -41,8 +40,9 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          PHP_VERSIONS=$( echo "[\"$PHP_MIN_SUPPORTED_VERSION\", \"7.3\", \"7.4\"]" )
-          echo "matrix={\"php\":$PHP_VERSIONS}" >> $GITHUB_OUTPUT
+          # PHP 7.3 requires Gutenberg 22.3.0 (last version supporting PHP 7.3)
+          # PHP 7.4+ can use latest Gutenberg
+          echo "matrix={\"php\":[\"7.4\"],\"gutenberg\":[\"latest\"],\"include\":[{\"php\":\"$PHP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"22.3.0\"}]}" >> $GITHUB_OUTPUT
 
   test:
     name: PHP testing
@@ -69,3 +69,4 @@ jobs:
       - run: bash bin/run-ci-tests.bash
         env:
           WC_VERSION: ${{ env.WC_MIN_SUPPORTED_VERSION }}
+          GUTENBERG_VERSION: ${{ matrix.gutenberg }}

--- a/changelog/fix-gutenberg-version-in-tests
+++ b/changelog/fix-gutenberg-version-in-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: updated Gutenberg version in phpunit tests running with PHP 7.3
+
+


### PR DESCRIPTION
Fixes WOOPMNT-5649

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Gutenberg latest now requires PHP 7.4
<img width="377" height="322" alt="Screenshot 2026-01-20 at 7 52 18 PM" src="https://github.com/user-attachments/assets/3e029555-1a84-48c1-a45f-d8708620dad0" />

But 22.3.0 still supports PHP 7.2: https://plugins.trac.wordpress.org/browser/gutenberg/tags/22.3.0/gutenberg.php#L7

We test against PHP 7.3. So we need to install an older version of Gutenberg for our tests running with an older version of PHP.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
