### PR TITLE
E2E Tests: Change behavior for WC >= 10.5.0

### DIFF
--- a/changelog/fix-e2e-woo-10-5-0-failures
+++ b/changelog/fix-e2e-woo-10-5-0-failures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix E2E tests for Woo 10.5.0
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-refund-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-refund-failures.spec.ts
@@ -10,6 +10,7 @@ import { emptyCart, placeOrderWithCurrency } from '../../../utils/shopper';
 import { getMerchant, getShopper } from '../../../utils/helpers';
 import { goToOrder } from '../../../utils/merchant-navigation';
 import { ensureOrderIsProcessed } from '../../../utils/merchant';
+import { isWooCommerceVersionAtLeast } from '../../../utils/constants';
 
 const selectorQty = '.refund_order_item_qty';
 const selectorLineAmount = '.refund_line_total';
@@ -42,7 +43,13 @@ test.describe( 'Order > Refund Failure', () => {
 		// Place an order to refund later
 		await emptyCart( shopperPage );
 		orderId = await placeOrderWithCurrency( shopperPage, 'USD' );
-		await ensureOrderIsProcessed( merchantPage, orderId );
+
+		// WooCommerce 10.5+ uses batch analytics imports (every 12 hours) instead of
+		// per-order Action Scheduler actions. For older versions, manually trigger
+		// the wc-admin_import_orders action to ensure the order is synced.
+		if ( ! isWooCommerceVersionAtLeast( '10.5.0' ) ) {
+			await ensureOrderIsProcessed( merchantPage, orderId );
+		}
 	} );
 
 	dataTable.forEach( ( [ fieldName, valueDescription, selector, value ] ) => {

--- a/tests/e2e/utils/constants.ts
+++ b/tests/e2e/utils/constants.ts
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import semver from 'semver';
+
 export const shouldRunSubscriptionsTests =
 	process.env.SKIP_WC_SUBSCRIPTIONS_TESTS !== '1';
 
@@ -7,6 +12,41 @@ export const shouldRunActionSchedulerTests =
 export const shouldRunWCBlocksTests = process.env.SKIP_WC_BLOCKS_TESTS !== '1';
 
 export const wooCoreVersion = process.env.E2E_WC_VERSION;
+
+/**
+ * Compares WooCommerce version strings.
+ * Returns true if the current version is greater than or equal to the target version.
+ * Handles semantic versions (e.g., "10.5.0") and special values ("latest", "beta").
+ *
+ * @param targetVersion - The version to compare against (e.g., "10.5.0")
+ * @return true if wooCoreVersion >= targetVersion
+ */
+export const isWooCommerceVersionAtLeast = (
+	targetVersion: string
+): boolean => {
+	const currentVersion = wooCoreVersion;
+
+	// If no version is set, assume latest
+	if ( ! currentVersion ) {
+		return true;
+	}
+
+	// "latest" and "beta" are assumed to be newer than any specific version
+	if ( currentVersion === 'latest' || currentVersion === 'beta' ) {
+		return true;
+	}
+
+	// Use semver to compare versions, coercing if needed for partial versions
+	const current = semver.coerce( currentVersion );
+	const target = semver.coerce( targetVersion );
+
+	if ( ! current || ! target ) {
+		// If we can't parse either version, assume the current version is newer
+		return true;
+	}
+
+	return semver.gte( current, target );
+};
 
 export const isAtomicSite = process.env.NODE_ENV === 'atomic';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See https://developer.woocommerce.com/2026/01/20/woocommerce-10-5-whats-coming-for-developers/. We cannot use the existing check to confirm that an order is already processing starting with WooCommerce 10.5 (beta 2)

#### Testing instructions

E2E Tests shall pass. I'll add a link here in a moment.

Workflow run: https://github.com/Automattic/woocommerce-payments/actions/runs/21490104124

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 