### PR TITLE
feat: add mccy merchant orders e2e tests

### DIFF
--- a/changelog/feat-mccy-merchant-orders-e2e-tests
+++ b/changelog/feat-mccy-merchant-orders-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+feat: add mccy merchant orders e2e tests

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
@@ -132,13 +132,13 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 
 		// Verify the refund button shows the correct currency (EUR)
 		const refundButton = merchantPage.getByRole( 'button', {
-			name: new RegExp( `Refund ${ orderAmount } via WooPayments` ),
+			name: `Refund ${ orderAmount } via WooPayments`,
 		} );
 		await expect( refundButton ).toBeVisible();
 		await expect( refundButton ).toContainText( '€' );
 
 		// Click refund and handle confirmation dialog
-		merchantPage.on( 'dialog', ( dialog ) => dialog.accept() );
+		merchantPage.once( 'dialog', ( dialog ) => dialog.accept() );
 		await refundButton.click();
 
 		// Wait for refund to process

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
@@ -35,14 +35,6 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 
 		// Place an order in EUR
 		eurOrderId = await shopper.placeOrderWithCurrency( shopperPage, 'EUR' );
-
-		// Get the order total for refund tests
-		orderAmount =
-			( await shopperPage
-				.locator(
-					'.woocommerce-order-overview__total .woocommerce-Price-amount'
-				)
-				.textContent() ) ?? '';
 	} );
 
 	test.afterAll( async () => {
@@ -116,6 +108,13 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 
 	test( 'can refund in correct currency', async () => {
 		await goToOrder( merchantPage, eurOrderId );
+
+		// Get the order total from the admin order page (formatted correctly for refund)
+		orderAmount =
+			( await merchantPage
+				.getByRole( 'row', { name: /Order Total/ } )
+				.locator( '.woocommerce-Price-amount' )
+				.textContent() ) ?? '';
 
 		// Click refund button
 		await merchantPage

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
@@ -24,7 +24,7 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 	let merchantPage: Page;
 	let shopperPage: Page;
 	let eurOrderId: string;
-	let orderAmount: string;
+	let refundAmount: string;
 
 	test.beforeAll( async ( { browser } ) => {
 		merchantPage = ( await getMerchant( browser ) ).merchantPage;
@@ -109,32 +109,44 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 	test( 'can refund in correct currency', async () => {
 		await goToOrder( merchantPage, eurOrderId );
 
-		// Get the order total from the admin order page (formatted correctly for refund)
-		orderAmount =
-			( await merchantPage
-				.getByRole( 'row', { name: /Order Total/ } )
-				.locator( '.woocommerce-Price-amount' )
-				.textContent() ) ?? '';
-
-		// Click refund button
+		// Click refund button to show the refund UI
 		await merchantPage
 			.getByRole( 'button', {
 				name: 'Refund',
 			} )
 			.click();
 
-		// Fill refund details with the EUR amount
-		await merchantPage.getByLabel( 'Refund amount' ).fill( orderAmount );
+		// Get the total available to refund amount (e.g., "€21.00")
+		refundAmount =
+			( await merchantPage
+				.getByRole( 'row', { name: 'Total available to refund' } )
+				.locator( '.woocommerce-Price-amount' )
+				.textContent() ) ?? '';
+
+		// Set the refund quantity to 1 for the first line item (full refund of item)
+		await merchantPage
+			.locator( '.refund_order_item_qty' )
+			.first()
+			.fill( '1' );
+
+		// Press Tab to trigger the refund amount calculation
+		await merchantPage.keyboard.press( 'Tab' );
+
+		// Wait for the refund amount field to be populated (non-empty)
+		await expect(
+			merchantPage.getByLabel( 'Refund amount' )
+		).not.toHaveValue( '' );
+
+		// Fill in refund reason
 		await merchantPage
 			.getByLabel( 'Reason for refund' )
 			.fill( 'Multi-currency refund test' );
 
-		// Verify the refund button shows the correct currency (EUR)
+		// Find the refund button and verify it shows the EUR amount
 		const refundButton = merchantPage.getByRole( 'button', {
-			name: `Refund ${ orderAmount } via WooPayments`,
+			name: `Refund ${ refundAmount } via WooPayments`,
 		} );
 		await expect( refundButton ).toBeVisible();
-		await expect( refundButton ).toContainText( '€' );
 
 		// Click refund and handle confirmation dialog
 		merchantPage.once( 'dialog', ( dialog ) => dialog.accept() );
@@ -143,21 +155,22 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 		// Wait for refund to process
 		await merchantPage.waitForLoadState( 'networkidle' );
 
-		// Verify refund details show EUR currency
+		// Verify refund details show EUR currency with the correct amount
 		await expect(
-			merchantPage.getByRole( 'cell', {
-				name: new RegExp( `-${ orderAmount }` ),
-			} )
-		).toBeVisible();
+			merchantPage.locator( '.refund .woocommerce-Price-amount' ).first()
+		).toContainText( refundAmount );
 
-		// Verify refund note contains the EUR amount
-		await expect(
-			merchantPage.getByText(
-				new RegExp(
-					`A refund of ${ orderAmount } was successfully processed using WooPayments`
-				)
-			)
-		).toBeVisible();
+		// Finding the refund note, and verify it contains the EUR amount
+		const refundNote = merchantPage
+			.locator( '#woocommerce-order-notes .note_content' )
+			.filter( { hasText: 'A refund of' } )
+			.filter( { hasText: 'was successfully processed' } );
+		await expect( refundNote ).toContainText( refundAmount );
+
+		// Verify order status is Refunded
+		await expect( merchantPage.locator( '#order_status' ) ).toHaveValue(
+			'wc-refunded'
+		);
 	} );
 
 	test( 'refund displays correctly on transaction page', async () => {
@@ -173,13 +186,11 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 		await goToPaymentDetails( merchantPage, paymentIntentId );
 
 		// Verify the refund is shown in the timeline with EUR currency
-		await expect(
-			merchantPage.getByText(
-				new RegExp(
-					`A payment of ${ orderAmount } was successfully refunded`
-				)
-			)
-		).toBeVisible();
+		const refundTimeline = merchantPage.getByText(
+			'was successfully refunded'
+		);
+		await expect( refundTimeline ).toBeVisible();
+		await expect( refundTimeline ).toContainText( refundAmount );
 
 		// Verify the payment status changed to Refunded
 		await expect(

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { getMerchant, getShopper } from '../../../utils/helpers';
+import {
+	activateMulticurrency,
+	addCurrency,
+	deactivateMulticurrency,
+	restoreCurrencies,
+} from '../../../utils/merchant';
+import * as shopper from '../../../utils/shopper';
+import {
+	goToOrder,
+	goToPaymentDetails,
+} from '../../../utils/merchant-navigation';
+
+test.describe( 'Admin Multi-Currency Orders', () => {
+	let wasMulticurrencyEnabled: boolean;
+	let merchantPage: Page;
+	let shopperPage: Page;
+	let eurOrderId: string;
+	let orderAmount: string;
+
+	test.beforeAll( async ( { browser } ) => {
+		merchantPage = ( await getMerchant( browser ) ).merchantPage;
+		shopperPage = ( await getShopper( browser ) ).shopperPage;
+
+		wasMulticurrencyEnabled = await activateMulticurrency( merchantPage );
+		await addCurrency( merchantPage, 'EUR' );
+
+		// Place an order in EUR
+		eurOrderId = await shopper.placeOrderWithCurrency( shopperPage, 'EUR' );
+
+		// Get the order total for refund tests
+		orderAmount =
+			( await shopperPage
+				.locator(
+					'.woocommerce-order-overview__total .woocommerce-Price-amount'
+				)
+				.textContent() ) ?? '';
+	} );
+
+	test.afterAll( async () => {
+		await restoreCurrencies( merchantPage );
+		await shopper.emptyCart( shopperPage );
+
+		if ( ! wasMulticurrencyEnabled ) {
+			await deactivateMulticurrency( merchantPage );
+		}
+	} );
+
+	test( 'order should display in shopper currency', async () => {
+		await goToOrder( merchantPage, eurOrderId );
+
+		// Get prices from order items table and confirm they are in the shopper currency (EUR)
+		const orderItemPrices = await merchantPage
+			.locator( '#woocommerce-order-items .woocommerce-Price-amount' )
+			.all();
+
+		expect( orderItemPrices.length ).toBeGreaterThan( 0 );
+
+		for ( const priceElement of orderItemPrices ) {
+			const priceText = await priceElement.textContent();
+			expect( priceText ).toContain( '€' );
+		}
+	} );
+
+	test( 'transaction page shows shopper currency', async () => {
+		await goToOrder( merchantPage, eurOrderId );
+
+		// Get the payment intent ID from the order page
+		const paymentIntentId = await merchantPage
+			.locator( '#order_data' )
+			.getByRole( 'link', { name: /pi_/ } )
+			.innerText();
+
+		// Navigate to the payment details page
+		await goToPaymentDetails( merchantPage, paymentIntentId );
+
+		// Verify that the transaction amount is displayed in the shopper's currency (EUR)
+		await expect(
+			merchantPage.locator( '.payment-details-summary__amount' )
+		).toContainText( '€' );
+	} );
+
+	test( 'transaction page shows converted merchant currency', async () => {
+		await goToOrder( merchantPage, eurOrderId );
+
+		// Get the payment intent ID from the order page
+		const paymentIntentId = await merchantPage
+			.locator( '#order_data' )
+			.getByRole( 'link', { name: /pi_/ } )
+			.innerText();
+
+		// Navigate to the payment details page
+		await goToPaymentDetails( merchantPage, paymentIntentId );
+
+		// Confirm that transaction page shows payment details breakdown in merchant currency (USD)
+		await expect(
+			merchantPage.locator( '.payment-details-summary__breakdown' )
+		).toContainText( '$' );
+
+		// Confirm that transaction page shows fee in merchant currency (USD)
+		const feesElement = merchantPage.locator(
+			'.payment-details-summary__breakdown'
+		);
+		const feesText = await feesElement.textContent();
+		expect( feesText ).toContain( 'Fee' );
+		expect( feesText ).toContain( '$' );
+	} );
+
+	test( 'can refund in correct currency', async () => {
+		await goToOrder( merchantPage, eurOrderId );
+
+		// Click refund button
+		await merchantPage
+			.getByRole( 'button', {
+				name: 'Refund',
+			} )
+			.click();
+
+		// Fill refund details with the EUR amount
+		await merchantPage.getByLabel( 'Refund amount' ).fill( orderAmount );
+		await merchantPage
+			.getByLabel( 'Reason for refund' )
+			.fill( 'Multi-currency refund test' );
+
+		// Verify the refund button shows the correct currency (EUR)
+		const refundButton = merchantPage.getByRole( 'button', {
+			name: new RegExp( `Refund ${ orderAmount } via WooPayments` ),
+		} );
+		await expect( refundButton ).toBeVisible();
+		await expect( refundButton ).toContainText( '€' );
+
+		// Click refund and handle confirmation dialog
+		merchantPage.on( 'dialog', ( dialog ) => dialog.accept() );
+		await refundButton.click();
+
+		// Wait for refund to process
+		await merchantPage.waitForLoadState( 'networkidle' );
+
+		// Verify refund details show EUR currency
+		await expect(
+			merchantPage.getByRole( 'cell', {
+				name: new RegExp( `-${ orderAmount }` ),
+			} )
+		).toBeVisible();
+
+		// Verify refund note contains the EUR amount
+		await expect(
+			merchantPage.getByText(
+				new RegExp(
+					`A refund of ${ orderAmount } was successfully processed using WooPayments`
+				)
+			)
+		).toBeVisible();
+	} );
+
+	test( 'refund displays correctly on transaction page', async () => {
+		await goToOrder( merchantPage, eurOrderId );
+
+		// Get the payment intent ID from the order page
+		const paymentIntentId = await merchantPage
+			.locator( '#order_data' )
+			.getByRole( 'link', { name: /pi_/ } )
+			.innerText();
+
+		// Navigate to the payment details page
+		await goToPaymentDetails( merchantPage, paymentIntentId );
+
+		// Verify the refund is shown in the timeline with EUR currency
+		await expect(
+			merchantPage.getByText(
+				new RegExp(
+					`A payment of ${ orderAmount } was successfully refunded`
+				)
+			)
+		).toBeVisible();
+
+		// Verify the payment status changed to Refunded
+		await expect(
+			merchantPage.getByText( 'Payment status changed to Refunded.' )
+		).toBeVisible();
+	} );
+} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-multi-currency.spec.ts
@@ -18,6 +18,7 @@ import {
 	goToOrder,
 	goToPaymentDetails,
 } from '../../../utils/merchant-navigation';
+import { goToShop } from '../../../utils/shopper-navigation';
 
 test.describe( 'Admin Multi-Currency Orders', () => {
 	let wasMulticurrencyEnabled: boolean;
@@ -38,8 +39,12 @@ test.describe( 'Admin Multi-Currency Orders', () => {
 	} );
 
 	test.afterAll( async () => {
-		await restoreCurrencies( merchantPage );
 		await shopper.emptyCart( shopperPage );
+
+		// Reset the shopper's currency preference back to USD to avoid affecting other tests
+		await goToShop( shopperPage, { currency: 'USD' } );
+
+		await restoreCurrencies( merchantPage );
 
 		if ( ! wasMulticurrencyEnabled ) {
 			await deactivateMulticurrency( merchantPage );


### PR DESCRIPTION
Fixes #7383
Fixes WOOPMNT-3425

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding E2E tests for multi-currency merchant order management.
Verifying that orders placed in a non-default currency (EUR) display correctly throughout the merchant admin:

- Order displays in shopper currency (order items show EUR prices in the admin order view)
- Transaction page shows shopper currency (the payment details page displays the amount in EUR)
- Transaction page shows converted merchant currency (the fee breakdown shows USD (which matches with merchant's deposit currency))
- Refund in correct currency (refunds process in EUR show the correct amount on the refund button)
- Refund displays on transaction page (the refund timeline shows the EUR amount)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It should be sufficient to see the latest runs passing: https://github.com/Automattic/woocommerce-payments/actions/runs/21516219463/job/61995150064?pr=11306

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
