### PR TITLE
UPE: retrieve appearance styles after fonts have been loaded

### DIFF
--- a/changelog/woopmnt-5789-upe-appearance-typography-mismatch-in-card-fields-on
+++ b/changelog/woopmnt-5789-upe-appearance-typography-mismatch-in-card-fields-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Retrieve UPE styling after fonts have been loaded to improve display consistency.

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -53,7 +53,7 @@ const ProductDetail = ( { cart, context } ) => {
 	useEffect( () => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance( 'bnpl_cart_block' );
+			let upeAppearance = await getAppearance( 'bnpl_cart_block' );
 			upeAppearance = await api.saveUPEAppearance(
 				upeAppearance,
 				'bnpl_cart_block'

--- a/client/checkout/api/__tests__/index.test.js
+++ b/client/checkout/api/__tests__/index.test.js
@@ -5,6 +5,7 @@ import WCPayAPI from '..';
 import request from 'wcpay/checkout/utils/request';
 import { buildAjaxURL } from 'wcpay/utils/express-checkout';
 import { getConfig } from 'wcpay/utils/checkout';
+import { getAppearance } from 'checkout/upe-styles';
 
 jest.mock( 'wcpay/checkout/utils/request', () =>
 	jest.fn( () => Promise.resolve( {} ).finally( () => {} ) )
@@ -15,6 +16,9 @@ jest.mock( 'wcpay/utils/express-checkout', () => ( {
 } ) );
 jest.mock( 'wcpay/utils/checkout', () => ( {
 	getConfig: jest.fn(),
+} ) );
+jest.mock( 'checkout/upe-styles', () => ( {
+	getAppearance: jest.fn(),
 } ) );
 
 const mockAppearance = {
@@ -115,6 +119,7 @@ describe( 'WCPayAPI', () => {
 
 	test( 'initializes woopay using config params', async () => {
 		buildAjaxURL.mockReturnValue( 'https://example.org/' );
+		getAppearance.mockResolvedValue( mockAppearance );
 		getConfig.mockImplementation( ( key ) => {
 			const mockProperties = {
 				initWooPayNonce: 'foo',

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -366,18 +366,19 @@ export default class WCPayAPI {
 			} );
 	}
 
-	initWooPay( userEmail, woopayUserSession ) {
+	async initWooPay( userEmail, woopayUserSession ) {
 		if ( ! this.isWooPayRequesting ) {
 			this.isWooPayRequesting = true;
 			const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
 			const nonce = getConfig( 'initWooPayNonce' );
 			const appearanceType = getAppearanceType();
+			const appearance = getConfig( 'isWooPayGlobalThemeSupportEnabled' )
+				? await getAppearance( appearanceType, true )
+				: null;
 
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 				_wpnonce: nonce,
-				appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-					? getAppearance( appearanceType, true )
-					: null,
+				appearance: appearance,
 				email: userEmail,
 				user_session: woopayUserSession,
 				order_id: getConfig( 'order_id' ),

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -46,7 +46,7 @@ const PaymentElements = ( { api, ...props } ) => {
 				getFontRulesFromPage( containerRef.current.ownerDocument )
 			);
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance(
+			let upeAppearance = await getAppearance(
 				'blocks_checkout',
 				false,
 				containerRef.current.ownerDocument

--- a/client/checkout/classic/__tests__/payment-processing.test.js
+++ b/client/checkout/classic/__tests__/payment-processing.test.js
@@ -209,7 +209,7 @@ describe( 'Stripe Payment Element mounting', () => {
 				document.body.dispatchEvent = dispatchMock;
 
 				const appearanceMock = { backgroundColor: '#fff' };
-				getAppearance.mockReturnValue( appearanceMock );
+				getAppearance.mockResolvedValue( appearanceMock );
 				getFingerprint.mockImplementation( () => {
 					return 'fingerprint';
 				} );
@@ -233,7 +233,7 @@ describe( 'Stripe Payment Element mounting', () => {
 
 			test( 'does not call getAppearance or saveUPEAppearance if appearance is already set', async () => {
 				const appearanceMock = { backgroundColor: '#fff' };
-				getAppearance.mockReturnValue( appearanceMock );
+				getAppearance.mockResolvedValue( appearanceMock );
 				getFingerprint.mockImplementation( () => {
 					return 'fingerprint';
 				} );

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -64,7 +64,7 @@ async function initializeAppearance( api, elementsLocation ) {
 	}
 
 	return await api.saveUPEAppearance(
-		getAppearance( elementsLocation ),
+		await getAppearance( elementsLocation ),
 		elementsLocation
 	);
 }

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -130,7 +130,7 @@ describe( 'Getting styles for automated theming', () => {
 		expect( fontRules ).toEqual( [] );
 	} );
 
-	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', () => {
+	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', async () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
 			createElement: jest.fn( ( htmlTag ) =>
@@ -139,9 +139,12 @@ describe( 'Getting styles for automated theming', () => {
 			defaultView: {
 				getComputedStyle: jest.fn( () => mockCSStyleDeclaration ),
 			},
+			fonts: {
+				ready: Promise.resolve(),
+			},
 		};
 
-		const appearance = upeStyles.getAppearance(
+		const appearance = await upeStyles.getAppearance(
 			'shortcode_checkout',
 			true,
 			scope
@@ -279,6 +282,47 @@ describe( 'Getting styles for automated theming', () => {
 		} );
 	} );
 
+	test( 'getAppearance re-fetches paragraph rules when initial font family is a generic CSS font', async () => {
+		const genericFontStyleDeclaration = {
+			...mockCSStyleDeclaration,
+			getPropertyValue: ( propertyName ) => {
+				if ( propertyName === 'font-family' ) return 'serif';
+				return cssPropertiesDashed[ propertyName ] ?? '';
+			},
+		};
+		const getComputedStyleMock = jest
+			.fn()
+			.mockImplementationOnce( () => genericFontStyleDeclaration )
+			.mockImplementation( () => mockCSStyleDeclaration );
+
+		const scope = {
+			querySelector: jest.fn( () => mockElement ),
+			createElement: jest.fn( ( htmlTag ) =>
+				document.createElement( htmlTag )
+			),
+			defaultView: {
+				getComputedStyle: getComputedStyleMock,
+			},
+			fonts: {
+				ready: Promise.resolve(),
+			},
+		};
+
+		const appearance = await upeStyles.getAppearance(
+			'shortcode_checkout',
+			false,
+			scope
+		);
+
+		// getComputedStyle is called a second time for the text selector after
+		// the 100ms delay, so the total call count must be greater than one.
+		expect( getComputedStyleMock.mock.calls.length ).toBeGreaterThan( 1 );
+		// The re-fetched (non-generic) font family is reflected in the appearance.
+		expect( appearance.variables.fontFamily ).toBe(
+			'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"'
+		);
+	} );
+
 	[
 		{
 			elementsLocation: 'shortcode_checkout',
@@ -309,7 +353,7 @@ describe( 'Getting styles for automated theming', () => {
 		},
 	].forEach( ( { elementsLocation, expectedSelectors } ) => {
 		describe( `when elementsLocation is ${ elementsLocation }`, () => {
-			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', () => {
+			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', async () => {
 				const scope = {
 					querySelector: jest.fn( () => mockElement ),
 					createElement: jest.fn( ( htmlTag ) =>
@@ -320,9 +364,12 @@ describe( 'Getting styles for automated theming', () => {
 							() => mockCSStyleDeclaration
 						),
 					},
+					fonts: {
+						ready: Promise.resolve(),
+					},
 				};
 
-				upeStyles.getAppearance( elementsLocation, false, scope );
+				await upeStyles.getAppearance( elementsLocation, false, scope );
 
 				expectedSelectors.forEach( ( selector ) => {
 					expect( scope.querySelector ).toHaveBeenCalledWith(

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -576,7 +576,7 @@ function ensureFontSizeSmallerThan(
 	return `${ fontSizeNumber }px`;
 }
 
-export const getAppearance = (
+export const getAppearance = async (
 	elementsLocation,
 	forWooPay = false,
 	scope = document
@@ -586,8 +586,39 @@ export const getAppearance = (
 		scope
 	);
 
+	// Wait for fonts to be loaded.
+	await scope.fonts.ready;
+
 	// Add hidden fields to DOM for generating styles.
 	hiddenElementsForUPE.init( elementsLocation, scope );
+
+	// Helper to validate font family
+	const isGenericFont = ( fontFamily ) => {
+		return /^(serif|sans-serif|cursive|monospace|fantasy|system-ui)$/i.test(
+			fontFamily
+		);
+	};
+
+	// Get paragraph rules first to check font family
+	const paragraphRules = getFieldStyles(
+		selectors.upeThemeTextSelectors,
+		'.Text',
+		null,
+		scope
+	);
+	if ( isGenericFont( paragraphRules.fontFamily ) ) {
+		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
+		// Re-fetch paragraph rules after delay
+		Object.assign(
+			paragraphRules,
+			getFieldStyles(
+				selectors.upeThemeTextSelectors,
+				'.Text',
+				null,
+				scope
+			)
+		);
+	}
 
 	const inputRules = getFieldStyles(
 		selectors.hiddenInput,
@@ -612,13 +643,6 @@ export const getAppearance = (
 	const labelRestingRules = {
 		fontSize: labelRules.fontSize,
 	};
-
-	const paragraphRules = getFieldStyles(
-		selectors.upeThemeTextSelectors,
-		'.Text',
-		null,
-		scope
-	);
 
 	const tabRules = getFieldStyles(
 		selectors.upeThemeInputSelector,

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -183,14 +183,14 @@ export const handleWooPayEmailInput = async (
 		}
 	};
 
-	iframe.addEventListener( 'load', () => {
+	iframe.addEventListener( 'load', async () => {
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
 		const appearance =
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? getAppearance( appearanceType, true )
+				? await getAppearance( appearanceType, true )
 				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -108,14 +108,14 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			Math.floor( window.innerWidth / 2 - iframeRect.width / 2 ) + 'px';
 	};
 
-	iframe.addEventListener( 'load', () => {
+	iframe.addEventListener( 'load', async () => {
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
 		const appearance =
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? getAppearance( appearanceType, true )
+				? await getAppearance( appearanceType, true )
 				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -200,7 +200,7 @@ export const WoopayExpressCheckoutButton = ( {
 	);
 
 	const onClickFirstPartyAuthFlow = useCallback(
-		( e ) => {
+		async ( e ) => {
 			e.preventDefault();
 
 			if ( isPreview || isLoadingRef.current ) {
@@ -225,7 +225,7 @@ export const WoopayExpressCheckoutButton = ( {
 			const appearance =
 				isSupportedThemeEntrypoint( appearanceType ) &&
 				getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-					? getAppearance( appearanceType, true )
+					? await getAppearance( appearanceType, true )
 					: null;
 
 			if ( isProductPage ) {

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -38,7 +38,7 @@ async function initializeAppearance( api, location ) {
 	}
 
 	return await api.saveUPEAppearance(
-		getAppearance( appearanceKey ),
+		await getAppearance( appearanceKey ),
 		appearanceKey
 	);
 }


### PR DESCRIPTION
Fixes WOOPMNT-5789

#### Changes proposed in this Pull Request

When preparing appeareance settings for the UPE checkout block wait until the fonts are loaded to provide correct styling to the elements.

The core change in this PR makes `getAppearance` an async function to fix a typography mismatch in UPE card fields. Previously, `getAppearance` was synchronous, meaning it read computed styles from the page immediately - before web fonts had finished loading. This caused Stripe's Payment Element to be initialized with a fallback generic font (like `serif` or `sans-serif`) instead of the theme's actual typeface, resulting in a visible mismatch between the card fields and the rest of the checkout form. Making the function async allows it to `await document.fonts.ready` before reading any styles, ensuring the correct font is captured. An additional safety net was added: if the resolved font family is still a generic CSS font after the fonts-ready event, the function waits a further 100ms and re-fetches the paragraph rules before building the final appearance object.

Because `getAppearance` is now async, every call site that consumed it needed to be updated to properly await the result. Several files in the WooPay flow (`api/index.js`, `email-input-iframe.js`, `express-checkout-iframe.js`, and `woopay-express-checkout-button.js`) had each been updated, making the enclosing callbacks/methods async, and directly awaiting the conditional expression to retrieve appearance styles.

On the testing side, all existing tests that called `getAppearance` synchronously were updated to reflect its async nature: test functions were made async, results are now properly awaited, and `mockReturnValue` calls were replaced with `mockResolvedValue` where the function is mocked. A new test was added to cover the `isGenericFont` retry path — it verifies that when computed styles initially return a generic font family, `getComputedStyle` is called a second time after the delay and the final appearance reflects the re-fetched, non-generic font. The checkout/api test suite also received a mock for `getAppearance` to prevent the real implementation from running in jsdom, where `document.fonts` is unavailable.

After the change:

<img width="1704" height="948" alt="image" src="https://github.com/user-attachments/assets/1f0b1b95-37c0-4194-ac05-cf8c874ed9d0" />

_The styling of the input fields was the main issue_

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 - Enable WooPayments with UPE on a store using the Checkout Block (CIAB codebase)
 - Navigate to the checkout page
 - Observe the typography in the card input fields (card number, expiry, CVC)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
