### PR TITLE
Fix WCPay account defaulting to Test when user selects Live

### DIFF
--- a/changelog/fix-woopmnt-5733-account-defaulting-test-mode
+++ b/changelog/fix-woopmnt-5733-account-defaulting-test-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WCPay account defaulting to Test mode when user selects Live during onboarding

--- a/client/embedded-components/hooks.tsx
+++ b/client/embedded-components/hooks.tsx
@@ -31,6 +31,7 @@ export const createKycAccountSession = async (
 	data: OnboardingFields
 ): Promise< AccountSession > => {
 	const urlParams = new URLSearchParams( window.location.search );
+	const isTestDrive = urlParams.get( 'test_drive' ) === 'true';
 
 	return await apiFetch< AccountSession >( {
 		path: `${ NAMESPACE }/onboarding/kyc/session`,
@@ -38,6 +39,7 @@ export const createKycAccountSession = async (
 		data: {
 			self_assessment: fromDotNotation( data ),
 			capabilities: urlParams.get( 'capabilities' ) || '',
+			mode: isTestDrive ? 'test' : 'live',
 		},
 	} );
 };

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -88,6 +88,12 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 							],
 						],
 					],
+					'mode'            => [
+						'description' => 'The account mode the user selected: live or test. Overrides environment-based auto-detection (except dev mode).',
+						'type'        => 'string',
+						'required'    => false,
+						'enum'        => [ 'live', 'test' ],
+					],
 				],
 			]
 		);
