### PR TITLE
Fix subscription renewals with saved Link payment tokens

### DIFF
--- a/changelog/fix-link-subscription-renewals
+++ b/changelog/fix-link-subscription-renewals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow subscription renewals with saved Link payment tokens even when Link is disabled at checkout

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2183,6 +2183,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$order           = $payment_information->get_order();
 			$order_id        = $order instanceof WC_Order ? $order->get_id() : null;
 			$payment_methods = $this->get_payment_methods_from_gateway_id( $token->get_gateway_id(), $order_id );
+
+			// For saved Link tokens (e.g., subscription renewals), ensure Link is included in payment method types
+			// regardless of whether Link is currently enabled at checkout. The token was valid when saved
+			// and should continue to work for renewals.
+			if ( $token instanceof \WC_Payment_Token_WCPay_Link && ! in_array( Payment_Method::LINK, $payment_methods, true ) ) {
+				$payment_methods[] = Payment_Method::LINK;
+			}
 		}
 
 		return $payment_methods;


### PR DESCRIPTION
## Summary
- Fix subscription renewals failing when using saved Link payment method tokens
- The issue occurred when Link was disabled at checkout or filtered out due to currency/country restrictions
- The fix ensures Link tokens work for renewals regardless of current checkout settings

## Root Cause
When processing subscription renewals, `get_payment_methods_from_gateway_id()` was checking if Link is currently enabled at checkout via `get_payment_method_ids_enabled_at_checkout()`. If Link was disabled, the PaymentIntent was created with only `['card']`, causing Stripe to reject the Link payment method.

## Fix
Added a check in `get_payment_method_types()` to detect when a saved Link token is being used (e.g., subscription renewal) and ensure Link is included in the payment method types regardless of current settings.

## Test plan
1. Enable Stripe Link payment method in WooCommerce Payments settings
2. Create a subscription product
3. Complete checkout using Stripe Link payment method
4. Disable Stripe Link payment method at checkout
5. Trigger subscription renewal (manually or wait for scheduled renewal)
6. Verify renewal succeeds without error

**Before fix:** Renewal fails with:
> The PaymentMethod provided (link) is not allowed for this PaymentIntent. Please attach a PaymentMethod of one of the following types: card.

**After fix:** Renewal succeeds using the saved Link token.

Fixes WOOPMNT-5613

🤖 Generated with [Claude Code](https://claude.com/claude-code)