### PR TITLE
chore: rename option for dynamic place order button

### DIFF
--- a/changelog/feature-rename-express-checkout-setting
+++ b/changelog/feature-rename-express-checkout-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+chore: rename option for dynamic place order button

--- a/client/data/settings/__tests__/actions.test.js
+++ b/client/data/settings/__tests__/actions.test.js
@@ -10,7 +10,7 @@ import { apiFetch } from '@wordpress/data-controls';
 import {
 	saveSettings,
 	updateIsSavingSettings,
-	updateIsAppleGooglePayInPaymentMethodsOptionsEnabled,
+	updateIsExpressCheckoutInPaymentMethodsEnabled,
 } from '../actions';
 
 jest.mock( '@wordpress/data' );
@@ -165,29 +165,29 @@ describe( 'Settings actions tests', () => {
 		} );
 	} );
 
-	describe( 'updateIsAppleGooglePayInPaymentMethodsOptionsEnabled()', () => {
+	describe( 'updateIsExpressCheckoutInPaymentMethodsEnabled()', () => {
 		test( 'returns action with correct payload for enabled state', () => {
-			const action = updateIsAppleGooglePayInPaymentMethodsOptionsEnabled(
+			const action = updateIsExpressCheckoutInPaymentMethodsEnabled(
 				true
 			);
 
 			expect( action ).toEqual( {
 				type: 'SET_SETTINGS_VALUES',
 				payload: {
-					is_apple_google_pay_in_payment_methods_options_enabled: true,
+					is_express_checkout_in_payment_methods_enabled: true,
 				},
 			} );
 		} );
 
 		test( 'returns action with correct payload for disabled state', () => {
-			const action = updateIsAppleGooglePayInPaymentMethodsOptionsEnabled(
+			const action = updateIsExpressCheckoutInPaymentMethodsEnabled(
 				false
 			);
 
 			expect( action ).toEqual( {
 				type: 'SET_SETTINGS_VALUES',
 				payload: {
-					is_apple_google_pay_in_payment_methods_options_enabled: false,
+					is_express_checkout_in_payment_methods_enabled: false,
 				},
 			} );
 		} );

--- a/client/data/settings/__tests__/hooks.test.js
+++ b/client/data/settings/__tests__/hooks.test.js
@@ -15,7 +15,7 @@ import {
 	useTestMode,
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
-	useAppleGooglePayInPaymentMethodsOptionsEnabledSettings,
+	useExpressCheckoutInPaymentMethodsEnabledSettings,
 	useWooPayEnabledSettings,
 	useWooPayCustomMessage,
 	useWooPayStoreLogo,
@@ -234,30 +234,28 @@ describe( 'Settings hooks tests', () => {
 		} );
 	} );
 
-	describe( 'useAppleGooglePayInPaymentMethodsOptionsEnabledSettings()', () => {
-		test( 'returns Apple Google Pay in payment methods options settings from selector', () => {
+	describe( 'useExpressCheckoutInPaymentMethodsEnabledSettings()', () => {
+		test( 'returns express checkout in payment methods settings from selector', () => {
 			actions = {
-				updateIsAppleGooglePayInPaymentMethodsOptionsEnabled: jest.fn(),
+				updateIsExpressCheckoutInPaymentMethodsEnabled: jest.fn(),
 			};
 
 			selectors = {
-				getIsAppleGooglePayInPaymentMethodsOptionsEnabled: jest.fn(
+				getIsExpressCheckoutInPaymentMethodsEnabled: jest.fn(
 					() => true
 				),
 			};
 
 			const [
-				isAppleGooglePayInPaymentMethodsOptionsEnabled,
-				updateIsAppleGooglePayInPaymentMethodsOptionsEnabled,
-			] = useAppleGooglePayInPaymentMethodsOptionsEnabledSettings();
+				isExpressCheckoutInPaymentMethodsEnabled,
+				updateIsExpressCheckoutInPaymentMethodsEnabled,
+			] = useExpressCheckoutInPaymentMethodsEnabledSettings();
 
-			updateIsAppleGooglePayInPaymentMethodsOptionsEnabled( false );
+			updateIsExpressCheckoutInPaymentMethodsEnabled( false );
 
-			expect( isAppleGooglePayInPaymentMethodsOptionsEnabled ).toEqual(
-				true
-			);
+			expect( isExpressCheckoutInPaymentMethodsEnabled ).toEqual( true );
 			expect(
-				actions.updateIsAppleGooglePayInPaymentMethodsOptionsEnabled
+				actions.updateIsExpressCheckoutInPaymentMethodsEnabled
 			).toHaveBeenCalledWith( false );
 		} );
 	} );

--- a/client/data/settings/__tests__/selectors.test.js
+++ b/client/data/settings/__tests__/selectors.test.js
@@ -9,7 +9,7 @@ import {
 	getAccountStatementDescriptor,
 	isSavingSettings,
 	getIsPaymentRequestEnabled,
-	getIsAppleGooglePayInPaymentMethodsOptionsEnabled,
+	getIsExpressCheckoutInPaymentMethodsEnabled,
 	getAccountBusinessSupportEmail,
 	getAccountBusinessSupportPhone,
 	getIsWooPayEnabled,
@@ -179,18 +179,18 @@ describe( 'Settings selectors tests', () => {
 		} );
 	} );
 
-	describe( 'getIsAppleGooglePayInPaymentMethodsOptionsEnabled()', () => {
-		test( 'returns the value of state.settings.data.is_apple_google_pay_in_payment_methods_options_enabled', () => {
+	describe( 'getIsExpressCheckoutInPaymentMethodsEnabled()', () => {
+		test( 'returns the value of state.settings.data.is_express_checkout_in_payment_methods_enabled', () => {
 			const state = {
 				settings: {
 					data: {
-						is_apple_google_pay_in_payment_methods_options_enabled: true,
+						is_express_checkout_in_payment_methods_enabled: true,
 					},
 				},
 			};
 
 			expect(
-				getIsAppleGooglePayInPaymentMethodsOptionsEnabled( state )
+				getIsExpressCheckoutInPaymentMethodsEnabled( state )
 			).toBeTruthy();
 		} );
 
@@ -201,7 +201,7 @@ describe( 'Settings selectors tests', () => {
 			[ { settings: { data: {} } } ],
 		] )( 'returns false if missing (tested state: %j)', ( state ) => {
 			expect(
-				getIsAppleGooglePayInPaymentMethodsOptionsEnabled( state )
+				getIsExpressCheckoutInPaymentMethodsEnabled( state )
 			).toBeFalsy();
 		} );
 	} );

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -62,11 +62,9 @@ export function updateIsPaymentRequestEnabled( isEnabled ) {
 	return updateSettingsValues( { is_payment_request_enabled: isEnabled } );
 }
 
-export function updateIsAppleGooglePayInPaymentMethodsOptionsEnabled(
-	isEnabled
-) {
+export function updateIsExpressCheckoutInPaymentMethodsEnabled( isEnabled ) {
 	return updateSettingsValues( {
-		is_apple_google_pay_in_payment_methods_options_enabled: isEnabled,
+		is_express_checkout_in_payment_methods_enabled: isEnabled,
 	} );
 }
 

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -371,21 +371,18 @@ export const usePaymentRequestEnabledSettings = () => {
 /**
  * @return {import('wcpay/types/wcpay-data-settings-hooks').GenericSettingsHook<boolean>}
  */
-export const useAppleGooglePayInPaymentMethodsOptionsEnabledSettings = () => {
-	const {
-		updateIsAppleGooglePayInPaymentMethodsOptionsEnabled,
-	} = useDispatch( STORE_NAME );
+export const useExpressCheckoutInPaymentMethodsEnabledSettings = () => {
+	const { updateIsExpressCheckoutInPaymentMethodsEnabled } = useDispatch(
+		STORE_NAME
+	);
 
-	const isAppleGooglePayInPaymentMethodsOptionsEnabled = useSelect(
-		( select ) =>
-			select(
-				STORE_NAME
-			).getIsAppleGooglePayInPaymentMethodsOptionsEnabled()
+	const isExpressCheckoutInPaymentMethodsEnabled = useSelect( ( select ) =>
+		select( STORE_NAME ).getIsExpressCheckoutInPaymentMethodsEnabled()
 	);
 
 	return [
-		isAppleGooglePayInPaymentMethodsOptionsEnabled,
-		updateIsAppleGooglePayInPaymentMethodsOptionsEnabled,
+		isExpressCheckoutInPaymentMethodsEnabled,
+		updateIsExpressCheckoutInPaymentMethodsEnabled,
 	];
 };
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -121,10 +121,10 @@ export const getIsPaymentRequestEnabled = ( state ) => {
 	return getSettings( state ).is_payment_request_enabled || false;
 };
 
-export const getIsAppleGooglePayInPaymentMethodsOptionsEnabled = ( state ) => {
+export const getIsExpressCheckoutInPaymentMethodsEnabled = ( state ) => {
 	return (
-		getSettings( state )
-			.is_apple_google_pay_in_payment_methods_options_enabled || false
+		getSettings( state ).is_express_checkout_in_payment_methods_enabled ||
+		false
 	);
 };
 

--- a/client/settings/express-checkout-settings/__tests__/amazon-pay-settings.test.js
+++ b/client/settings/express-checkout-settings/__tests__/amazon-pay-settings.test.js
@@ -21,7 +21,17 @@ jest.mock( 'wcpay/data', () => ( {
 		.fn()
 		.mockReturnValue( [ 'amazon_pay' ] ),
 	usePaymentRequestEnabledSettings: jest.fn().mockReturnValue( [ false ] ),
+	useExpressCheckoutInPaymentMethodsEnabledSettings: jest
+		.fn()
+		.mockReturnValue( [ false, jest.fn() ] ),
 } ) );
+
+// Set up global wcpaySettings for feature flag check.
+global.wcpaySettings = {
+	featureFlags: {
+		isDynamicCheckoutPlaceOrderButtonEnabled: true,
+	},
+};
 
 const renderWithSettingsProvider = ( ui ) =>
 	render(

--- a/client/settings/express-checkout-settings/__tests__/index.test.js
+++ b/client/settings/express-checkout-settings/__tests__/index.test.js
@@ -27,7 +27,7 @@ jest.mock( 'wcpay/data', () => ( {
 	usePaymentRequestLocations: jest
 		.fn()
 		.mockReturnValue( [ [ true, true, true ], jest.fn() ] ),
-	useAppleGooglePayInPaymentMethodsOptionsEnabledSettings: jest
+	useExpressCheckoutInPaymentMethodsEnabledSettings: jest
 		.fn()
 		.mockReturnValue( [ false, jest.fn() ] ),
 	useWooPayEnabledSettings: jest.fn().mockReturnValue( [ true, jest.fn() ] ),

--- a/client/settings/express-checkout-settings/__tests__/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/__tests__/payment-request-settings.test.js
@@ -18,7 +18,7 @@ import {
 	usePaymentRequestButtonSize,
 	usePaymentRequestButtonTheme,
 	useWooPayEnabledSettings,
-	useAppleGooglePayInPaymentMethodsOptionsEnabledSettings,
+	useExpressCheckoutInPaymentMethodsEnabledSettings,
 } from '../../../data';
 import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
 
@@ -33,7 +33,7 @@ jest.mock( '../../../data', () => ( {
 	useWooPayEnabledSettings: jest.fn(),
 	useGetAvailablePaymentMethodIds: jest.fn().mockReturnValue( [] ),
 	useWooPayShowIncompatibilityNotice: jest.fn().mockReturnValue( false ),
-	useAppleGooglePayInPaymentMethodsOptionsEnabledSettings: jest.fn(),
+	useExpressCheckoutInPaymentMethodsEnabledSettings: jest.fn(),
 	useAmazonPayEnabledSettings: jest
 		.fn()
 		.mockReturnValue( [ false, jest.fn() ] ),
@@ -57,10 +57,10 @@ const getMockPaymentRequestEnabledSettings = (
 
 const getMockWooPayEnabledSettings = ( isEnabled ) => [ isEnabled ];
 
-const getMockAppleGooglePayInPaymentMethodsOptionsEnabledSettings = (
+const getMockExpressCheckoutInPaymentMethodsEnabledSettings = (
 	isEnabled,
-	updateIsAppleGooglePayInPaymentMethodsOptionsEnabledHandler
-) => [ isEnabled, updateIsAppleGooglePayInPaymentMethodsOptionsEnabledHandler ];
+	updateIsExpressCheckoutInPaymentMethodsEnabledHandler
+) => [ isEnabled, updateIsExpressCheckoutInPaymentMethodsEnabledHandler ];
 
 const getMockPaymentRequestLocations = (
 	isCheckoutEnabled,
@@ -134,8 +134,8 @@ describe( 'PaymentRequestSettings', () => {
 			getMockWooPayEnabledSettings( true )
 		);
 
-		useAppleGooglePayInPaymentMethodsOptionsEnabledSettings.mockReturnValue(
-			getMockAppleGooglePayInPaymentMethodsOptionsEnabledSettings(
+		useExpressCheckoutInPaymentMethodsEnabledSettings.mockReturnValue(
+			getMockExpressCheckoutInPaymentMethodsEnabledSettings(
 				false,
 				jest.fn()
 			)
@@ -153,19 +153,19 @@ describe( 'PaymentRequestSettings', () => {
 		expect( checkboxes ).toHaveLength( 5 ); // Apple/Google Pay in payment methods, express buttons, and 3 location checkboxes
 	} );
 
-	it( 'renders Apple Pay / Google Pay in payment methods checkbox when feature flag is enabled', () => {
+	it( 'renders express checkout in payment methods checkbox when feature flag is enabled', () => {
 		renderWithSettingsProvider(
 			<PaymentRequestSettings section="enable" />
 		);
 
 		expect(
 			screen.getByLabelText(
-				'Enable Apple Pay / Google Pay as options in the payment methods list'
+				'Enable express checkout methods as options in the payment methods list'
 			)
 		).toBeInTheDocument();
 	} );
 
-	it( 'does not render Apple Pay / Google Pay in payment methods checkbox when feature flag is disabled', () => {
+	it( 'does not render express checkout in payment methods checkbox when feature flag is disabled', () => {
 		// Mock the feature flag as disabled
 		global.wcpaySettings.featureFlags.isDynamicCheckoutPlaceOrderButtonEnabled = false;
 
@@ -175,7 +175,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		expect(
 			screen.queryByLabelText(
-				'Enable Apple Pay / Google Pay as options in the payment methods list'
+				'Enable express checkout methods as options in the payment methods list'
 			)
 		).not.toBeInTheDocument();
 	} );
@@ -210,13 +210,13 @@ describe( 'PaymentRequestSettings', () => {
 		);
 	} );
 
-	it( 'triggers the Apple Pay / Google Pay in payment methods hook when the checkbox is interacted with', async () => {
-		const updateIsAppleGooglePayInPaymentMethodsOptionsEnabledHandler = jest.fn();
+	it( 'triggers the express checkout in payment methods hook when the checkbox is interacted with', async () => {
+		const updateIsExpressCheckoutInPaymentMethodsEnabledHandler = jest.fn();
 
-		useAppleGooglePayInPaymentMethodsOptionsEnabledSettings.mockReturnValue(
-			getMockAppleGooglePayInPaymentMethodsOptionsEnabledSettings(
+		useExpressCheckoutInPaymentMethodsEnabledSettings.mockReturnValue(
+			getMockExpressCheckoutInPaymentMethodsEnabledSettings(
 				true,
-				updateIsAppleGooglePayInPaymentMethodsOptionsEnabledHandler
+				updateIsExpressCheckoutInPaymentMethodsEnabledHandler
 			)
 		);
 
@@ -225,22 +225,22 @@ describe( 'PaymentRequestSettings', () => {
 		);
 
 		expect(
-			updateIsAppleGooglePayInPaymentMethodsOptionsEnabledHandler
+			updateIsExpressCheckoutInPaymentMethodsEnabledHandler
 		).not.toHaveBeenCalled();
 
 		await userEvent.click(
 			screen.getByLabelText(
-				'Enable Apple Pay / Google Pay as options in the payment methods list'
+				'Enable express checkout methods as options in the payment methods list'
 			)
 		);
 		expect(
-			updateIsAppleGooglePayInPaymentMethodsOptionsEnabledHandler
+			updateIsExpressCheckoutInPaymentMethodsEnabledHandler
 		).toHaveBeenCalledWith( false );
 	} );
 
-	it( 'displays the correct checked state for Apple Pay / Google Pay in payment methods checkbox', () => {
-		useAppleGooglePayInPaymentMethodsOptionsEnabledSettings.mockReturnValue(
-			getMockAppleGooglePayInPaymentMethodsOptionsEnabledSettings(
+	it( 'displays the correct checked state for express checkout in payment methods checkbox', () => {
+		useExpressCheckoutInPaymentMethodsEnabledSettings.mockReturnValue(
+			getMockExpressCheckoutInPaymentMethodsEnabledSettings(
 				true,
 				jest.fn()
 			)
@@ -252,7 +252,7 @@ describe( 'PaymentRequestSettings', () => {
 
 		expect(
 			screen.getByLabelText(
-				'Enable Apple Pay / Google Pay as options in the payment methods list'
+				'Enable express checkout methods as options in the payment methods list'
 			)
 		).toBeChecked();
 	} );

--- a/client/settings/express-checkout-settings/amazon-pay-settings.js
+++ b/client/settings/express-checkout-settings/amazon-pay-settings.js
@@ -18,6 +18,7 @@ import {
 	usePaymentRequestButtonSize,
 	useAmazonPayEnabledSettings,
 	useAmazonPayLocations,
+	useExpressCheckoutInPaymentMethodsEnabledSettings,
 } from 'wcpay/data';
 import interpolateComponents from '@automattic/interpolate-components';
 import ExpressCheckoutSettingsNotices from './express-checkout-settings-notices';
@@ -87,6 +88,10 @@ const AmazonPaySettings = ( { section } ) => {
 		amazonPayLocations,
 		updateAmazonPayLocations,
 	] = useAmazonPayLocations();
+	const [
+		isExpressCheckoutInPaymentMethodsEnabled,
+		updateIsExpressCheckoutInPaymentMethodsEnabled,
+	] = useExpressCheckoutInPaymentMethodsEnabledSettings();
 
 	const makeLocationChangeHandler = ( location ) => ( isChecked ) => {
 		updateAmazonPayLocations( location, isChecked );
@@ -97,6 +102,29 @@ const AmazonPaySettings = ( { section } ) => {
 			{ section === 'enable' && (
 				<CardBody className="wcpay-card-body">
 					<div className="wcpay-payment-request-settings__enable">
+						{ wcpaySettings.featureFlags
+							.isDynamicCheckoutPlaceOrderButtonEnabled && (
+							<CheckboxControl
+								className="wcpay-payment-request-settings__enable__checkbox"
+								checked={
+									isExpressCheckoutInPaymentMethodsEnabled
+								}
+								onChange={
+									updateIsExpressCheckoutInPaymentMethodsEnabled
+								}
+								label={ __(
+									'Enable express checkout methods as options in the payment methods list',
+									'woocommerce-payments'
+								) }
+								help={ __(
+									// Amazon Pay settings page always has Amazon Pay available.
+									'Apple Pay, Google Pay, and Amazon Pay will appear as options in the payment methods list ' +
+										'instead of as separate express checkout buttons.',
+									'woocommerce-payments'
+								) }
+								__nextHasNoMarginBottom
+							/>
+						) }
 						<CheckboxControl
 							className="wcpay-payment-request-settings__enable__checkbox"
 							checked={ isAmazonPayEnabled }

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -14,7 +14,7 @@ import GeneralPaymentRequestButtonSettings from './general-payment-request-butto
 import {
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
-	useAppleGooglePayInPaymentMethodsOptionsEnabledSettings,
+	useExpressCheckoutInPaymentMethodsEnabledSettings,
 } from 'wcpay/data';
 
 const PaymentRequestSettings = ( { section } ) => {
@@ -24,9 +24,9 @@ const PaymentRequestSettings = ( { section } ) => {
 	] = usePaymentRequestEnabledSettings();
 
 	const [
-		isAppleGooglePayInPaymentMethodsOptionsEnabled,
-		updateIsAppleGooglePayInPaymentMethodsOptionsEnabled,
-	] = useAppleGooglePayInPaymentMethodsOptionsEnabledSettings();
+		isExpressCheckoutInPaymentMethodsEnabled,
+		updateIsExpressCheckoutInPaymentMethodsEnabled,
+	] = useExpressCheckoutInPaymentMethodsEnabledSettings();
 
 	const [
 		paymentRequestLocations,
@@ -47,20 +47,28 @@ const PaymentRequestSettings = ( { section } ) => {
 							<CheckboxControl
 								className="wcpay-payment-request-settings__enable__checkbox"
 								checked={
-									isAppleGooglePayInPaymentMethodsOptionsEnabled
+									isExpressCheckoutInPaymentMethodsEnabled
 								}
 								onChange={
-									updateIsAppleGooglePayInPaymentMethodsOptionsEnabled
+									updateIsExpressCheckoutInPaymentMethodsEnabled
 								}
 								label={ __(
-									'Enable Apple Pay / Google Pay as options in the payment methods list',
+									'Enable express checkout methods as options in the payment methods list',
 									'woocommerce-payments'
 								) }
-								help={ __(
-									'Customers with Apple Pay or Google Pay enabled will be able to pay with ' +
-										'their preferred wallet as options in the payment methods list.',
-									'woocommerce-payments'
-								) }
+								help={
+									wcpaySettings.featureFlags.amazonPay
+										? __(
+												'Apple Pay, Google Pay, and Amazon Pay will appear as options ' +
+													'in the payment methods list instead of as separate express checkout buttons.',
+												'woocommerce-payments'
+										  )
+										: __(
+												'Apple Pay and Google Pay will appear as options in the payment methods list ' +
+													'instead of as separate express checkout buttons.',
+												'woocommerce-payments'
+										  )
+								}
 								__nextHasNoMarginBottom
 							/>
 						) }

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -227,8 +227,8 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_apple_google_pay_in_payment_methods_options_enabled' => [
-						'description'       => __( 'If Apple Pay / Google Pay should be enabled as an option in the payment methods list.', 'woocommerce-payments' ),
+					'is_express_checkout_in_payment_methods_enabled' => [
+						'description'       => __( 'If express checkout methods (Apple Pay, Google Pay, Amazon Pay) should be enabled as options in the payment methods list.', 'woocommerce-payments' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
@@ -555,7 +555,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'account_domestic_currency'              => $this->wcpay_gateway->get_option( 'account_domestic_currency' ),
 				'account_communications_email'           => $this->wcpay_gateway->get_option( 'account_communications_email' ),
 				'is_payment_request_enabled'             => $this->wcpay_gateway->is_payment_request_enabled(),
-				'is_apple_google_pay_in_payment_methods_options_enabled' => 'yes' === $this->wcpay_gateway->get_option( 'apple_google_pay_in_payment_methods_options' ),
+				'is_express_checkout_in_payment_methods_enabled' => 'yes' === $this->wcpay_gateway->get_option( 'express_checkout_in_payment_methods' ),
 				'is_debug_log_enabled'                   => 'yes' === $this->wcpay_gateway->get_option( 'enable_logging' ),
 				'payment_request_button_size'            => $this->wcpay_gateway->get_option( 'payment_request_button_size' ),
 				'payment_request_button_type'            => $this->wcpay_gateway->get_option( 'payment_request_button_type' ),
@@ -600,7 +600,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$this->update_is_multi_currency_enabled( $request );
 		$this->update_is_wcpay_subscriptions_enabled( $request );
 		$this->update_is_payment_request_enabled( $request );
-		$this->update_is_apple_google_pay_in_payment_methods_options_enabled( $request );
+		$this->update_is_express_checkout_in_payment_methods_enabled( $request );
 		$this->update_payment_request_appearance( $request );
 		$this->update_is_saved_cards_enabled( $request );
 		$this->update_is_woopay_enabled( $request );
@@ -931,18 +931,20 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	}
 
 	/**
-	 * Updates the "Apple Pay / Google Pay in payment methods options" enable/disable settings.
+	 * Updates the "express checkout in payment methods" enable/disable settings.
+	 * This controls whether Apple Pay, Google Pay, and Amazon Pay appear as options
+	 * in the payment methods list instead of as separate express checkout buttons.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 */
-	private function update_is_apple_google_pay_in_payment_methods_options_enabled( WP_REST_Request $request ) {
-		if ( ! $request->has_param( 'is_apple_google_pay_in_payment_methods_options_enabled' ) ) {
+	private function update_is_express_checkout_in_payment_methods_enabled( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'is_express_checkout_in_payment_methods_enabled' ) ) {
 			return;
 		}
 
-		$is_apple_google_pay_in_payment_methods_options_enabled = $request->get_param( 'is_apple_google_pay_in_payment_methods_options_enabled' );
+		$is_express_checkout_in_payment_methods_enabled = $request->get_param( 'is_express_checkout_in_payment_methods_enabled' );
 
-		$this->wcpay_gateway->update_option( 'apple_google_pay_in_payment_methods_options', $is_apple_google_pay_in_payment_methods_options_enabled ? 'yes' : 'no' );
+		$this->wcpay_gateway->update_option( 'express_checkout_in_payment_methods', $is_express_checkout_in_payment_methods_enabled ? 'yes' : 'no' );
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2726,14 +2726,14 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 		return [
 			// The WooPayments setup details.
-			'gateway'                => [
+			'gateway'                                     => [
 				'enabled'              => $gateway->is_enabled(),
 				'test_mode'            => WC_Payments::mode()->is_test(),
 				'test_mode_onboarding' => WC_Payments::mode()->is_test_mode_onboarding(),
 			],
 
 			// Payment methods setup.
-			'payment_methods'        => [
+			'payment_methods'                             => [
 				'available'  => $payment_methods_available,
 				'enabled'    => $payment_methods_enabled,
 				'disabled'   => $payment_methods_disabled,
@@ -2741,18 +2741,18 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			],
 			// Payment methods mapped to capabilities, for flexibility with the Transact Platform.
 			// E.g. 'card_payments' capability corresponds to 'card' payment method.
-			'provider_capabilities'  => [
+			'provider_capabilities'                       => [
 				'available' => $provider_capabilities_available,
 				'enabled'   => $provider_capabilities_enabled,
 				'disabled'  => $provider_capabilities_disabled,
 			],
-			'apple_google_pay_in_payment_methods_options_enabled' => $gateway->get_option( 'apple_google_pay_in_payment_methods_options' ),
+			'express_checkout_in_payment_methods_enabled' => $gateway->get_option( 'express_checkout_in_payment_methods' ),
 
-			'saved_cards_enabled'    => $gateway->is_saved_cards_enabled(),
-			'manual_capture_enabled' => 'yes' === $gateway->get_option( 'manual_capture' ),
-			'debug_log_enabled'      => 'yes' === $gateway->get_option( 'enable_logging' ),
+			'saved_cards_enabled'                         => $gateway->is_saved_cards_enabled(),
+			'manual_capture_enabled'                      => 'yes' === $gateway->get_option( 'manual_capture' ),
+			'debug_log_enabled'                           => 'yes' === $gateway->get_option( 'enable_logging' ),
 
-			'payment_request'        => [
+			'payment_request'                             => [
 				'enabled'              => $gateway->is_payment_request_enabled(),
 				'enabled_locations'    => $this->get_express_checkout_method_locations( $gateway, 'payment_request' ),
 				'button_type'          => $gateway->get_option( 'payment_request_button_type' ),
@@ -2761,7 +2761,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 				'button_border_radius' => $gateway->get_option( 'payment_request_button_border_radius' ),
 			],
 
-			'woopay'                 => [
+			'woopay'                                      => [
 				'enabled'                 => WC_Payments_Features::is_woopay_enabled(),
 				'enabled_locations'       => $this->get_express_checkout_method_locations( $gateway, 'woopay' ),
 				'store_logo'              => $gateway->get_option( 'platform_checkout_store_logo' ),
@@ -2770,17 +2770,17 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			],
 
 			// WooPayments features.
-			'multi_currency_enabled' => WC_Payments_Features::is_customer_multi_currency_enabled(),
-			'stripe_billing_enabled' => WC_Payments_Features::is_stripe_billing_enabled(),
+			'multi_currency_enabled'                      => WC_Payments_Features::is_customer_multi_currency_enabled(),
+			'stripe_billing_enabled'                      => WC_Payments_Features::is_stripe_billing_enabled(),
 
 			// Other WooPayments details.
-			'plugin'                 => [
+			'plugin'                                      => [
 				'version'              => defined( 'WCPAY_VERSION_NUMBER' ) ? explode( '-', WCPAY_VERSION_NUMBER, 2 )[0] : '',
 				'activation_timestamp' => get_option( 'wcpay_activation_timestamp', null ),
 			],
 
 			// Other store setup details.
-			'wp_setup'               => [
+			'wp_setup'                                    => [
 				'name'           => get_bloginfo( 'name' ),
 				'url'            => home_url(),
 				'active_theme'   => $this->get_store_theme_details(),
@@ -2788,7 +2788,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 				'version'        => get_bloginfo( 'version' ),
 				'locale'         => get_locale(),
 			],
-			'wc_setup'               => [
+			'wc_setup'                                    => [
 				'version'                     => defined( 'WC_VERSION' ) ? explode( '-', WC_VERSION, 2 )[0] : '',
 				'store_id'                    => ( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) ) ? get_option( \WC_Install::STORE_ID_OPTION, null ) : null,
 				'currency'                    => get_woocommerce_currency(),

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -690,33 +690,33 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'book', $this->gateway->get_option( 'payment_request_button_type' ) );
 	}
 
-	public function test_update_settings_enables_apple_google_pay_in_payment_methods_options() {
+	public function test_update_settings_enables_express_checkout_in_payment_methods() {
 		$request = new WP_REST_Request();
-		$request->set_param( 'is_apple_google_pay_in_payment_methods_options_enabled', true );
+		$request->set_param( 'is_express_checkout_in_payment_methods_enabled', true );
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( 'yes', $this->gateway->get_option( 'apple_google_pay_in_payment_methods_options' ) );
+		$this->assertEquals( 'yes', $this->gateway->get_option( 'express_checkout_in_payment_methods' ) );
 	}
 
-	public function test_update_settings_disables_apple_google_pay_in_payment_methods_options() {
+	public function test_update_settings_disables_express_checkout_in_payment_methods() {
 		$request = new WP_REST_Request();
-		$request->set_param( 'is_apple_google_pay_in_payment_methods_options_enabled', false );
+		$request->set_param( 'is_express_checkout_in_payment_methods_enabled', false );
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( 'no', $this->gateway->get_option( 'apple_google_pay_in_payment_methods_options' ) );
+		$this->assertEquals( 'no', $this->gateway->get_option( 'express_checkout_in_payment_methods' ) );
 	}
 
-	public function test_update_settings_does_not_toggle_apple_google_pay_in_payment_methods_options_if_not_supplied() {
-		$this->gateway->update_option( 'apple_google_pay_in_payment_methods_options', 'yes' );
-		$status_before_request = $this->gateway->get_option( 'apple_google_pay_in_payment_methods_options' );
+	public function test_update_settings_does_not_toggle_express_checkout_in_payment_methods_if_not_supplied() {
+		$this->gateway->update_option( 'express_checkout_in_payment_methods', 'yes' );
+		$status_before_request = $this->gateway->get_option( 'express_checkout_in_payment_methods' );
 
 		$request = new WP_REST_Request();
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( $status_before_request, $this->gateway->get_option( 'apple_google_pay_in_payment_methods_options' ) );
+		$this->assertEquals( $status_before_request, $this->gateway->get_option( 'express_checkout_in_payment_methods' ) );
 	}
 
 	public function test_update_settings_does_not_save_account_if_not_supplied() {
@@ -981,28 +981,28 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->gateway->update_option( 'platform_checkout', $current_platform_checkout );
 	}
 
-	public function test_get_settings_returns_apple_google_pay_in_payment_methods_options_enabled_true(): void {
-		$this->gateway->update_option( 'apple_google_pay_in_payment_methods_options', 'yes' );
+	public function test_get_settings_returns_express_checkout_in_payment_methods_enabled_true(): void {
+		$this->gateway->update_option( 'express_checkout_in_payment_methods', 'yes' );
 
 		$response = $this->controller->get_settings();
 
-		$this->assertTrue( $response->get_data()['is_apple_google_pay_in_payment_methods_options_enabled'] );
+		$this->assertTrue( $response->get_data()['is_express_checkout_in_payment_methods_enabled'] );
 	}
 
-	public function test_get_settings_returns_apple_google_pay_in_payment_methods_options_enabled_false(): void {
-		$this->gateway->update_option( 'apple_google_pay_in_payment_methods_options', 'no' );
+	public function test_get_settings_returns_express_checkout_in_payment_methods_enabled_false(): void {
+		$this->gateway->update_option( 'express_checkout_in_payment_methods', 'no' );
 
 		$response = $this->controller->get_settings();
 
-		$this->assertFalse( $response->get_data()['is_apple_google_pay_in_payment_methods_options_enabled'] );
+		$this->assertFalse( $response->get_data()['is_express_checkout_in_payment_methods_enabled'] );
 	}
 
-	public function test_get_settings_returns_apple_google_pay_in_payment_methods_options_enabled_false_by_default(): void {
-		$this->gateway->update_option( 'apple_google_pay_in_payment_methods_options', '' );
+	public function test_get_settings_returns_express_checkout_in_payment_methods_enabled_false_by_default(): void {
+		$this->gateway->update_option( 'express_checkout_in_payment_methods', '' );
 
 		$response = $this->controller->get_settings();
 
-		$this->assertFalse( $response->get_data()['is_apple_google_pay_in_payment_methods_options_enabled'] );
+		$this->assertFalse( $response->get_data()['is_express_checkout_in_payment_methods_enabled'] );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3658,7 +3658,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$mock_gateway->method( 'get_option' )->willReturnCallback(
 			function ( $key, $default = null ) {
 				$options = [
-					'apple_google_pay_in_payment_methods_options' => 'yes',
+					'express_checkout_in_payment_methods'  => 'yes',
 					'manual_capture'                       => 'no',
 					'enable_logging'                       => 'no',
 					'payment_request_button_type'          => 'default',
@@ -3708,7 +3708,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'gateway', $captured_data );
 		$this->assertArrayHasKey( 'payment_methods', $captured_data );
 		$this->assertArrayHasKey( 'provider_capabilities', $captured_data );
-		$this->assertArrayHasKey( 'apple_google_pay_in_payment_methods_options_enabled', $captured_data );
+		$this->assertArrayHasKey( 'express_checkout_in_payment_methods_enabled', $captured_data );
 		$this->assertArrayHasKey( 'saved_cards_enabled', $captured_data );
 		$this->assertArrayHasKey( 'manual_capture_enabled', $captured_data );
 		$this->assertArrayHasKey( 'debug_log_enabled', $captured_data );
@@ -3755,7 +3755,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		);
 
 		// Assert: Verify simple boolean/string values match mocked data.
-		$this->assertEquals( 'yes', $captured_data['apple_google_pay_in_payment_methods_options_enabled'] );
+		$this->assertEquals( 'yes', $captured_data['express_checkout_in_payment_methods_enabled'] );
 		$this->assertTrue( $captured_data['saved_cards_enabled'] );
 		$this->assertFalse( $captured_data['manual_capture_enabled'] );
 		$this->assertFalse( $captured_data['debug_log_enabled'] );


### PR DESCRIPTION
Fixes WOOPMNT-5741

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Renaming `is_apple_google_pay_in_payment_methods_options_enabled` to `is_express_checkout_in_payment_methods_enabled` across the codebase (PHP REST API, JS
  data layer, and tests) to reflect that the setting now covers all express checkout methods, not just Apple/Google Pay
- Adding the "enable express checkout in payment methods list" checkbox to the Amazon Pay settings page (previously only on the Apple Pay / Google Pay page)
- Updating checkbox labels and help text to reference all express checkout methods (Apple Pay, Google Pay, Amazon Pay)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the feature via `wp option update _wcpay_feature_dynamic_checkout_place_order_button 1`
- Navigate to Payments > Settings
- On Google Pay/Apple Pay, click "Customize"
- You should see the option
- Enable it
- Save the changes
- Refresh the page
- The option should persist
- The feature is also available for the Amazon Pay screen
- The feature is not available for WooPay

<img width="1237" height="342" alt="Screenshot 2026-02-13 at 6 30 57 PM" src="https://github.com/user-attachments/assets/3f18ddf4-3b21-4a4f-9f2e-019a7335565b" />
<img width="1233" height="339" alt="Screenshot 2026-02-13 at 6 30 49 PM" src="https://github.com/user-attachments/assets/c14aa294-1d2f-43c4-abd9-fb4d074df0f7" />
<img width="1240" height="347" alt="Screenshot 2026-02-13 at 6 30 39 PM" src="https://github.com/user-attachments/assets/97346ded-f3fe-4ad5-8533-1ac91c7b891b" />
<img width="1218" height="367" alt="Screenshot 2026-02-13 at 6 30 32 PM" src="https://github.com/user-attachments/assets/57ac24d7-4e43-4fa4-a0e5-b5c68e78a9ed" />
<img width="1274" height="372" alt="Screenshot 2026-02-13 at 6 30 27 PM" src="https://github.com/user-attachments/assets/7b6cf4c7-88e5-4e6a-9c92-b060b1c16110" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
