### PR TITLE
chore: re-enable confirmation tokens for 10.6.0

### DIFF
--- a/changelog/chore-confirmation-tokens-disable-for-10-5-0
+++ b/changelog/chore-confirmation-tokens-disable-for-10-5-0
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: chore: disable confirmation tokens for 10.5.0 release
-
-

--- a/changelog/chore-re-enable-confirmation-tokens
+++ b/changelog/chore-re-enable-confirmation-tokens
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: chore: re-enable confirmation tokens
+
+

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -31,7 +31,6 @@ class WC_Payments_Features {
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME               = '_wcpay_feature_woopay_global_theme_support';
 	const WCPAY_DYNAMIC_CHECKOUT_PLACE_ORDER_BUTTON_FLAG_NAME = '_wcpay_feature_dynamic_checkout_place_order_button';
 	const AMAZON_PAY_FLAG_NAME                                = '_wcpay_feature_amazon_pay';
-	const ECE_CONFIRMATION_TOKENS_FLAG_NAME                   = '_wcpay_feature_ece_confirmation_tokens';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -371,11 +370,6 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_ece_confirmation_tokens_enabled(): bool {
-		// Feature is disabled by default while being stabilized.
-		if ( '1' !== get_option( self::ECE_CONFIRMATION_TOKENS_FLAG_NAME, '0' ) ) {
-			return false;
-		}
-
 		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 
 		return is_array( $account ) && ! ( $account['ece_confirmation_tokens_disabled'] ?? false );

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -58,17 +58,6 @@ function _manually_load_plugin() {
 		1
 	);
 
-	// Enable the ECE confirmation tokens feature flag in tests to ensure existing
-	// tests continue to work. The feature is disabled by default in production.
-	add_filter(
-		'default_option__wcpay_feature_ece_confirmation_tokens',
-		function ( $default ) {
-			return '1';
-		},
-		10,
-		1
-	);
-
 	$_plugin_dir = __DIR__ . '/../../';
 
 	require $_plugin_dir . 'woocommerce-payments.php';


### PR DESCRIPTION
This reverts commit 412ce8773d0b1911321ff59ff7209247f29b249a.

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
