### PR TITLE
Fix: Skeleton loader styling issue when step numbers are enabled on checkout blocks

### DIFF
--- a/changelog/woopmnt-5648-skeleton-loader-styling-issue-when-step-numbers-are-enabled
+++ b/changelog/woopmnt-5648-skeleton-loader-styling-issue-when-step-numbers-are-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skeleton loader styling issue when step numbers are enabled on checkout blocks

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -9,13 +9,6 @@
 	width: 100%;
 }
 
-.wc-block-components-main
-	.wc-block-components-checkout-step--with-step-number
-	.wc-block-components-checkout-step__content
-	> :last-child {
-	padding: 0;
-}
-
 .wc-block-checkout__payment-method {
 	// Style the WooCommerce Blocks payment method label with icon.
 	// The markup has icon first, then text. We use flexbox with order to


### PR DESCRIPTION
Fixes WOOPMNT-5648

#### Changes proposed in this Pull Request

Removes a leftover CSS rule that was stripping padding from the last child of every checkout step when step numbers are enabled:

```css
.wc-block-components-main
	.wc-block-components-checkout-step--with-step-number
	.wc-block-components-checkout-step__content
	> :last-child {
	padding: 0;
}
```

**History:** This rule was introduced in [#3662](https://github.com/Automattic/woocommerce-payments/pull/3662) (Feb 2022) to fix spacing when the Platform Checkout (WooPay) email field was injected at the top of the blocks checkout. Two weeks later in [#3736](https://github.com/Automattic/woocommerce-payments/pull/3736), the surrounding Platform Checkout code (the iframe styles and `#contact-fields` spinner) was removed, but this rule was accidentally left behind.

Fast-forward to today: the skeleton loader for the payment element is rendered as the last child inside `.wc-block-components-checkout-step__content`, so when step numbers are enabled, this orphaned rule zeroes out its padding — causing the visual issue in WOOPMNT-5648.

The fix is simply to remove the now-orphaned rule entirely.

#### Testing instructions

1. Enable the blocks checkout with **step numbers** enabled (Appearance → Customize → WooCommerce → Checkout → Show step numbers).
2. Go to the checkout page and observe the payment step as it loads.
3. Verify the skeleton loader displays with correct padding (not collapsed/zero-padded).
4. Verify no other checkout step's last child appears differently than before.

| Step numbers are enabled, in current `develop` | Step numbers are enabled, with this PR |
|--------|--------|
| ❌ Bad | ✅ Good | 
| <img width="469" height="94" alt="image" src="https://github.com/user-attachments/assets/1b97073a-a97f-4fa4-af91-5fa0e448f488" /> | <img width="523" height="100" alt="image (1)" src="https://github.com/user-attachments/assets/fb9ca74b-c01e-4d37-89db-c96829256210" /> |



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.