### PR TITLE
fix: add email confirmation field to account notification settings

### DIFF
--- a/changelog/woopmnt-5706-woopayments-account-notifications-email-opsec-issue
+++ b/changelog/woopmnt-5706-woopayments-account-notifications-email-opsec-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add email confirmation field and warning notice to account notification email settings to prevent typos and improve security awareness

--- a/client/settings/notification-settings/__tests__/index.test.tsx
+++ b/client/settings/notification-settings/__tests__/index.test.tsx
@@ -50,7 +50,9 @@ describe( 'NotificationSettings', () => {
 
 		render( <NotificationSettings /> );
 
-		expect( screen.getByDisplayValue( testEmail ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Email address' ) ).toHaveValue(
+			testEmail
+		);
 	} );
 } );
 

--- a/client/settings/notification-settings/__tests__/notifications-email-input.test.tsx
+++ b/client/settings/notification-settings/__tests__/notifications-email-input.test.tsx
@@ -285,7 +285,7 @@ describe( 'NotificationsEmailInput', () => {
 		);
 		expect( warningNotice ).not.toBeNull();
 		expect( warningNotice?.textContent ).toContain(
-			'Any communication sent to this email will be treated as coming from the account owner.'
+			'Anyone with access to this email address will be treated as the account owner.'
 		);
 	} );
 

