### PR TITLE
feat: add phone number character limit filter

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1179,7 +1179,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order = wc_get_order( $order_id );
 
 		try {
-			if ( 20 < strlen( $order->get_billing_phone() ) ) {
+			/**
+			 * Filter the maximum length of a phone number accepted by Stripe.
+			 *
+			 * Stripe's API enforces a 20-character maximum on the billing_details.phone field
+			 * (designed for E.164 international format). Increase at your own risk, as values
+			 * exceeding 20 characters may still be rejected by Stripe's API.
+			 *
+			 * @param int $max_length The maximum phone number length. Default: 20.
+			 *
+			 * @return int The filtered maximum phone number length.
+			 *
+			 * @since 7.8.0
+			 */
+			$phone_max_length = apply_filters( 'woocommerce_payments_phone_number_max_length', 20 );
+			if ( $phone_max_length < strlen( $order->get_billing_phone() ) ) {
 				throw new Invalid_Phone_Number_Exception(
 					__( 'Invalid phone number.', 'woocommerce-payments' ),
 					'invalid_phone_number'

--- a/src/Internal/Service/OrderService.php
+++ b/src/Internal/Service/OrderService.php
@@ -217,7 +217,21 @@ class OrderService {
 	 */
 	public function is_valid_phone_number( int $order_id ): bool {
 		$order = $this->get_order( $order_id );
-		return strlen( $order->get_billing_phone() ) < 20;
+		/**
+		 * Filter the maximum length of a phone number accepted by Stripe.
+		 *
+		 * Stripe's API enforces a 20-character maximum on the billing_details.phone field
+		 * (designed for E.164 international format). Increase at your own risk, as values
+		 * exceeding 20 characters may still be rejected by Stripe's API.
+		 *
+		 * @param int $max_length The maximum phone number length. Default: 20.
+		 *
+		 * @return int The filtered maximum phone number length.
+		 *
+		 * @since 7.8.0
+		 */
+		$phone_max_length = apply_filters( 'woocommerce_payments_phone_number_max_length', 20 );
+		return strlen( $order->get_billing_phone() ) < $phone_max_length;
 	}
 
 	/**

--- a/tests/unit/src/Internal/Service/OrderServiceTest.php
+++ b/tests/unit/src/Internal/Service/OrderServiceTest.php
@@ -309,6 +309,34 @@ class OrderServiceTest extends WCPAY_UnitTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	public function test_is_valid_phone_number_with_filter() {
+		$phone_number = '123456789012345678901'; // 21 characters - invalid at default
+
+		// First test: should be invalid with default 20-char limit
+		$this->mock_get_order()
+			->expects( $this->once() )
+			->method( 'get_billing_phone' )
+			->willReturn( $phone_number );
+
+		$result = $this->sut->is_valid_phone_number( $this->order_id );
+		$this->assertFalse( $result, 'Phone number should be invalid with default 20-char limit' );
+
+		// Second test: should be valid when filter increases limit to 25
+		add_filter( 'woocommerce_payments_phone_number_max_length', function() {
+			return 25;
+		} );
+
+		$this->mock_get_order()
+			->expects( $this->once() )
+			->method( 'get_billing_phone' )
+			->willReturn( $phone_number );
+
+		$result = $this->sut->is_valid_phone_number( $this->order_id );
+		$this->assertTrue( $result, 'Phone number should be valid with filtered 25-char limit' );
+
+		remove_all_filters( 'woocommerce_payments_phone_number_max_length' );
+	}
+
 	public function test_add_note() {
 		$note_id      = 321;
 		$note_content = 'Note content';


### PR DESCRIPTION
## Description

This PR adds a filterable hook for the phone number character limit validation in WooPayments. This addresses a customer issue where longer phone numbers (with extensions or multiple numbers) are rejected during checkout.

## Related Issue

**Zendesk Ticket:** [#10832808](https://a8c.zendesk.com/agent/tickets/10832808)

**Customer Issue:** A merchant needed to store phone numbers with extensions or multiple phone numbers (e.g., "555-555-5555 or 555-555-5566"), which exceeded the current 20-character limit enforced by WooPayments.

## Problem

WooPayments enforces a hard-coded 20-character maximum on phone numbers in billing details:
- Stripe's API requires this limitation for the `billing_details.phone` field
- The limit is designed for E.164 international format (+12025551234 = 16 chars max)
- However, merchants may have legitimate business needs for longer phone numbers

## Solution

Introduces the `woocommerce_payments_phone_number_max_length` filter, allowing merchants and developers to customize the maximum phone number length without modifying plugin code.

### Filter Signature

```php
/**
 * Filter the maximum length of a phone number accepted by Stripe.
 *
 * Stripe's API enforces a 20-character maximum on the billing_details.phone field
 * (designed for E.164 international format). Increase at your own risk, as values
 * exceeding 20 characters may still be rejected by Stripe's API.
 *
 * @param int $max_length The maximum phone number length. Default: 20.
 *
 * @return int The filtered maximum phone number length.
 *
 * @since 7.8.0
 */
apply_filters( 'woocommerce_payments_phone_number_max_length', 20 )
```

### Usage Example

For merchants needing to increase the limit:

```php
add_filter( 'woocommerce_payments_phone_number_max_length', function() {
    return 30; // Allow up to 30 characters for phone extensions
} );
```

## Changes Made

1. **`includes/class-wc-payment-gateway-wcpay.php`** (lines 1182)
   - Replaced hard-coded `20` with filterable `$phone_max_length` variable
   - Updated validation to use the filter
   - Added comprehensive documentation

2. **`src/Internal/Service/OrderService.php`** (lines 220)
   - Updated `is_valid_phone_number()` method to use the filter
   - Maintains backward compatibility (default 20 characters)

3. **`tests/unit/src/Internal/Service/OrderServiceTest.php`**
   - Added `test_is_valid_phone_number_with_filter()` to verify filter functionality
   - Tests default behavior and filtered behavior

## Backward Compatibility

✅ Fully backward compatible - default behavior unchanged (20-character limit)

## Testing

- [x] Unit tests pass (filter defaults to 20 characters)
- [x] Unit tests verify filter increases limit when applied
- [x] PHP syntax validation passes
- [x] All modified validation points use the filter

## Important Notes

⚠️ Merchants increasing the limit should be aware that:
- Stripe's API may still reject phone numbers exceeding 20 characters
- This filter only controls WooPayments' client-side validation
- The E.164 standard recommends 15-16 characters maximum for international numbers

## Related Documentation

- [Stripe API: Phone Number Validation](https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details-phone)
- [E.164 Phone Number Format](https://www.twilio.com/docs/glossary/what-e164)
