### PR TITLE
Fix agent pipeline workflows blocked by enterprise Actions allowlist

### DIFF
--- a/.github/workflows/agent-address-comments.yml
+++ b/.github/workflows/agent-address-comments.yml
@@ -89,10 +89,17 @@ jobs:
           git config user.name "botwoo"
           git config user.email "botwoo@users.noreply.github.com"
 
+      - name: Install Bun
+        id: bun
+        run: |
+          npm install -g bun@1.3.6
+          echo "path=$(which bun)" >> "$GITHUB_OUTPUT"
+
       - name: Run Address Comments Agent
         id: address-comments
         uses: anthropics/claude-code-action@v1
         with:
+          path_to_bun_executable: ${{ steps.bun.outputs.path }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: ${{ inputs.model }}
           prompt: ${{ steps.prompt.outputs.content }}

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -74,10 +74,17 @@ jobs:
       - name: Clean up gamma-ai-tools checkout
         run: rm -rf .gamma-ai-tools
 
+      - name: Install Bun
+        id: bun
+        run: |
+          npm install -g bun@1.3.6
+          echo "path=$(which bun)" >> "$GITHUB_OUTPUT"
+
       - name: Run Plan Agent
         id: plan
         uses: anthropics/claude-code-action@v1
         with:
+          path_to_bun_executable: ${{ steps.bun.outputs.path }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: ${{ inputs.model }}
           prompt: ${{ steps.prompt.outputs.content }}

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -79,10 +79,17 @@ jobs:
       - name: Clean up gamma-ai-tools checkout
         run: rm -rf .gamma-ai-tools
 
+      - name: Install Bun
+        id: bun
+        run: |
+          npm install -g bun@1.3.6
+          echo "path=$(which bun)" >> "$GITHUB_OUTPUT"
+
       - name: Run Review Agent
         id: review
         uses: anthropics/claude-code-action@v1
         with:
+          path_to_bun_executable: ${{ steps.bun.outputs.path }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: ${{ inputs.model }}
           prompt: ${{ steps.prompt.outputs.content }}


### PR DESCRIPTION
## Summary
- `anthropics/claude-code-action@v1` internally uses `oven-sh/setup-bun`, which is not on the Automattic enterprise Actions allowlist
- Work around this by pre-installing Bun via `npm install -g` and passing the path via `path_to_bun_executable`, which skips the blocked action step
- Applied to all three agent pipeline workflows: plan, review, and address-comments

## Test plan
- [ ] Trigger agent-pipeline workflow and verify it no longer fails with the allowlist error
- [ ] Verify Bun installs correctly and claude-code-action runs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)