--- a/client/settings/notification-settings/__tests__/notifications-email-input.test.tsx
+++ b/client/settings/notification-settings/__tests__/notifications-email-input.test.tsx
@@ -43,7 +43,9 @@ describe( 'NotificationsEmailInput', () => {
 
 		render( <NotificationsEmailInput /> );
 
-		expect( screen.getByDisplayValue( oldEmail ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Email address' ) ).toHaveValue(
+			oldEmail
+		);
 
 		const newEmail = 'new.communications@test.com';
 		fireEvent.change( screen.getByLabelText( 'Email address' ), {
@@ -214,5 +216,209 @@ describe( 'NotificationsEmailInput', () => {
 			container.querySelector( '.components-notice.is-error' )
 				?.textContent
 		).toMatch( /Error: Invalid email address: invalid-email/ );
+	} );
+
+	it( 'does not render the confirm field when email has not changed', () => {
+		render( <NotificationsEmailInput /> );
+
+		expect(
+			screen.queryByLabelText( 'Confirm email address' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the confirm field when email is changed', () => {
+		const setEmail = jest.fn();
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+
+		const { rerender } = render( <NotificationsEmailInput /> );
+
+		// Simulate email change
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'new@test.com',
+			setEmail,
+		] );
+		rerender( <NotificationsEmailInput /> );
+
+		expect(
+			screen.getByLabelText( 'Confirm email address' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'hides the confirm field when email is changed back to original', () => {
+		const setEmail = jest.fn();
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+
+		const { rerender } = render( <NotificationsEmailInput /> );
+
+		// Change email
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'new@test.com',
+			setEmail,
+		] );
+		rerender( <NotificationsEmailInput /> );
+		expect(
+			screen.getByLabelText( 'Confirm email address' )
+		).toBeInTheDocument();
+
+		// Change back to original
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+		rerender( <NotificationsEmailInput /> );
+		expect(
+			screen.queryByLabelText( 'Confirm email address' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders warning notice about email significance', () => {
+		const { container } = render( <NotificationsEmailInput /> );
+
+		const warningNotice = container.querySelector(
+			'.components-notice.is-warning'
+		);
+		expect( warningNotice ).not.toBeNull();
+		expect( warningNotice?.textContent ).toContain(
+			'Any communication sent to this email will be treated as coming from the account owner.'
+		);
+	} );
+
+	it( 'shows mismatch error after blurring confirm field with different value', () => {
+		const setEmail = jest.fn();
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+
+		const { container, rerender } = render( <NotificationsEmailInput /> );
+
+		// Simulate email change to show confirm field
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'changed@test.com',
+			setEmail,
+		] );
+		rerender( <NotificationsEmailInput /> );
+
+		// Type a different value in confirm field
+		fireEvent.change( screen.getByLabelText( 'Confirm email address' ), {
+			target: { value: 'mismatch@test.com' },
+		} );
+
+		// Error should not show before blur
+		expect(
+			container.querySelectorAll( '.components-notice.is-error' )
+		).toHaveLength( 0 );
+
+		// Blur the confirm field
+		fireEvent.blur( screen.getByLabelText( 'Confirm email address' ) );
+
+		// Mismatch error should now be shown
+		const errorNotices = container.querySelectorAll(
+			'.components-notice.is-error'
+		);
+		const mismatchNotice = Array.from( errorNotices ).find( ( el ) =>
+			el.textContent?.includes( 'Email addresses do not match' )
+		);
+		expect( mismatchNotice ).toBeDefined();
+	} );
+
+	it( 'does not show mismatch error when confirm email matches', () => {
+		const setEmail = jest.fn();
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+
+		const { container, rerender } = render( <NotificationsEmailInput /> );
+
+		// Simulate email change to show confirm field
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'changed@test.com',
+			setEmail,
+		] );
+		rerender( <NotificationsEmailInput /> );
+
+		// Type matching value in confirm field
+		fireEvent.change( screen.getByLabelText( 'Confirm email address' ), {
+			target: { value: 'changed@test.com' },
+		} );
+		fireEvent.blur( screen.getByLabelText( 'Confirm email address' ) );
+
+		const errorNotices = container.querySelectorAll(
+			'.components-notice.is-error'
+		);
+		const mismatchNotice = Array.from( errorNotices ).find( ( el ) =>
+			el.textContent?.includes( 'Email addresses do not match' )
+		);
+		expect( mismatchNotice ).toBeUndefined();
+	} );
+
+	it( 'calls onValidationChange with false when emails do not match', () => {
+		const onValidationChange = jest.fn();
+		const setEmail = jest.fn();
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+
+		const { rerender } = render(
+			<NotificationsEmailInput
+				onValidationChange={ onValidationChange }
+			/>
+		);
+
+		// Simulate email change to show confirm field
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'changed@test.com',
+			setEmail,
+		] );
+		rerender(
+			<NotificationsEmailInput
+				onValidationChange={ onValidationChange }
+			/>
+		);
+
+		// Email changed but confirm is empty → mismatch → invalid
+		expect( onValidationChange ).toHaveBeenLastCalledWith( false );
+	} );
+
+	it( 'calls onValidationChange with true when confirm email matches', () => {
+		const onValidationChange = jest.fn();
+		const setEmail = jest.fn();
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'original@test.com',
+			setEmail,
+		] );
+
+		const { rerender } = render(
+			<NotificationsEmailInput
+				onValidationChange={ onValidationChange }
+			/>
+		);
+
+		// Simulate email change
+		mockUseAccountCommunicationsEmail.mockReturnValue( [
+			'changed@test.com',
+			setEmail,
+		] );
+		rerender(
+			<NotificationsEmailInput
+				onValidationChange={ onValidationChange }
+			/>
+		);
+		expect( onValidationChange ).toHaveBeenCalledWith( false );
+
+		// Type matching confirm email
+		fireEvent.change( screen.getByLabelText( 'Confirm email address' ), {
+			target: { value: 'changed@test.com' },
+		} );
+
+		expect( onValidationChange ).toHaveBeenCalledWith( true );
 	} );
 } );

--- a/client/settings/notification-settings/index.tsx
+++ b/client/settings/notification-settings/index.tsx
@@ -14,6 +14,10 @@ import CardBody from '../card-body';
 import NotificationsEmailInput from './notifications-email-input';
 import './style.scss';
 
