### PR TITLE
Disputes: Replace old external icon with ↗ arrow on Preview cover letter CTA

### DIFF
--- a/changelog/woopmnt-5682-disputes-use-new-link-icon-on-preview-cover-letter-cta
+++ b/changelog/woopmnt-5682-disputes-use-new-link-icon-on-preview-cover-letter-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Replace old external icon with new arrow symbol on Preview cover letter button in disputes

--- a/client/disputes/new-evidence/__tests__/cover-letter.test.tsx
+++ b/client/disputes/new-evidence/__tests__/cover-letter.test.tsx
@@ -125,7 +125,9 @@ describe( 'CoverLetter', () => {
 		render( <CoverLetter { ...baseProps } /> );
 		expect( screen.getByLabelText( /COVER LETTER/i ) ).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'button', { name: /View cover letter/i } )
+			screen.getByRole( 'button', {
+				name: /Preview cover letter ↗/i,
+			} )
 		).toBeInTheDocument();
 	} );
 

--- a/client/disputes/new-evidence/cover-letter.tsx
+++ b/client/disputes/new-evidence/cover-letter.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -114,12 +113,10 @@ const CoverLetter: React.FC< CoverLetterProps > = ( {
 				className="wcpay-dispute-evidence-cover-letter__print"
 				variant="primary"
 				onClick={ handleViewCoverLetter }
-				iconPosition="right"
-				iconSize={ 24 }
-				icon={ external }
 				__next40pxDefaultSize
 			>
-				{ __( 'Preview cover letter', 'woocommerce-payments' ) }
+				{ __( 'Preview cover letter', 'woocommerce-payments' ) + ' ' }
+				&#8599;
 			</Button>
 		</section>
 	);


### PR DESCRIPTION
Fixes WOOPMNT-5682

#### Changes proposed in this Pull Request

Replaced the old `external` icon from `@wordpress/icons` with the `↗` Unicode arrow symbol (`&#8599;`) on the "Preview cover letter" button in the disputes evidence flow.

This matches the pattern established in WOOPMNT-5604 for the `LearnMoreButton` component in `dispute-steps.tsx`, where we used the same symbol that `ExternalLink` uses as inline text rather than the `icon` prop.

#### Testing instructions

* Navigate to **Payments → Disputes** and open a dispute that requires evidence
* Scroll to the cover letter section
* Verify the "Preview cover letter" button shows a `↗` arrow to the right of the text (not the old box-with-arrow SVG icon)
* Verify the button still opens the cover letter preview when clicked

#### Screenshots

**Before**

<img width="732" height="106" alt="Screenshot 2026-01-29 at 16 34 54" src="https://github.com/user-attachments/assets/14be74ec-18f1-4973-acd6-4d2de4d6e052" />

**After**

<img width="478" height="70" alt="Screenshot 2026-01-29 at 16 35 08" src="https://github.com/user-attachments/assets/0fa50ea1-213b-4eba-95d9-e52f8f91f0de" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.