### PR TITLE
fix: utility method called on null

### DIFF
--- a/changelog/fix-is_express_checkout_in_payment_methods_enabled-on-null
+++ b/changelog/fix-is_express_checkout_in_payment_methods_enabled-on-null
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: avoid is_express_checkout_in_payment_methods_enabled on null errors with beta WC
+
+

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -603,7 +603,7 @@ class WC_Payments {
 
 		// Build the card gateway first so that WC_Payments::get_gateway() is available
 		// during construction of the other gateways (e.g. for settings checks).
-		$card_payment_method                                        = $payment_methods['card'];
+		$card_payment_method                                        = $payment_methods[ CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID ];
 		self::$payment_method_map[ $card_payment_method->get_id() ] = $card_payment_method;
 		self::$card_gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $card_payment_method, $payment_methods, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service, self::$fraud_service, self::$duplicates_detection_service, self::$failed_transaction_rate_limiter );
 		self::$payment_gateway_map[ $card_payment_method->get_id() ] = self::$card_gateway;

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -601,20 +601,27 @@ class WC_Payments {
 			$payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}
 
+		// Build the card gateway first so that WC_Payments::get_gateway() is available
+		// during construction of the other gateways (e.g. for settings checks).
+		$card_payment_method                                        = $payment_methods['card'];
+		self::$payment_method_map[ $card_payment_method->get_id() ] = $card_payment_method;
+		self::$card_gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $card_payment_method, $payment_methods, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service, self::$fraud_service, self::$duplicates_detection_service, self::$failed_transaction_rate_limiter );
+		self::$payment_gateway_map[ $card_payment_method->get_id() ] = self::$card_gateway;
+
 		foreach ( $payment_methods as $payment_method ) {
+			if ( 'card' === $payment_method->get_id() ) {
+				continue;
+			}
+
 			self::$payment_method_map[ $payment_method->get_id() ] = $payment_method;
 
 			$split_gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $payment_method, $payment_methods, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service, self::$fraud_service, self::$duplicates_detection_service, self::$failed_transaction_rate_limiter );
 
-			// Card gateway hooks are registered once below.
-			if ( 'card' !== $payment_method->get_id() ) {
-				$split_gateway->init_hooks();
-			}
+			$split_gateway->init_hooks();
 
 			self::$payment_gateway_map[ $payment_method->get_id() ] = $split_gateway;
 		}
 
-		self::$card_gateway         = self::get_payment_gateway_by_id( 'card' );
 		self::$wc_payments_checkout = new WC_Payments_Checkout( self::get_gateway(), self::$woopay_util, self::$account, self::$customer_service, self::$fraud_service );
 
 		self::$card_gateway->init_hooks();


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In https://github.com/Automattic/woocommerce-payments/pull/11352 I modified the logic to call `is_express_checkout_in_payment_methods_enabled` on the main gateway.
The problem is that the `self::$card_gateway` attribute doesn't get added to the `WC_Payments` class until _after_ all the other methods are added.
So, if a method tries to access `\WC_Payments::get_gateway()->is_express_checkout_in_payment_methods_enabled()`, the codebase throws an error because `\WC_Payments::get_gateway()` returns `null`.

Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
