### PR TITLE
Add agent pipeline GitHub Actions workflows

### DIFF
--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -1,0 +1,84 @@
+name: "Agent Pipeline"
+
+on:
+  workflow_dispatch:
+    inputs:
+      linear_issue_id:
+        description: "Linear issue ID (e.g. GAMMA-123) or issue description"
+        required: true
+        type: string
+      target_branch:
+        description: "Base branch to work from"
+        required: false
+        default: "develop"
+        type: string
+      stages:
+        description: "Pipeline stages to run (comma-separated: plan,dev,review,compound)"
+        required: false
+        default: "plan"
+        type: string
+      model:
+        description: "Claude model to use"
+        required: false
+        default: "claude-sonnet-4-5-20250929"
+        type: choice
+        options:
+          - claude-sonnet-4-5-20250929
+          - claude-opus-4-6
+
+concurrency:
+  group: agent-pipeline-${{ inputs.linear_issue_id }}
+  cancel-in-progress: true
+
+jobs:
+  # ─── Stage 1: Plan ───────────────────────────────
+  plan:
+    if: contains(inputs.stages, 'plan')
+    uses: ./.github/workflows/agent-plan.yml
+    with:
+      linear_issue_id: ${{ inputs.linear_issue_id }}
+      target_branch: ${{ inputs.target_branch }}
+      model: ${{ inputs.model }}
+    secrets: inherit
+
+  # ─── Stage 2: Dev (Phase 2) ──────────────────────
+  # dev:
+  #   needs: plan
+  #   if: contains(inputs.stages, 'dev')
+  #   uses: ./.github/workflows/agent-dev.yml
+  #   with:
+  #     linear_issue_id: ${{ inputs.linear_issue_id }}
+  #     target_branch: ${{ inputs.target_branch }}
+  #     model: ${{ inputs.model }}
+  #   secrets: inherit
+
+  # ─── Stage 3: Review (Phase 2) ───────────────────
+  # review:
+  #   needs: dev
+  #   if: contains(inputs.stages, 'review')
+  #   uses: ./.github/workflows/agent-review.yml
+  #   with:
+  #     linear_issue_id: ${{ inputs.linear_issue_id }}
+  #     target_branch: ${{ inputs.target_branch }}
+  #     model: ${{ inputs.model }}
+  #   secrets: inherit
+
+  # ─── Human Gate (Phase 2) ────────────────────────
+  # Requires GitHub Environment "agent-pipeline-approval" with required reviewers.
+  # human-approval:
+  #   needs: review
+  #   runs-on: ubuntu-latest
+  #   environment: agent-pipeline-approval
+  #   steps:
+  #     - run: echo "Approved by human reviewer"
+
+  # ─── Stage 4: Compound (Phase 2) ─────────────────
+  # compound:
+  #   needs: human-approval
+  #   if: contains(inputs.stages, 'compound')
+  #   uses: ./.github/workflows/agent-compound.yml
+  #   with:
+  #     linear_issue_id: ${{ inputs.linear_issue_id }}
+  #     target_branch: ${{ inputs.target_branch }}
+  #     model: ${{ inputs.model }}
+  #   secrets: inherit

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -1,0 +1,106 @@
+name: "Agent Pipeline — Plan Stage"
+
+on:
+  workflow_call:
+    inputs:
+      linear_issue_id:
+        type: string
+        required: true
+        description: "Linear issue ID (e.g. GAMMA-123) or issue description"
+      target_branch:
+        type: string
+        required: false
+        default: "develop"
+        description: "Base branch to work from"
+      model:
+        type: string
+        required: false
+        default: "claude-sonnet-4-5-20250929"
+        description: "Claude model to use"
+
+jobs:
+  plan:
+    name: "Plan: ${{ inputs.linear_issue_id }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout WooPayments
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+
+      - name: Checkout gamma-ai-tools (prompt templates)
+        uses: actions/checkout@v4
+        with:
+          repository: Automattic/gamma-ai-tools
+          github-server-url: https://github.a8c.com
+          token: ${{ secrets.GHE_TOKEN }}
+          path: .gamma-ai-tools
+          sparse-checkout: prompts/pipeline
+
+      - name: Prepare prompt from template
+        id: prompt
+        run: |
+          TEMPLATE=".gamma-ai-tools/prompts/pipeline/plan.md"
+          if [ ! -f "$TEMPLATE" ]; then
+            echo "::error::Prompt template not found: $TEMPLATE"
+            exit 1
+          fi
+
+          # Substitute variables
+          sed \
+            -e 's|{{LINEAR_ISSUE_ID}}|${{ inputs.linear_issue_id }}|g' \
+            -e 's|{{TARGET_BRANCH}}|${{ inputs.target_branch }}|g' \
+            "$TEMPLATE" > /tmp/plan-prompt.md
+
+          # Write multiline output
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "content<<$EOF" >> "$GITHUB_OUTPUT"
+          cat /tmp/plan-prompt.md >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Clean up gamma-ai-tools checkout
+        run: rm -rf .gamma-ai-tools
+
+      - name: Run Plan Agent
+        id: plan
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: ${{ inputs.model }}
+          prompt: ${{ steps.prompt.outputs.content }}
+          max_turns: "30"
+          allowed_tools: "Read,Glob,Grep,Bash(git log*),Bash(git blame*),Bash(git show*),Bash(git diff*),Bash(wc *),Write(plan.md)"
+
+      - name: Upload plan.md as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plan-${{ inputs.linear_issue_id }}
+          path: plan.md
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## Plan Agent Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Issue:** ${{ inputs.linear_issue_id }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Branch:** ${{ inputs.target_branch }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Model:** ${{ inputs.model }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f plan.md ]; then
+            echo "**Status:** plan.md generated" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "<details><summary>Full plan.md</summary>" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat plan.md >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Status:** plan.md was NOT generated" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/changelog/add-agent-pipeline-workflow
+++ b/changelog/add-agent-pipeline-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add agent pipeline GitHub Actions workflows
+
+


### PR DESCRIPTION
## Summary
- Adds `agent-pipeline.yml` orchestrator workflow with `workflow_dispatch` trigger (inputs: Linear issue ID, target branch, stages, model)
- Adds `agent-plan.yml` reusable workflow for the Plan Agent stage — checks out gamma-ai-tools for prompt templates, runs Claude Code headlessly via `anthropics/claude-code-action@v1`, uploads `plan.md` artifact
- Future stages (dev, review, human gate, compound) stubbed as comments for later phases

## Context
Follow-up to the pcreKM-3R1-p2. The decision: workflow YAML lives here in WooPayments, prompt templates live in gamma-ai-tools.

**Required secrets before this can run:**
- `ANTHROPIC_API_KEY` — Claude API authentication
- `GHE_TOKEN` — PAT to checkout gamma-ai-tools from github.a8c.com

## Testing instructions
1. After merging, add the required secrets to the repo
2. Go to Actions → "Agent Pipeline" → Run workflow
3. Enter a Linear issue ID (e.g. `GAMMA-123`) and click "Run workflow"
4. Verify the Plan Agent produces a `plan.md` artifact

### Does this PR need to be tested on mobile?
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)