+interface NotificationSettingsProps {
+	setNotificationEmailValid?: ( valid: boolean ) => void;
+}
+
 export const NotificationSettingsDescription: React.FC = () => (
 	<>
 		<h2>{ __( 'Account notifications', 'woocommerce-payments' ) }</h2>
@@ -29,11 +33,15 @@ export const NotificationSettingsDescription: React.FC = () => (
 	</>
 );
 
-const NotificationSettings: React.FC = () => {
+const NotificationSettings: React.FC< NotificationSettingsProps > = ( {
+	setNotificationEmailValid,
+} ) => {
 	return (
 		<Card className="notification-settings">
 			<CardBody className="wcpay-card-body">
-				<NotificationsEmailInput />
+				<NotificationsEmailInput
+					onValidationChange={ setNotificationEmailValid }
+				/>
 			</CardBody>
 		</Card>
 	);

--- a/client/settings/notification-settings/notifications-email-input.tsx
+++ b/client/settings/notification-settings/notifications-email-input.tsx
@@ -5,7 +5,7 @@
  */
 import { TextControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -27,13 +27,32 @@ const isValidEmail = ( email: string ): boolean => {
 	return emailRegex.test( email );
 };
 
-const NotificationsEmailInput: React.FC = () => {
+interface NotificationsEmailInputProps {
+	onValidationChange?: ( isValid: boolean ) => void;
+}
+
+const NotificationsEmailInput: React.FC< NotificationsEmailInputProps > = ( {
+	onValidationChange,
+} ) => {
 	const [
 		accountCommunicationsEmail,
 		setAccountCommunicationsEmail,
 	] = useAccountCommunicationsEmail();
 
 	const [ hasBlurred, setHasBlurred ] = useState( false );
+	const [ confirmEmail, setConfirmEmail ] = useState( '' );
+	const [ hasConfirmBlurred, setHasConfirmBlurred ] = useState( false );
+	const [ initialEmail, setInitialEmail ] = useState< string | null >( null );
+
+	// Capture the initial email value once it loads from the server.
+	useEffect( () => {
+		if ( accountCommunicationsEmail && initialEmail === null ) {
+			setInitialEmail( accountCommunicationsEmail );
+		}
+	}, [ accountCommunicationsEmail, initialEmail ] );
+
+	const emailHasChanged =
+		initialEmail !== null && accountCommunicationsEmail !== initialEmail;
 
 	const savingError = useGetSavingError();
 	const serverError =
@@ -52,6 +71,25 @@ const NotificationsEmailInput: React.FC = () => {
 	// Server error takes precedence over client validation error
 	const errorMessage = serverError || clientValidationError;
 
+	const emailsMatch =
+		! emailHasChanged || accountCommunicationsEmail === confirmEmail;
+	const showMismatchError =
+		emailHasChanged && hasConfirmBlurred && ! emailsMatch;
+
+	const mismatchError = showMismatchError
+		? __(
+				'Email addresses do not match. Please re-enter your email address.',
+				'woocommerce-payments'
+		  )
+		: null;
+
+	// Notify parent of validation state changes.
+	useEffect( () => {
+		if ( onValidationChange ) {
+			onValidationChange( emailsMatch );
+		}
+	}, [ emailsMatch, onValidationChange ] );
+
 	return (
 		<>
 			<h4>{ __( 'Notifications email', 'woocommerce-payments' ) }</h4>
@@ -61,6 +99,19 @@ const NotificationsEmailInput: React.FC = () => {
 					'woocommerce-payments'
 				) }
 			</p>
+
+			<Notice
+				className="settings__notifications-email-warning"
+				status="warning"
+				isDismissible={ false }
+			>
+				<span>
+					{ __(
+						'Any communication sent to this email will be treated as coming from the account owner. Please verify the address carefully.',
+						'woocommerce-payments'
+					) }
+				</span>
+			</Notice>
 
 			{ errorMessage && (
 				<Notice status="error" isDismissible={ false }>
@@ -80,6 +131,32 @@ const NotificationsEmailInput: React.FC = () => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
+
+			{ emailHasChanged && (
+				<>
+					{ mismatchError && (
+						<Notice status="error" isDismissible={ false }>
+							<span>{ mismatchError }</span>
+						</Notice>
+					) }
+
+					<TextControl
+						className="settings__notifications-email-confirm-input"
+						label={ __(
+							'Confirm email address',
+							'woocommerce-payments'
+						) }
+						value={ confirmEmail }
+						onChange={ setConfirmEmail }
+						onBlur={ () => setHasConfirmBlurred( true ) }
+						data-testid={ 'notifications-email-confirm-input' }
+						type="email"
+						required
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				</>
+			) }
 		</>
 	);
 };

--- a/client/settings/notification-settings/notifications-email-input.tsx
+++ b/client/settings/notification-settings/notifications-email-input.tsx
@@ -107,7 +107,7 @@ const NotificationsEmailInput: React.FC< NotificationsEmailInputProps > = ( {
 			>
 				<span>
 					{ __(
-						'Any communication sent to this email will be treated as coming from the account owner. Please verify the address carefully.',
+						'Anyone with access to this email address will be treated as the account owner. Please verify the address carefully.',
 						'woocommerce-payments'
 					) }
 				</span>

--- a/client/settings/notification-settings/style.scss
+++ b/client/settings/notification-settings/style.scss
@@ -5,7 +5,8 @@
 		margin-bottom: 1em;
 	}
 
-	.settings__notifications-email-input {
+	.settings__notifications-email-input,
+	.settings__notifications-email-confirm-input {
 		max-width: 500px;
 	}
 }

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -150,6 +150,9 @@ const SettingsManager = () => {
 	const [ isTransactionInputsValid, setTransactionInputsValid ] = useState(
 		true
 	);
+	const [ isNotificationEmailValid, setNotificationEmailValid ] = useState(
+		true
+	);
 
 	const { isLoading, isDirty } = useSettings();
 
@@ -290,7 +293,11 @@ const SettingsManager = () => {
 			>
 				<LoadableSettingsSection numLines={ 20 }>
 					<ErrorBoundary>
-						<NotificationSettings />
+						<NotificationSettings
+							setNotificationEmailValid={
+								setNotificationEmailValid
+							}
+						/>
 					</ErrorBoundary>
 				</LoadableSettingsSection>
 			</SettingsSection>
@@ -314,7 +321,11 @@ const SettingsManager = () => {
 					</ErrorBoundary>
 				</LoadableSettingsSection>
 			</SettingsSection>
-			<SaveSettingsSection disabled={ ! isTransactionInputsValid } />
+			<SaveSettingsSection
+				disabled={
+					! isTransactionInputsValid || ! isNotificationEmailValid
+				}
+			/>
 			<VatFormModal
 				isModalOpen={ isVatFormModalOpen }
 				setModalOpen={ handleVatFormModalClose }


### PR DESCRIPTION
Fixes WOOPMNT-5706

#### Changes proposed in this Pull Request

The account notification email field (shipped in 10.5.0) allows merchants to change their WooPayments notification email with no ownership verification. A typo could send sensitive account communications to an unintended recipient.

This PR adds a quick-fix mitigation:

- **Confirm email field** — appears only when the merchant changes the email from its current value. Both fields must match before Save is enabled.
- **Warning notice** — a persistent yellow notice reminding merchants that communications sent to this email will be treated as coming from the account owner.
- **Save button disabled** — when the email and confirm email don't match, the Save button is disabled at the settings-manager level.

https://github.com/user-attachments/assets/172055ff-348e-4f30-9373-e1a4134f2626

A full email verification flow is deferred to a future cycle.

#### Testing instructions

1. Go to **Payments → Settings → Account notifications**
2. Verify the **warning notice** (yellow) is visible below the description
3. Verify only the email field is shown (no confirm field yet)
4. Change the email address to something different
5. Verify the **Confirm email address** field appears
6. Type a **different** email in the confirm field, blur it → verify the mismatch error appears
7. Verify the **Save** button is **disabled**
8. Type the **matching** email in the confirm field → verify the error disappears and Save is enabled
9. Change the email **back to the original** → verify the confirm field disappears
10. Save with matching emails → verify it saves successfully

* Tested on desktop

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.