### PR TITLE
fix: correct option type for duplicate payment method dismissed notices

### DIFF
--- a/changelog/woopmnt-5707-duplicate-payment-method-inline-warning-persists-after-the
+++ b/changelog/woopmnt-5707-duplicate-payment-method-inline-warning-persists-after-the
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed duplicate payment method dismissed notices option type from bool to array, allowing notice dismissals to persist across page refreshes.

--- a/includes/admin/class-wc-rest-payments-settings-option-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-option-controller.php
@@ -27,7 +27,7 @@ class WC_REST_Payments_Settings_Option_Controller extends WC_Payments_REST_Contr
 		'wcpay_onboarding_eligibility_modal_dismissed'     => 'bool',
 		'wcpay_connection_success_modal_dismissed'         => 'bool',
 		'wcpay_next_deposit_notice_dismissed'              => 'bool',
-		'wcpay_duplicate_payment_method_notices_dismissed' => 'bool',
+		'wcpay_duplicate_payment_method_notices_dismissed' => 'array',
 		'wcpay_instant_deposit_notice_dismissed'           => 'bool',
 		'wcpay_exit_survey_last_shown'                     => 'string',
 	];

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-option-controller.php
@@ -83,12 +83,16 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 	 */
 	public function provider_valid_values(): array {
 		return [
-			'bool option with true'          => [ 'wcpay_multi_currency_setup_completed', true ],
-			'bool option with false'         => [ 'wcpay_multi_currency_setup_completed', false ],
-			'array option with empty array'  => [ 'woocommerce_dismissed_todo_tasks', [] ],
-			'array option with array'        => [ 'woocommerce_dismissed_todo_tasks', [ 'key' => 'value' ] ],
-			'array option with nested array' => [ 'woocommerce_dismissed_todo_tasks', [ 'key' => [ 'nested' => 'value' ] ] ],
-			'string option with string'      => [ 'wcpay_exit_survey_last_shown', '2026-01-09T09:23:30.444Z' ],
+			'bool option with true'                        => [ 'wcpay_multi_currency_setup_completed', true ],
+			'bool option with false'                       => [ 'wcpay_multi_currency_setup_completed', false ],
+			'array option with empty array'                => [ 'woocommerce_dismissed_todo_tasks', [] ],
+			'array option with array'                      => [ 'woocommerce_dismissed_todo_tasks', [ 'key' => 'value' ] ],
+			'array option with nested array'               => [ 'woocommerce_dismissed_todo_tasks', [ 'key' => [ 'nested' => 'value' ] ] ],
+			'string option with string'                    => [ 'wcpay_exit_survey_last_shown', '2026-01-09T09:23:30.444Z' ],
+			'array option for dismissed duplicate notices' => [
+				'wcpay_duplicate_payment_method_notices_dismissed',
+				[ 'card' => [ 'woocommerce_payments', 'stripe' ] ],
+			],
 		];
 	}
 
@@ -110,14 +114,15 @@ class WC_REST_Payments_Settings_Option_Controller_Test extends WCPAY_UnitTestCas
 	 */
 	public function provider_invalid_values(): array {
 		return [
-			'bool option with string'  => [ 'wcpay_multi_currency_setup_completed', 'string' ],
-			'bool option with array'   => [ 'wcpay_multi_currency_setup_completed', [] ],
-			'bool option with int'     => [ 'wcpay_multi_currency_setup_completed', 123 ],
-			'array option with bool'   => [ 'woocommerce_dismissed_todo_tasks', true ],
-			'array option with string' => [ 'woocommerce_dismissed_todo_tasks', 'string' ],
-			'string option with bool'  => [ 'wcpay_exit_survey_last_shown', true ],
-			'string option with array' => [ 'wcpay_exit_survey_last_shown', [] ],
-			'string option with int'   => [ 'wcpay_exit_survey_last_shown', 123 ],
+			'bool option with string'                    => [ 'wcpay_multi_currency_setup_completed', 'string' ],
+			'bool option with array'                     => [ 'wcpay_multi_currency_setup_completed', [] ],
+			'bool option with int'                       => [ 'wcpay_multi_currency_setup_completed', 123 ],
+			'array option with bool'                     => [ 'woocommerce_dismissed_todo_tasks', true ],
+			'array option with string'                   => [ 'woocommerce_dismissed_todo_tasks', 'string' ],
+			'string option with bool'                    => [ 'wcpay_exit_survey_last_shown', true ],
+			'string option with array'                   => [ 'wcpay_exit_survey_last_shown', [] ],
+			'string option with int'                     => [ 'wcpay_exit_survey_last_shown', 123 ],
+			'array option (dismissed notices) with bool' => [ 'wcpay_duplicate_payment_method_notices_dismissed', true ],
 		];
 	}
 

--- a/tests/unit/duplicate-detection/test-class-duplicates-detection-service.php
+++ b/tests/unit/duplicate-detection/test-class-duplicates-detection-service.php
@@ -116,6 +116,22 @@ class Duplicates_Detection_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'apple_pay_google_pay', array_keys( $result )[0] );
 	}
 
+	public function test_prb_detection_excludes_disabled_stripe_gateway() {
+		// WCPay gateway enabled with PRB.
+		$this->woopayments_gateway->id                               = 'woocommerce_payments';
+		$this->woopayments_gateway->enabled                          = 'yes';
+		$this->woopayments_gateway->is_payment_request_enabled_value = true;
+
+		// Stripe gateway disabled but with payment_request still enabled in settings.
+		$this->gateway_from_another_plugin->id       = 'stripe';
+		$this->gateway_from_another_plugin->enabled  = 'no';
+		$this->gateway_from_another_plugin->settings = [ 'payment_request' => 'yes' ];
+
+		$result = $this->service->find_duplicates();
+
+		$this->assertEmpty( $result );
+	}
+
 	public function test_duplicate_not_enabled_in_woopayments() {
 		$this->set_duplicates( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, 'yes', 'yes' );
 		$this->woopayments_gateway->id = 'not_woopayments_card';


### PR DESCRIPTION
Fixes WOOPMNT-5707

#### Changes proposed in this Pull Request

The `wcpay_duplicate_payment_method_notices_dismissed` option was incorrectly typed as `'bool'` when type-based REST validation was introduced in #11244 (commit `81e9c1eaf`, Jan 13 2026). The actual value stored is an array/map of payment methods to gateway IDs (e.g. `{"card": ["woocommerce_payments", "stripe"]}`), so saving dismissed notices via the REST API failed with a 400 validation error.

This meant that dismissing a duplicate payment method inline warning only worked for the current session — on page refresh, the notice would reappear because the dismissal was never persisted to the database.

**Fix:** Change the option type from `'bool'` to `'array'` in the `ALLOWED_OPTIONS` map.

#### Testing instructions

1. Enable both WooPayments and Stripe gateways with card payments enabled on both
2. Go to WooPayments settings page — observe the duplicate payment method inline warning
3. Dismiss the warning by clicking the X button
4. Refresh the page — the warning should **stay dismissed** (before this fix, it would reappear)
5. Re-enable the warning by enabling a new conflicting gateway, then disable the conflicting gateway
6. Refresh — the warning should no longer appear

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.