### PR TITLE
Make the WooPay button work on product pages, fix spinners

### DIFF
--- a/changelog/woopmnt-5700-spinner-misalignment-in-the-checkout-submit-button
+++ b/changelog/woopmnt-5700-spinner-misalignment-in-the-checkout-submit-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the logic of the WooPay button on single product pages.

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -157,32 +157,35 @@
  * Sourced from https://github.com/woocommerce/woocommerce-blocks/blob/4dfe904f761423c1ac494f0d6319c602965b5efe/assets/js/base/components/spinner/style.scss.
  * Depending on the wc-blocks version, these styles are not loaded, so they need to be included here.
  */
-.wc-block-components-spinner {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	color: inherit;
-	box-sizing: content-box;
-	text-align: center;
-	font-size: 1.25em;
-	top: initial;
-	left: initial;
-
-	&::after {
-		content: ' ';
+.wcpay-express-checkout-wrapper,
+#wcpay-woopay-button {
+	.wc-block-components-spinner {
 		position: absolute;
-		top: 50%;
-		left: 50%;
-		margin: -0.5em 0 0 -0.5em;
-		width: 1em;
-		height: 1em;
-		box-sizing: border-box;
-		transform-origin: 50% 50%;
-		transform: translateZ( 0 ) scale( 0.5 );
-		backface-visibility: hidden;
-		border-radius: 50%;
-		border: 0.2em solid currentColor;
-		border-left-color: transparent;
-		animation: spinner__animation 1s infinite linear;
+		width: 100%;
+		height: 100%;
+		color: inherit;
+		box-sizing: content-box;
+		text-align: center;
+		font-size: 1.25em;
+		top: initial;
+		left: initial;
+
+		&::after {
+			content: ' ';
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			margin: -0.5em 0 0 -0.5em;
+			width: 1em;
+			height: 1em;
+			box-sizing: border-box;
+			transform-origin: 50% 50%;
+			transform: translateZ( 0 ) scale( 0.5 );
+			backface-visibility: hidden;
+			border-radius: 50%;
+			border: 0.2em solid currentColor;
+			border-left-color: transparent;
+			animation: spinner__animation 1s infinite linear;
+		}
 	}
 }

--- a/client/checkout/woopay/style.scss
+++ b/client/checkout/woopay/style.scss
@@ -157,6 +157,7 @@
  * Sourced from https://github.com/woocommerce/woocommerce-blocks/blob/4dfe904f761423c1ac494f0d6319c602965b5efe/assets/js/base/components/spinner/style.scss.
  * Depending on the wc-blocks version, these styles are not loaded, so they need to be included here.
  */
+.woopay-billing-email,
 .wcpay-express-checkout-wrapper,
 #wcpay-woopay-button {
 	.wc-block-components-spinner {

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1739,21 +1739,23 @@ class WC_Payments {
 			$is_test_mode = false;
 		}
 
+		$common_config = [
+			'woopayHost'                    => WooPay_Utilities::get_woopay_url(),
+			'testMode'                      => $is_test_mode,
+			'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
+			'woopayMerchantId'              => Jetpack_Options::get_option( 'id' ),
+			'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
+			'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
+			'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
+			'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
+		];
+
 		wp_register_script( 'WCPAY_WOOPAY_COMMON_CONFIG', '', [], WCPAY_VERSION_NUMBER, false );
-		wp_localize_script(
+		wp_add_inline_script(
 			'WCPAY_WOOPAY_COMMON_CONFIG',
-			'wcpayConfig',
-			[
-				'woopayHost'                    => WooPay_Utilities::get_woopay_url(),
-				'testMode'                      => $is_test_mode,
-				'wcAjaxUrl'                     => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-				'woopaySessionNonce'            => wp_create_nonce( 'woopay_session_nonce' ),
-				'woopayMerchantId'              => Jetpack_Options::get_option( 'id' ),
-				'isWooPayDirectCheckoutEnabled' => WC_Payments_Features::is_woopay_direct_checkout_enabled(),
-				'platformTrackerNonce'          => wp_create_nonce( 'platform_tracks_nonce' ),
-				'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
-				'woopayMinimumSessionData'      => WooPay_Session::get_woopay_minimum_session_data(),
-			]
+			'var wcpayConfig = Object.assign( wcpayConfig || {}, ' . wp_json_encode( $common_config ) . ' );',
+			'before'
 		);
 		wp_enqueue_script( 'WCPAY_WOOPAY_COMMON_CONFIG' );
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1727,10 +1727,16 @@ class WC_Payments {
 
 	/**
 	 * Enqueues the common config script.
+	 * Only enqueues if the full config hasn't already been loaded via express button scripts.
 	 *
 	 * @return void
 	 */
 	public static function enqueue_woopay_common_config_script() {
+		// Skip if the express button script is already enqueued/registered, as it includes the full config.
+		if ( wp_script_is( 'WCPAY_WOOPAY_EXPRESS_BUTTON', 'enqueued' ) || wp_script_is( 'WCPAY_WOOPAY_EXPRESS_BUTTON', 'registered' ) ) {
+			return;
+		}
+
 		try {
 			// is_test() throws if the class 'Mode' has not been initialized.
 			$is_test_mode = self::mode()->is_test();


### PR DESCRIPTION
Fixes WOOPMNT-5700

#### Changes proposed in this Pull Request

Two-fold.

#### Fix how WooPay configures `wcpayConfig`.

https://github.com/Automattic/woocommerce-payments/pull/11234 changed when the WooPay common config was loaded, effectively overriding the superset of the same values that is already contained in `wcpayConfig`.

This PR makes sure to check whether the WooPay button, together with all necessary values, is already enqueued. If that's the case, it drops the common config.

#### Fix the spinner in the submit button of the checkout block

https://github.com/Automattic/woocommerce-payments/pull/7432 imported some styles from WooCommerce Blocks, targetting `.wc-block-components-spinner` directly. This misaligned the submit button on checkout pages, even though it should be limited to WooPay buttons. This PR adds `.wcpay-express-checkout-wrapper and #wcpay-woopay-button` as a boundary.

| Before | After |
| - | - |
| <img width="3022" height="1484" alt="image" src="https://github.com/user-attachments/assets/2226fcd5-3c9c-449f-b2ea-d759a4c5bc09" /> | <img width="1480" height="695" alt="image" src="https://github.com/user-attachments/assets/f9e2e245-c5a3-406f-a974-f83615e9c267" /> |


#### Testing instructions

1. Enable WooPay on checkout & product pages.
2. Navigate to a product page and make sure that the WooPay button is visible.
3. Click the WooPay button just to make sur ethe spinner is in the right place.
4. Navigate to Checkout.
5. Again, click the WooPay button to make sure the spinner is in the right place. Do not continue with WooPay.
6. Submit the checkout form. The spinner of the submit button should look alright.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (it's just different hooks, no way to test).