### PR TITLE
Add PR reviewer and label requirements to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -231,6 +231,9 @@ npm run i18n:pot                    # Generate translations
   - Include testing instructions
   - Check mobile testing requirement
   - Link to release testing docs post-merge
+- **After creating a PR:**
+  - Assign `Automattic/gamma` as reviewer: `gh pr edit <number> --add-reviewer Automattic/gamma`
+  - Add the `pr: needs review` label: `gh pr edit <number> --add-label "pr: needs review"`
 
 ### Docker Environment
 - WordPress: http://localhost:<PORT> (check `.env` for your port; default 8082 for main checkout, 8180-8199 for worktrees)

--- a/changelog/update-claude-md-pr-requirements
+++ b/changelog/update-claude-md-pr-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add PR reviewer and label requirements to CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds post-PR-creation checklist to CLAUDE.md requiring `Automattic/gamma` reviewer assignment and `pr: needs review` label for all PRs
- Ensures consistent PR workflow for both human and automated contributions

## Test plan
- [ ] Verify CLAUDE.md renders correctly with the new section
- [ ] Confirm the `gh pr edit` commands work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)