### PR TITLE
fix: address formatting in disputes

### DIFF
--- a/changelog/fix-dispute-address-formatting
+++ b/changelog/fix-dispute-address-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: address formatting in disputes

--- a/client/disputes/new-evidence/__tests__/cover-letter-generator.test.ts
+++ b/client/disputes/new-evidence/__tests__/cover-letter-generator.test.ts
@@ -175,7 +175,7 @@ describe( 'Cover Letter Generator', () => {
 		it( 'should fall back to client-side formatting', () => {
 			const result = formatMerchantAddress( mockAccountDetails );
 			expect( result ).toBe(
-				'123 Main St, Suite 100, Test City, TS 12345, US'
+				'123 Main St, Suite 100, Test City, TS, 12345, US'
 			);
 		} );
 
@@ -864,7 +864,7 @@ describe( 'Cover Letter Generator', () => {
 			);
 			expect( result ).toContain( 'Test Store' );
 			expect( result ).toContain(
-				'123 Main St, Suite 100, Test City, TS 12345, US'
+				'123 Main St, Suite 100, Test City, TS, 12345, US'
 			);
 			expect( result ).toContain( 'test@example.com' );
 			expect( result ).toContain( 'Test Bank' );

--- a/client/disputes/new-evidence/__tests__/cover-letter-generator.test.ts
+++ b/client/disputes/new-evidence/__tests__/cover-letter-generator.test.ts
@@ -154,14 +154,32 @@ describe( 'Cover Letter Generator', () => {
 	};
 
 	describe( 'formatMerchantAddress', () => {
-		it( 'should format merchant address correctly', () => {
+		const originalWcpaySettings = ( window as any ).wcpaySettings;
+
+		afterEach( () => {
+			( window as any ).wcpaySettings = originalWcpaySettings;
+		} );
+
+		it( 'should use server-formatted address when available', () => {
+			( window as any ).wcpaySettings = {
+				...originalWcpaySettings,
+				formattedStoreAddress:
+					'123 Main St, Suite 100, Test City, TS 12345, United States (US)',
+			};
 			const result = formatMerchantAddress( mockAccountDetails );
 			expect( result ).toBe(
-				'123 Main St, Suite 100, Test City, TS 12345 US'
+				'123 Main St, Suite 100, Test City, TS 12345, United States (US)'
 			);
 		} );
 
-		it( 'should handle empty address fields', () => {
+		it( 'should fall back to client-side formatting', () => {
+			const result = formatMerchantAddress( mockAccountDetails );
+			expect( result ).toBe(
+				'123 Main St, Suite 100, Test City, TS 12345, US'
+			);
+		} );
+
+		it( 'should handle empty address fields in fallback', () => {
 			const emptyAddressDetails = {
 				...mockAccountDetails,
 				support_address_line2: '',
@@ -170,7 +188,7 @@ describe( 'Cover Letter Generator', () => {
 				support_address_postal_code: '',
 			};
 			const result = formatMerchantAddress( emptyAddressDetails );
-			expect( result ).toBe( '123 Main St, , ,   US' );
+			expect( result ).toBe( '123 Main St, US' );
 		} );
 	} );
 
@@ -846,7 +864,7 @@ describe( 'Cover Letter Generator', () => {
 			);
 			expect( result ).toContain( 'Test Store' );
 			expect( result ).toContain(
-				'123 Main St, Suite 100, Test City, TS 12345 US'
+				'123 Main St, Suite 100, Test City, TS 12345, US'
 			);
 			expect( result ).toContain( 'test@example.com' );
 			expect( result ).toContain( 'Test Bank' );

--- a/client/disputes/new-evidence/__tests__/customer-details.test.tsx
+++ b/client/disputes/new-evidence/__tests__/customer-details.test.tsx
@@ -16,14 +16,7 @@ describe( 'CustomerDetails', () => {
 				name: 'John Doe',
 				phone: '123-456-7890',
 				email: 'john@example.com',
-				address: {
-					line1: '123 Main St',
-					line2: '',
-					city: 'City',
-					state: 'ST',
-					postal_code: '12345',
-					country: 'US',
-				},
+				formatted_address: '123 Main St, City, ST 12345, US',
 			},
 		},
 		order: { ip_address: '1.2.3.4' },
@@ -36,33 +29,31 @@ describe( 'CustomerDetails', () => {
 		expect( screen.getByText( '123-456-7890' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'john@example.com' ) ).toBeInTheDocument();
 		expect( screen.getByText( '1.2.3.4' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders formatted billing address as single line', () => {
+		render( <CustomerDetails dispute={ baseDispute as any } /> );
 		expect(
-			screen.getByText( '123 Main St, City, ST, 12345, US' )
+			screen.getByText( '123 Main St, City, ST 12345, US' )
 		).toBeInTheDocument();
 	} );
 
-	it( 'renders address without empty parts', () => {
+	it( 'renders dash when formatted address is missing', () => {
 		const dispute = {
-			...baseDispute,
 			charge: {
-				...baseDispute.charge,
 				billing_details: {
-					...baseDispute.charge.billing_details,
-					address: {
-						line1: '456 Oak Ave',
-						line2: 'Apt 2B',
-						city: 'Town',
-						state: '',
-						postal_code: '99999',
-						country: 'US',
-					},
+					name: 'Jane Doe',
+					phone: '555-000-1234',
+					email: 'jane@example.com',
 				},
 			},
+			order: { ip_address: '5.6.7.8' },
 		};
 		render( <CustomerDetails dispute={ dispute as any } /> );
-		expect(
-			screen.getByText( '456 Oak Ave, Apt 2B, Town, 99999, US' )
-		).toBeInTheDocument();
+		const addressEl = document.querySelector(
+			'.wcpay-dispute-evidence-customer-details__billing-value'
+		);
+		expect( addressEl?.textContent ).toBe( '-' );
 	} );
 
 	it( 'renders dashes for missing data', () => {

--- a/client/disputes/new-evidence/__tests__/customer-details.test.tsx
+++ b/client/disputes/new-evidence/__tests__/customer-details.test.tsx
@@ -36,7 +36,33 @@ describe( 'CustomerDetails', () => {
 		expect( screen.getByText( '123-456-7890' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'john@example.com' ) ).toBeInTheDocument();
 		expect( screen.getByText( '1.2.3.4' ) ).toBeInTheDocument();
-		expect( screen.getByText( /123 Main St/ ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( '123 Main St, City, ST, 12345, US' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders address without empty parts', () => {
+		const dispute = {
+			...baseDispute,
+			charge: {
+				...baseDispute.charge,
+				billing_details: {
+					...baseDispute.charge.billing_details,
+					address: {
+						line1: '456 Oak Ave',
+						line2: 'Apt 2B',
+						city: 'Town',
+						state: '',
+						postal_code: '99999',
+						country: 'US',
+					},
+				},
+			},
+		};
+		render( <CustomerDetails dispute={ dispute as any } /> );
+		expect(
+			screen.getByText( '456 Oak Ave, Apt 2B, Town, 99999, US' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'renders dashes for missing data', () => {

--- a/client/disputes/new-evidence/cover-letter-generator.ts
+++ b/client/disputes/new-evidence/cover-letter-generator.ts
@@ -35,7 +35,24 @@ export const getBusinessDetails = (): AccountDetails => {
 export const formatMerchantAddress = (
 	accountDetails: AccountDetails
 ): string => {
-	return `${ accountDetails.support_address_line1 }, ${ accountDetails.support_address_line2 }, ${ accountDetails.support_address_city }, ${ accountDetails.support_address_state } ${ accountDetails.support_address_postal_code } ${ accountDetails.support_address_country }`;
+	if ( wcpaySettings?.formattedStoreAddress ) {
+		return wcpaySettings.formattedStoreAddress;
+	}
+
+	return [
+		accountDetails.support_address_line1,
+		accountDetails.support_address_line2,
+		accountDetails.support_address_city,
+		[
+			accountDetails.support_address_state,
+			accountDetails.support_address_postal_code,
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+		accountDetails.support_address_country,
+	]
+		.filter( Boolean )
+		.join( ', ' );
 };
 
 export const formatDeliveryDate = (

--- a/client/disputes/new-evidence/cover-letter-generator.ts
+++ b/client/disputes/new-evidence/cover-letter-generator.ts
@@ -40,16 +40,12 @@ export const formatMerchantAddress = (
 	}
 
 	return [
-		accountDetails.support_address_line1,
-		accountDetails.support_address_line2,
-		accountDetails.support_address_city,
-		[
-			accountDetails.support_address_state,
-			accountDetails.support_address_postal_code,
-		]
-			.filter( Boolean )
-			.join( ' ' ),
-		accountDetails.support_address_country,
+		accountDetails.support_address_line1 || '',
+		accountDetails.support_address_line2 || '',
+		accountDetails.support_address_city || '',
+		accountDetails.support_address_state || '',
+		accountDetails.support_address_postal_code || '',
+		accountDetails.support_address_country || '',
 	]
 		.filter( Boolean )
 		.join( ', ' );

--- a/client/disputes/new-evidence/customer-details.tsx
+++ b/client/disputes/new-evidence/customer-details.tsx
@@ -24,17 +24,7 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 	const phone = charge?.billing_details?.phone || '-';
 	const email = charge?.billing_details?.email || '-';
 	const ip = dispute.order?.ip_address || '-';
-	const address = charge?.billing_details?.address;
-	const billingAddress = [
-		address?.line1 || '',
-		address?.line2 || '',
-		address?.city || '',
-		address?.state || '',
-		address?.postal_code || '',
-		address?.country || '',
-	]
-		.filter( Boolean )
-		.join( ', ' );
+	const formattedAddress = charge?.billing_details?.formatted_address || '-';
 	return (
 		<section className="wcpay-dispute-evidence-customer-details">
 			<h3 className="wcpay-dispute-evidence-customer-details__heading">
@@ -92,7 +82,7 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 					{ __( 'BILLING ADDRESS', 'woocommerce-payments' ) }
 				</div>
 				<div className="wcpay-dispute-evidence-customer-details__billing-value">
-					{ billingAddress }
+					{ formattedAddress }
 				</div>
 			</div>
 		</section>

--- a/client/disputes/new-evidence/customer-details.tsx
+++ b/client/disputes/new-evidence/customer-details.tsx
@@ -31,7 +31,16 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 	const billingState = address?.state || '';
 	const billingPostcode = address?.postal_code || '';
 	const billingCountry = address?.country || '';
-	const billingAddress = `${ billingLine1 }, ${ billingLine2 }, ${ billingCity }, ${ billingState }, ${ billingPostcode }, ${ billingCountry }`;
+	const billingAddress = [
+		billingLine1,
+		billingLine2,
+		billingCity,
+		billingState,
+		billingPostcode,
+		billingCountry,
+	]
+		.filter( Boolean )
+		.join( ', ' );
 	return (
 		<section className="wcpay-dispute-evidence-customer-details">
 			<h3 className="wcpay-dispute-evidence-customer-details__heading">

--- a/client/disputes/new-evidence/customer-details.tsx
+++ b/client/disputes/new-evidence/customer-details.tsx
@@ -25,19 +25,13 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 	const email = charge?.billing_details?.email || '-';
 	const ip = dispute.order?.ip_address || '-';
 	const address = charge?.billing_details?.address;
-	const billingLine1 = address?.line1 || '';
-	const billingLine2 = address?.line2 || '';
-	const billingCity = address?.city || '';
-	const billingState = address?.state || '';
-	const billingPostcode = address?.postal_code || '';
-	const billingCountry = address?.country || '';
 	const billingAddress = [
-		billingLine1,
-		billingLine2,
-		billingCity,
-		billingState,
-		billingPostcode,
-		billingCountry,
+		address?.line1 || '',
+		address?.line2 || '',
+		address?.city || '',
+		address?.state || '',
+		address?.postal_code || '',
+		address?.country || '',
 	]
 		.filter( Boolean )
 		.join( ', ' );

--- a/client/disputes/new-evidence/customer-details.tsx
+++ b/client/disputes/new-evidence/customer-details.tsx
@@ -21,10 +21,8 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 			? dispute.charge
 			: null;
 	const name = charge?.billing_details?.name || '-';
-	const phone = charge?.billing_details?.phone || '-';
 	const email = charge?.billing_details?.email || '-';
-	const ip = dispute.order?.ip_address || '-';
-	const formattedAddress = charge?.billing_details?.formatted_address || '-';
+
 	return (
 		<section className="wcpay-dispute-evidence-customer-details">
 			<h3 className="wcpay-dispute-evidence-customer-details__heading">
@@ -50,7 +48,7 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 						{ __( 'PHONE', 'woocommerce-payments' ) }
 					</div>
 					<span className="wcpay-dispute-evidence-customer-details__phone-number">
-						{ phone }
+						{ charge?.billing_details?.phone || '-' }
 					</span>
 				</div>
 				<div>
@@ -73,7 +71,7 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 						{ __( 'IP ADDRESS', 'woocommerce-payments' ) }
 					</div>
 					<span className="wcpay-dispute-evidence-customer-details__ip-address">
-						{ ip }
+						{ dispute.order?.ip_address || '-' }
 					</span>
 				</div>
 			</div>
@@ -82,7 +80,7 @@ const CustomerDetails: React.FC< CustomerDetailsProps > = ( { dispute } ) => {
 					{ __( 'BILLING ADDRESS', 'woocommerce-payments' ) }
 				</div>
 				<div className="wcpay-dispute-evidence-customer-details__billing-value">
-					{ formattedAddress }
+					{ charge?.billing_details?.formatted_address || '-' }
 				</div>
 			</div>
 		</section>

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -156,6 +156,7 @@ declare global {
 		defaultExpressCheckoutBorderRadius: string;
 		dateFormat: string;
 		timeFormat: string;
+		formattedStoreAddress: string;
 	};
 
 	const wooPaymentsPaymentMethodDefinitions: Record<

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1028,6 +1028,17 @@ class WC_Payments_Admin {
 			'isWooPayGlobalThemeSupportEligible' => WC_Payments_Features::is_woopay_global_theme_support_eligible(),
 			'dateFormat'                         => wc_date_format(),
 			'timeFormat'                         => get_option( 'time_format' ),
+			'formattedStoreAddress'              => WC()->countries->get_formatted_address(
+				[
+					'address_1' => get_option( 'woocommerce_store_address', '' ),
+					'address_2' => get_option( 'woocommerce_store_address_2', '' ),
+					'city'      => get_option( 'woocommerce_store_city', '' ),
+					'state'     => WC()->countries->get_base_state(),
+					'postcode'  => get_option( 'woocommerce_store_postcode', '' ),
+					'country'   => WC()->countries->get_base_country(),
+				],
+				', '
+			),
 		];
 
 		/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -654,7 +654,13 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		}
 
 		$charge_id = is_array( $dispute['charge'] ) ? $dispute['charge']['id'] : $dispute['charge'];
-		return $this->add_order_info_to_charge_object( $charge_id, $dispute );
+		$dispute   = $this->add_order_info_to_charge_object( $charge_id, $dispute );
+
+		if ( is_array( $dispute['charge'] ) ) {
+			$dispute['charge'] = $this->add_formatted_address_to_charge_object( $dispute['charge'], ', ' );
+		}
+
+		return $dispute;
 	}
 
 	/**
@@ -710,7 +716,13 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		}
 
 		$charge_id = is_array( $dispute['charge'] ) ? $dispute['charge']['id'] : $dispute['charge'];
-		return $this->add_order_info_to_charge_object( $charge_id, $dispute );
+		$dispute   = $this->add_order_info_to_charge_object( $charge_id, $dispute );
+
+		if ( is_array( $dispute['charge'] ) ) {
+			$dispute['charge'] = $this->add_formatted_address_to_charge_object( $dispute['charge'], ', ' );
+		}
+
+		return $dispute;
 	}
 
 	/**
@@ -739,7 +751,13 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		}
 
 		$charge_id = is_array( $dispute['charge'] ) ? $dispute['charge']['id'] : $dispute['charge'];
-		return $this->add_order_info_to_charge_object( $charge_id, $dispute );
+		$dispute   = $this->add_order_info_to_charge_object( $charge_id, $dispute );
+
+		if ( is_array( $dispute['charge'] ) ) {
+			$dispute['charge'] = $this->add_formatted_address_to_charge_object( $dispute['charge'], ', ' );
+		}
+
+		return $dispute;
 	}
 
 	/**
@@ -2254,11 +2272,12 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	/**
 	 * Adds the formatted address to the Charge object
 	 *
-	 * @param array $charge - Charge object.
+	 * @param array  $charge    - Charge object.
+	 * @param string $separator - Separator for the formatted address. Defaults to '<br/>'.
 	 *
 	 * @return array
 	 */
-	public function add_formatted_address_to_charge_object( array $charge ): array {
+	public function add_formatted_address_to_charge_object( array $charge, string $separator = '<br/>' ): array {
 		$has_billing_details = isset( $charge['billing_details'] );
 
 		if ( $has_billing_details ) {
@@ -2272,7 +2291,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
 			$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
 
-			$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
+			$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details, $separator );
 		}
 
 		return $charge;


### PR DESCRIPTION
Fixes WOOPMNT-5775

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that in the disputes area, the address' "second line" might be formatted as `{line1}, , {rest of address}`.
<img width="383" height="92" alt="Screenshot 2026-02-24 at 8 14 22 AM" src="https://github.com/user-attachments/assets/dc9abd4e-edce-4b86-aa0b-eb87d6744a97" />

Adjusting so that empty address "pieces" get ignored.
<img width="414" height="66" alt="Screenshot 2026-02-24 at 8 19 24 AM" src="https://github.com/user-attachments/assets/a0d3b85e-bdd6-4c4e-96e4-0ce48a24e1f1" />

Also ensuring that international addresses are formatted according to the country's formatting rules from the existing PHP utilities - e.g.:
<img width="340" height="69" alt="Screenshot 2026-02-24 at 8 35 29 AM" src="https://github.com/user-attachments/assets/d5a27da6-b735-4bec-bd8e-0b41d1b5566a" />
(notice the zip code placement being different than US addresses)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product to cart
- Go to the checkout page
- Use a billing address with empty second line
- Use card `4000000000002685` to place the order
- Navigate to WooCommerce > Orders
- Click on the latest order
- Navigate to the order's dispute page
- Click "Continue with challenge"
- Check the billing address' formatting

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
