### PR TITLE
Add root AGENTS.md symlink for cross-agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/changelog/add-agents-md-root-symlink
+++ b/changelog/add-agents-md-root-symlink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add root AGENTS.md symlink for cross-agent discoverability


### PR DESCRIPTION
See PAY-511

## Summary
- Adds a root-level `AGENTS.md` that symlinks to `.claude/CLAUDE.md`
- Enables non-Claude coding agents (Codex, Gemini CLI, etc.) to discover repository instructions at the standard location

## Test plan
- [ ] Verify `AGENTS.md` symlink resolves to `.claude/CLAUDE.md`
- [ ] No functional changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)