### PR TITLE
Store ipp_channel from intent metadata and suppress IPP receipt for POS orders

### DIFF
--- a/changelog/add-ipp-channel-meta-and-pos-email-suppression
+++ b/changelog/add-ipp-channel-meta-and-pos-email-suppression
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Store ipp_channel from Stripe intent metadata on WooCommerce orders and suppress IPP receipt email for POS orders

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -253,6 +253,12 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 				}
 			}
 
+			// Store the IPP channel from intent metadata on the order.
+			$ipp_channel = $intent_metadata['ipp_channel'] ?? '';
+			if ( '' !== $ipp_channel ) {
+				$this->order_service->set_ipp_channel_for_order( $order, $ipp_channel );
+			}
+
 			// Actualize order status.
 			$this->order_service->mark_terminal_payment_completed( $order, $intent_id, $result['status'] );
 

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -191,11 +191,9 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			$order->set_payment_method_title( __( 'WooCommerce In-Person Payments', 'woocommerce-payments' ) );
 			$this->order_service->attach_intent_info_to_order( $order, $intent );
 
-			// Store the IPP channel from intent metadata on the order.
-			// This must happen before update_order_status_from_intent() so the POS flag
-			// is available when transactional emails fire during status transitions.
-			$ipp_channel = $intent_metadata['ipp_channel'] ?? '';
-			if ( '' !== $ipp_channel ) {
+			$ipp_channel      = $intent_metadata['ipp_channel'] ?? '';
+			$allowed_channels = [ 'mobile_pos', 'mobile_store_management' ];
+			if ( in_array( $ipp_channel, $allowed_channels, true ) ) {
 				$this->order_service->set_ipp_channel_for_order( $order, $ipp_channel );
 			}
 

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -191,12 +191,6 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			$order->set_payment_method_title( __( 'WooCommerce In-Person Payments', 'woocommerce-payments' ) );
 			$this->order_service->attach_intent_info_to_order( $order, $intent );
 
-			$ipp_channel      = $intent_metadata['ipp_channel'] ?? '';
-			$allowed_channels = [ 'mobile_pos', 'mobile_store_management' ];
-			if ( in_array( $ipp_channel, $allowed_channels, true ) ) {
-				$this->order_service->set_ipp_channel_for_order( $order, $ipp_channel );
-			}
-
 			$this->order_service->update_order_status_from_intent( $order, $intent );
 
 			// Certain payments (eg. Interac) are captured on the client-side (mobile app).

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -190,6 +190,15 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
 			$order->set_payment_method_title( __( 'WooCommerce In-Person Payments', 'woocommerce-payments' ) );
 			$this->order_service->attach_intent_info_to_order( $order, $intent );
+
+			// Store the IPP channel from intent metadata on the order.
+			// This must happen before update_order_status_from_intent() so the POS flag
+			// is available when transactional emails fire during status transitions.
+			$ipp_channel = $intent_metadata['ipp_channel'] ?? '';
+			if ( '' !== $ipp_channel ) {
+				$this->order_service->set_ipp_channel_for_order( $order, $ipp_channel );
+			}
+
 			$this->order_service->update_order_status_from_intent( $order, $intent );
 
 			// Certain payments (eg. Interac) are captured on the client-side (mobile app).
@@ -251,12 +260,6 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 						$subscription->save();
 					}
 				}
