### PR TITLE
Fix WooPay button not rendering on product pages

### DIFF
--- a/changelog/WOOPMNT-5801
+++ b/changelog/WOOPMNT-5801
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay button and BNPL site messaging not rendering on product pages when a BNPL payment method is active.

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -342,16 +342,22 @@ export default class WCPayAPI {
 	 *
 	 * @param {Object} appearance The UPE appearance object with style values
 	 * @param {string} elementsLocation The location of the elements.
+	 * @param {Object} [options] Optional overrides for contexts where wcpayConfig is unavailable.
+	 * @param {string} [options.ajaxUrl] The admin-ajax.php URL.
+	 * @param {string} [options.nonce] The save UPE appearance nonce.
 	 *
 	 * @return {Promise} The final promise for the request to the server.
 	 */
-	saveUPEAppearance( appearance, elementsLocation ) {
-		return this.request( getConfig( 'ajaxUrl' ), {
+	saveUPEAppearance( appearance, elementsLocation, options = {} ) {
+		const ajaxUrl = options.ajaxUrl || getConfig( 'ajaxUrl' );
+		const nonce = options.nonce || getConfig( 'saveUPEAppearanceNonce' );
+
+		return this.request( ajaxUrl, {
 			elements_location: elementsLocation,
 			appearance: JSON.stringify( appearance ),
 			action: 'save_upe_appearance',
 			// eslint-disable-next-line camelcase
-			_ajax_nonce: getConfig( 'saveUPEAppearanceNonce' ),
+			_ajax_nonce: nonce,
 		} )
 			.then( ( response ) => {
 				return response.data;

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -5,7 +5,6 @@
 import './style.scss';
 import WCPayAPI from 'wcpay/checkout/api';
 import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
-import { getUPEConfig } from 'wcpay/utils/checkout';
 import apiRequest from 'wcpay/checkout/utils/request';
 
 const elementsLocations = {
@@ -32,7 +31,7 @@ const elementsLocations = {
 async function initializeAppearance( api, location ) {
 	const { configKey, appearanceKey } = elementsLocations[ location ];
 
-	const appearance = getUPEConfig( configKey );
+	const appearance = window.wcpayStripeSiteMessaging?.[ configKey ];
 	if ( appearance ) {
 		return Promise.resolve( appearance );
 	}

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -38,7 +38,7 @@ async function initializeAppearance( api, location ) {
 	}
 
 	return await api.saveUPEAppearance(
-		getAppearance( appearanceKey ),
+		await getAppearance( appearanceKey ),
 		appearanceKey,
 		{
 			ajaxUrl: messaging?.ajaxUrl,

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -31,14 +31,19 @@ const elementsLocations = {
 async function initializeAppearance( api, location ) {
 	const { configKey, appearanceKey } = elementsLocations[ location ];
 
-	const appearance = window.wcpayStripeSiteMessaging?.[ configKey ];
+	const messaging = window.wcpayStripeSiteMessaging;
+	const appearance = messaging?.[ configKey ];
 	if ( appearance ) {
 		return Promise.resolve( appearance );
 	}
 
 	return await api.saveUPEAppearance(
 		getAppearance( appearanceKey ),
-		appearanceKey
+		appearanceKey,
+		{
+			ajaxUrl: messaging?.ajaxUrl,
+			nonce: messaging?.saveUPEAppearanceNonce,
+		}
 	);
 }
 

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -160,6 +160,8 @@ class WC_Payments_Payment_Method_Messaging_Element {
 				'is_bnpl_available' => wp_create_nonce( 'wcpay-is-bnpl-available' ),
 			],
 			'wcAjaxUrl'                    => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'ajaxUrl'                      => admin_url( 'admin-ajax.php' ),
+			'saveUPEAppearanceNonce'       => wp_create_nonce( 'wcpay_save_upe_appearance_nonce' ),
 			'shouldInitializePMME'         => WC_Payments_Utils::is_any_bnpl_supporting_country( array_values( $bnpl_payment_methods ), $country, $currency_code ),
 			'upeBnplProductPageAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT ),
 			'upeBnplClassicCartAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT ),

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -144,23 +144,25 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		$country = empty( $billing_country ) ? $store_country : $billing_country;
 
 		$script_data = [
-			'productId'            => 'base_product',
-			'productVariations'    => $product_variations,
-			'country'              => $country,
-			'locale'               => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
-			'accountId'            => $this->account->get_stripe_account_id(),
-			'publishableKey'       => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
-			'paymentMethods'       => array_values( $bnpl_payment_methods ),
-			'currencyCode'         => $currency_code,
-			'isCart'               => is_cart(),
-			'isCartBlock'          => $is_cart_block,
-			'cartTotal'            => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
-			'nonce'                => [
+			'productId'                    => 'base_product',
+			'productVariations'            => $product_variations,
+			'country'                      => $country,
+			'locale'                       => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
+			'accountId'                    => $this->account->get_stripe_account_id(),
+			'publishableKey'               => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
+			'paymentMethods'               => array_values( $bnpl_payment_methods ),
+			'currencyCode'                 => $currency_code,
+			'isCart'                       => is_cart(),
+			'isCartBlock'                  => $is_cart_block,
+			'cartTotal'                    => WC_Payments_Utils::prepare_amount( $cart_total, $currency_code ),
+			'nonce'                        => [
 				'get_cart_total'    => wp_create_nonce( 'wcpay-get-cart-total' ),
 				'is_bnpl_available' => wp_create_nonce( 'wcpay-is-bnpl-available' ),
 			],
-			'wcAjaxUrl'            => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-			'shouldInitializePMME' => WC_Payments_Utils::is_any_bnpl_supporting_country( array_values( $bnpl_payment_methods ), $country, $currency_code ),
+			'wcAjaxUrl'                    => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'shouldInitializePMME'         => WC_Payments_Utils::is_any_bnpl_supporting_country( array_values( $bnpl_payment_methods ), $country, $currency_code ),
+			'upeBnplProductPageAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT ),
+			'upeBnplClassicCartAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT ),
 		];
 
 		if ( $product ) {

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -174,25 +174,6 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			$script_data
 		);
 
-		// Ensure wcpayConfig is available in the page with only the keys the product-details script needs.
-		$wcpay_config = rawurlencode(
-			wp_json_encode(
-				[
-					'ajaxUrl'                      => admin_url( 'admin-ajax.php' ),
-					'saveUPEAppearanceNonce'       => wp_create_nonce( 'wcpay_save_upe_appearance_nonce' ),
-					'upeBnplProductPageAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT ),
-					'upeBnplClassicCartAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT ),
-				]
-			)
-		);
-		wp_add_inline_script(
-			'WCPAY_PRODUCT_DETAILS',
-			"
-			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
-			",
-			'before'
-		);
-
 		if ( ! $is_cart_block ) {
 			return '<div id="payment-method-message"></div>';
 		}

--- a/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
+++ b/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
@@ -213,34 +213,4 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 		$script_data = $this->get_script_data();
 		$this->assertEquals( 0, $script_data['cartTotal'] );
 	}
-
-	/**
-	 * Test that inline script contains only minimal config keys, not the full checkout config.
-	 */
-	public function test_init_inline_script_contains_only_minimal_config() {
-		$this->setup_gateway_mocks();
-
-		$this->messaging_element->init();
-
-		// Get the inline script added before WCPAY_PRODUCT_DETAILS.
-		$registered = wp_scripts()->registered['WCPAY_PRODUCT_DETAILS'];
-		$before     = $registered->extra['before'] ?? [];
-		$inline_js  = implode( '', $before );
-
-		// Extract the JSON from the inline script.
-		preg_match( "/decodeURIComponent\(\s*'([^']+)'\s*\)/", $inline_js, $matches );
-		$this->assertNotEmpty( $matches[1], 'Inline script should contain encoded config' );
-
-		$config = json_decode( urldecode( $matches[1] ), true );
-		$this->assertIsArray( $config );
-
-		// Should contain only the 4 minimal keys.
-		$expected_keys = [ 'ajaxUrl', 'saveUPEAppearanceNonce', 'upeBnplProductPageAppearance', 'upeBnplClassicCartAppearance' ];
-		$this->assertEqualsCanonicalizing( $expected_keys, array_keys( $config ) );
-
-		// Should NOT contain keys from the full checkout config.
-		$this->assertArrayNotHasKey( 'fraudServices', $config );
-		$this->assertArrayNotHasKey( 'paymentMethodsConfig', $config );
-		$this->assertArrayNotHasKey( 'woopayMinimumSessionData', $config );
-	}
 }

--- a/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
+++ b/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
@@ -228,10 +228,7 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 		$this->messaging_element->init();
 
 		$script_data = $this->get_script_data();
-		$this->assertEquals( $product_page_appearance, $script_data['upeBnplProductPageAppearance'] );
-		$this->assertEquals( $classic_cart_appearance, $script_data['upeBnplClassicCartAppearance'] );
-
-		delete_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT );
-		delete_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT );
+		$this->assertSame( $product_page_appearance, $script_data['upeBnplProductPageAppearance'] );
+		$this->assertSame( $classic_cart_appearance, $script_data['upeBnplClassicCartAppearance'] );
 	}
 }

--- a/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
+++ b/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
@@ -213,4 +213,25 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 		$script_data = $this->get_script_data();
 		$this->assertEquals( 0, $script_data['cartTotal'] );
 	}
+
+	/**
+	 * Test that BNPL appearance transients are included in the script data.
+	 */
+	public function test_init_includes_bnpl_appearance_transients() {
+		$this->setup_gateway_mocks();
+
+		$product_page_appearance = [ 'theme' => 'stripe' ];
+		$classic_cart_appearance = [ 'theme' => 'flat' ];
+		set_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT, $product_page_appearance );
+		set_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT, $classic_cart_appearance );
+
+		$this->messaging_element->init();
+
+		$script_data = $this->get_script_data();
+		$this->assertEquals( $product_page_appearance, $script_data['upeBnplProductPageAppearance'] );
+		$this->assertEquals( $classic_cart_appearance, $script_data['upeBnplClassicCartAppearance'] );
+
+		delete_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT );
+		delete_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5801

## Summary

The BNPL messaging element (`WC_Payments_Payment_Method_Messaging_Element`) injected a minimal 4-key `wcpayConfig` stub via an inline script using the `var wcpayConfig = wcpayConfig || ...` pattern. Because this stub loaded before the full config (50+ keys), the first-wins `||` pattern prevented the real config from being set. This caused:

- **WooPay button**: `getConfig('woopayButton')` returned `null` → destructuring failed with `TypeError: Cannot destructure property 'height' of 'r' as it is null`
- **BNPL messaging**: rendered as a blank section


The stub existed so the `product-details` bundle could read cached BNPL appearance transients and save new ones via `saveUPEAppearance()` (which internally reads `ajaxUrl` and `saveUPEAppearanceNonce` from `wcpayConfig`). But the bundle already has its own config variable (`wcpayStripeSiteMessaging` via `wp_localize_script`), so all that data belongs there instead.

#### Changes proposed in this Pull Request
- Remove the `wcpayConfig` inline stub
- Move appearance transients (`upeBnplProductPageAppearance`, `upeBnplClassicCartAppearance`) and AJAX config (`ajaxUrl`, `saveUPEAppearanceNonce`) into `wcpayStripeSiteMessaging`
- Update `initializeAppearance()` to read cached appearances from `wcpayStripeSiteMessaging`
- Add optional `options` parameter to `saveUPEAppearance()` so callers can pass `ajaxUrl` and `nonce` directly, without relying on `wcpayConfig`

#### Testing instructions

**Prerequisites:** WooPay enabled, at least one BNPL method active (Afterpay/Klarna), USD currency, US country.

1. Visit any simple product page
2. **Verify**: WooPay button renders correctly (purple button below Add to Cart)
3. **Verify**: BNPL messaging shows installment info (e.g. "4 interest-free payments of $X.XX")
4. **Verify**: No JavaScript errors in the browser console related to `wcpayConfig`, `height`, or `startsWith`
5. Visit the cart page and checkout page — verify express checkout buttons still render
6. Complete a test purchase — verify the payment flow works end-to-end

**Testing appearance caching (optional):**
1. Delete the transient: `wp transient delete wcpay_upe_bnpl_product_page_appearance`
2. Visit a product page — the appearance should be regenerated and saved automatically
3. Verify the transient was recreated: `wp transient get wcpay_upe_bnpl_product_page_appearance`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.