### PR TITLE
refactor: ECE utilities extraction for reuse

### DIFF
--- a/changelog/refactor-express-checkout-utilities-extraction
+++ b/changelog/refactor-express-checkout-utilities-extraction
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: refactor: extract express checkout utilities for reuse in the upcoming dynamic place order button
+
+

--- a/client/express-checkout/blocks/components/express-checkout-component.js
+++ b/client/express-checkout/blocks/components/express-checkout-component.js
@@ -11,55 +11,10 @@ import {
 } from '../../event-handlers';
 import { useExpressCheckout } from '../hooks/use-express-checkout';
 import { PAYMENT_METHOD_NAME_EXPRESS_CHECKOUT_ELEMENT } from 'wcpay/checkout/constants';
-
-const getPaymentMethodsOverride = ( enabledPaymentMethod ) => {
-	const allDisabled = {
-		applePay: 'never',
-		googlePay: 'never',
-		amazonPay: 'never',
-		link: 'never',
-		paypal: 'never',
-		klarna: 'never',
-	};
-
-	const enabledParam = [ 'applePay', 'googlePay' ].includes(
-		enabledPaymentMethod
-	)
-		? 'always'
-		: 'auto';
-
-	return {
-		paymentMethods: {
-			...allDisabled,
-			[ enabledPaymentMethod ]: enabledParam,
-		},
-	};
-};
-
-// Visual adjustments to horizontally align the buttons.
-const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
-	// Apple Pay has a nearly imperceptible height difference. We increase it by 1px here.
-	if ( buttonOptions.buttonTheme.applePay === 'black' ) {
-		if ( expressPaymentMethod === 'applePay' ) {
-			buttonOptions.buttonHeight = buttonOptions.buttonHeight + 0.4;
-		}
-	}
-
-	// GooglePay with the white theme has a 2px height difference due to its border.
-	if (
-		expressPaymentMethod === 'googlePay' &&
-		buttonOptions.buttonTheme.googlePay === 'white'
-	) {
-		buttonOptions.buttonHeight = buttonOptions.buttonHeight - 2;
-	}
-
-	// Clamp the button height to the allowed range 40px to 55px.
-	buttonOptions.buttonHeight = Math.max(
-		40,
-		Math.min( buttonOptions.buttonHeight, 55 )
-	);
-	return buttonOptions;
-};
+import {
+	getPaymentMethodsOverride,
+	adjustButtonHeights,
+} from '../../utils/payment-method-overrides';
 
 /**
  * ExpressCheckout express payment method component.

--- a/client/express-checkout/utils/__tests__/payment-method-overrides.test.ts
+++ b/client/express-checkout/utils/__tests__/payment-method-overrides.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getPaymentMethodsOverride,
+	adjustButtonHeights,
+} from '../payment-method-overrides';
+
+describe( 'getPaymentMethodsOverride', () => {
+	test( 'enables only applePay with "always" mode', () => {
+		const result = getPaymentMethodsOverride( 'applePay' );
+		expect( result.paymentMethods.applePay ).toBe( 'always' );
+		expect( result.paymentMethods.googlePay ).toBe( 'never' );
+		expect( result.paymentMethods.amazonPay ).toBe( 'never' );
+	} );
+
+	test( 'enables only googlePay with "always" mode', () => {
+		const result = getPaymentMethodsOverride( 'googlePay' );
+		expect( result.paymentMethods.googlePay ).toBe( 'always' );
+		expect( result.paymentMethods.applePay ).toBe( 'never' );
+		expect( result.paymentMethods.amazonPay ).toBe( 'never' );
+	} );
+
+	test( 'enables amazonPay with "auto" mode (not "always")', () => {
+		const result = getPaymentMethodsOverride( 'amazonPay' );
+		expect( result.paymentMethods.amazonPay ).toBe( 'auto' );
+		expect( result.paymentMethods.applePay ).toBe( 'never' );
+		expect( result.paymentMethods.googlePay ).toBe( 'never' );
+	} );
+
+	test( 'disables all other methods (link, paypal, klarna)', () => {
+		const result = getPaymentMethodsOverride( 'applePay' );
+		expect( result.paymentMethods.link ).toBe( 'never' );
+		expect( result.paymentMethods.paypal ).toBe( 'never' );
+		expect( result.paymentMethods.klarna ).toBe( 'never' );
+	} );
+} );
+
+describe( 'adjustButtonHeights', () => {
+	const baseOptions = ( overrides = {} ) => ( {
+		buttonHeight: 48,
+		buttonTheme: {
+			applePay: 'black',
+			googlePay: 'black',
+		},
+		buttonType: {
+			applePay: 'plain',
+			googlePay: 'plain',
+		},
+		...overrides,
+	} );
+
+	test( 'increases Apple Pay height by 0.4px when theme is black', () => {
+		const result = adjustButtonHeights( baseOptions(), 'applePay' );
+		expect( result.buttonHeight ).toBe( 48.4 );
+	} );
+
+	test( 'does not adjust Apple Pay height when theme is not black', () => {
+		const result = adjustButtonHeights(
+			baseOptions( {
+				buttonTheme: { applePay: 'white', googlePay: 'black' },
+			} ),
+			'applePay'
+		);
+		expect( result.buttonHeight ).toBe( 48 );
+	} );
+
+	test( 'decreases Google Pay height by 2px when theme is white', () => {
+		const result = adjustButtonHeights(
+			baseOptions( {
+				buttonTheme: { applePay: 'black', googlePay: 'white' },
+			} ),
+			'googlePay'
+		);
+		expect( result.buttonHeight ).toBe( 46 );
+	} );
+
+	test( 'does not adjust Google Pay height when theme is not white', () => {
+		const result = adjustButtonHeights( baseOptions(), 'googlePay' );
+		expect( result.buttonHeight ).toBe( 48 );
+	} );
+
+	test( 'clamps height to minimum 40px', () => {
+		const result = adjustButtonHeights(
+			baseOptions( {
+				buttonHeight: 40,
+				buttonTheme: { applePay: 'black', googlePay: 'white' },
+			} ),
+			'googlePay'
+		);
+		expect( result.buttonHeight ).toBe( 40 );
+	} );
+
+	test( 'clamps height to maximum 55px', () => {
+		const result = adjustButtonHeights(
+			baseOptions( { buttonHeight: 56 } ),
+			'amazonPay'
+		);
+		expect( result.buttonHeight ).toBe( 55 );
+	} );
+
+	test( 'does not mutate the original options object', () => {
+		const original = baseOptions();
+		adjustButtonHeights( original, 'applePay' );
+		expect( original.buttonHeight ).toBe( 48 );
+	} );
+} );

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.tsx
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.tsx
@@ -12,6 +12,7 @@ import { memoize } from 'lodash';
  */
 import type WCPayAPI from 'wcpay/checkout/api';
 import { getExpressCheckoutData, getStripeElementsMode } from '.';