-			}
-
-			// Store the IPP channel from intent metadata on the order.
-			$ipp_channel = $intent_metadata['ipp_channel'] ?? '';
-			if ( '' !== $ipp_channel ) {
-				$this->order_service->set_ipp_channel_for_order( $order, $ipp_channel );
 			}
 
 			// Actualize order status.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -977,7 +977,7 @@ class WC_Payments_Order_Service {
 	 */
 	public function get_ipp_channel_for_order( $order ): string {
 		$order = $this->get_order( $order );
-		return $order->get_meta( self::IPP_CHANNEL_META_KEY, true );
+		return $order->get_meta( self::IPP_CHANNEL_META_KEY );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -953,12 +953,15 @@ class WC_Payments_Order_Service {
 	/**
 	 * Set the IPP channel for an order.
 	 *
-	 * @param WC_Order $order   The order object.
-	 * @param string   $channel The IPP channel value (e.g. 'mobile_pos', 'mobile_store_management').
+	 * @param mixed  $order   The order ID or order object.
+	 * @param string $channel The IPP channel value (e.g. 'mobile_pos', 'mobile_store_management').
 	 *
 	 * @return void
+	 *
+	 * @throws Order_Not_Found_Exception
 	 */
 	public function set_ipp_channel_for_order( $order, string $channel ): void {
+		$order = $this->get_order( $order );
 		$order->update_meta_data( self::IPP_CHANNEL_META_KEY, $channel );
 		$order->save_meta_data();
 	}

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -169,6 +169,13 @@ class WC_Payments_Order_Service {
 	const PAYMENT_METHOD_DETAILS_META_KEY = '_wcpay_payment_method_details';
 
 	/**
+	 * Meta key used to store the IPP channel from Stripe intent metadata.
+	 *
+	 * @const string
+	 */
+	const IPP_CHANNEL_META_KEY = '_wcpay_ipp_channel';
+
+	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -941,6 +948,33 @@ class WC_Payments_Order_Service {
 	public function get_fraud_meta_box_type_for_order( $order ): string {
 		$order = $this->get_order( $order );
 		return $order->get_meta( self::WCPAY_FRAUD_META_BOX_TYPE_META_KEY, true );
+	}
+
+	/**
+	 * Set the IPP channel for an order.
+	 *
+	 * @param WC_Order $order   The order object.
+	 * @param string   $channel The IPP channel value (e.g. 'mobile_pos', 'mobile_store_management').
+	 *
+	 * @return void
+	 */
+	public function set_ipp_channel_for_order( $order, string $channel ): void {
+		$order->update_meta_data( self::IPP_CHANNEL_META_KEY, $channel );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Get the IPP channel for an order.
+	 *
+	 * @param mixed $order The order Id or order object.
+	 *
+	 * @return string
+	 *
+	 * @throws Order_Not_Found_Exception
+	 */
+	public function get_ipp_channel_for_order( $order ): string {
+		$order = $this->get_order( $order );
+		return $order->get_meta( self::IPP_CHANNEL_META_KEY, true );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1017,6 +1017,14 @@ class WC_Payments_Order_Service {
 				$this->store_payment_method_details( $order, $payment_method_details );
 			}
 		}
+
+		// Store IPP channel from intent metadata if present.
+		$metadata         = $intent->get_metadata();
+		$ipp_channel      = $metadata['ipp_channel'] ?? '';
+		$allowed_channels = [ 'mobile_pos', 'mobile_store_management' ];
+		if ( in_array( $ipp_channel, $allowed_channels, true ) ) {
+			$this->set_ipp_channel_for_order( $order, $ipp_channel );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -523,6 +523,12 @@ class WC_Payments_Webhook_Processing_Service {
 		// This is an incoming request from WCPay server rather than an outgoing request to WCPay server.
 		// However, the shape of the payment intent object are the same.
 		// Using this extraction method will reduce the code duplication.
+		$ipp_channel      = $event_object['metadata']['ipp_channel'] ?? '';
+		$allowed_channels = [ 'mobile_pos', 'mobile_store_management' ];
+		if ( in_array( $ipp_channel, $allowed_channels, true ) ) {
+			$this->order_service->set_ipp_channel_for_order( $order, $ipp_channel );
+		}
+
 		$payment_intent = $this->api_client->deserialize_payment_intention_object_from_array( $event_object );
 		$this->order_service->update_order_status_from_intent( $order, $payment_intent );
 

--- a/includes/emails/class-wc-payments-email-ipp-receipt.php
+++ b/includes/emails/class-wc-payments-email-ipp-receipt.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'WC_Payments_Email_IPP_Receipt' ) ) :
 		 * @param array    $charge The charge data.
 		 */
 		public function trigger( WC_Order $order, array $merchant_settings, array $charge ) {
-			if ( 'mobile_pos' === $order->get_meta( WC_Payments_Order_Service::IPP_CHANNEL_META_KEY, true ) ) {
+			if ( 'mobile_pos' === WC_Payments::get_order_service()->get_ipp_channel_for_order( $order ) ) {
 				return;
 			}
 

--- a/includes/emails/class-wc-payments-email-ipp-receipt.php
+++ b/includes/emails/class-wc-payments-email-ipp-receipt.php
@@ -167,6 +167,10 @@ if ( ! class_exists( 'WC_Payments_Email_IPP_Receipt' ) ) :
 		 * @param array    $charge The charge data.
 		 */
 		public function trigger( WC_Order $order, array $merchant_settings, array $charge ) {
+			if ( 'mobile_pos' === $order->get_meta( WC_Payments_Order_Service::IPP_CHANNEL_META_KEY ) ) {
+				return;
+			}
+
 			$this->setup_locale();
 			$email_already_sent = false;
 

--- a/includes/emails/class-wc-payments-email-ipp-receipt.php
+++ b/includes/emails/class-wc-payments-email-ipp-receipt.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'WC_Payments_Email_IPP_Receipt' ) ) :
 		 * @param array    $charge The charge data.
 		 */
 		public function trigger( WC_Order $order, array $merchant_settings, array $charge ) {
-			if ( 'mobile_pos' === $order->get_meta( WC_Payments_Order_Service::IPP_CHANNEL_META_KEY ) ) {
+			if ( 'mobile_pos' === $order->get_meta( WC_Payments_Order_Service::IPP_CHANNEL_META_KEY, true ) ) {
 				return;
 			}
 

--- a/tests/unit/emails/test-class-wc-payments-email-ipp-receipt.php
+++ b/tests/unit/emails/test-class-wc-payments-email-ipp-receipt.php
@@ -63,4 +63,113 @@ class WC_Payments_Email_IPP_Receipt_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $order, $result );
 		$this->assertSame( 'WooCommerce In-Person Payments', $result->get_payment_method_title() );
 	}
+
+	/**
+	 * Test that trigger skips sending when the order has mobile_pos ipp_channel.
+	 */
+	public function test_trigger_skips_sending_for_pos_order() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( WC_Payments_Order_Service::IPP_CHANNEL_META_KEY, 'mobile_pos' );
+		$order->save();
+
+		$merchant_settings = [
+			'business_name' => 'Test Store',
+			'support_info'  => [
+				'address' => [],
+				'phone'   => '',
+				'email'   => '',
+			],
+		];
+		$charge            = [
+			'amount_captured'        => 1000,
+			'payment_method_details' => [
+				'card_present' => [
+					'brand'   => 'visa',
+					'last4'   => '4242',
+					'receipt' => [
+						'application_preferred_name' => 'Test',
+						'dedicated_file_name'        => 'Test',
+						'account_type'               => 'credit',
+					],
+				],
+			],
+		];
+
+		$this->email->trigger( $order, $merchant_settings, $charge );
+
+		$this->assertEmpty( $order->get_meta( '_new_receipt_email_sent' ) );
+	}
+
+	/**
+	 * Test that trigger does not skip for mobile_store_management ipp_channel.
+	 */
+	public function test_trigger_sends_for_store_management_order() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( WC_Payments_Order_Service::IPP_CHANNEL_META_KEY, 'mobile_store_management' );
+		$order->set_billing_email( 'test@example.com' );
+		$order->save();
+
+		$merchant_settings = [
+			'business_name' => 'Test Store',
+			'support_info'  => [
+				'address' => [],
+				'phone'   => '',
+				'email'   => '',
+			],
+		];
+		$charge            = [
+			'amount_captured'        => 1000,
+			'payment_method_details' => [
+				'card_present' => [
+					'brand'   => 'visa',
+					'last4'   => '4242',
+					'receipt' => [
+						'application_preferred_name' => 'Test',
+						'dedicated_file_name'        => 'Test',
+						'account_type'               => 'credit',
+					],
+				],
+			],
+		];
+
+		$this->email->trigger( $order, $merchant_settings, $charge );
+
+		$this->assertEquals( 'true', $order->get_meta( '_new_receipt_email_sent' ) );
+	}
+
+	/**
+	 * Test that trigger sends the email for non-POS card-present orders.
+	 */
+	public function test_trigger_sends_for_non_pos_card_present_order() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_billing_email( 'test@example.com' );
+		$order->save();
+
+		$merchant_settings = [
+			'business_name' => 'Test Store',
+			'support_info'  => [
+				'address' => [],
+				'phone'   => '',
+				'email'   => '',
+			],
+		];
+		$charge            = [
+			'amount_captured'        => 1000,
+			'payment_method_details' => [
+				'card_present' => [
+					'brand'   => 'visa',
+					'last4'   => '4242',
+					'receipt' => [
+						'application_preferred_name' => 'Test',
+						'dedicated_file_name'        => 'Test',
+						'account_type'               => 'credit',
+					],
+				],
+			],
+		];
+
+		$this->email->trigger( $order, $merchant_settings, $charge );
+
+		$this->assertEquals( 'true', $order->get_meta( '_new_receipt_email_sent' ) );
+	}
 }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce/pull/63322

#### Changes proposed in this Pull Request

This PR stores the `ipp_channel` value from Stripe PaymentIntent metadata as WooCommerce order meta and uses it to suppress WCPay's IPP receipt email for POS orders.

**Context:**
The mobile apps already send `ipp_channel` in Stripe PaymentIntent metadata with values:
- `mobile_pos`: payment made from the POS mode in the mobile app
- `mobile_store_management`: payment made from store management part of the mobile app

This metadata was previously only passed to Stripe, but not stored on the WooCommerce order. Storing it enables server-side identification of POS vs non-POS terminal payments.

**Changes:**
1. **New `_wcpay_ipp_channel` meta key** in `WC_Payments_Order_Service` with `set_ipp_channel_for_order()` and `get_ipp_channel_for_order()` methods.
2. **Store ipp_channel in `capture_terminal_payment()`** — after intent metadata is retrieved and before `mark_terminal_payment_completed()`, the ipp_channel value from the intent metadata is stored on the order. This keeps `mark_terminal_payment_completed()` unchanged and stores the value only when the actual intent metadata is available.
3. **Suppress WCPay's IPP receipt email for POS orders** — `WC_Payments_Email_IPP_Receipt::trigger()` now returns early when `_wcpay_ipp_channel` is `mobile_pos`. POS orders are handled by the mobile app which manages its own receipt delivery. Orders with `mobile_store_management` or no ipp_channel still receive the IPP receipt email.

**Note:** Standard WooCommerce transactional email suppression (customer_completed_order, etc.) for POS is handled by WooCommerce core's `PointOfSaleEmailHandler`, not by this PR.

#### Testing instructions

1. Create and pay for an order using the POS
2. Verify the order has `_wcpay_ipp_channel = mobile_pos` meta
3. Verify no WCPay IPP receipt email is sent for the POS order

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.