### PR TITLE
Fix lint-staged to only lint staged CSS/SCSS files

### DIFF
--- a/changelog/fix-1455-lint-staged-only-staged-files
+++ b/changelog/fix-1455-lint-staged-only-staged-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix lint-staged to only lint staged CSS/SCSS files instead of all files.

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	'*.{js,jsx,ts,tsx}': [ 'npm run format:provided', 'eslint' ],
 	'*.{ts,tsx}': [ () => 'tsc --noEmit' ],
-	'*.{scss,css}': [ 'npm run format:provided', 'npm run lint:css' ],
+	'*.{scss,css}': [ 'npm run format:provided', 'stylelint' ],
 	'*.php':
 		'./vendor/bin/phpcs --standard=phpcs.xml.dist --basepath=. --colors',
 	'composer.json': 'composer validate --strict --no-check-all',


### PR DESCRIPTION
Fixes #1455

#### Changes proposed in this Pull Request

The lint-staged config was using `npm run lint:css` which runs `stylelint 'client/**/*.scss' 'client/**/*.css' 'assets/**/*.scss' 'assets/**/*.css'` - this lints **all** CSS/SCSS files regardless of which files are staged.

This PR replaces `npm run lint:css` with `stylelint` directly, so lint-staged passes only the staged filenames to stylelint, making pre-commit hooks faster.

#### Testing instructions

1. Stage a CSS/SCSS file: `git add client/components/stepper/style.scss`
2. Run lint-staged in verbose mode: `npx lint-staged --verbose`
3. Verify that only the staged file is linted (not all files in client/**/assets/**)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) - This is a devops config change, no automated tests needed
- [x] Tested on mobile (or does not apply) - Does not apply

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) - Not applicable
- [x] Add what's changed to the release announcement post - Not applicable
