### PR TITLE
fix: prevent memory exhaustion and null customer fatal in BNPL site messaging

### DIFF
--- a/changelog/woopmnt-5693-fatal-memory-exhaustion-in-bnpl-site-messaging-on-product
+++ b/changelog/woopmnt-5693-fatal-memory-exhaustion-in-bnpl-site-messaging-on-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix memory exhaustion and null customer fatal errors in BNPL site messaging on product and cart pages

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -54,8 +54,8 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		global $product;
 		$currency_code      = get_woocommerce_currency();
 		$store_country      = WC()->countries->get_base_country();
-		$billing_country    = WC()->customer->get_billing_country();
-		$cart_total         = WC()->cart->total;
+		$billing_country    = WC()->customer ? WC()->customer->get_billing_country() : '';
+		$cart_total         = WC()->cart ? WC()->cart->total : 0;
 		$product_variations = [];
 
 		if ( $product ) {
@@ -67,7 +67,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 					wc_prices_include_tax() &&
 					(
 						get_option( 'woocommerce_tax_display_shop' ) !== 'incl' ||
-						WC()->customer->get_is_vat_exempt()
+						( WC()->customer && WC()->customer->get_is_vat_exempt() )
 					)
 				) {
 					$get_price_fn = function ( $product ) {
@@ -75,7 +75,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 					};
 				} elseif (
 					get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-					&& ! WC()->customer->get_is_vat_exempt()
+					&& ! ( WC()->customer && WC()->customer->get_is_vat_exempt() )
 				) {
 					$get_price_fn = function ( $product ) {
 						return wc_get_price_including_tax( $product );
@@ -174,8 +174,17 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			$script_data
 		);
 
-		// Ensure wcpayConfig is available in the page.
-		$wcpay_config = rawurlencode( wp_json_encode( WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() ) );
+		// Ensure wcpayConfig is available in the page with only the keys the product-details script needs.
+		$wcpay_config = rawurlencode(
+			wp_json_encode(
+				[
+					'ajaxUrl'                      => admin_url( 'admin-ajax.php' ),
+					'saveUPEAppearanceNonce'       => wp_create_nonce( 'wcpay_save_upe_appearance_nonce' ),
+					'upeBnplProductPageAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT ),
+					'upeBnplClassicCartAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT ),
+				]
+			)
+		);
 		wp_add_inline_script(
 			'WCPAY_PRODUCT_DETAILS',
 			"

--- a/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
+++ b/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
@@ -64,6 +64,21 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 	public function tear_down(): void {
 		parent::tear_down();
 		wp_reset_postdata();
+		wp_scripts()->remove( 'WCPAY_PRODUCT_DETAILS' );
+	}
+
+	private function setup_gateway_mocks() {
+		$this->mock_account->method( 'get_stripe_account_id' )->willReturn( 'acct_test' );
+		$this->mock_account->method( 'get_publishable_key' )->willReturn( 'pk_test_key' );
+		$this->mock_gateway->method( 'get_upe_enabled_payment_method_ids' )->willReturn(
+			[ Payment_Method::AFFIRM ]
+		);
+		$this->mock_gateway->method( 'get_upe_enabled_payment_method_statuses' )->willReturn(
+			[ 'affirm_payments' => [ 'status' => 'active' ] ]
+		);
+		$this->mock_gateway->method( 'get_payment_method_capability_key_map' )->willReturn(
+			[ Payment_Method::AFFIRM => 'affirm_payments' ]
+		);
 	}
 
 	private function get_script_data() {
@@ -124,8 +139,6 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 		$this->assertNotContains( Payment_Method::AFTERPAY, $script_data['paymentMethods'], 'Afterpay should not be included' );
 		$this->assertNotContains( Payment_Method::CARD, $script_data['paymentMethods'], 'Card should not be included' );
 		$this->assertNotContains( Payment_Method::IDEAL, $script_data['paymentMethods'], 'iDEAL should not be included' );
-
-		wp_scripts()->remove( 'WCPAY_PRODUCT_DETAILS' );
 	}
 
 	/**
@@ -162,7 +175,72 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 
 		// no payment methods should be included.
 		$this->assertEmpty( $script_data['paymentMethods'], 'No BNPL methods should be included when all are inactive' );
+	}
 
-		wp_scripts()->remove( 'WCPAY_PRODUCT_DETAILS' );
+	/**
+	 * Test that init handles null WC()->customer gracefully.
+	 */
+	public function test_init_handles_null_customer() {
+		$this->setup_gateway_mocks();
+
+		$original_customer = WC()->customer;
+		WC()->customer     = null;
+
+		$result = $this->messaging_element->init();
+
+		WC()->customer = $original_customer;
+
+		// Should complete without fatal error and return the container div.
+		$this->assertSame( '<div id="payment-method-message"></div>', $result );
+	}
+
+	/**
+	 * Test that init handles null WC()->cart gracefully.
+	 */
+	public function test_init_handles_null_cart() {
+		$this->setup_gateway_mocks();
+
+		$original_cart = WC()->cart;
+		WC()->cart     = null;
+
+		$result = $this->messaging_element->init();
+
+		WC()->cart = $original_cart;
+
+		// Should complete without fatal error and return the container div.
+		$this->assertSame( '<div id="payment-method-message"></div>', $result );
+
+		$script_data = $this->get_script_data();
+		$this->assertEquals( 0, $script_data['cartTotal'] );
+	}
+
+	/**
+	 * Test that inline script contains only minimal config keys, not the full checkout config.
+	 */
+	public function test_init_inline_script_contains_only_minimal_config() {
+		$this->setup_gateway_mocks();
+
+		$this->messaging_element->init();
+
+		// Get the inline script added before WCPAY_PRODUCT_DETAILS.
+		$registered = wp_scripts()->registered['WCPAY_PRODUCT_DETAILS'];
+		$before     = $registered->extra['before'] ?? [];
+		$inline_js  = implode( '', $before );
+
+		// Extract the JSON from the inline script.
+		preg_match( "/decodeURIComponent\(\s*'([^']+)'\s*\)/", $inline_js, $matches );
+		$this->assertNotEmpty( $matches[1], 'Inline script should contain encoded config' );
+
+		$config = json_decode( urldecode( $matches[1] ), true );
+		$this->assertIsArray( $config );
+
+		// Should contain only the 4 minimal keys.
+		$expected_keys = [ 'ajaxUrl', 'saveUPEAppearanceNonce', 'upeBnplProductPageAppearance', 'upeBnplClassicCartAppearance' ];
+		$this->assertEqualsCanonicalizing( $expected_keys, array_keys( $config ) );
+
+		// Should NOT contain keys from the full checkout config.
+		$this->assertArrayNotHasKey( 'fraudServices', $config );
+		$this->assertArrayNotHasKey( 'paymentMethodsConfig', $config );
+		$this->assertArrayNotHasKey( 'woopayMinimumSessionData', $config );
 	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5693 / WOOPMNT-5690

#### Changes proposed in this Pull Request

Two related bugs in `class-wc-payments-payment-method-messaging-element.php`:

1. **Memory exhaustion (WOOPMNT-5693):** `init()` called `get_payment_fields_js_config()` which builds a ~49-key checkout config (fraud services, payment method configs, WooPay session data, etc.) and passes it to `wp_json_encode()`. Corrupted data or circular references in this large object could cause a 140TB allocation attempt and PHP fatal. The product-details frontend script only actually uses **4 keys** from this config. Replaced with a minimal inline config containing only `ajaxUrl`, `saveUPEAppearanceNonce`, `upeBnplProductPageAppearance`, and `upeBnplClassicCartAppearance`.

2. **Null customer (WOOPMNT-5690):** `WC()->customer` and `WC()->cart` were accessed without null checks. When the hook fires in REST API or block editor context, the customer session may not exist, causing a fatal error. Added null-safe access with sensible defaults.

#### Testing instructions

**Null customer/cart fix:**

_This is a bit tricky_

Reproduction steps:
1. Create Product A (one that has BNPL eligible pricing)
2. Create Product B, and in its description put: [product_page id="<Product_A_ID>"]
3. Generate WooCommerce REST API keys (WooCommerce > Settings > Advanced > REST API)
4. Make the REST API call:

```
curl "http://localhost:8082/wp-json/wc/v3/products/<Product_B_ID>" \
    -u "ck_xxxxx:cs_xxxxx"
```
The default context is view, so WooCommerce will call `do_shortcode()` on Product B's description, which renders the `[product_page]` shortcode, which fires `woocommerce_single_product_summary`, which triggers the BNPL messaging code — all without a customer session.

You should expect the API responds normally, no fatal. BTW, you can pass a local cookie to an LLM and that will perform that easily.

**Minimal config fix:**

1. On a product page with BNPL messaging enabled, inspect the page source
2. Search for `wcpayConfig` — it should only contain 4 keys: `ajaxUrl`, `saveUPEAppearanceNonce`, `upeBnplProductPageAppearance`, `upeBnplClassicCartAppearance`
3. It should NOT contain `fraudServices`, `paymentMethodsConfig`, `woopayMinimumSessionData`, or other heavy checkout config keys
4. Verify BNPL messaging still appears and updates correctly when selecting product variations
6. Verify BNPL messaging appears on the classic cart page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.