+import { getPaymentMethodsOverride } from './payment-method-overrides';
 
 // types from https://github.com/woocommerce/woocommerce/blob/360d9bc0f5709e6cf13c646860360fca9968ebb0/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart.ts
 interface CartTotals {
@@ -78,26 +79,7 @@ const checkPaymentMethodIsAvailableInternal = (
 						root.unmount();
 						containerEl.remove();
 					} }
-					options={ {
-						paymentMethods: {
-							applePay:
-								paymentMethod === 'applePay'
-									? 'always'
-									: 'never',
-							googlePay:
-								paymentMethod === 'googlePay'
-									? 'always'
-									: 'never',
-							amazonPay:
-								// amazon pay can be "auto" or "never", but not "always"
-								paymentMethod === 'amazonPay'
-									? 'auto'
-									: 'never',
-							link: 'never',
-							paypal: 'never',
-							klarna: 'never',
-						},
-					} }
+					options={ getPaymentMethodsOverride( paymentMethod ) }
 					onReady={ ( { availablePaymentMethods } ) => {
 						resolve(
 							Boolean(

--- a/client/express-checkout/utils/index.ts
+++ b/client/express-checkout/utils/index.ts
@@ -3,6 +3,10 @@
  */
 export * from './normalize';
 export * from './shipping-fields';
+export {
+	getPaymentMethodsOverride,
+	adjustButtonHeights,
+} from './payment-method-overrides';
 import { getDefaultBorderRadius } from 'wcpay/utils/express-checkout';
 
 interface MyWindow extends Window {

--- a/client/express-checkout/utils/payment-method-overrides.ts
+++ b/client/express-checkout/utils/payment-method-overrides.ts
@@ -1,0 +1,81 @@
+type PaymentMethodMode = 'always' | 'auto' | 'never';
+
+interface PaymentMethodsOverride {
+	paymentMethods: Record< string, PaymentMethodMode >;
+}
+
+/**
+ * Returns Stripe ECE payment method overrides that enable only the specified
+ * express payment method and disable all others.
+ *
+ * Apple Pay and Google Pay use 'always' to force availability.
+ * Amazon Pay uses 'auto' because Stripe doesn't support 'always' for it.
+ */
+export const getPaymentMethodsOverride = (
+	enabledPaymentMethod: string
+): PaymentMethodsOverride => {
+	const allDisabled: Record< string, PaymentMethodMode > = {
+		applePay: 'never',
+		googlePay: 'never',
+		amazonPay: 'never',
+		link: 'never',
+		paypal: 'never',
+		klarna: 'never',
+	};
+
+	const enabledParam: PaymentMethodMode = [
+		'applePay',
+		'googlePay',
+	].includes( enabledPaymentMethod )
+		? 'always'
+		: 'auto';
+
+	return {
+		paymentMethods: {
+			...allDisabled,
+			[ enabledPaymentMethod ]: enabledParam,
+		},
+	};
+};
+
+interface ButtonOptions {
+	buttonHeight: number;
+	buttonTheme: Record< string, string >;
+	[ key: string ]: unknown;
+}
+
+/**
+ * Visual adjustments to horizontally align the ECE buttons.
+ *
+ * Corrects small height differences between Apple Pay and Google Pay
+ * caused by button themes and borders, and clamps the result to Stripe's
+ * allowed range (40–55 px).
+ */
+export const adjustButtonHeights = (
+	buttonOptions: ButtonOptions,
+	expressPaymentMethod: string
+): ButtonOptions => {
+	const adjusted = { ...buttonOptions };
+
+	// Apple Pay has a nearly imperceptible height difference. We increase it by 0.4px here.
+	if ( adjusted.buttonTheme.applePay === 'black' ) {
+		if ( expressPaymentMethod === 'applePay' ) {
+			adjusted.buttonHeight = adjusted.buttonHeight + 0.4;
+		}
+	}
+
+	// GooglePay with the white theme has a 2px height difference due to its border.
+	if (
+		expressPaymentMethod === 'googlePay' &&
+		adjusted.buttonTheme.googlePay === 'white'
+	) {
+		adjusted.buttonHeight = adjusted.buttonHeight - 2;
+	}
+
+	// Clamp the button height to the allowed range 40px to 55px.
+	adjusted.buttonHeight = Math.max(
+		40,
+		Math.min( adjusted.buttonHeight, 55 )
+	);
+	return adjusted;
+};

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -370,6 +370,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// only when the feature is available. Other payment methods like WooPay or card will return `false` for `is_express_checkout()`.
 		if ( property_exists( $this, 'has_custom_place_order_button' ) && $this->payment_method->is_express_checkout() && \WC_Payments::get_gateway()->is_express_checkout_in_payment_methods_enabled() ) {
 			$this->has_custom_place_order_button = true;
+			$this->has_fields                    = false;
 		}
 	}
 


### PR DESCRIPTION
Fixes WOOPMNT-5764

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Splitting a larger PR into smaller pieces: I need to extract the `getPaymentMethodsOverride` and the `adjustButtonHeights` utilities into separate files, so they can be reused in the Dynamic Place Order Button work.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
