### PR TITLE
Update E2E test configuration to remove PHP 7.3 support

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,7 +6,7 @@ on:
 env:
   WC_MIN_SUPPORTED_VERSION: '7.6.0'
   WP_MIN_SUPPORTED_VERSION: '6.0'
-  PHP_MIN_SUPPORTED_VERSION: '7.3'
+  PHP_MIN_SUPPORTED_VERSION: '7.4'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -72,7 +72,7 @@ jobs:
           # - WC RC: YES blocks tests (newest version, test upcoming release)
 
           # Define common values to reduce repetition
-          PHP_LEGACY="7.3"
+          PHP_LEGACY="7.4"
           PHP_STABLE="8.3"
           PHP_LATEST="8.4"
           TEST_GROUPS_WCPAY="wcpay"
@@ -84,7 +84,7 @@ jobs:
           # Initialize empty matrix array
           MATRIX_ENTRIES=()
 
-          # Add WC 7.7.0 with PHP 7.3 only (legacy - NO blocks tests)
+          # Add WC 7.7.0 with PHP 7.4 only (legacy - NO blocks tests)
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_MERCHANT\"}")
           MATRIX_ENTRIES+=("{\"woocommerce\":\"7.7.0\",\"php\":\"$PHP_LEGACY\",\"test_groups\":\"$TEST_GROUPS_WCPAY\",\"test_branches\":\"$TEST_BRANCHES_SHOPPER\"}")
           # The following tests are temporarily disabled due to a fatal error with WC 7.7.0.

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -40,7 +40,6 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          # PHP 7.4 can use Gutenberg 22.3.0 or later
           # PHP 7.4+ can use latest Gutenberg
           echo "matrix={\"php\":[\"7.4\"],\"gutenberg\":[\"latest\"],\"include\":[{\"php\":\"$PHP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"22.3.0\"}]}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -7,7 +7,7 @@ on:
 env:
   WP_VERSION:        latest
   WC_MIN_SUPPORTED_VERSION: '7.6.0'
-  PHP_MIN_SUPPORTED_VERSION: '7.3'
+  PHP_MIN_SUPPORTED_VERSION: '7.4'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,7 +40,7 @@ jobs:
       - name: "Generate matrix"
         id: generate_matrix
         run: |
-          # PHP 7.3 requires Gutenberg 22.3.0 (last version supporting PHP 7.3)
+          # PHP 7.4 can use Gutenberg 22.3.0 or later
           # PHP 7.4+ can use latest Gutenberg
           echo "matrix={\"php\":[\"7.4\"],\"gutenberg\":[\"latest\"],\"include\":[{\"php\":\"$PHP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"22.3.0\"}]}" >> $GITHUB_OUTPUT
 

--- a/changelog/woopmnt-5689-update-e2e-test-configuration-to-remove-php-73-support
+++ b/changelog/woopmnt-5689-update-e2e-test-configuration-to-remove-php-73-support
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Update E2E test configuration to remove PHP 7.3 support and update minimum PHP version to 7.4

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -26,7 +26,7 @@ Note: The Playwright config sets `video: on-first-retry`, which applies only if 
 CI coverage differences:
 
 - Pull requests: Run against WC latest and WC L-1 on PHP 8.3
-- Scheduled/full runs: Include WC 7.7.0 (PHP 7.3), WC L-1 (PHP 8.3), WC latest (PHP 8.3), optional WC beta (PHP 8.3), and WC RC (PHP 8.4 when applicable)
+- Scheduled/full runs: Include WC 7.7.0 (PHP 7.4), WC L-1 (PHP 8.3), WC latest (PHP 8.3), optional WC beta (PHP 8.3), and WC RC (PHP 8.4 when applicable)
 
 ## Setting up & running E2E tests
 
@@ -328,7 +328,7 @@ The E2E test matrix is dynamically generated using the `.github/scripts/generate
 - L-1 policy: Automatically tests against the latest WooCommerce version and the L-1 (previous major) version
 - Version resolution: Fetches latest WC, RC, and beta versions from WordPress.org API
 - PHP strategy:
-  - WC 7.7.0: PHP 7.3 (legacy support)
+  - WC 7.7.0: PHP 7.4 (legacy support)
   - WC L-1 & latest: PHP 8.3 (stable)
   - WC RC: PHP 8.4 (latest)
 - Business continuity: Maintains WC 7.7.0 support for significant TPV reasons
@@ -339,7 +339,7 @@ This ensures comprehensive test coverage while optimizing CI execution time and 
 
 - GitHub Action test runs
   - View GitHub checks in the "Checks" tab of a PR
-  - The E2E test matrix is generated dynamically. PRs cover WC latest and L-1 on PHP 8.3; scheduled runs also include 7.7.0 (PHP 7.3), RC (PHP 8.4), and beta (when available)
+  - The E2E test matrix is generated dynamically. PRs cover WC latest and L-1 on PHP 8.3; scheduled runs also include 7.7.0 (PHP 7.4), RC (PHP 8.4), and beta (when available)
   - Click on the details link to the right of the failed job to see the summary
   - In the job summary, click on the "Run tests, upload screenshots & logs" section
   - Click on the artifact download link at the end of the section, then extract and copy the `playwright-report` directory to the root of the WooPayments repository


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

While running the [pre-release E2E suite](https://github.com/Automattic/woocommerce-payments/actions/runs/21477738992), I realized that the matrix includes a now un-suppoerted PHP 7.3 test. This PR transitions to 7.4.

#### Testing instructions

I'll run the tests against this branch and add a link here. They should pass.

Here it is: https://github.com/Automattic/woocommerce-payments/actions/runs/21484266568

Note: The 7.4 test is green. There is an issue with Woo 10.5.0-beta2, but that's a separate topic.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)