### PR TITLE
JS Config: Fall back to UPE values if a setting is not available globally

### DIFF
--- a/changelog/woopmnt-5672-unable-to-add-a-payment-method-from-my-account
+++ b/changelog/woopmnt-5672-unable-to-add-a-payment-method-from-my-account
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure that nonces are loaded correctly for the Add Payment Method page.

--- a/client/utils/checkout.js
+++ b/client/utils/checkout.js
@@ -8,7 +8,10 @@
  */
 export const getConfig = ( name ) => {
 	// Classic checkout or blocks-based one.
-	if ( typeof wcpayConfig !== 'undefined' ) {
+	if (
+		typeof wcpayConfig !== 'undefined' &&
+		typeof wcpayConfig[ name ] !== 'undefined'
+	) {
 		return wcpayConfig[ name ];
 	}
 


### PR DESCRIPTION
Fixes WOOPMNT-5672

#### Changes proposed in this Pull Request

In `client/utils/checkout.js`, instead of using `wcpayConfig` every time it is available, only use it when a given key is available in there. Try to retrieve it from the UPE config otherwise. This fixes an issue that was introduced in https://github.com/Automattic/woocommerce-payments/pull/11234.

#### Testing instructions

1. Try adding a payment method from within My Account locally with `develop`. It "should" fail.
    - I've got WooPay & Apple+Google Pay enabled, and it just happened.
2. With this branch, try adding the payment method again.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
