### PR TITLE
chore: charge details static method to payment method definition class

### DIFF
--- a/changelog/chore-add-static-method-to-payment-method-definition
+++ b/changelog/chore-add-static-method-to-payment-method-definition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: chore: add static method to each payment method definition
+
+

--- a/includes/payment-methods/Configs/Definitions/AffirmDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AffirmDefinition.php
@@ -57,6 +57,18 @@ class AffirmDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/AfterpayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AfterpayDefinition.php
@@ -66,6 +66,18 @@ class AfterpayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
@@ -57,6 +57,18 @@ class AlipayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/AmazonPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AmazonPayDefinition.php
@@ -57,6 +57,18 @@ class AmazonPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/ApplePayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/ApplePayDefinition.php
@@ -55,6 +55,18 @@ class ApplePayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/BancontactDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/BancontactDefinition.php
@@ -57,6 +57,18 @@ class BancontactDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/BecsDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/BecsDefinition.php
@@ -57,6 +57,18 @@ class BecsDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/EpsDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/EpsDefinition.php
@@ -57,6 +57,18 @@ class EpsDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/GiropayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GiropayDefinition.php
@@ -57,6 +57,18 @@ class GiropayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/GooglePayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GooglePayDefinition.php
@@ -55,6 +55,18 @@ class GooglePayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/GrabPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GrabPayDefinition.php
@@ -57,6 +57,18 @@ class GrabPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/IdealDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/IdealDefinition.php
@@ -57,6 +57,18 @@ class IdealDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/KlarnaDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/KlarnaDefinition.php
@@ -58,6 +58,18 @@ class KlarnaDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/LinkDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/LinkDefinition.php
@@ -56,6 +56,18 @@ class LinkDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/MultibancoDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/MultibancoDefinition.php
@@ -57,6 +57,18 @@ class MultibancoDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/P24Definition.php
+++ b/includes/payment-methods/Configs/Definitions/P24Definition.php
@@ -57,6 +57,18 @@ class P24Definition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/SepaDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/SepaDefinition.php
@@ -57,6 +57,18 @@ class SepaDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/SofortDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/SofortDefinition.php
@@ -57,6 +57,18 @@ class SofortDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/WechatPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/WechatPayDefinition.php
@@ -57,6 +57,18 @@ class WechatPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
+++ b/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
@@ -42,6 +42,16 @@ interface PaymentMethodDefinitionInterface {
 	public static function get_title( ?string $account_country = null ): string;
 
 	/**
+	 * Get a dynamic title based on charge details from Stripe.
+	 *
+	 * @param string $account_country The merchant's account country.
+	 * @param array  $payment_details The payment method details from the Stripe charge.
+	 *
+	 * @return string|null The dynamic title, or null to use the default get_title().
+	 */
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string;
+
+	/**
 	 * Get the title of the payment method for the settings page.
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
@@ -34,6 +34,10 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return 'Second Mock Method';
 	}
 
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
 	public static function get_settings_label( ?string $account_country = null ): string {
 		return 'Second Mock Method';
 	}

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
@@ -34,6 +34,10 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return 'Mock Method';
 	}
 
+	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		return null;
+	}
+
 	public static function get_settings_label( ?string $account_country = null ): string {
 		return 'Mock Method';
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Splitting https://github.com/Automattic/woocommerce-payments/pull/11225 in smaller pieces - adding a static method to all the payment method definition classes and interface.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Functionality is not affected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
