### PR TITLE
Add Mode system documentation for dev/test/live hierarchy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,6 +67,7 @@ Checkout Form (JS) → WC_Payment_Gateway_WCPay::process_payment()
 
 - `.claude/docs/payment-flow.md` — Complete call chain with method signatures, data transformations, and hooks
 - `.claude/docs/test-patterns.md` — Testing conventions, base classes, mocking patterns, example tests
+- `.claude/docs/mode-system.md` — Mode hierarchy (dev/test/live), frontend data flow, debugging test vs dev mode UI
 
 ### External Documentation
 

--- a/.claude/docs/mode-system.md
+++ b/.claude/docs/mode-system.md
@@ -61,7 +61,7 @@ Read by utility functions:
 
 ### 2. `@wordpress/data` Store (REST API)
 
-The settings store fetches from `GET /wc/v3/payments/settings`. The REST response includes `is_dev_mode`, `is_test_mode_onboarding`, `is_test_mode`.
+The settings store fetches from `GET /wc/v3/payments/settings`. The REST response includes `is_dev_mode_enabled`, `is_test_mode_onboarding`, `is_test_mode_enabled`.
 
 Read by hooks:
 - `useDevMode()` — from settings store
@@ -109,7 +109,7 @@ Check the REST API directly:
 GET /wp-json/wc/v3/payments/settings
 ```
 
-Look for `is_dev_mode`, `is_test_mode_onboarding`, `is_test_mode` in the response.
+Look for `is_dev_mode_enabled`, `is_test_mode_onboarding`, `is_test_mode_enabled` in the response.
 
 Or in PHP:
 

--- a/.claude/docs/mode-system.md
+++ b/.claude/docs/mode-system.md
@@ -1,0 +1,132 @@
+# WooPayments Mode System
+
+Reference for how WooPayments determines its operating mode (live, test, dev). Source: `includes/core/class-mode.php`.
+
+## Mode Hierarchy
+
+Dev mode sits at the top — when active, it forces everything below it to `true`:
+
+```
+dev_mode = true
+  └─ test_mode_onboarding = true  (always, when dev)
+      └─ test_mode = true         (always, when test_mode_onboarding)
+```
+
+### How Each Flag Is Set (in `maybe_init()`)
+
+1. **`dev_mode`** — `true` if any of:
+   - `WCPAY_DEV_MODE` constant is defined and truthy
+   - `wp_get_environment_type()` returns `'development'` or `'staging'`
+   - `wp_get_development_mode()` returns a non-empty string
+   - The `wcpay_dev_mode` filter returns `true` (used by WCPay Dev Tools plugin)
+
+2. **`test_mode_onboarding`** — `true` if:
+   - `dev_mode` is `true`, **OR**
+   - `WC_Payments_Onboarding_Service::is_test_mode_enabled()` returns `true` (checks `wcpay_onboarding_test_mode` DB option)
+   - Can be overridden by `wcpay_test_mode_onboarding` filter
+
+3. **`test_mode`** — `true` if:
+   - `test_mode_onboarding` is `true` (forced to `true`), **OR**
+   - The gateway setting `test_mode` is `'yes'` (from `woocommerce_woocommerce_payments_settings` option)
+   - Can be overridden by `wcpay_test_mode` filter
+
+### Key Implication
+
+**In any dev environment, `is_test_mode_onboarding()` is always `true`.** This is by design (line 85) but has significant UI consequences — see below.
+
+## UI Consequences
+
+The admin UI renders different messaging depending on which mode flags are set:
+
+| Condition | Settings Page | Overview Banner |
+|-----------|--------------|-----------------|
+| `is_dev()` only | Shows dev mode notice, test mode checkbox visible | Dev mode banner |
+| `is_test_mode_onboarding()` | Test mode checkbox **hidden** (forced on) | Sandbox/test-account messaging |
+| `is_test()` only | Test mode checkbox checked | Test mode banner |
+
+Because dev mode forces `is_test_mode_onboarding() = true`, you will **never** see the dev-mode-specific UI in a standard dev environment — it's masked by the test-mode-onboarding UI. To see dev-mode UI, you must override `is_test_mode_onboarding()` to return `false` (see Debugging section below).
+
+## Frontend Data Flow
+
+Mode state reaches the frontend through two independent paths that must agree:
+
+### 1. `wcpaySettings` JS Global
+
+Set in `WC_Payments_Admin::get_js_settings()` (`includes/admin/class-wc-payments-admin.php`, ~line 972). Contains `devMode`, `testModeOnboarding`, `testMode` booleans.
+
+Read by utility functions:
+- `isInDevMode()` — checks `wcpaySettings.devMode`
+- `isInTestMode()` — checks `wcpaySettings.testMode`
+- `isInTestModeOnboarding()` — checks `wcpaySettings.testModeOnboarding`
+
+### 2. `@wordpress/data` Store (REST API)
+
+The settings store fetches from `GET /wc/v3/payments/settings`. The REST response includes `is_dev_mode`, `is_test_mode_onboarding`, `is_test_mode`.
+
+Read by hooks:
+- `useDevMode()` — from settings store
+- `useTestModeOnboarding()` — from settings store
+- `useTestMode()` — from settings store
+
+### Common Pitfall
+
+If you change mode logic in PHP but only check the `wcpaySettings` global in the frontend (or vice versa), the UI may appear correct on initial load but break after a store fetch, or vice versa. Always verify both paths.
+
+## WCPay Dev Tools Plugin
+
+The [WCPay Dev Tools](https://github.com/nickarges/wcpay-dev-tools) plugin interacts with the mode system:
+
+- Hooks `wcpay_dev_mode` filter to force dev mode on/off
+- Manages the `wcpay_onboarding_test_mode` DB option (toggling test mode onboarding)
+- Provides a UI panel in the WCPay admin to toggle these settings
+
+When debugging mode issues, check whether Dev Tools is active and what state it has set.
+
+## Debugging Tips
+
+### See Dev-Mode UI in a Dev Environment
+
+Since `is_test_mode_onboarding()` masks dev-mode UI, temporarily override it:
+
+```php
+// In class-mode.php, temporarily:
+public function is_test_mode_onboarding(): bool {
+    return false; // Override to see dev-mode-specific UI
+}
+```
+
+Then restart Apache to clear OPcache:
+
+```bash
+docker compose exec wordpress apache2ctl graceful
+```
+
+### Verify Current Mode State
+
+Check the REST API directly:
+
+```
+GET /wp-json/wc/v3/payments/settings
+```
+
+Look for `is_dev_mode`, `is_test_mode_onboarding`, `is_test_mode` in the response.
+
+Or in PHP:
+
+```php
+$mode = WC_Payments::mode();
+error_log( 'dev=' . $mode->is_dev() . ' tmo=' . $mode->is_test_mode_onboarding() . ' test=' . $mode->is_test() );
+```
+
+### Filters for Testing
+
+```php
+// Force dev mode off (even in dev environment):
+add_filter( 'wcpay_dev_mode', '__return_false' );
+
+// Force test mode onboarding off:
+add_filter( 'wcpay_test_mode_onboarding', '__return_false' );
+
+// Force test mode on:
+add_filter( 'wcpay_test_mode', '__return_true' );
+```

--- a/changelog/docs-mode-system-reference
+++ b/changelog/docs-mode-system-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add internal documentation for WooPayments Mode system (dev/test/live mode hierarchy)


### PR DESCRIPTION
Fixes WOOPMNT-5709

#### Changes proposed in this Pull Request

Adds internal developer documentation (`.claude/docs/mode-system.md`) for the WooPayments Mode system (`includes/core/class-mode.php`), based on knowledge gained during manual testing of PR #11347.

This documents:
- **Mode hierarchy**: How `dev_mode` forces `test_mode_onboarding` and `test_mode` to `true`
- **Key gotcha**: `is_test_mode_onboarding()` is always `true` in dev environments, which masks dev-mode-specific UI
- **Frontend data flow**: The two independent paths (`wcpaySettings` global vs `@wordpress/data` store) that must agree
- **WCPay Dev Tools plugin**: How it hooks into the mode system via `wcpay_dev_mode` filter
- **Debugging tips**: How to override modes for testing, restart Apache for OPcache, and verify mode state via REST API

Also adds a reference to the new doc in `CLAUDE.md`.

#### Testing instructions

This is documentation-only (no runtime code changes).

1. Read `.claude/docs/mode-system.md` and verify it accurately reflects `includes/core/class-mode.php`
2. Verify the CLAUDE.md reference is properly placed in the "Detailed Reference Docs" section

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — documentation only, no runtime changes
- [x] Tested on mobile (or does not apply) — does not apply

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)