### PR TITLE
fix: WC Beta unit tests compatibility

### DIFF
--- a/changelog/fix-wc-beta-unit-tests-compatibility
+++ b/changelog/fix-wc-beta-unit-tests-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+fix: WC Beta unit tests compatibility

--- a/tests/unit/test-class-wc-payments-payment-request-session.php
+++ b/tests/unit/test-class-wc-payments-payment-request-session.php
@@ -60,7 +60,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 		// manually calling 'rest_post_dispatch' because it is not called within the context of unit tests.
 		$response = apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
 
-		$this->assertNotNull( apply_filters( 'woocommerce_session_handler', null ) );
+		$this->assertSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
 		$this->assertIsString( $response->get_headers()['X-WooPayments-Tokenized-Cart-Session'] );
 	}
 
@@ -83,7 +83,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 		// manually calling 'rest_post_dispatch' because it is not called within the context of unit tests.
 		$response = apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
 
-		$this->assertNull( apply_filters( 'woocommerce_session_handler', null ) );
+		$this->assertNotSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
 		$this->assertNotContains( 'X-WooPayments-Tokenized-Cart-Session', array_keys( $response->get_headers() ) );
 	}
 
@@ -99,7 +99,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 		$session = new WC_Payments_Payment_Request_Session();
 		$session->init();
 
-		$this->assertNull( apply_filters( 'woocommerce_session_handler', null ) );
+		$this->assertNotSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
 	}
 
 	public function test_uses_custom_session_handler() {
@@ -124,7 +124,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 
 		rest_do_request( $request );
 
-		$this->assertNotNull( apply_filters( 'woocommerce_session_handler', null ) );
+		$this->assertSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
 
 		$this->assertInstanceOf( WC_Payments_Payment_Request_Session_Handler::class, WC()->session );
 		// cart contents are not cleared.


### PR DESCRIPTION
Fixes WOOPMNT-5772

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

WooCommerce Beta (10.6.0+) added a new method `Authentication::maybe_use_store_api_session_handler()` with a strict string return type :

https://github.com/woocommerce/woocommerce/blob/5030d9dc1fdc69224a9aaaf0f5f3269eac90c659/plugins/woocommerce/src/StoreApi/Authentication.php#L50

This method is hooked to the `woocommerce_session_handler` filter at priority `0` in `StoreApi.php`:

https://github.com/woocommerce/woocommerce/blob/5030d9dc1fdc69224a9aaaf0f5f3269eac90c659/plugins/woocommerce/src/StoreApi/StoreApi.php#L30

Our 4 failing tests all call `apply_filters( 'woocommerce_session_handler', null )`, passing `null` as the default value. When WooCommerce's callback receives `null` as `$handler` and tries to return `$handler`, PHP throws a `TypeError` because `null` is not a `string`.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
