### PR TITLE
tests: Respect express checkout location settings on block-based cart

### DIFF
--- a/changelog/fix-express-checkout-blocks-cart-visibility
+++ b/changelog/fix-express-checkout-blocks-cart-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix express checkout buttons showing on block-based cart when cart location is unchecked

--- a/client/express-checkout/blocks/__tests__/index.test.js
+++ b/client/express-checkout/blocks/__tests__/index.test.js
@@ -1,0 +1,189 @@
+/**
+ * Internal dependencies
+ */
+import {
+	expressCheckoutElementApplePay,
+	expressCheckoutElementGooglePay,
+	expressCheckoutElementAmazonPay,
+} from '../index';
+import { checkPaymentMethodIsAvailable } from '../../utils/checkPaymentMethodIsAvailable';
+
+jest.mock( '../../utils/checkPaymentMethodIsAvailable', () => ( {
+	checkPaymentMethodIsAvailable: jest.fn(),
+} ) );
+
+jest.mock( 'wcpay/utils/checkout', () => ( {
+	getConfig: jest.fn().mockReturnValue( [] ),
+} ) );
+
+jest.mock( 'wcpay/checkout/constants', () => ( {
+	PAYMENT_METHOD_NAME_EXPRESS_CHECKOUT_ELEMENT:
+		'woocommerce_payments_express_checkout',
+} ) );
+
+const mockCart = {
+	cartTotals: {
+		total_price: '1000',
+		currency_code: 'USD',
+	},
+};
+
+const mockApi = {
+	loadStripeForExpressCheckout: jest.fn(),
+};
+
+describe( 'Express checkout blocks registration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		delete global.wcpayExpressCheckoutParams;
+	} );
+
+	describe( 'canMakePayment', () => {
+		describe( 'when wcpayExpressCheckoutParams is undefined', () => {
+			it( 'should return false for Apple Pay', () => {
+				const result = expressCheckoutElementApplePay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should return false for Google Pay', () => {
+				const result = expressCheckoutElementGooglePay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should return false for Amazon Pay', () => {
+				const result = expressCheckoutElementAmazonPay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'when payment_request is NOT in enabled_methods', () => {
+			beforeEach( () => {
+				global.wcpayExpressCheckoutParams = {
+					enabled_methods: [],
+				};
+			} );
+
+			it( 'should return false for Apple Pay', () => {
+				const result = expressCheckoutElementApplePay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should return false for Google Pay', () => {
+				const result = expressCheckoutElementGooglePay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'when amazon_pay is NOT in enabled_methods', () => {
+			beforeEach( () => {
+				global.wcpayExpressCheckoutParams = {
+					enabled_methods: [ 'payment_request' ],
+				};
+			} );
+
+			it( 'should return false for Amazon Pay', () => {
+				const result = expressCheckoutElementAmazonPay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'when payment_request IS in enabled_methods', () => {
+			beforeEach( () => {
+				global.wcpayExpressCheckoutParams = {
+					enabled_methods: [ 'payment_request' ],
+				};
+				checkPaymentMethodIsAvailable.mockResolvedValue( true );
+			} );
+
+			it( 'should call checkPaymentMethodIsAvailable for Apple Pay', () => {
+				expressCheckoutElementApplePay( mockApi ).canMakePayment( {
+					cart: mockCart,
+				} );
+				expect( checkPaymentMethodIsAvailable ).toHaveBeenCalledWith(
+					'applePay',
+					mockCart,
+					mockApi
+				);
+			} );
+
+			it( 'should call checkPaymentMethodIsAvailable for Google Pay', () => {
+				expressCheckoutElementGooglePay( mockApi ).canMakePayment( {
+					cart: mockCart,
+				} );
+				expect( checkPaymentMethodIsAvailable ).toHaveBeenCalledWith(
+					'googlePay',
+					mockCart,
+					mockApi
+				);
+			} );
+		} );
+
+		describe( 'when amazon_pay IS in enabled_methods', () => {
+			beforeEach( () => {
+				global.wcpayExpressCheckoutParams = {
+					enabled_methods: [ 'amazon_pay' ],
+				};
+				checkPaymentMethodIsAvailable.mockResolvedValue( true );
+			} );
+
+			it( 'should call checkPaymentMethodIsAvailable for Amazon Pay', () => {
+				expressCheckoutElementAmazonPay( mockApi ).canMakePayment( {
+					cart: mockCart,
+				} );
+				expect( checkPaymentMethodIsAvailable ).toHaveBeenCalledWith(
+					'amazonPay',
+					mockCart,
+					mockApi
+				);
+			} );
+		} );
+
+		describe( 'when enabled_methods is missing from params', () => {
+			beforeEach( () => {
+				global.wcpayExpressCheckoutParams = {};
+			} );
+
+			it( 'should return false for Apple Pay (defaults to empty array)', () => {
+				const result = expressCheckoutElementApplePay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should return false for Google Pay (defaults to empty array)', () => {
+				const result = expressCheckoutElementGooglePay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should return false for Amazon Pay (defaults to empty array)', () => {
+				const result = expressCheckoutElementAmazonPay(
+					mockApi
+				).canMakePayment( { cart: mockCart } );
+				expect( result ).toBe( false );
+				expect( checkPaymentMethodIsAvailable ).not.toHaveBeenCalled();
+			} );
+		} );
+	} );
+} );

--- a/client/express-checkout/blocks/index.js
+++ b/client/express-checkout/blocks/index.js
@@ -11,6 +11,7 @@ import { PAYMENT_METHOD_NAME_EXPRESS_CHECKOUT_ELEMENT } from 'wcpay/checkout/con
 import { getConfig } from 'wcpay/utils/checkout';
 import ExpressCheckoutContainer from './components/express-checkout-container';
 import { checkPaymentMethodIsAvailable } from '../utils/checkPaymentMethodIsAvailable';
+import { getExpressCheckoutData } from '../utils';
 import '../compatibility/wc-order-attribution';
 
 const LazyApplePayPreview = lazy( () =>
@@ -71,6 +72,12 @@ export const expressCheckoutElementApplePay = ( api ) => ( {
 			return false;
 		}
 
+		const enabledMethods =
+			getExpressCheckoutData( 'enabled_methods' ) ?? [];
+		if ( ! enabledMethods.includes( 'payment_request' ) ) {
+			return false;
+		}
+
 		return checkPaymentMethodIsAvailable( 'applePay', cart, api );
 	},
 } );
@@ -100,6 +107,12 @@ export const expressCheckoutElementGooglePay = ( api ) => ( {
 			return false;
 		}
 
+		const enabledMethods =
+			getExpressCheckoutData( 'enabled_methods' ) ?? [];
+		if ( ! enabledMethods.includes( 'payment_request' ) ) {
+			return false;
+		}
+
 		return checkPaymentMethodIsAvailable( 'googlePay', cart, api );
 	},
 } );
@@ -123,6 +136,12 @@ export const expressCheckoutElementAmazonPay = ( api ) => ( {
 	},
 	canMakePayment: ( { cart } ) => {
 		if ( typeof wcpayExpressCheckoutParams === 'undefined' ) {
+			return false;
+		}
+
+		const enabledMethods =
+			getExpressCheckoutData( 'enabled_methods' ) ?? [];
+		if ( ! enabledMethods.includes( 'amazon_pay' ) ) {
 			return false;
 		}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -109,8 +109,18 @@ class WC_Payments_Express_Checkout_Button_Handler {
 	 * @return mixed
 	 */
 	public function payment_fields_js_config( $config ) {
-		$config['isPaymentRequestEnabled'] = $this->gateway->is_payment_request_enabled() && $this->express_checkout_helper->is_express_checkout_method_enabled_at( 'checkout', 'payment_request' );
-		$config['isAmazonPayEnabled']      = $this->express_checkout_helper->can_use_amazon_pay() && $this->express_checkout_helper->is_express_checkout_method_enabled_at( 'checkout', 'amazon_pay' );
+		$context = $this->express_checkout_helper->get_button_context();
+
+		$config['isPaymentRequestEnabled'] = $this->gateway->is_payment_request_enabled()
+			&& (
+				empty( $context )
+				|| $this->express_checkout_helper->is_express_checkout_method_enabled_at( $context, 'payment_request' )
+			);
+		$config['isAmazonPayEnabled']      = $this->express_checkout_helper->can_use_amazon_pay()
+			&& (
+				empty( $context )
+				|| $this->express_checkout_helper->is_express_checkout_method_enabled_at( $context, 'amazon_pay' )
+			);
 
 		return $config;
 	}

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
@@ -148,4 +148,92 @@ class WC_Payments_Express_Checkout_Button_Handler_Test extends WCPAY_UnitTestCas
 		$this->assertArrayHasKey( 'store_name', $params );
 		$this->assertEquals( get_bloginfo( 'name' ), $params['store_name'] );
 	}
+
+	public function test_payment_fields_js_config_on_cart_page_with_cart_disabled() {
+		$this->mock_ece_button_helper
+			->method( 'get_button_context' )
+			->willReturn( 'cart' );
+
+		$this->mock_wcpay_gateway
+			->method( 'is_payment_request_enabled' )
+			->willReturn( true );
+
+		$this->mock_ece_button_helper
+			->method( 'is_express_checkout_method_enabled_at' )
+			->with( 'cart', 'payment_request' )
+			->willReturn( false );
+
+		$this->mock_ece_button_helper
+			->method( 'can_use_amazon_pay' )
+			->willReturn( false );
+
+		$config = $this->system_under_test->payment_fields_js_config( [] );
+
+		$this->assertFalse( $config['isPaymentRequestEnabled'] );
+	}
+
+	public function test_payment_fields_js_config_on_checkout_page_with_checkout_enabled() {
+		$this->mock_ece_button_helper
+			->method( 'get_button_context' )
+			->willReturn( 'checkout' );
+
+		$this->mock_wcpay_gateway
+			->method( 'is_payment_request_enabled' )
+			->willReturn( true );
+
+		$this->mock_ece_button_helper
+			->method( 'is_express_checkout_method_enabled_at' )
+			->with( 'checkout', 'payment_request' )
+			->willReturn( true );
+
+		$this->mock_ece_button_helper
+			->method( 'can_use_amazon_pay' )
+			->willReturn( false );
+
+		$config = $this->system_under_test->payment_fields_js_config( [] );
+
+		$this->assertTrue( $config['isPaymentRequestEnabled'] );
+	}
+
+	public function test_payment_fields_js_config_with_empty_context_defaults_to_enabled() {
+		$this->mock_ece_button_helper
+			->method( 'get_button_context' )
+			->willReturn( '' );
+
+		$this->mock_wcpay_gateway
+			->method( 'is_payment_request_enabled' )
+			->willReturn( true );
+
+		$this->mock_ece_button_helper
+			->method( 'can_use_amazon_pay' )
+			->willReturn( true );
+
+		$config = $this->system_under_test->payment_fields_js_config( [] );
+
+		$this->assertTrue( $config['isPaymentRequestEnabled'] );
+		$this->assertTrue( $config['isAmazonPayEnabled'] );
+	}
+
+	public function test_payment_fields_js_config_amazon_pay_on_cart_with_cart_disabled() {
+		$this->mock_ece_button_helper
+			->method( 'get_button_context' )
+			->willReturn( 'cart' );
+
+		$this->mock_wcpay_gateway
+			->method( 'is_payment_request_enabled' )
+			->willReturn( false );
+
+		$this->mock_ece_button_helper
+			->method( 'can_use_amazon_pay' )
+			->willReturn( true );
+
+		$this->mock_ece_button_helper
+			->method( 'is_express_checkout_method_enabled_at' )
+			->with( 'cart', 'amazon_pay' )
+			->willReturn( false );
+
+		$config = $this->system_under_test->payment_fields_js_config( [] );
+
+		$this->assertFalse( $config['isAmazonPayEnabled'] );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5763

#### Changes proposed in this Pull Request

Express checkout buttons (Apple Pay, Google Pay, Amazon Pay) incorrectly appeared on block-based Cart pages when only "Checkout page" was selected in display settings. This was a regression from #11267.

**Root cause (two issues):**
1. **PHP**: `payment_fields_js_config` hardcoded the `'checkout'` location when checking `isPaymentRequestEnabled` / `isAmazonPayEnabled`, so on the cart page these flags were always based on checkout settings instead of cart settings.
2. **JS**: The blocks `canMakePayment` callbacks did not check the `enabled_methods` array from `wcpayExpressCheckoutParams`, which is correctly populated by PHP based on the current page context.

**Fix:**
1. **PHP**: Use `get_button_context()` to determine the current page and check location settings for that context. When context is empty (AJAX/admin), fall back to enabled to maintain backward compatibility.
2. **JS**: Add `enabled_methods` check in each express payment method's `canMakePayment` callback before calling `checkPaymentMethodIsAvailable`. Apple Pay / Google Pay check for `'payment_request'`; Amazon Pay checks for `'amazon_pay'`.

This provides defense-in-depth: the PHP fix ensures `isPaymentRequestEnabled` is correctly set per context, while the JS fix adds a client-side guard using the already-correct `enabled_methods` data.

#### Testing instructions

1. Set up a block-based Cart page and block-based Checkout page
2. Go to WooPayments settings > enable express checkout for Apple Pay / Google Pay
3. Configure display settings: check only **Checkout page**, uncheck **Cart** and **Product page**
4. Visit the Cart page -- express checkout buttons should NOT appear
5. Visit the Checkout page -- express checkout buttons should appear
6. Re-enable Cart in display settings, visit the Cart page -- express checkout buttons should appear
7. Verify classic cart/checkout still works correctly (no regression)

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.