### PR TITLE
Fix fatal error: missing WC_Payments_Explicit_Price_Formatter in loan note

### DIFF
--- a/changelog/fix-woopmnt-5740-fatal-error-missing-class-loan-note
+++ b/changelog/fix-woopmnt-5740-fatal-error-missing-class-loan-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when WC_Payments_Explicit_Price_Formatter class is loaded before loan approved note

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2575,6 +2575,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	 */
 	public function handle_loan_approved_inbox_note( $account ) {
 		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-loan-approved.php';
+		require_once WCPAY_ABSPATH . 'includes/class-wc-payments-explicit-price-formatter.php';
 
 		// If the account cache is empty, don't try to create an inbox note.
 		if ( empty( $account ) ) {

--- a/tests/unit/notes/test-class-wc-payments-notes-loan-approved.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-loan-approved.php
@@ -1,0 +1,40 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class WC_Payments_Notes_Loan_Approved_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-loan-approved.php';
+
+/**
+ * Class WC_Payments_Notes_Loan_Approved_Test
+ */
+class WC_Payments_Notes_Loan_Approved_Test extends WCPAY_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+		}
+	}
+
+	public function test_get_note_generates_content_with_formatted_price() {
+		WC_Payments_Notes_Loan_Approved::set_loan_details(
+			[
+				'details' => [
+					'advance_amount'      => 1234567,
+					'advance_paid_out_at' => time(),
+					'currency'            => 'USD',
+				],
+			]
+		);
+
+		$note = WC_Payments_Notes_Loan_Approved::get_note();
+
+		$this->assertInstanceOf( \Automattic\WooCommerce\Admin\Notes\Note::class, $note );
+		$this->assertStringContainsString( 'capital loan has been approved', $note->get_content() );
+		$this->assertEquals( 'wc-payments-notes-loan-approved', $note->get_name() );
+	}
+}


### PR DESCRIPTION
Fixes WOOPMNT-5740

#### Changes proposed in this Pull Request

The plugin crashes with `Fatal error: Class "WC_Payments_Explicit_Price_Formatter" not found` in the loan approved admin inbox note. This happens when the account data cache is refreshed during payment method construction in `WC_Payments::init()`, before the formatter class has been included (line 720).

The fix adds a `require_once` for `class-wc-payments-explicit-price-formatter.php` in `handle_loan_approved_inbox_note()`, right alongside the existing `require_once` for the loan note file itself. This is idempotent and follows the same pattern already used in the method.

#### Testing instructions

1. This is a class loading race condition that's hard to reproduce manually — it depends on the account cache being stale at exactly the right moment during plugin init.
2. Verify the new unit test passes: `npm run test:php -- --filter=WC_Payments_Notes_Loan_Approved_Test`
3. Verify existing loan note tests still pass: `npm run test:php -- --filter=test_handle_loan_approved_inbox_note`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.