@@ -217,10 +223,12 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 	public function create_embedded_kyc_session( WP_REST_Request $request ) {
 		$self_assessment_data = ! empty( $request->get_param( 'self_assessment' ) ) ? wc_clean( wp_unslash( $request->get_param( 'self_assessment' ) ) ) : [];
 		$capabilities         = ! empty( $request->get_param( 'capabilities' ) ) ? wc_clean( wp_unslash( $request->get_param( 'capabilities' ) ) ) : [];
+		$mode                 = ! empty( $request->get_param( 'mode' ) ) ? sanitize_text_field( $request->get_param( 'mode' ) ) : null;
 
 		$account_session = $this->onboarding_service->create_embedded_kyc_session(
 			$self_assessment_data,
-			$capabilities
+			$capabilities,
+			$mode
 		);
 
 		if ( empty( $account_session ) ) {

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -325,7 +325,7 @@ class WC_Payments_Onboarding_Service {
 		// Determine setup mode: dev mode always forces test; explicit user selection overrides auto-detection.
 		if ( WC_Payments::mode()->is_dev() ) {
 			$setup_mode = 'test';
-		} elseif ( null !== $explicit_mode && in_array( $explicit_mode, [ 'live', 'test' ], true ) ) {
+		} elseif ( null !== $explicit_mode && in_array( strtolower( $explicit_mode ), [ 'live', 'test' ], true ) ) {
 			$setup_mode = $explicit_mode;
 		} else {
 			$setup_mode = WC_Payments::mode()->is_live() ? 'live' : 'test';

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -297,16 +297,18 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * Will return the session key used to initialise the embedded onboarding session.
 	 *
-	 * @param array $self_assessment_data Self assessment data.
-	 * @param array $capabilities Optional. List keyed by capabilities IDs (payment methods) with boolean values
-	 *                           indicating whether the capability should be requested when the account is created
-	 *                           and enabled in the settings.
+	 * @param array       $self_assessment_data Self assessment data.
+	 * @param array       $capabilities Optional. List keyed by capabilities IDs (payment methods) with boolean values
+	 *                                  indicating whether the capability should be requested when the account is created
+	 *                                  and enabled in the settings.
+	 * @param string|null $explicit_mode Optional. The user's explicit mode selection ('live' or 'test').
+	 *                                   When provided, overrides the auto-detected mode (unless dev mode is active).
 	 *
 	 * @return array Session data.
 	 *
 	 * @throws API_Exception|Exception
 	 */
-	public function create_embedded_kyc_session( array $self_assessment_data, array $capabilities = [] ): array {
+	public function create_embedded_kyc_session( array $self_assessment_data, array $capabilities = [], ?string $explicit_mode = null ): array {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
 			WC_Payments_Utils::log_to_wc( 'Failed to create embedded KYC session: Jetpack connection not available.' );
 			return [];
@@ -320,7 +322,14 @@ class WC_Payments_Onboarding_Service {
 
 		$this->set_onboarding_init_in_progress();
 
-		$setup_mode = WC_Payments::mode()->is_live() ? 'live' : 'test';
+		// Determine setup mode: dev mode always forces test; explicit user selection overrides auto-detection.
+		if ( WC_Payments::mode()->is_dev() ) {
+			$setup_mode = 'test';
+		} elseif ( null !== $explicit_mode && in_array( $explicit_mode, [ 'live', 'test' ], true ) ) {
+			$setup_mode = $explicit_mode;
+		} else {
+			$setup_mode = WC_Payments::mode()->is_live() ? 'live' : 'test';
+		}
 
 		// Make sure the onboarding test mode DB flag is set.
 		self::set_test_mode( 'live' !== $setup_mode );

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -642,4 +642,118 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Test that explicit 'live' mode overrides environment-based auto-detection.
+	 */
+	public function test_create_embedded_kyc_session_explicit_live_mode_overrides_auto_detection() {
+		// Arrange: Force test mode via the onboarding test mode option (simulates leftover from test drive).
+		WC_Payments_Onboarding_Service::set_test_mode( true );
+
+		$this->mock_api_client
+			->method( 'is_server_connected' )
+			->willReturn( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'initialize_onboarding_embedded_kyc' )
+			->with( true ) // First arg is $live_account = true.
+			->willReturn(
+				[
+					'client_secret'             => 'secret',
+					'expires_at'                => time() + 3600,
+					'account_id'                => 'acc_123',
+					'is_live'                   => true,
+					'account_created'           => true,
+					'publishable_key'           => 'pk_live_123',
+					'woopay_enabled_by_default' => false,
+				]
+			);
+
+		$this->onboarding_service->clear_embedded_kyc_in_progress();
+
+		// Act: Pass explicit 'live' mode.
+		$result = $this->onboarding_service->create_embedded_kyc_session( [], [], 'live' );
+
+		// Assert: The session was created and the test mode flag was cleared.
+		$this->assertNotEmpty( $result );
+		$this->assertFalse( WC_Payments_Onboarding_Service::is_test_mode_enabled() );
+	}
+
+	/**
+	 * Test that dev mode forces test even when explicit 'live' is passed.
+	 */
+	public function test_create_embedded_kyc_session_dev_mode_forces_test_despite_explicit_live() {
+		// Arrange: Force dev mode.
+		WC_Payments::mode()->dev();
+
+		$this->mock_api_client
+			->method( 'is_server_connected' )
+			->willReturn( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'initialize_onboarding_embedded_kyc' )
+			->with( false ) // First arg is $live_account = false (forced by dev mode).
+			->willReturn(
+				[
+					'client_secret'             => 'secret',
+					'expires_at'                => time() + 3600,
+					'account_id'                => 'acc_123',
+					'is_live'                   => false,
+					'account_created'           => true,
+					'publishable_key'           => 'pk_test_123',
+					'woopay_enabled_by_default' => false,
+				]
+			);
+
+		$this->onboarding_service->clear_embedded_kyc_in_progress();
+
+		// Act: Pass explicit 'live' mode, but dev mode should override.
+		$result = $this->onboarding_service->create_embedded_kyc_session( [], [], 'live' );
+
+		// Assert.
+		$this->assertNotEmpty( $result );
+		$this->assertTrue( WC_Payments_Onboarding_Service::is_test_mode_enabled() );
+
+		// Clean up: Reset mode to avoid affecting other tests.
+		WC_Payments::mode()->live();
+	}
+
+	/**
+	 * Test backwards compatibility: no explicit mode falls back to auto-detection.
+	 */
+	public function test_create_embedded_kyc_session_no_explicit_mode_uses_auto_detection() {
+		// Arrange: Ensure live mode (no test mode flag, no dev mode).
+		WC_Payments_Onboarding_Service::set_test_mode( false );
+		WC_Payments::mode()->live();
+
+		$this->mock_api_client
+			->method( 'is_server_connected' )
+			->willReturn( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'initialize_onboarding_embedded_kyc' )
+			->with( true ) // First arg is $live_account = true (auto-detected as live).
+			->willReturn(
+				[
+					'client_secret'             => 'secret',
+					'expires_at'                => time() + 3600,
+					'account_id'                => 'acc_123',
+					'is_live'                   => true,
+					'account_created'           => true,
+					'publishable_key'           => 'pk_live_123',
+					'woopay_enabled_by_default' => false,
+				]
+			);
+
+		$this->onboarding_service->clear_embedded_kyc_in_progress();
+
+		// Act: No explicit mode (backwards compat).
+		$result = $this->onboarding_service->create_embedded_kyc_session( [] );
+
+		// Assert.
+		$this->assertNotEmpty( $result );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5733

#### Changes proposed in this Pull Request

When a merchant selects "Live" during WooPayments onboarding, the account could be created in test mode instead. This happened because the onboarding flow determined account mode from the site's environment state (`WP_ENVIRONMENT_TYPE`, dev mode flags, leftover test drive option) instead of the user's explicit selection.

**Root cause:** `create_embedded_kyc_session()` used `WC_Payments::mode()->is_live()` to determine the mode, which checks environment variables. Sites with `WP_ENVIRONMENT_TYPE=staging` (common on WP Engine dev sites) or a leftover `wcpay_onboarding_test_mode` option from a previous test drive would always create test accounts.

**Fix:** Pass the user's explicit live/test selection from the client through the REST API to the onboarding service:
- Client derives mode from the `test_drive` URL parameter (already distinguishes the two flows)
- REST controller accepts and sanitizes a new `mode` enum parameter (`live` | `test`)
- Onboarding service uses explicit mode when provided, falling back to auto-detection for backwards compatibility
- Dev mode (`WCPAY_DEV_MODE`) still forces test mode as a safety constraint

**Verified with Transact API:** The server respects `create_live_account` from the client and does not independently override it. No server-side change needed.

#### Testing instructions

1. Set `WP_ENVIRONMENT_TYPE` to `staging` in `wp-config.php` (or define `WCPAY_DEV_MODE` as `false` and ensure `WP_ENVIRONMENT_TYPE` is `staging`)
2. Navigate to WooPayments onboarding (Payments > Set up)
3. Select "Set up" for a live account (not test drive)
4. Complete the embedded KYC flow
5. Verify the account is created in **live mode**, not test mode
6. Verify test drive flow still creates a test account

**Edge cases:**
- With `WCPAY_DEV_MODE=true`: should still force test mode regardless of user selection (security constraint)
- After a previous test drive, selecting live should clear the stale test mode flag

* New PHP unit tests cover: explicit live override, dev mode constraint, backwards compat
* JS tests pass (existing component tests unaffected)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (3 new PHPUnit tests for mode override logic)
- [ ] Tested on mobile (does not apply — admin-only onboarding flow)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)