### PR TITLE
Fix REST schema type from 'int' to 'integer' for Stripe Billing counts

### DIFF
--- a/changelog/fix-rest-schema-int-to-integer
+++ b/changelog/fix-rest-schema-int-to-integer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix REST schema type for stripe_billing_subscription_count and stripe_billing_migrated_count from 'int' to 'integer'

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -297,12 +297,12 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 					],
 					'stripe_billing_subscription_count'    => [
 						'description'       => __( 'The number of subscriptions using Stripe Billing', 'woocommerce-payments' ),
-						'type'              => 'int',
+						'type'              => 'integer',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
 					'stripe_billing_migrated_count'        => [
 						'description'       => __( 'The number of subscriptions migrated from Stripe Billing to on-site billing.', 'woocommerce-payments' ),
-						'type'              => 'int',
+						'type'              => 'integer',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
 					'express_checkout_product_methods'     => [


### PR DESCRIPTION
## Summary
- Fix REST schema type for `stripe_billing_subscription_count` and `stripe_billing_migrated_count` from `'int'` to `'integer'`
- The `'int'` type is not a valid JSON Schema type per WordPress REST API standards
- This was causing `X-Wp-Doingitwrong` response headers when saving settings

## Test plan
- [ ] Go to **Payments > Settings** page
- [ ] Make a change (e.g., support email)
- [ ] Open browser dev tools Network tab
- [ ] Click "Save settings"
- [ ] Verify the `settings?_locale=user` response no longer has `X-Wp-Doingitwrong` header

Fixes WOOPMNT-3845

🤖 Generated with [Claude Code](https://claude.com/claude-code)