### PR TITLE
feat: surface support phone number status in System Status Report

### DIFF
--- a/changelog/woopmnt-5703-surface-woopayments-support-phone-status-in-ssr
+++ b/changelog/woopmnt-5703-surface-woopayments-support-phone-status-in-ssr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Surface WooPayments support phone number status in the System Status Report.

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -572,6 +572,20 @@ class WC_Payments_Status {
 						</td>
 					</tr>
 					<tr>
+						<td data-export-label="Support Phone"><?php esc_html_e( 'Support Phone', 'woocommerce-payments' ); ?>:</td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'The support phone number set in WooPayments settings. If not set, the settings Save button will be disabled.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td>
+						<?php
+						$support_phone = $this->gateway->get_option( 'account_business_support_phone' );
+						if ( ! empty( $support_phone ) ) {
+							echo esc_html( $support_phone );
+						} else {
+							echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Not set', 'woocommerce-payments' ) . '</mark>';
+						}
+						?>
+						</td>
+					</tr>
+					<tr>
 						<td data-export-label="Documents"><?php esc_html_e( 'Documents', 'woocommerce-payments' ); ?>:</td>
 						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the tax documents section is enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments_Features::is_documents_section_enabled() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>


### PR DESCRIPTION
Fixes WOOPMNT-5703

#### Changes proposed in this Pull Request

Adds a **Support Phone** row to the WooPayments section of the WooCommerce System Status Report (WooCommerce > Status). This lets support agents quickly see whether a merchant has configured their support phone number without asking the customer to navigate their settings.

- When the phone number **is set**: displays the number (e.g., `+1 555-123-4567`)
- When **not set**: displays a warning icon with "Not set"

This is helpful because an unset support phone number causes the WooPayments settings **Save button to remain disabled**, which can be mistaken for a plugin conflict.

<img width="1103" height="243" alt="image" src="https://github.com/user-attachments/assets/c9d5e8f8-d98a-4bd3-b52e-353ec66c85b5" />

<img width="1115" height="238" alt="image" src="https://github.com/user-attachments/assets/61cf3c15-cf40-49c1-9f35-11305f57f0a2" />

#### Testing instructions

1. Go to **WooCommerce > Status** (System status tab)
2. Scroll to the **WooPayments** section
3. Verify there is a new **Support Phone** row
4. If your support phone is configured, it should display the number
5. Clear the support phone in **WooCommerce > Settings > Payments > WooPayments** and verify the SSR shows a warning with "Not set"

You can remove your existing phone number by doing:

```
wp eval "\$d=get_option('wcpay_account_data'); \$d['data']['business_profile']['support_phone']=''; update_option('wcpay_account_data',\$d);" --allow-root
```

To restore it, run:

```
wp eval "\$d=get_option('wcpay_account_data'); \$d['data']['business_profile']['support_phone']='0000000000'; update_option('wcpay_account_data',\$d);"  --allow-root
```
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

> **Note on tests:** The `render_status_report_section()` method has no existing unit test coverage. The new row follows the exact same pattern as all other rows in the method (pure HTML output using `$this->gateway->get_option()`), so it carries minimal risk. Adding output-buffering tests for this template method would be out of scope for this small change.

> **Note on PHPCS:** The pre-commit hook fails due to 2 pre-existing `SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder` errors in this file (lines 85 and 407), which are present on `develop` as well and unrelated to this change.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)