### PR TITLE
fix: WooPay & Stripe Link mutual compatibility in settings

### DIFF
--- a/changelog/fix-woopay-link-compatibility-double-enablement
+++ b/changelog/fix-woopay-link-compatibility-double-enablement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: WooPay & Stripe Link mutual compatibility in settings

--- a/client/settings/express-checkout-settings/__tests__/index.test.js
+++ b/client/settings/express-checkout-settings/__tests__/index.test.js
@@ -20,6 +20,7 @@ jest.mock( 'wcpay/data', () => ( {
 	useSettings: jest.fn().mockReturnValue( {} ),
 	useGetAvailablePaymentMethodIds: jest.fn().mockReturnValue( [] ),
 	useGetPaymentMethodStatuses: jest.fn(),
+	useEnabledPaymentMethodIds: jest.fn().mockReturnValue( [ [], jest.fn() ] ),
 	usePaymentRequestEnabledSettings: jest
 		.fn()
 		.mockReturnValue( [ true, jest.fn() ] ),

--- a/client/settings/express-checkout-settings/__tests__/woopay-settings.test.js
+++ b/client/settings/express-checkout-settings/__tests__/woopay-settings.test.js
@@ -112,6 +112,8 @@ describe( 'WooPaySettings', () => {
 			getMockWooPayLocations( [ true, true, true ], jest.fn() )
 		);
 
+		useWooPayShowIncompatibilityNotice.mockReturnValue( false );
+
 		global.wcpaySettings = {
 			restUrl: 'http://example.com/wp-json/',
 		};
@@ -202,25 +204,12 @@ describe( 'WooPaySettings', () => {
 		const enableCheckbox = screen.getByLabelText( /Enable WooPay/ );
 		expect( enableCheckbox ).toBeDisabled();
 
+		// Use getAllByText since a11y regions may duplicate the text
 		expect(
 			screen.getAllByText(
 				'To enable WooPay, you must first disable Link by Stripe.'
-			).length
-		).toBeGreaterThan( 0 );
-	} );
-
-	it( 'does not show Stripe Link warning when Stripe Link is not enabled', () => {
-		useEnabledPaymentMethodIds.mockReturnValue( [ [], jest.fn() ] );
-
-		const { container } = render( <WooPaySettings section="enable" /> );
-
-		const enableCheckbox = screen.getByLabelText( /Enable WooPay/ );
-		expect( enableCheckbox ).not.toBeDisabled();
-
-		// Check that no InlineNotice with warning content exists in the component
-		expect(
-			container.querySelector( '.wcpay-inline-notice' )
-		).not.toBeInTheDocument();
+			)[ 0 ]
+		).toBeInTheDocument();
 	} );
 
 	it( 'hides incompatibility notice when Stripe Link is enabled', () => {
@@ -235,10 +224,25 @@ describe( 'WooPaySettings', () => {
 			)
 		).not.toBeInTheDocument();
 
+		// Use getAllByText since a11y regions may duplicate the text
 		expect(
 			screen.getAllByText(
 				'To enable WooPay, you must first disable Link by Stripe.'
-			).length
-		).toBeGreaterThan( 0 );
+			)[ 0 ]
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not show notices when Stripe Link is not enabled', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [ [], jest.fn() ] );
+
+		const { container } = render( <WooPaySettings section="enable" /> );
+
+		const enableCheckbox = screen.getByLabelText( /Enable WooPay/ );
+		expect( enableCheckbox ).not.toBeDisabled();
+
+		// checking that there are no `InlineNotice`s rendered, just in case.
+		expect(
+			container.querySelector( '.wcpay-inline-notice' )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/express-checkout-settings/__tests__/woopay-settings.test.js
+++ b/client/settings/express-checkout-settings/__tests__/woopay-settings.test.js
@@ -11,6 +11,7 @@ import userEvent from '@testing-library/user-event';
  */
 import WooPaySettings from '../woopay-settings';
 import {
+	useEnabledPaymentMethodIds,
 	useWooPayEnabledSettings,
 	useWooPayCustomMessage,
 	useWooPayStoreLogo,
@@ -22,6 +23,7 @@ import {
 } from '../../../data';
 
 jest.mock( '../../../data', () => ( {
+	useEnabledPaymentMethodIds: jest.fn(),
 	useWooPayEnabledSettings: jest.fn(),
 	useWooPayCustomMessage: jest.fn(),
 	useWooPayStoreLogo: jest.fn(),
@@ -80,6 +82,8 @@ const getMockWooPayLocations = ( message, updateWooPayLocationsHandler ) => [
 
 describe( 'WooPaySettings', () => {
 	beforeEach( () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [ [], jest.fn() ] );
+
 		useWooPayEnabledSettings.mockReturnValue(
 			getMockWooPayEnabledSettings( true, jest.fn() )
 		);
@@ -188,5 +192,53 @@ describe( 'WooPaySettings', () => {
 				'One or more of your extensions are incompatible with WooPay.'
 			)
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'disables the enable checkbox and shows warning when Stripe Link is enabled', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'link' ], jest.fn() ] );
+
+		render( <WooPaySettings section="enable" /> );
+
+		const enableCheckbox = screen.getByLabelText( /Enable WooPay/ );
+		expect( enableCheckbox ).toBeDisabled();
+
+		expect(
+			screen.getAllByText(
+				'To enable WooPay, you must first disable Link by Stripe.'
+			).length
+		).toBeGreaterThan( 0 );
+	} );
+
+	it( 'does not show Stripe Link warning when Stripe Link is not enabled', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [ [], jest.fn() ] );
+
+		const { container } = render( <WooPaySettings section="enable" /> );
+
+		const enableCheckbox = screen.getByLabelText( /Enable WooPay/ );
+		expect( enableCheckbox ).not.toBeDisabled();
+
+		// Check that no InlineNotice with warning content exists in the component
+		expect(
+			container.querySelector( '.wcpay-inline-notice' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides incompatibility notice when Stripe Link is enabled', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'link' ], jest.fn() ] );
+		useWooPayShowIncompatibilityNotice.mockReturnValue( true );
+
+		render( <WooPaySettings section="enable" /> );
+
+		expect(
+			screen.queryByText(
+				'One or more of your extensions are incompatible with WooPay.'
+			)
+		).not.toBeInTheDocument();
+
+		expect(
+			screen.getAllByText(
+				'To enable WooPay, you must first disable Link by Stripe.'
+			).length
+		).toBeGreaterThan( 0 );
 	} );
 } );

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -22,6 +22,7 @@ import CardBody from '../card-body';
 import WooPayFileUpload from './file-upload';
 import WooPayPreview from './woopay-preview';
 import {
+	useEnabledPaymentMethodIds,
 	useWooPayEnabledSettings,
 	useWooPayCustomMessage,
 	useWooPayStoreLogo,
@@ -29,10 +30,13 @@ import {
 	useWooPayShowIncompatibilityNotice,
 	useWooPayGlobalThemeSupportEnabledSettings,
 } from 'wcpay/data';
+import InlineNotice from 'wcpay/components/inline-notice';
 import GeneralPaymentRequestButtonSettings from './general-payment-request-button-settings';
 import { WooPayIncompatibilityNotice } from '../settings-warnings/incompatibility-notice';
 
 const WooPaySettings = ( { section } ) => {
+	const [ enabledMethodIds ] = useEnabledPaymentMethodIds();
+
 	const [
 		isWooPayEnabled,
 		updateIsWooPayEnabled,
@@ -56,7 +60,10 @@ const WooPaySettings = ( { section } ) => {
 		updateWooPayLocations( location, isChecked );
 	};
 
-	const showIncompatibilityNotice = useWooPayShowIncompatibilityNotice();
+	const isStripeLinkEnabled = enabledMethodIds.includes( 'link' );
+
+	const showIncompatibilityNotice =
+		useWooPayShowIncompatibilityNotice() && ! isStripeLinkEnabled;
 
 	return (
 		<Card
@@ -70,9 +77,18 @@ const WooPaySettings = ( { section } ) => {
 					{ showIncompatibilityNotice && (
 						<WooPayIncompatibilityNotice />
 					) }
+					{ isStripeLinkEnabled && (
+						<InlineNotice status="warning" isDismissible={ false }>
+							{ __(
+								'To enable WooPay, you must first disable Link by Stripe.',
+								'woocommerce-payments'
+							) }
+						</InlineNotice>
+					) }
 					<div className="wcpay-woopay-settings__enable">
 						<CheckboxControl
 							checked={ isWooPayEnabled }
+							disabled={ isStripeLinkEnabled }
 							onChange={ updateIsWooPayEnabled }
 							label={ __(
 								'Enable WooPay',


### PR DESCRIPTION
Fixes WOOPMNT-5701

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Trying to avoid this scenario:
<img width="1235" height="604" alt="Screenshot 2026-02-03 at 6 16 21 PM" src="https://github.com/user-attachments/assets/ba4b9772-703e-45c9-baf5-9f52e1388a21" />

I noticed that it's technically possible to enable both WooPay and Stripe Link at the same time by:
- Navigating to Payments > Settings
- Disabling WooPay
- Enabling Stripe Link
- Saving Settings
- Click "Customize" next to WooPay to land on the WooPay customization page
- Enable WooPay 
- Go back to Payments > Settings
- Stripe Link & WooPay appear both enabled, but you cannot disable either one of them

I didn't write a migration to enforce - this scenario shouldn't have been possible in the first place. So I don't _think_ it would affect too many people.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to Payments > Settings
- Disable WooPay
- Enable Stripe Link
- Save the settings
- Click "Customize" next to WooPay to land on the WooPay customization page
- You should not be able to enable WooPay
<img width="1252" height="352" alt="Screenshot 2026-02-03 at 6 36 52 PM" src="https://github.com/user-attachments/assets/3130ca22-6a8e-499a-b769-13235364ae1a" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
