### PR TITLE
Fix stale WP object cache entries persisting after Database_Cache::delete() on Memcached sites

### DIFF
--- a/changelog/fix-database-cache-delete-object-cache
+++ b/changelog/fix-database-cache-delete-object-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed stale WP object cache entries persisting after cache invalidation on sites with Memcached/Redis.

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -213,10 +213,14 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 		unset( $this->in_memory_cache[ $key ] );
 
 		// Remove from the DB cache.
-		if ( delete_option( $key ) ) {
-			// Clear the WP object cache to ensure the new data is fetched by other processes.
-			wp_cache_delete( $key, 'options' );
-		}
+		delete_option( $key );
+
+		// Always clear the WP object cache, even if the DB row didn't exist.
+		// wp_cache_delete on a missing key is a no-op, but skipping it when the
+		// DB row is gone while Memcached still has a stale entry causes persistent
+		// stale data across requests (see #8601 for the original fix, #9639 for
+		// the regression).
+		wp_cache_delete( $key, 'options' );
 	}
 
 	/**

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -544,18 +544,19 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 	public function test_delete_clears_wp_object_cache_when_db_option_exists() {
 		$value = [ 'mock' => true ];
 
-		// Write a valid cache entry to DB (via update_option, which also populates the alloptions object cache).
+		// Write a valid cache entry to DB (non-autoloaded, matching production behavior).
 		$this->write_mock_cache( $value );
 
-		// Sanity check: get_option returns the data (from DB/alloptions cache).
-		$this->assertNotFalse( get_option( self::MOCK_KEY ), 'Precondition: option should be retrievable.' );
+		// Sanity check: both DB and WP object cache have the entry.
+		$this->assertNotFalse( get_option( self::MOCK_KEY ), 'Precondition: DB option should exist.' );
+		$this->assertNotFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'Precondition: WP object cache should have the entry.' );
 
 		// Act: delete via Database_Cache.
 		$this->database_cache->delete( self::MOCK_KEY );
 
-		// Assert: option is no longer retrievable from either DB or WP object cache.
-		$this->assertFalse( get_option( self::MOCK_KEY ), 'Option should not be retrievable after delete.' );
-		$this->assertFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'Individual WP object cache entry should not exist after delete.' );
+		// Assert: both DB and WP object cache entries must be gone.
+		$this->assertFalse( get_option( self::MOCK_KEY ), 'DB option should be deleted.' );
+		$this->assertFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'WP object cache entry should be deleted.' );
 	}
 
 	public function test_get_or_add_does_not_refresh_if_disabled() {
@@ -589,7 +590,8 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 				'data'    => $data,
 				'fetched' => $fetch_time ?? time(),
 				'errored' => $errored,
-			]
+			],
+			'no' // Match production: Database_Cache stores options as non-autoloaded.
 		);
 	}
 

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -518,6 +518,29 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 		remove_all_filters( 'query' );
 	}
 
+	public function test_delete_clears_wp_object_cache_even_when_db_option_missing() {
+		$cache_contents = [
+			'data'    => [ 'stale' => true ],
+			'fetched' => time() - HOUR_IN_SECONDS,
+			'errored' => false,
+		];
+
+		// Seed the WP object cache directly (simulating Memcached having a stale entry).
+		wp_cache_set( self::MOCK_KEY, $cache_contents, 'options' );
+
+		// Ensure there's NO DB option row — simulates the double-delete scenario.
+		delete_option( self::MOCK_KEY );
+
+		// Sanity check: WP object cache has the stale entry.
+		$this->assertNotFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'Precondition: WP object cache should have the stale entry.' );
+
+		// Act: delete via Database_Cache.
+		$this->database_cache->delete( self::MOCK_KEY );
+
+		// Assert: WP object cache entry must be gone.
+		$this->assertFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'wp_cache_delete should be called even when delete_option returns false.' );
+	}
+
 	public function test_get_or_add_does_not_refresh_if_disabled() {
 		$refreshed = false;
 		$value     = [ 'mock' => true ];

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -541,6 +541,23 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'wp_cache_delete should be called even when delete_option returns false.' );
 	}
 
+	public function test_delete_clears_wp_object_cache_when_db_option_exists() {
+		$value = [ 'mock' => true ];
+
+		// Write a valid cache entry to DB (via update_option, which also populates the alloptions object cache).
+		$this->write_mock_cache( $value );
+
+		// Sanity check: get_option returns the data (from DB/alloptions cache).
+		$this->assertNotFalse( get_option( self::MOCK_KEY ), 'Precondition: option should be retrievable.' );
+
+		// Act: delete via Database_Cache.
+		$this->database_cache->delete( self::MOCK_KEY );
+
+		// Assert: option is no longer retrievable from either DB or WP object cache.
+		$this->assertFalse( get_option( self::MOCK_KEY ), 'Option should not be retrievable after delete.' );
+		$this->assertFalse( wp_cache_get( self::MOCK_KEY, 'options' ), 'Individual WP object cache entry should not exist after delete.' );
+	}
+
 	public function test_get_or_add_does_not_refresh_if_disabled() {
 		$refreshed = false;
 		$value     = [ 'mock' => true ];


### PR DESCRIPTION
Fixes a regression from #9639 where `Database_Cache::delete()` conditionally calls `wp_cache_delete` only when `delete_option()` returns `true`. This was previously unconditional, as introduced in #8601.

#### Changes proposed in this Pull Request

##### How we found this

A store was stuck showing the WooPayments onboarding screen despite having a fully provisioned test drive account on the platform. Investigation revealed:

- **Memcached** had a stale `wcpay_account_data` entry: `{data: [], fetched: <recent>, errored: false}`
- **DB** had no corresponding `wp_options` row
- **Platform** had a healthy, complete account (confirmed via `refresh_account_data()`)

The stale Memcached entry was the sole source of the broken state.

##### Root cause

PR #9639 (in-memory cache for DB write failures) inadvertently wrapped `wp_cache_delete` inside an `if (delete_option($key))` guard in `Database_Cache::delete()`. This means:

1. `delete()` is called (e.g., via `clear_cache()` or dev tools)
2. `delete_option()` queries the DB — no row exists → returns `false`
3. `wp_cache_delete` is **skipped** — stale Memcached entry persists
4. Next `get_option()` call finds the stale entry in Memcached and returns it as if real
5. `get_or_add()` sees valid, non-expired data → no refresh triggered

This is **self-reinforcing**: the stale entry also blocks `write_to_cache()` via `add_option()` (which calls `get_option()` internally to check existence, hits Memcached, and bails with "option already exists"). So even incoming `account.updated` webhooks with `force_refresh=true` cannot persist the corrected data. The fix from #8601 was neutralized.

##### The fix

Make `wp_cache_delete` unconditional again in `delete()`. This is safe because:

- `wp_cache_delete` on a missing key is a documented no-op (returns `false`, no side effects)
- The in-memory cache backstop from #9639 is a separate mechanism (`$this->in_memory_cache`) and is unaffected
- All existing tests pass without modification

##### Validation

All assumptions were validated on a live Atomic site with real Memcached before writing the fix:

| # | Assumption | Result |
|---|-----------|--------|
| 1 | `[]` is valid non-errored cache → gets 2h TTL (not 2min error TTL) | Confirmed |
| 2 | `get_option()` reads Memcached before DB | Confirmed |
| 3 | `delete()` leaves stale Memcached entry when DB row absent | **Bug confirmed** |
| 4 | Unconditional `wp_cache_delete` clears the stale entry | **Fix confirmed** |
| 5 | After cache clear, `get_cached_account_data()` fetches real account from platform | Confirmed |

Running `wp cache delete wcpay_account_data options` on the affected site immediately resolved the issue, confirming the fix direction.

##### Risks & caveats

- **Risk: Minimal.** The change adds one unconditional `wp_cache_delete` call that was already being called conditionally. On the no-DB-row path, this adds a single cache delete that is a no-op if the key doesn't exist in object cache.
- **Scope caveat:** This PR does not address *why* the DB row was absent in the first place. The `delete()` bug creates the self-reinforcing state, but the initial trigger (a previous `delete()` call that succeeded, or a failed write) is a separate question.
- **Not addressed (intentional):** A shorter TTL for the `data: []` state would reduce the blast radius of similar cache inconsistencies. This needs traffic data analysis before shipping globally and is tracked separately.

**Key commits:**
- Add failing test for the bug scenario (`0ba7f98`)
- Fix: make `wp_cache_delete` unconditional (`8d00ec2`)
- Add happy-path test covering DB-row-exists scenario (`65bd93b`)
- Align test helper `write_mock_cache` with production `autoload='no'` (`3815660`)

#### Testing instructions

##### Automated
- Run `npm run test:php -- --filter 'Database_Cache_Test'` — all 15 tests should pass (107 assertions)

##### Manual (requires a site with persistent object caching, e.g., Memcached/Redis)
1. Seed a stale entry in the object cache: `wp cache set wcpay_account_data 'a:3:{s:4:"data";a:0:{}s:7:"fetched";i:9999999999;s:7:"errored";b:0;}' options`
2. Ensure no DB row: `wp db query "DELETE FROM wp_options WHERE option_name = 'wcpay_account_data'"`
3. Navigate to WP Admin → WooPayments settings
- [ ] Verify the account data loads correctly (not stuck on onboarding)
4. Use WCPay Dev Tools → Clear account cache
- [ ] Verify the cache is actually cleared: `wp cache get wcpay_account_data options` should return nothing

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.


