### PR TITLE
fix(docker): respect custom dev-tools path in setup script

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -161,19 +161,25 @@ echo "Installing and activating Disable WordPress Updates..."
 cli wp plugin install disable-wordpress-updates --activate
 
 echo "Installing dev tools plugin..."
+# Load local.env for custom dev-tools path (same file the post-merge hook uses).
+if [[ -f "$(pwd)/local.env" ]]; then
+	source "$(pwd)/local.env"
+fi
+DEV_TOOLS_CLONE_PATH=${LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH:-"docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools"}
+
 set +e
-# Check if dev tools already exists in the shared plugins volume (e.g., from main checkout setup)
-cli wp plugin path woocommerce-payments-dev-tools > /dev/null 2>&1
-if [[ $? -ne 0 ]]; then
-	# Not present - clone to the local path (which is the shared volume when running from main checkout)
-	git clone git@github.com:Automattic/woocommerce-payments-dev-tools.git docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools
-	if [[ $? -ne 0 ]]; then
+if [[ -d "$DEV_TOOLS_CLONE_PATH/.git" ]]; then
+	echo "Dev tools already cloned at $DEV_TOOLS_CLONE_PATH — skipping clone."
+	cli wp plugin activate woocommerce-payments-dev-tools
+else
+	git clone git@github.com:Automattic/woocommerce-payments-dev-tools.git "$DEV_TOOLS_CLONE_PATH"
+	if [[ $? -eq 0 ]]; then
+		cli wp plugin activate woocommerce-payments-dev-tools
+	else
 		echo
 		echo "WARN: Could not clone the dev tools repository. Skipping the install."
 	fi
-fi
-# Try to activate (may already be active, that's fine)
-cli wp plugin activate woocommerce-payments-dev-tools 2>/dev/null || true
+fi;
 set -e
 
 echo

--- a/changelog/fix-docker-setup-dev-tools-path
+++ b/changelog/fix-docker-setup-dev-tools-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Respect custom dev-tools path in Docker setup script via local.env.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`bin/docker-setup.sh` hardcodes the dev-tools clone path to `docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools`. The post-merge hook (`.husky/post-merge`) already reads `LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH` from `local.env` to support custom locations, but the setup script ignored it.

This aligns `docker-setup.sh` with the post-merge hook:

- Sources `local.env` (if present) before deciding the clone path
- Uses `LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH` with fallback to the default nested location
- Checks for existing `.git` directory to skip re-cloning
- Activates the plugin only on successful clone or when already present

This lets developers keep their dev-tools checkout at a more accessible location (e.g., `~/Work/a8c/woocommerce-payments-dev-tools/`) using the same `local.env` config that the post-merge hook already supports.

#### Testing instructions

1. **Without `local.env`** (default behavior): Run `bin/docker-setup.sh` on a fresh setup — dev-tools clones to the default nested path as before.
2. **With custom path via `local.env`**: Set `LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH=/path/to/dev-tools` in `local.env`, run setup — detects existing clone, skips re-cloning.
3. **Re-run idempotency**: Run `bin/docker-setup.sh` again — skips clone step.

* Dev-tools only change, no customer-facing impact

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) — Shell script change, tested manually. No unit test infrastructure for bash scripts.
- [x] Tested on mobile (or does not apply) — N/A, CLI script

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.