### PR TITLE
refactor: UPE styles to be managed through the front-end

### DIFF
--- a/changelog/fix-remove-upe-appearance-transient-caching
+++ b/changelog/fix-remove-upe-appearance-transient-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove server-side appearance caching in favor of client-side caching

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -11,10 +11,16 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
+import {
+	getCachedAppearance,
+	setCachedAppearance,
+	dispatchAppearanceEvent,
+} from 'wcpay/utils/appearance-cache';
 import { useStripeAsync } from 'wcpay/hooks/use-stripe-async';
 import { getUPEConfig } from 'utils/checkout';
 import WCPayAPI from '../../checkout/api';
 import request from '../../checkout/utils/request';
+
 import { useEffect, useState } from 'react';
 
 // Create an API object, which will be used throughout the checkout.
@@ -42,29 +48,28 @@ const normalizeAmount = ( amount, decimalPlaces = 2 ) => {
 const { ExperimentalOrderMeta } = window.wc.blocksCheckout;
 
 const ProductDetail = ( { cart, context } ) => {
-	const [ appearance, setAppearance ] = useState(
-		getUPEConfig( 'upeBnplCartBlockAppearance' ) || {}
+	const [ appearance, setAppearance ] = useState( () =>
+		getCachedAppearance(
+			'bnpl_cart_block',
+			getUPEConfig( 'stylesCacheVersion' )
+		)
 	);
-
 	const [ fontRules ] = useState( getFontRulesFromPage() );
 
-	const stripe = useStripeAsync( api );
-
 	useEffect( () => {
-		async function generateUPEAppearance() {
-			// Generate UPE input styles.
-			let upeAppearance = getAppearance( 'bnpl_cart_block' );
-			upeAppearance = await api.saveUPEAppearance(
-				upeAppearance,
-				'bnpl_cart_block'
+		if ( ! appearance ) {
+			const computed = getAppearance( 'bnpl_cart_block' );
+			dispatchAppearanceEvent( computed, 'bnpl_cart_block' );
+			setCachedAppearance(
+				'bnpl_cart_block',
+				getUPEConfig( 'stylesCacheVersion' ),
+				computed
 			);
-			setAppearance( upeAppearance );
-		}
-
-		if ( Object.keys( appearance ).length === 0 ) {
-			generateUPEAppearance();
+			setAppearance( computed );
 		}
 	}, [ appearance ] );
+
+	const stripe = useStripeAsync( api );
 
 	if ( ! stripe ) {
 		return null;

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -337,35 +337,6 @@ export default class WCPayAPI {
 		return setupIntent;
 	}
 
-	/**
-	 * Saves the calculated UPE appearance values in a transient.
-	 *
-	 * @param {Object} appearance The UPE appearance object with style values
-	 * @param {string} elementsLocation The location of the elements.
-	 *
-	 * @return {Promise} The final promise for the request to the server.
-	 */
-	saveUPEAppearance( appearance, elementsLocation ) {
-		return this.request( getConfig( 'ajaxUrl' ), {
-			elements_location: elementsLocation,
-			appearance: JSON.stringify( appearance ),
-			action: 'save_upe_appearance',
-			// eslint-disable-next-line camelcase
-			_ajax_nonce: getConfig( 'saveUPEAppearanceNonce' ),
-		} )
-			.then( ( response ) => {
-				return response.data;
-			} )
-			.catch( ( error ) => {
-				if ( error.message ) {
-					throw error;
-				} else {
-					// Covers the case of error on the Ajaxrequest.
-					throw new Error( error.statusText );
-				}
-			} );
-	}
-
 	initWooPay( userEmail, woopayUserSession ) {
 		if ( ! this.isWooPayRequesting ) {
 			this.isWooPayRequesting = true;

--- a/client/checkout/blocks/__tests__/payment-method-label.test.js
+++ b/client/checkout/blocks/__tests__/payment-method-label.test.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { render, screen, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PaymentMethodLabel from '../payment-method-label';
+import { getUPEConfig } from 'wcpay/utils/checkout';
+
+// Mock dependencies.
+jest.mock( 'wcpay/utils/checkout', () => ( {
+	getUPEConfig: jest.fn(),
+} ) );
+
+jest.mock( 'wcpay/utils/appearance-cache', () => ( {
+	getCachedTheme: jest.fn(),
+} ) );
+
+jest.mock( 'wcpay/checkout/utils/icon-theme', () => ( {
+	getIconTheme: jest.fn( () => 'stripe' ),
+} ) );
+
+jest.mock( '../payment-methods-logos', () => ( {
+	PaymentMethodsLogos: () => <div data-testid="card-logos" />,
+} ) );
+
+jest.mock( 'wcpay/utils/card-brands', () => ( {
+	getCardBrands: jest.fn( () => [] ),
+} ) );
+
+import { getCachedTheme } from 'wcpay/utils/appearance-cache';
+import { getIconTheme } from 'wcpay/checkout/utils/icon-theme';
+
+const MockLabel = ( { text, icon } ) => (
+	<span>
+		{ text }
+		{ icon }
+	</span>
+);
+
+const defaultProps = {
+	components: { PaymentMethodLabel: MockLabel },
+	title: 'iDEAL',
+	paymentMethodId: 'ideal',
+	icon: '/light-icon.svg',
+	darkIcon: '/dark-icon.svg',
+};
+
+describe( 'PaymentMethodLabel', () => {
+	beforeEach( () => {
+		localStorage.clear();
+		getCachedTheme.mockReturnValue( null );
+		getIconTheme.mockReturnValue( 'stripe' );
+		getUPEConfig.mockImplementation( ( key ) => {
+			if ( key === 'testMode' ) return false;
+			if ( key === 'stylesCacheVersion' ) return 'v1';
+			return null;
+		} );
+	} );
+
+	test( 'renders light icon by default', () => {
+		render( <PaymentMethodLabel { ...defaultProps } /> );
+		const img = screen.getByAltText( 'iDEAL' );
+		expect( img.src ).toContain( '/light-icon.svg' );
+	} );
+
+	test( 'renders dark icon when cached theme is night', () => {
+		getCachedTheme.mockReturnValue( 'night' );
+		render( <PaymentMethodLabel { ...defaultProps } /> );
+		const img = screen.getByAltText( 'iDEAL' );
+		expect( img.src ).toContain( '/dark-icon.svg' );
+	} );
+
+	test( 'falls back to light icon when darkIcon is not provided', () => {
+		getCachedTheme.mockReturnValue( 'night' );
+		render(
+			<PaymentMethodLabel { ...defaultProps } darkIcon={ undefined } />
+		);
+		const img = screen.getByAltText( 'iDEAL' );
+		expect( img.src ).toContain( '/light-icon.svg' );
+	} );
+
+	test( 'renders dark icon immediately on dark background without cache', () => {
+		getIconTheme.mockReturnValue( 'night' );
+		render( <PaymentMethodLabel { ...defaultProps } /> );
+		const img = screen.getByAltText( 'iDEAL' );
+		expect( img.src ).toContain( '/dark-icon.svg' );
+	} );
+
+	test( 'swaps to dark icon when appearance-cached event fires', () => {
+		render( <PaymentMethodLabel { ...defaultProps } /> );
+		const img = screen.getByAltText( 'iDEAL' );
+		expect( img.src ).toContain( '/light-icon.svg' );
+
+		// Simulate appearance being computed and cached.
+		getCachedTheme.mockReturnValue( 'night' );
+		act( () => {
+			window.dispatchEvent( new Event( 'wcpay-appearance-cached' ) );
+		} );
+
+		expect( img.src ).toContain( '/dark-icon.svg' );
+	} );
+} );

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -11,6 +11,11 @@ import { StoreNotice } from '@woocommerce/blocks-checkout';
  */
 import './style.scss';
 import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
+import {
+	getCachedAppearance,
+	setCachedAppearance,
+	dispatchAppearanceEvent,
+} from 'wcpay/utils/appearance-cache';
 import { useStripeForUPE } from 'wcpay/hooks/use-stripe-async';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import { useFingerprint } from './hooks';
@@ -27,8 +32,11 @@ const PaymentElements = ( { api, ...props } ) => {
 		paymentProcessorLoadErrorMessage,
 		setPaymentProcessorLoadErrorMessage,
 	] = useState( undefined );
-	const [ appearance, setAppearance ] = useState(
-		getUPEConfig( 'wcBlocksUPEAppearance' )
+	const [ appearance, setAppearance ] = useState( () =>
+		getCachedAppearance(
+			'blocks_checkout',
+			getUPEConfig( 'stylesCacheVersion' )
+		)
 	);
 	const [ fontRules, setFontRules ] = useState( [] );
 
@@ -38,35 +46,33 @@ const PaymentElements = ( { api, ...props } ) => {
 	const paymentMethodTypes = getPaymentMethodTypes( props.paymentMethodId );
 
 	useEffect( () => {
-		async function generateUPEAppearance() {
-			if ( ! containerRef.current ) {
-				return;
-			}
+		if ( ! appearance && containerRef.current ) {
 			setFontRules(
 				getFontRulesFromPage( containerRef.current.ownerDocument )
 			);
 			// Generate UPE input styles.
-			let upeAppearance = getAppearance(
+			const upeAppearance = getAppearance(
 				'blocks_checkout',
 				false,
 				containerRef.current.ownerDocument
 			);
-			upeAppearance = await api.saveUPEAppearance(
-				upeAppearance,
-				'blocks_checkout'
+			dispatchAppearanceEvent( upeAppearance, 'blocks_checkout' );
+			setCachedAppearance(
+				'blocks_checkout',
+				getUPEConfig( 'stylesCacheVersion' ),
+				upeAppearance
 			);
 			setAppearance( upeAppearance );
-		}
-
-		if ( ! appearance ) {
-			generateUPEAppearance();
+			// Defer dispatch so all payment method label listeners are attached first.
+			setTimeout( () => {
+				window.dispatchEvent( new Event( 'wcpay-appearance-cached' ) );
+			}, 0 );
 		}
 
 		if ( fingerprintErrorMessage ) {
 			setErrorMessage( fingerprintErrorMessage );
 		}
 	}, [
-		api,
 		appearance,
 		fingerprint,
 		fingerprintErrorMessage,

--- a/client/checkout/blocks/payment-method-label.js
+++ b/client/checkout/blocks/payment-method-label.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,6 +10,8 @@ import { __ } from '@wordpress/i18n';
 import { PaymentMethodsLogos } from './payment-methods-logos';
 import { getCardBrands } from 'wcpay/utils/card-brands';
 import { getUPEConfig } from 'wcpay/utils/checkout';
+import { getCachedTheme } from 'wcpay/utils/appearance-cache';
+import { getIconTheme } from 'wcpay/checkout/utils/icon-theme';
 
 const cardBrandsBreakpointConfigs = [
 	{ breakpoint: 550, maxElements: 2 },
@@ -20,12 +22,11 @@ const cardBrandsBreakpointConfigs = [
  * Renders the payment method icon along with the test mode badge.
  * The badge is included here so it can be positioned via CSS within the same flex container.
  * For card payments, shows card brand logos.
- * For other payment methods, shows the payment method icon based on theme.
+ * For other payment methods, shows the payment method icon.
  *
  * @param {Object} props Component props.
  * @param {string} props.paymentMethodId The payment method ID (e.g., 'card', 'giropay').
- * @param {string} props.icon The light theme icon URL.
- * @param {string} props.darkIcon The dark theme icon URL.
+ * @param {string} props.icon The icon URL.
  * @param {string} props.title The payment method title for alt text.
  * @return {JSX.Element} The payment method icon component.
  */
@@ -36,6 +37,24 @@ const PaymentMethodIcon = memo( function PaymentMethodIcon( {
 	title,
 } ) {
 	const isTestMode = getUPEConfig( 'testMode' );
+	const stylesCacheVersion = getUPEConfig( 'stylesCacheVersion' );
+
+	const [ theme, setTheme ] = useState( () => {
+		const cached = getCachedTheme( 'blocks_checkout', stylesCacheVersion );
+		if ( cached ) {
+			return cached;
+		}
+		// First load with empty cache: determine theme from page background.
+		return getIconTheme( 'blocks' );
+	} );
+
+	useEffect( () => {
+		const handler = () =>
+			setTheme( getCachedTheme( 'blocks_checkout', stylesCacheVersion ) );
+		window.addEventListener( 'wcpay-appearance-cached', handler );
+		return () =>
+			window.removeEventListener( 'wcpay-appearance-cached', handler );
+	}, [ stylesCacheVersion ] );
 
 	const testModeBadge = isTestMode && (
 		<span className="test-mode badge">
@@ -56,9 +75,7 @@ const PaymentMethodIcon = memo( function PaymentMethodIcon( {
 		);
 	}
 
-	const upeAppearanceTheme = getUPEConfig( 'wcBlocksUPEAppearanceTheme' );
-	const iconSrc =
-		upeAppearanceTheme === 'night' && darkIcon ? darkIcon : icon;
+	const iconSrc = theme === 'night' && darkIcon ? darkIcon : icon;
 
 	return (
 		<>
@@ -80,8 +97,7 @@ const PaymentMethodIcon = memo( function PaymentMethodIcon( {
  * @param {Object} props.components Components provided by WooCommerce Blocks, including PaymentMethodLabel.
  * @param {string} props.title The payment method title to display.
  * @param {string} props.paymentMethodId The payment method ID (e.g., 'card', 'giropay').
- * @param {string} props.icon The light theme icon URL.
- * @param {string} props.darkIcon The dark theme icon URL.
+ * @param {string} props.icon The icon URL.
  * @return {JSX.Element} The payment method label component.
  */
 const PaymentMethodLabel = ( {

--- a/client/checkout/classic/__tests__/event-handlers-dark-icons.test.js
+++ b/client/checkout/classic/__tests__/event-handlers-dark-icons.test.js
@@ -1,0 +1,150 @@
+/**
+ * Internal dependencies
+ */
+import { getUPEConfig } from 'wcpay/utils/checkout';
+
+jest.mock( 'wcpay/utils/checkout', () => ( {
+	getUPEConfig: jest.fn(),
+} ) );
+
+const mockGetIconTheme = jest.fn( () => 'night' );
+
+jest.mock( 'wcpay/checkout/utils/icon-theme', () => ( {
+	getIconTheme: ( ...args ) => mockGetIconTheme( ...args ),
+} ) );
+
+/**
+ * Creates a payment method DOM structure matching classic checkout layout.
+ *
+ * @param {string} paymentMethodType The payment method type.
+ * @param {Array}  imgSrcs           Image source URLs.
+ * @return {Object} The container element and image elements.
+ */
+function setupPaymentMethodDOM(
+	paymentMethodType,
+	imgSrcs = [ '/original.svg' ]
+) {
+	const container = document.createElement( 'div' );
+	container.classList.add( 'wc_payment_method' );
+
+	const label = document.createElement( 'label' );
+	const imgs = imgSrcs.map( ( src ) => {
+		const img = document.createElement( 'img' );
+		img.src = src;
+		label.appendChild( img );
+		return img;
+	} );
+
+	const upeElement = document.createElement( 'div' );
+	upeElement.classList.add( 'wcpay-upe-element' );
+	upeElement.dataset.paymentMethodType = paymentMethodType;
+
+	container.appendChild( label );
+	container.appendChild( upeElement );
+	document.body.appendChild( container );
+
+	return { container, imgs };
+}
+
+describe( 'swapDarkIcons in classic checkout', () => {
+	let containers = [];
+
+	beforeEach( () => {
+		containers = [];
+		mockGetIconTheme.mockReturnValue( 'night' );
+		getUPEConfig.mockImplementation( ( key ) => {
+			if ( key === 'paymentMethodsConfig' ) {
+				return {
+					giropay: {
+						icon: '/giropay.svg',
+						darkIcon: '/dark-giropay.svg',
+					},
+					card: {
+						icon: '/card.svg',
+						darkIcon: '/dark-card.svg',
+					},
+				};
+			}
+			return null;
+		} );
+	} );
+
+	afterEach( () => {
+		containers.forEach( ( c ) => c.remove() );
+		jest.clearAllMocks();
+	} );
+
+	// Import the module dynamically so mocks are applied.
+	function getSwapDarkIcons() {
+		// We can't import swapDarkIcons directly since it's inside the
+		// jQuery ready block. Instead, replicate the logic to test it.
+		// This tests the same algorithm used in event-handlers.js.
+		const { getIconTheme } = require( 'wcpay/checkout/utils/icon-theme' );
+
+		return function swapDarkIcons() {
+			const useDark = getIconTheme( 'classic' ) === 'night';
+
+			document
+				.querySelectorAll( '.wcpay-upe-element' )
+				.forEach( ( el ) => {
+					const type = el.dataset.paymentMethodType;
+					if ( type === 'card' ) {
+						return;
+					}
+					const config = getUPEConfig( 'paymentMethodsConfig' )?.[
+						type
+					];
+					const targetIcon = useDark
+						? config?.darkIcon
+						: config?.icon;
+					if ( targetIcon ) {
+						el.closest( '.wc_payment_method' )
+							?.querySelectorAll( 'label img' )
+							.forEach( ( img ) => {
+								img.src = targetIcon;
+							} );
+					}
+				} );
+		};
+	}
+
+	test( 'swaps non-card icons when background is dark', () => {
+		const { container, imgs } = setupPaymentMethodDOM( 'giropay' );
+		containers.push( container );
+
+		const swapDarkIcons = getSwapDarkIcons();
+		swapDarkIcons();
+
+		expect( imgs[ 0 ].src ).toContain( '/dark-giropay.svg' );
+		expect( mockGetIconTheme ).toHaveBeenCalledWith( 'classic' );
+	} );
+
+	test( 'does not swap card brand icons', () => {
+		const { container, imgs } = setupPaymentMethodDOM( 'card', [
+			'/visa.svg',
+			'/mc.svg',
+		] );
+		containers.push( container );
+
+		const swapDarkIcons = getSwapDarkIcons();
+		swapDarkIcons();
+
+		expect( imgs[ 0 ].src ).toContain( '/visa.svg' );
+		expect( imgs[ 1 ].src ).toContain( '/mc.svg' );
+	} );
+
+	test( 'reverts to light icons when background is light', () => {
+		// First swap to dark icons.
+		const { container, imgs } = setupPaymentMethodDOM( 'giropay' );
+		containers.push( container );
+
+		const swapDarkIcons = getSwapDarkIcons();
+		swapDarkIcons();
+		expect( imgs[ 0 ].src ).toContain( '/dark-giropay.svg' );
+
+		// Now switch to light background and swap again.
+		mockGetIconTheme.mockReturnValue( 'stripe' );
+		swapDarkIcons();
+		expect( imgs[ 0 ].src ).toContain( '/giropay.svg' );
+	} );
+} );

--- a/client/checkout/classic/__tests__/payment-processing.test.js
+++ b/client/checkout/classic/__tests__/payment-processing.test.js
@@ -26,6 +26,7 @@ import {
 import { PAYMENT_METHOD_ERROR } from 'wcpay/checkout/constants';
 
 jest.mock( '../../upe-styles' );
+jest.mock( 'wcpay/utils/appearance-cache' );
 
 jest.mock( '../upe-utils' );
 
@@ -33,13 +34,6 @@ jest.mock( 'wcpay/checkout/utils/upe' );
 
 jest.mock( 'wcpay/utils/checkout', () => ( {
 	getUPEConfig: jest.fn( ( argument ) => {
-		if (
-			argument === 'wcBlocksUPEAppearance' ||
-			argument === 'upeAppearance'
-		) {
-			return {};
-		}
-
 		if ( argument === 'paymentMethodsConfig' ) {
 			return {
 				card: {
@@ -107,7 +101,6 @@ const mockCreatePaymentMethod = jest.fn().mockResolvedValue( {
 } );
 
 const apiMock = {
-	saveUPEAppearance: jest.fn().mockResolvedValue( {} ),
 	getStripeForUPE: jest.fn( () =>
 		Promise.resolve( {
 			elements: mockElements,
@@ -124,13 +117,6 @@ describe( 'Stripe Payment Element mounting', () => {
 		mockDomElement = document.createElement( 'div' );
 		eventHandlersFromElementsCreate = {};
 		getUPEConfig.mockImplementation( ( argument ) => {
-			if (
-				argument === 'wcBlocksUPEAppearance' ||
-				argument === 'upeAppearance'
-			) {
-				return {};
-			}
-
 			if ( argument === 'paymentMethodsConfig' ) {
 				return {
 					card: {
@@ -163,33 +149,17 @@ describe( 'Stripe Payment Element mounting', () => {
 	} );
 
 	[
-		{
-			elementsLocation: 'shortcode_checkout',
-			expectedProperty: 'upeAppearance',
-		},
-		{
-			elementsLocation: 'add_payment_method',
-			expectedProperty: 'upeAddPaymentMethodAppearance',
-		},
-		{
-			elementsLocation: 'other',
-			expectedProperty: 'upeAppearance',
-		},
-	].forEach( ( { elementsLocation, expectedProperty } ) => {
+		{ elementsLocation: 'shortcode_checkout' },
+		{ elementsLocation: 'add_payment_method' },
+		{ elementsLocation: 'other' },
+	].forEach( ( { elementsLocation } ) => {
 		describe( `when elementsLocation is ${ elementsLocation }`, () => {
 			beforeEach( () => {
 				__resetGatewayUPEComponentsElement( 'giropay' );
 			} );
 
-			test( 'initializes the appearance when it is not set and saves it', async () => {
+			test( 'initializes the appearance by computing it from the DOM', async () => {
 				getUPEConfig.mockImplementation( ( argument ) => {
-					if (
-						argument === 'upeAddPaymentMethodAppearance' ||
-						argument === 'upeAppearance'
-					) {
-						return null;
-					}
-
 					if ( argument === 'paymentMethodsConfig' ) {
 						return {
 							giropay: {
@@ -222,56 +192,10 @@ describe( 'Stripe Payment Element mounting', () => {
 					elementsLocation
 				);
 
-				expect( getAppearance ).toHaveBeenCalled();
-				expect( apiMock.saveUPEAppearance ).toHaveBeenCalledWith(
-					appearanceMock,
+				expect( getAppearance ).toHaveBeenCalledWith(
 					elementsLocation
 				);
-				expect( getUPEConfig ).toHaveBeenCalledWith( expectedProperty );
 				expect( dispatchMock ).toHaveBeenCalled();
-			} );
-
-			test( 'does not call getAppearance or saveUPEAppearance if appearance is already set', async () => {
-				const appearanceMock = { backgroundColor: '#fff' };
-				getAppearance.mockReturnValue( appearanceMock );
-				getFingerprint.mockImplementation( () => {
-					return 'fingerprint';
-				} );
-				getUPEConfig.mockImplementation( ( argument ) => {
-					if ( argument === 'currency' ) {
-						return 'eur';
-					}
-
-					if (
-						argument === 'upeAppearance' ||
-						argument === 'upeAddPaymentMethodAppearance'
-					) {
-						return {
-							backgroundColor: '#fff',
-						};
-					}
-
-					if ( argument === 'paymentMethodsConfig' ) {
-						return {
-							giropay: {
-								label: 'Giropay',
-								forceNetworkSavedCards: false,
-							},
-						};
-					}
-				} );
-
-				mockDomElement.dataset.paymentMethodType = 'giropay';
-
-				await mountStripePaymentElement(
-					apiMock,
-					mockDomElement,
-					elementsLocation
-				);
-
-				expect( getUPEConfig ).toHaveBeenCalledWith( expectedProperty );
-				expect( getAppearance ).not.toHaveBeenCalled();
-				expect( apiMock.saveUPEAppearance ).not.toHaveBeenCalled();
 			} );
 		} );
 	} );
@@ -338,13 +262,6 @@ describe( 'Stripe Payment Element mounting', () => {
 		} );
 
 		getUPEConfig.mockImplementation( ( argument ) => {
-			if (
-				argument === 'wcBlocksUPEAppearance' ||
-				argument === 'upeAppearance'
-			) {
-				return {};
-			}
-
 			if ( argument === 'currency' ) {
 				return 'eur';
 			}

--- a/client/checkout/classic/event-handlers.js
+++ b/client/checkout/classic/event-handlers.js
@@ -6,6 +6,7 @@
 import './style.scss';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import { isLinkEnabled } from '../utils/upe';
+import { getIconTheme } from 'wcpay/checkout/utils/icon-theme';
 import {
 	generateCheckoutEventNames,
 	getSelectedUPEGatewayPaymentMethod,
@@ -70,6 +71,7 @@ jQuery( function ( $ ) {
 	} );
 
 	$( document.body ).on( 'updated_checkout', () => {
+		swapDarkIcons();
 		maybeMountStripePaymentElement( 'shortcode_checkout' );
 		injectPaymentMethodLogos();
 	} );
@@ -122,10 +124,12 @@ jQuery( function ( $ ) {
 
 	if ( $addPaymentMethodForm.length ) {
 		maybeMountStripePaymentElement( 'add_payment_method' );
+		swapDarkIcons();
 	}
 
 	if ( $payForOrderForm.length ) {
 		maybeMountStripePaymentElement( 'shortcode_checkout' );
+		swapDarkIcons();
 	}
 
 	$addPaymentMethodForm.on( 'submit', function () {
@@ -370,6 +374,26 @@ jQuery( function ( $ ) {
 
 		// Update on window resize
 		window.addEventListener( 'resize', updateLogos );
+	}
+
+	function swapDarkIcons() {
+		const useDark = getIconTheme( 'classic' ) === 'night';
+
+		document.querySelectorAll( '.wcpay-upe-element' ).forEach( ( el ) => {
+			const type = el.dataset.paymentMethodType;
+			if ( type === 'card' ) {
+				return;
+			}
+			const config = getUPEConfig( 'paymentMethodsConfig' )?.[ type ];
+			const targetIcon = useDark ? config?.darkIcon : config?.icon;
+			if ( targetIcon ) {
+				el.closest( '.wc_payment_method' )
+					?.querySelectorAll( 'label img' )
+					.forEach( ( img ) => {
+						img.src = targetIcon;
+					} );
+			}
+		} );
 	}
 
 	function processPaymentIfNotUsingSavedMethod( $form ) {

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -8,6 +8,11 @@ import { __ } from '@wordpress/i18n';
  */
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import { getAppearance, getFontRulesFromPage } from '../upe-styles';
+import {
+	getCachedAppearance,
+	setCachedAppearance,
+	dispatchAppearanceEvent,
+} from 'wcpay/utils/appearance-cache';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 import {
 	appendFingerprintInputToForm,
@@ -43,30 +48,22 @@ for ( const paymentMethodType in getUPEConfig( 'paymentMethodsConfig' ) ) {
 }
 
 /**
- * Initializes the appearance of the payment element by retrieving the UPE configuration
- * from the API and saving the appearance if it doesn't exist. If the appearance already exists,
- * it is simply returned.
+ * Initializes the appearance of the payment element by computing it from the DOM.
  *
- * @param {Object} api The API object used to save the UPE configuration.
  * @param {string} elementsLocation The location of the UPE elements.
- * @return {Promise<Object>} The appearance object for the UPE.
+ * @return {Object} The appearance object for the UPE.
  */
-async function initializeAppearance( api, elementsLocation ) {
-	const upeConfigMap = {
-		shortcode_checkout: 'upeAppearance',
-		add_payment_method: 'upeAddPaymentMethodAppearance',
-	};
-	const upeConfigProperty =
-		upeConfigMap[ elementsLocation ] ?? 'upeAppearance';
-	const appearance = getUPEConfig( upeConfigProperty );
-	if ( appearance ) {
-		return Promise.resolve( appearance );
+function initializeAppearance( elementsLocation ) {
+	const version = getUPEConfig( 'stylesCacheVersion' );
+	const cached = getCachedAppearance( elementsLocation, version );
+	if ( cached ) {
+		return cached;
 	}
 
-	return await api.saveUPEAppearance(
-		getAppearance( elementsLocation ),
-		elementsLocation
-	);
+	const appearance = getAppearance( elementsLocation );
+	dispatchAppearanceEvent( appearance, elementsLocation );
+	setCachedAppearance( elementsLocation, version, appearance );
+	return appearance;
 }
 
 /**
@@ -251,7 +248,7 @@ async function createStripePaymentElement(
 ) {
 	const amount = Number( getUPEConfig( 'cartTotal' ) );
 	const paymentMethodTypes = getPaymentMethodTypes( paymentMethodType );
-	const appearance = await initializeAppearance( api, elementsLocation );
+	const appearance = initializeAppearance( elementsLocation );
 	document
 		.querySelector(
 			`.wcpay-upe-element[data-payment-method-type="${ paymentMethodType }"]`

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -112,8 +112,11 @@ export const getBackgroundColor = ( selectors, scope = document ) => {
 
 		const bgColor = windowObject.getComputedStyle( element )
 			.backgroundColor;
-		// If backgroundColor property present and alpha > 0.
-		if ( bgColor && tinycolor( bgColor ).getAlpha() > 0 ) {
+		// Accept colors that are mostly opaque (alpha >= 0.5).  Low-alpha
+		// values like rgba(129,110,153,0.14) are decorative overlays, not
+		// real backgrounds — skip them so we fall through to the actual
+		// page background beneath.
+		if ( bgColor && tinycolor( bgColor ).getAlpha() >= 0.5 ) {
 			color = bgColor;
 		}
 		i++;
@@ -124,11 +127,28 @@ export const getBackgroundColor = ( selectors, scope = document ) => {
 /**
  * Determines whether background color is light or dark.
  *
+ * When the color has an alpha channel (e.g. rgba), it is composited against
+ * white first, since that is the default page background.  Without this,
+ * a low-opacity dark color like rgba(129,110,153,0.14) would be reported as
+ * "dark" even though it appears nearly white to the user.
+ *
  * @param {string} color CSS color value.
  * @return {boolean} True, if background is light; false, if background is dark.
  */
 export const isColorLight = ( color ) => {
-	return tinycolor( color ).getBrightness() > 125;
+	const tc = tinycolor( color );
+	const alpha = tc.getAlpha();
+	if ( alpha < 1 ) {
+		// Composite against white (#fff) using "source over" blending.
+		const rgb = tc.toRgb();
+		const blended = tinycolor( {
+			r: Math.round( rgb.r * alpha + 255 * ( 1 - alpha ) ),
+			g: Math.round( rgb.g * alpha + 255 * ( 1 - alpha ) ),
+			b: Math.round( rgb.b * alpha + 255 * ( 1 - alpha ) ),
+		} );
+		return blended.getBrightness() > 125;
+	}
+	return tc.getBrightness() > 125;
 };
 
 /**

--- a/client/checkout/utils/icon-theme.js
+++ b/client/checkout/utils/icon-theme.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getBackgroundColor,
+	isColorLight,
+} from 'wcpay/checkout/upe-styles/utils';
+
+/**
+ * Classic checkout: skips .payment_box which may have an explicit light
+ * background even on dark themes. Icons sit in the <label> above
+ * .payment_box, so we check page-level containers instead.
+ */
+const classicIconBackgroundSelectors = [
+	'#payment',
+	'#order_review',
+	'form.checkout',
+	'body',
+];
+
+/**
+ * Blocks checkout: icons sit in the same background as the payment elements.
+ */
+const blocksIconBackgroundSelectors = [
+	'#payment-method .wc-block-components-radio-control-accordion-option',
+	'#payment-method',
+	'form.wc-block-checkout__form',
+	'.wc-block-checkout',
+	'body',
+];
+
+/**
+ * Detects whether the icon background is light or dark for a given checkout
+ * context and returns the matching Stripe appearance theme name.
+ *
+ * @param {'classic'|'blocks'} context The checkout context.
+ * @return {'stripe'|'night'} The theme to use for payment method icons.
+ */
+export function getIconTheme( context ) {
+	const selectors =
+		context === 'classic'
+			? classicIconBackgroundSelectors
+			: blocksIconBackgroundSelectors;
+	const bgColor = getBackgroundColor( selectors );
+	return isColorLight( bgColor ) ? 'stripe' : 'night';
+}

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -282,7 +282,6 @@ declare global {
 		wcAjaxUrl: string;
 		createSetupIntentNonce: string;
 		initWooPayNonce: string;
-		saveUPEAppearanceNonce: string;
 		genericErrorMessage: string;
 		fraudServices: unknown[];
 		features: string[];
@@ -308,13 +307,6 @@ declare global {
 		gatewayId: string;
 		isCheckout: boolean;
 		paymentMethodsConfig: typeof wooPaymentsPaymentMethodsConfig;
-		upeAppearance: string | false;
-		upeAddPaymentMethodAppearance: string | false;
-		upeBnplProductPageAppearance: string | false;
-		upeBnplClassicCartAppearance: string | false;
-		upeBnplCartBlockAppearance: string | false;
-		wcBlocksUPEAppearance: string | false;
-		wcBlocksUPEAppearanceTheme: string | false;
 		cartContainsSubscription: boolean;
 		currency: string;
 		cartTotal: number;
@@ -326,6 +318,7 @@ declare global {
 		>;
 		storeCountry: string;
 		isExpressCheckoutInPaymentMethodsEnabled: boolean;
+		stylesCacheVersion: string;
 		isOrderPay?: boolean;
 		orderId?: number;
 		isChangingPayment?: boolean;

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -5,43 +5,17 @@
 import './style.scss';
 import WCPayAPI from 'wcpay/checkout/api';
 import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
-import { getUPEConfig } from 'wcpay/utils/checkout';
+import {
+	getCachedAppearance,
+	setCachedAppearance,
+	dispatchAppearanceEvent,
+} from 'wcpay/utils/appearance-cache';
 import apiRequest from 'wcpay/checkout/utils/request';
 
 const elementsLocations = {
-	bnplProductPage: {
-		configKey: 'upeBnplProductPageAppearance',
-		appearanceKey: 'bnpl_product_page',
-	},
-	bnplClassicCart: {
-		configKey: 'upeBnplClassicCartAppearance',
-		appearanceKey: 'bnpl_classic_cart',
-	},
+	bnplProductPage: 'bnpl_product_page',
+	bnplClassicCart: 'bnpl_classic_cart',
 };
-
-/**
- * Initializes the appearance of the payment element by retrieving the UPE configuration
- * from the API and saving the appearance if it doesn't exist. If the appearance already exists,
- * it is simply returned.
- *
- * @param {Object} api The API object used to save the UPE configuration.
- * @param {string} location The location of the UPE.
- *
- * @return {Promise<Object>} The appearance object for the UPE.
- */
-async function initializeAppearance( api, location ) {
-	const { configKey, appearanceKey } = elementsLocations[ location ];
-
-	const appearance = getUPEConfig( configKey );
-	if ( appearance ) {
-		return Promise.resolve( appearance );
-	}
-
-	return await api.saveUPEAppearance(
-		getAppearance( appearanceKey ),
-		appearanceKey
-	);
-}
 
 export const initializeBnplSiteMessaging = async () => {
 	const {
@@ -90,8 +64,17 @@ export const initializeBnplSiteMessaging = async () => {
 		countryCode: country, // Customer's country or base country of the store.
 	};
 
+	const location = elementsLocations[ elementLocation ];
+	const cacheVersion = window.wcpayStripeSiteMessaging.stylesCacheVersion;
+	let appearance = getCachedAppearance( location, cacheVersion );
+	if ( ! appearance ) {
+		appearance = getAppearance( location );
+		dispatchAppearanceEvent( appearance, location );
+		setCachedAppearance( location, cacheVersion, appearance );
+	}
+
 	const elementsOptions = {
-		appearance: await initializeAppearance( api, elementLocation ),
+		appearance,
 		fonts: getFontRulesFromPage(),
 	};
 

--- a/client/utils/__tests__/appearance-cache.test.js
+++ b/client/utils/__tests__/appearance-cache.test.js
@@ -1,0 +1,177 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getCachedAppearance,
+	setCachedAppearance,
+	getCachedTheme,
+	dispatchAppearanceEvent,
+} from '../appearance-cache';
+
+describe( 'Appearance cache', () => {
+	const mockAppearance = {
+		variables: { colorBackground: '#fff' },
+		theme: 'stripe',
+		labels: 'floating',
+		rules: {},
+	};
+
+	beforeEach( () => {
+		localStorage.clear();
+	} );
+
+	describe( 'getCachedAppearance', () => {
+		test( 'returns null when no cached value exists', () => {
+			expect( getCachedAppearance( 'blocks_checkout', 'v1' ) ).toBeNull();
+		} );
+
+		test( 'returns appearance when version matches', () => {
+			localStorage.setItem(
+				'wcpay_appearance_blocks_checkout',
+				JSON.stringify( {
+					version: 'v1',
+					appearance: mockAppearance,
+				} )
+			);
+
+			expect( getCachedAppearance( 'blocks_checkout', 'v1' ) ).toEqual(
+				mockAppearance
+			);
+		} );
+
+		test( 'returns null when version does not match', () => {
+			localStorage.setItem(
+				'wcpay_appearance_blocks_checkout',
+				JSON.stringify( {
+					version: 'v1',
+					appearance: mockAppearance,
+				} )
+			);
+
+			expect( getCachedAppearance( 'blocks_checkout', 'v2' ) ).toBeNull();
+		} );
+
+		test( 'returns null when stored data is corrupt', () => {
+			localStorage.setItem(
+				'wcpay_appearance_blocks_checkout',
+				'not-valid-json'
+			);
+
+			expect( getCachedAppearance( 'blocks_checkout', 'v1' ) ).toBeNull();
+		} );
+
+		test( 'returns null when localStorage throws', () => {
+			const original = Storage.prototype.getItem;
+			Storage.prototype.getItem = jest.fn( () => {
+				throw new Error( 'Access denied' );
+			} );
+
+			expect( getCachedAppearance( 'blocks_checkout', 'v1' ) ).toBeNull();
+
+			Storage.prototype.getItem = original;
+		} );
+	} );
+
+	describe( 'setCachedAppearance', () => {
+		test( 'stores appearance with version in localStorage', () => {
+			setCachedAppearance( 'blocks_checkout', 'v1', mockAppearance );
+
+			const stored = JSON.parse(
+				localStorage.getItem( 'wcpay_appearance_blocks_checkout' )
+			);
+			expect( stored ).toEqual( {
+				version: 'v1',
+				appearance: mockAppearance,
+			} );
+		} );
+
+		test( 'uses location-specific cache keys', () => {
+			setCachedAppearance( 'bnpl_product_page', 'v1', mockAppearance );
+
+			expect(
+				localStorage.getItem( 'wcpay_appearance_bnpl_product_page' )
+			).not.toBeNull();
+			expect(
+				localStorage.getItem( 'wcpay_appearance_blocks_checkout' )
+			).toBeNull();
+		} );
+
+		test( 'does not throw when localStorage is unavailable', () => {
+			const original = Storage.prototype.setItem;
+			Storage.prototype.setItem = jest.fn( () => {
+				throw new Error( 'Quota exceeded' );
+			} );
+
+			expect( () => {
+				setCachedAppearance( 'blocks_checkout', 'v1', mockAppearance );
+			} ).not.toThrow();
+
+			Storage.prototype.setItem = original;
+		} );
+	} );
+
+	describe( 'getCachedTheme', () => {
+		test( 'returns theme from cached appearance', () => {
+			setCachedAppearance( 'blocks_checkout', 'v1', {
+				variables: {},
+				theme: 'night',
+				labels: 'floating',
+				rules: {},
+			} );
+
+			expect( getCachedTheme( 'blocks_checkout', 'v1' ) ).toBe( 'night' );
+		} );
+
+		test( 'returns null when no cached value exists', () => {
+			expect( getCachedTheme( 'blocks_checkout', 'v1' ) ).toBeNull();
+		} );
+
+		test( 'returns null when version does not match', () => {
+			setCachedAppearance( 'blocks_checkout', 'v1', {
+				variables: {},
+				theme: 'night',
+				labels: 'floating',
+				rules: {},
+			} );
+
+			expect( getCachedTheme( 'blocks_checkout', 'v2' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'dispatchAppearanceEvent', () => {
+		test( 'dispatches a CustomEvent with appearance and elementsLocation', () => {
+			const handler = jest.fn();
+			document.addEventListener( 'wcpay_elements_appearance', handler );
+
+			const appearance = { theme: 'stripe', rules: {} };
+			dispatchAppearanceEvent( appearance, 'blocks_checkout' );
+
+			expect( handler ).toHaveBeenCalledTimes( 1 );
+			const event = handler.mock.calls[ 0 ][ 0 ];
+			expect( event.detail.appearance ).toBe( appearance );
+			expect( event.detail.elementsLocation ).toBe( 'blocks_checkout' );
+
+			document.removeEventListener(
+				'wcpay_elements_appearance',
+				handler
+			);
+		} );
+
+		test( 'allows listeners to mutate the appearance object', () => {
+			const handler = ( event ) => {
+				event.detail.appearance.theme = 'night';
+			};
+			document.addEventListener( 'wcpay_elements_appearance', handler );
+
+			const appearance = { theme: 'stripe', rules: {} };
+			dispatchAppearanceEvent( appearance, 'blocks_checkout' );
+
+			expect( appearance.theme ).toBe( 'night' );
+
+			document.removeEventListener(
+				'wcpay_elements_appearance',
+				handler
+			);
+		} );
+	} );
+} );

--- a/client/utils/appearance-cache.js
+++ b/client/utils/appearance-cache.js
@@ -1,0 +1,78 @@
+const CACHE_KEY_PREFIX = 'wcpay_appearance_';
+
+function getCacheKey( location ) {
+	return CACHE_KEY_PREFIX + location;
+}
+
+/**
+ * Retrieves a cached Stripe Elements appearance from localStorage.
+ *
+ * @param {string} location The elements location (e.g. 'blocks_checkout').
+ * @param {string} version  The current cache version for invalidation.
+ * @return {Object|null} The cached appearance object, or null on miss/mismatch.
+ */
+export function getCachedAppearance( location, version ) {
+	try {
+		const raw = localStorage.getItem( getCacheKey( location ) );
+		if ( ! raw ) {
+			return null;
+		}
+		const cached = JSON.parse( raw );
+		if ( cached?.version === version ) {
+			return cached.appearance;
+		}
+	} catch {
+		// Silent failure (private browsing, quota exceeded, corrupt data, etc.)
+	}
+	return null;
+}
+
+/**
+ * Stores a Stripe Elements appearance in localStorage.
+ *
+ * @param {string} location   The elements location (e.g. 'blocks_checkout').
+ * @param {string} version    The current cache version for invalidation.
+ * @param {Object} appearance The appearance object to cache.
+ */
+export function setCachedAppearance( location, version, appearance ) {
+	try {
+		localStorage.setItem(
+			getCacheKey( location ),
+			JSON.stringify( { version, appearance } )
+		);
+	} catch {
+		// Silent failure
+	}
+}
+
+/**
+ * Retrieves only the theme from a cached Stripe Elements appearance.
+ *
+ * @param {string} location The elements location (e.g. 'blocks_checkout').
+ * @param {string} version  The current cache version for invalidation.
+ * @return {string|null} The cached theme ('stripe' or 'night'), or null on miss/mismatch.
+ */
+export function getCachedTheme( location, version ) {
+	const appearance = getCachedAppearance( location, version );
+	return appearance?.theme ?? null;
+}
+
+/**
+ * Dispatches a synchronous CustomEvent that allows merchants to modify
+ * the appearance object before it is cached and passed to Stripe Elements.
+ *
+ * Merchants hook in via:
+ *   document.addEventListener( 'wcpay_elements_appearance', ( event ) => {
+ *     event.detail.appearance.theme = 'night';
+ *   } );
+ *
+ * @param {Object} appearance       The appearance object (mutated in-place by listeners).
+ * @param {string} elementsLocation The location identifier (e.g. 'blocks_checkout').
+ */
+export function dispatchAppearanceEvent( appearance, elementsLocation ) {
+	document.dispatchEvent(
+		new CustomEvent( 'wcpay_elements_appearance', {
+			detail: { appearance, elementsLocation },
+		} )
+	);
+}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -112,37 +112,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	const USER_FORMATTED_TOKENS_LIMIT = 100;
 
-	const PROCESS_REDIRECT_ORDER_MISMATCH_ERROR_CODE        = 'upe_process_redirect_order_id_mismatched';
-	const UPE_APPEARANCE_TRANSIENT                          = 'wcpay_upe_appearance';
-	const UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT       = 'wcpay_upe_add_payment_method_appearance';
-	const WC_BLOCKS_UPE_APPEARANCE_TRANSIENT                = 'wcpay_wc_blocks_upe_appearance';
-	const UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT        = 'wcpay_upe_bnpl_product_page_appearance';
-	const UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT        = 'wcpay_upe_bnpl_classic_cart_appearance';
-	const UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT          = 'wcpay_upe_bnpl_cart_block_appearance';
-	const UPE_APPEARANCE_THEME_TRANSIENT                    = 'wcpay_upe_appearance_theme';
-	const UPE_ADD_PAYMENT_METHOD_APPEARANCE_THEME_TRANSIENT = 'wcpay_upe_add_payment_method_appearance_theme';
-	const WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT          = 'wcpay_wc_blocks_upe_appearance_theme';
-	const UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT  = 'wcpay_upe_bnpl_product_page_appearance_theme';
-	const UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT  = 'wcpay_upe_bnpl_classic_cart_appearance_theme';
-	const UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT    = 'wcpay_upe_bnpl_cart_block_appearance_theme';
-
-	/**
-	 * The locations of appearance transients.
-	 */
-	const APPEARANCE_THEME_TRANSIENTS = [
-		'checkout'     => [
-			'blocks'  => self::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT,
-			'classic' => self::UPE_APPEARANCE_THEME_TRANSIENT,
-		],
-		'product_page' => [
-			'blocks'  => self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT,
-			'classic' => self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT,
-		],
-		'cart'         => [
-			'blocks'  => self::UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT,
-			'classic' => self::UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT,
-		],
-	];
+	const PROCESS_REDIRECT_ORDER_MISMATCH_ERROR_CODE = 'upe_process_redirect_order_id_mismatched';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -4375,102 +4345,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return array_values( array_intersect( $available_methods, $methods_with_fees ) );
 	}
 
-	/**
-	 * Handle AJAX request for saving UPE appearance value to transient.
-	 *
-	 * @throws Exception - If nonce or setup intent is invalid.
-	 */
-	public function save_upe_appearance_ajax() {
-		try {
-			$is_nonce_valid = check_ajax_referer( 'wcpay_save_upe_appearance_nonce', false, false );
-			if ( ! $is_nonce_valid ) {
-				throw new Exception(
-					__( 'Unable to update UPE appearance values at this time.', 'woocommerce-payments' )
-				);
-			}
 
-			$elements_location = isset( $_POST['elements_location'] ) ? wc_clean( wp_unslash( $_POST['elements_location'] ) ) : null;
-			$appearance        = isset( $_POST['appearance'] ) ? json_decode( wc_clean( wp_unslash( $_POST['appearance'] ) ) ) : null;
-
-			$valid_locations = [ 'blocks_checkout', 'shortcode_checkout', 'bnpl_product_page', 'bnpl_classic_cart', 'bnpl_cart_block', 'add_payment_method' ];
-			if ( ! $elements_location || ! in_array( $elements_location, $valid_locations, true ) ) {
-				throw new Exception(
-					__( 'Unable to update UPE appearance values at this time.', 'woocommerce-payments' )
-				);
-			}
-
-			if ( in_array( $elements_location, [ 'blocks_checkout', 'shortcode_checkout' ], true ) ) {
-				$is_blocks_checkout = 'blocks_checkout' === $elements_location;
-				/**
-				 * This filter is only called on "save" of the appearance, to avoid calling it on every page load.
-				 * If you apply changes through this filter, you'll need to clear the transient data to see them at checkout.
-				 *
-				 * @deprecated 7.4.0 Use {@see 'wcpay_elements_appearance'} instead.
-				 * @since 7.3.0
-				 */
-				$appearance = apply_filters_deprecated( 'wcpay_upe_appearance', [ $appearance, $is_blocks_checkout ], '7.4.0', 'wcpay_elements_appearance' );
-			}
-
-			/**
-			 * This filter is only called on "save" of the appearance, to avoid calling it on every page load.
-			 * If you apply changes through this filter, you'll need to clear the transient data to see them at checkout.
-			 * $elements_location can be 'blocks_checkout', 'shortcode_checkout', 'bnpl_product_page', 'bnpl_classic_cart', 'bnpl_cart_block', 'add_payment_method'.
-			 *
-			 * @since 7.4.0
-			 */
-			$appearance = apply_filters( 'wcpay_elements_appearance', $appearance, $elements_location );
-
-			$appearance_transient       = [
-				'shortcode_checkout' => self::UPE_APPEARANCE_TRANSIENT,
-				'add_payment_method' => self::UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT,
-				'blocks_checkout'    => self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT,
-				'bnpl_product_page'  => self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT,
-				'bnpl_classic_cart'  => self::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT,
-				'bnpl_cart_block'    => self::UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT,
-			][ $elements_location ];
-			$appearance_theme_transient = [
-				'shortcode_checkout' => self::UPE_APPEARANCE_THEME_TRANSIENT,
-				'add_payment_method' => self::UPE_ADD_PAYMENT_METHOD_APPEARANCE_THEME_TRANSIENT,
-				'blocks_checkout'    => self::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT,
-				'bnpl_product_page'  => self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT,
-				'bnpl_classic_cart'  => self::UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT,
-				'bnpl_cart_block'    => self::UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT,
-			][ $elements_location ];
-
-			if ( null !== $appearance ) {
-				set_transient( $appearance_transient, $appearance, DAY_IN_SECONDS );
-				set_transient( $appearance_theme_transient, $appearance->theme, DAY_IN_SECONDS );
-			}
-
-			wp_send_json_success( $appearance, 200 );
-		} catch ( Exception $e ) {
-			// Send back error so it can be displayed to the customer.
-			wp_send_json_error(
-				[
-					'error' => [
-						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
-					],
-				],
-				WC_Payments_Utils::get_filtered_error_status_code( $e )
-			);
-		}
-	}
-
-	/**
-	 * Clear the saved UPE appearance transient value.
-	 */
-	public function clear_upe_appearance_transient() {
-		delete_transient( self::UPE_APPEARANCE_TRANSIENT );
-		delete_transient( self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
-		delete_transient( self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT );
-		delete_transient( self::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT );
-		delete_transient( self::UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT );
-		delete_transient( self::UPE_APPEARANCE_THEME_TRANSIENT );
-		delete_transient( self::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT );
-		delete_transient( self::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_THEME_TRANSIENT );
-		delete_transient( self::UPE_BNPL_CLASSIC_CART_APPEARANCE_THEME_TRANSIENT );
-		delete_transient( self::UPE_BNPL_CART_BLOCK_APPEARANCE_THEME_TRANSIENT );
-	}
 
 	/**
 	 * Returns true if the code returned from the API represents an error that should be rate-limited.
@@ -4646,15 +4521,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Checks if UPE appearance theme is set and returns appropriate icon URL.
+	 * Returns the appropriate icon URL for the payment method.
 	 *
 	 * @return string
 	 */
 	public function get_theme_icon() {
-		$upe_appearance_theme = get_transient( self::UPE_APPEARANCE_THEME_TRANSIENT );
-		if ( $upe_appearance_theme ) {
-			return 'night' === $upe_appearance_theme ? $this->payment_method->get_dark_icon() : $this->payment_method->get_icon();
-		}
 		return $this->payment_method->get_icon();
 	}
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -96,10 +96,6 @@ class WC_Payments_Checkout {
 		add_action( 'wc_payments_set_gateway', [ $this, 'set_gateway' ] );
 		add_action( 'wc_payments_add_upe_payment_fields', [ $this, 'payment_fields' ] );
 		add_action( 'wp', [ $this->gateway, 'maybe_process_upe_redirect' ] );
-		add_action( 'wp_ajax_save_upe_appearance', [ $this->gateway, 'save_upe_appearance_ajax' ] );
-		add_action( 'wp_ajax_nopriv_save_upe_appearance', [ $this->gateway, 'save_upe_appearance_ajax' ] );
-		add_action( 'switch_theme', [ $this->gateway, 'clear_upe_appearance_transient' ] );
-		add_action( 'woocommerce_woocommerce_payments_updated', [ $this->gateway, 'clear_upe_appearance_transient' ] );
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts_for_zero_order_total' ], 11 );
@@ -191,7 +187,6 @@ class WC_Payments_Checkout {
 			'wcAjaxUrl'                         => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'createSetupIntentNonce'            => wp_create_nonce( 'wcpay_create_setup_intent_nonce' ),
 			'initWooPayNonce'                   => wp_create_nonce( 'wcpay_init_woopay_nonce' ),
-			'saveUPEAppearanceNonce'            => wp_create_nonce( 'wcpay_save_upe_appearance_nonce' ),
 			'genericErrorMessage'               => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),
 			'fraudServices'                     => $this->fraud_service->get_fraud_services_config(),
 			'features'                          => $this->gateway->supports,
@@ -218,21 +213,15 @@ class WC_Payments_Checkout {
 
 		$payment_fields = $js_config;
 
-		$payment_fields['gatewayId']                     = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$payment_fields['isCheckout']                    = is_checkout();
-		$payment_fields['paymentMethodsConfig']          = $this->get_enabled_payment_method_config();
-		$payment_fields['testMode']                      = WC_Payments::mode()->is_test();
-		$payment_fields['upeAppearance']                 = get_transient( WC_Payment_Gateway_WCPay::UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['upeAddPaymentMethodAppearance'] = get_transient( WC_Payment_Gateway_WCPay::UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplProductPageAppearance']  = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplClassicCartAppearance']  = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT );
-		$payment_fields['upeBnplCartBlockAppearance']    = get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CART_BLOCK_APPEARANCE_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearance']         = get_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearanceTheme']    = get_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT );
-		$payment_fields['cartContainsSubscription']      = $this->gateway->is_subscription_item_in_cart();
-		$payment_fields['currency']                      = get_woocommerce_currency();
-		$cart_total                                      = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
-		$payment_fields['cartTotal']                     = WC_Payments_Utils::prepare_amount( $cart_total, get_woocommerce_currency() );
+		$payment_fields['gatewayId']                = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$payment_fields['isCheckout']               = is_checkout();
+		$payment_fields['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
+		$payment_fields['testMode']                 = WC_Payments::mode()->is_test();
+		$payment_fields['cartContainsSubscription'] = $this->gateway->is_subscription_item_in_cart();
+		$payment_fields['currency']                 = get_woocommerce_currency();
+		$payment_fields['stylesCacheVersion']       = WC_Payments_Utils::get_styles_cache_version();
+		$cart_total                                 = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
+		$payment_fields['cartTotal']                = WC_Payments_Utils::prepare_amount( $cart_total, get_woocommerce_currency() );
 
 		$enabled_billing_fields = [];
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
@@ -386,70 +375,6 @@ class WC_Payments_Checkout {
 	}
 
 	/**
-	 * Gets the config for a payment method.
-	 *
-	 * @param string $payment_method_id The payment method ID.
-	 * @param string $account_country The account country.
-	 * @return array
-	 */
-	private function get_config_for_payment_method( $payment_method_id, $account_country ) {
-		$payment_method = $this->gateway->wc_payments_get_payment_method_by_id( $payment_method_id );
-
-		if ( ! $payment_method ) {
-			return [];
-		}
-
-		$config = [
-			'isReusable'        => $payment_method->is_reusable(),
-			'isBnpl'            => $payment_method->is_bnpl(),
-			'isExpressCheckout' => $payment_method->is_express_checkout(),
-			'title'             => $payment_method->get_title( $account_country ),
-			'icon'              => $payment_method->get_icon( $account_country ),
-			'darkIcon'          => $payment_method->get_dark_icon( $account_country ),
-			'showSaveOption'    => $this->should_upe_payment_method_show_save_option( $payment_method ),
-			'countries'         => $payment_method->get_countries(),
-		];
-
-		$gateway_for_payment_method = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
-		if ( ! $gateway_for_payment_method ) {
-			return [];
-		}
-		$config['gatewayId']           = $gateway_for_payment_method->id;
-		$config['testingInstructions'] = WC_Payments_Utils::esc_interpolated_html(
-			/* translators: link to Stripe testing page */
-			$payment_method->get_testing_instructions( $account_country ),
-			[
-				'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
-				'strong' => '<strong>',
-				'number' => '<button type="button" class="js-woopayments-copy-test-number" aria-label="' . esc_attr( __( 'Click to copy the test number to clipboard', 'woocommerce-payments' ) ) . '" title="' . esc_attr( __( 'Copy to clipboard', 'woocommerce-payments' ) ) . '"><i></i><span>',
-			]
-		);
-
-		$should_enable_network_saved_cards = Payment_Method::CARD === $payment_method_id && WC_Payments::is_network_saved_cards_enabled();
-		$config['forceNetworkSavedCards']  = $should_enable_network_saved_cards || $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
-
-		return $config;
-	}
-
-	/**
-	 * Checks if the save option for a payment method should be displayed or not.
-	 *
-	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
-	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
-	 */
-	private function should_upe_payment_method_show_save_option( $payment_method ) {
-		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
-			return false;
-		}
-
-		if ( $payment_method->is_reusable() ) {
-			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
-		}
-
-		return false;
-	}
-
-	/**
 	 * Renders the UPE input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.
@@ -587,6 +512,70 @@ class WC_Payments_Checkout {
 		if ( null !== $payment_method_id ) {
 			$this->gateway = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
 		}
+	}
+
+	/**
+	 * Gets the config for a payment method.
+	 *
+	 * @param string $payment_method_id The payment method ID.
+	 * @param string $account_country The account country.
+	 * @return array
+	 */
+	private function get_config_for_payment_method( $payment_method_id, $account_country ) {
+		$payment_method = $this->gateway->wc_payments_get_payment_method_by_id( $payment_method_id );
+
+		if ( ! $payment_method ) {
+			return [];
+		}
+
+		$config = [
+			'isReusable'        => $payment_method->is_reusable(),
+			'isBnpl'            => $payment_method->is_bnpl(),
+			'isExpressCheckout' => $payment_method->is_express_checkout(),
+			'title'             => $payment_method->get_title( $account_country ),
+			'icon'              => $payment_method->get_icon( $account_country ),
+			'darkIcon'          => $payment_method->get_dark_icon( $account_country ),
+			'showSaveOption'    => $this->should_upe_payment_method_show_save_option( $payment_method ),
+			'countries'         => $payment_method->get_countries(),
+		];
+
+		$gateway_for_payment_method = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
+		if ( ! $gateway_for_payment_method ) {
+			return [];
+		}
+		$config['gatewayId']           = $gateway_for_payment_method->id;
+		$config['testingInstructions'] = WC_Payments_Utils::esc_interpolated_html(
+			/* translators: link to Stripe testing page */
+			$payment_method->get_testing_instructions( $account_country ),
+			[
+				'a'      => '<a href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
+				'strong' => '<strong>',
+				'number' => '<button type="button" class="js-woopayments-copy-test-number" aria-label="' . esc_attr( __( 'Click to copy the test number to clipboard', 'woocommerce-payments' ) ) . '" title="' . esc_attr( __( 'Copy to clipboard', 'woocommerce-payments' ) ) . '"><i></i><span>',
+			]
+		);
+
+		$should_enable_network_saved_cards = Payment_Method::CARD === $payment_method_id && WC_Payments::is_network_saved_cards_enabled();
+		$config['forceNetworkSavedCards']  = $should_enable_network_saved_cards || $gateway_for_payment_method->should_use_stripe_platform_on_checkout_page();
+
+		return $config;
+	}
+
+	/**
+	 * Checks if the save option for a payment method should be displayed or not.
+	 *
+	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
+	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
+	 */
+	private function should_upe_payment_method_show_save_option( $payment_method ) {
+		if ( $payment_method->get_id() === Payment_Method::CARD && is_user_logged_in() && WC_Payments_Features::is_woopay_enabled() ) {
+			return false;
+		}
+
+		if ( $payment_method->is_reusable() ) {
+			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -233,10 +233,14 @@ class WC_Payments_Order_Success_Page {
 			return 'Payment Request';
 		}
 
+		$icon_url      = $payment_method->get_icon();
+		$dark_icon_url = $payment_method->get_dark_icon();
+		$dark_attr     = $dark_icon_url !== $icon_url ? ' data-dark-src="' . esc_url_raw( $dark_icon_url ) . '"' : '';
+
 		ob_start();
 		?>
 		<div class="wc-payment-gateway-method-logo-wrapper wc-payment-card-logo">
-			<img alt="<?php echo esc_attr( $payment_method->get_title() ); ?>" src="<?php echo esc_url_raw( $payment_method->get_icon() ); ?>">
+			<img alt="<?php echo esc_attr( $payment_method->get_title() ); ?>" src="<?php echo esc_url_raw( $icon_url ); ?>"<?php echo $dark_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php
 			if ( $order->get_meta( 'last4' ) ) {
 				echo esc_html_e( '•••', 'woocommerce-payments' ) . ' ';
@@ -312,10 +316,11 @@ class WC_Payments_Order_Success_Page {
 	 * @return string|false
 	 */
 	public function show_lpm_payment_method_name( $gateway, $payment_method ) {
+		$account_country = $gateway->get_account_country();
 		$method_logo_url = apply_filters_deprecated(
 			'wc_payments_thank_you_page_bnpl_payment_method_logo_url',
 			[
-				$payment_method->get_payment_method_icon_for_location( 'checkout', false, $gateway->get_account_country() ),
+				$payment_method->get_icon( $account_country ),
 				$payment_method->get_id(),
 			],
 			'8.5.0',
@@ -332,10 +337,13 @@ class WC_Payments_Order_Success_Page {
 			return false;
 		}
 
+		$dark_icon_url = $payment_method->get_dark_icon( $account_country );
+		$dark_attr     = $dark_icon_url !== $method_logo_url ? ' data-dark-src="' . esc_url_raw( $dark_icon_url ) . '"' : '';
+
 		ob_start();
 		?>
 		<div class="wc-payment-gateway-method-logo-wrapper wc-payment-lpm-logo wc-payment-lpm-logo--<?php echo esc_attr( $payment_method->get_id() ); ?>">
-			<img alt="<?php echo esc_attr( $payment_method->get_title() ); ?>" title="<?php echo esc_attr( $payment_method->get_title() ); ?>" src="<?php echo esc_url_raw( $method_logo_url ); ?>">
+			<img alt="<?php echo esc_attr( $payment_method->get_title() ); ?>" title="<?php echo esc_attr( $payment_method->get_title() ); ?>" src="<?php echo esc_url_raw( $method_logo_url ); ?>"<?php echo $dark_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		</div>
 		<?php
 		return ob_get_clean();
@@ -373,40 +381,6 @@ class WC_Payments_Order_Success_Page {
 		}
 
 		return $text;
-	}
-
-	/**
-	 * Formats the additional text to be displayed on the thank you page, with the side effect
-	 * as a workaround for an issue in Woo core 8.1.x and 8.2.x.
-	 *
-	 * @param string $additional_text The additional text to be displayed.
-	 *
-	 * @return string Formatted text.
-	 */
-	private function format_addtional_thankyou_order_received_text( string $additional_text ): string {
-		/**
-		 * This condition is a workaround for Woo core 8.1.x and 8.2.x as it formatted the filtered text,
-		 * while it should format the original text only.
-		 *
-		 * It's safe to remove this conditional when WooPayments requires Woo core 8.3.x or higher.
-		 *
-		 * @see https://github.com/woocommerce/woocommerce/pull/39758 Introduce the issue since 8.1.0.
-		 * @see https://github.com/woocommerce/woocommerce/pull/40353 Fix the issue since 8.3.0.
-		 */
-		if (
-			version_compare( WC_VERSION, '8.0', '>' )
-			&& version_compare( WC_VERSION, '8.3', '<' )
-		) {
-			echo "
-				<script type='text/javascript'>
-					document.querySelector('.woocommerce-thankyou-order-received')?.classList?.add('woocommerce-info');
-				</script>
-			";
-
-			return ' ' . $additional_text;
-		}
-
-		return sprintf( '<div class="woocommerce-info">%s</div>', $additional_text );
 	}
 
 	/**
@@ -481,6 +455,10 @@ class WC_Payments_Order_Success_Page {
 					}
 				</script>
 			";
+		}
+
+		if ( is_order_received_page() || is_view_order_page() ) {
+			$this->output_dark_icon_swap_script();
 		}
 	}
 
@@ -641,5 +619,87 @@ class WC_Payments_Order_Success_Page {
 			<p></p>
 			<?php
 		}
+	}
+
+	/**
+	 * Outputs an inline script that detects dark backgrounds and swaps
+	 * payment method icons to their dark variants on the order success page.
+	 */
+	private function output_dark_icon_swap_script() {
+		?>
+		<script type="text/javascript">
+		(function() {
+			var imgs = document.querySelectorAll( 'img[data-dark-src]' );
+			if ( ! imgs.length ) return;
+
+			var selectors = [
+				'.wc-payment-gateway-method-logo-wrapper',
+				'.woocommerce-order',
+				'.woocommerce',
+				'body'
+			];
+			var bgColor = null;
+			for ( var i = 0; i < selectors.length; i++ ) {
+				var el = document.querySelector( selectors[ i ] );
+				if ( ! el ) continue;
+				var bg = window.getComputedStyle( el ).backgroundColor;
+				if ( bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent' ) {
+					bgColor = bg;
+					break;
+				}
+			}
+			if ( ! bgColor ) return;
+
+			var match = bgColor.match( /\d+/g );
+			if ( ! match || match.length < 3 ) return;
+
+			var r = parseInt( match[0], 10 );
+			var g = parseInt( match[1], 10 );
+			var b = parseInt( match[2], 10 );
+			// sRGB relative luminance.
+			var luminance = ( 0.299 * r + 0.587 * g + 0.114 * b ) / 255;
+
+			if ( luminance < 0.5 ) {
+				imgs.forEach( function( img ) {
+					img.src = img.getAttribute( 'data-dark-src' );
+				});
+			}
+		})();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Formats the additional text to be displayed on the thank you page, with the side effect
+	 * as a workaround for an issue in Woo core 8.1.x and 8.2.x.
+	 *
+	 * @param string $additional_text The additional text to be displayed.
+	 *
+	 * @return string Formatted text.
+	 */
+	private function format_addtional_thankyou_order_received_text( string $additional_text ): string {
+		/**
+		 * This condition is a workaround for Woo core 8.1.x and 8.2.x as it formatted the filtered text,
+		 * while it should format the original text only.
+		 *
+		 * It's safe to remove this conditional when WooPayments requires Woo core 8.3.x or higher.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/pull/39758 Introduce the issue since 8.1.0.
+		 * @see https://github.com/woocommerce/woocommerce/pull/40353 Fix the issue since 8.3.0.
+		 */
+		if (
+			version_compare( WC_VERSION, '8.0', '>' )
+			&& version_compare( WC_VERSION, '8.3', '<' )
+		) {
+			echo "
+				<script type='text/javascript'>
+					document.querySelector('.woocommerce-thankyou-order-received')?.classList?.add('woocommerce-info');
+				</script>
+			";
+
+			return ' ' . $additional_text;
+		}
+
+		return sprintf( '<div class="woocommerce-info">%s</div>', $additional_text );
 	}
 }

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -161,6 +161,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			],
 			'wcAjaxUrl'            => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'shouldInitializePMME' => WC_Payments_Utils::is_any_bnpl_supporting_country( array_values( $bnpl_payment_methods ), $country, $currency_code ),
+			'stylesCacheVersion'   => WC_Payments_Utils::get_styles_cache_version(),
 		];
 
 		if ( $product ) {
@@ -172,25 +173,6 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			'WCPAY_PRODUCT_DETAILS',
 			'wcpayStripeSiteMessaging',
 			$script_data
-		);
-
-		// Ensure wcpayConfig is available in the page with only the keys the product-details script needs.
-		$wcpay_config = rawurlencode(
-			wp_json_encode(
-				[
-					'ajaxUrl'                      => admin_url( 'admin-ajax.php' ),
-					'saveUPEAppearanceNonce'       => wp_create_nonce( 'wcpay_save_upe_appearance_nonce' ),
-					'upeBnplProductPageAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_PRODUCT_PAGE_APPEARANCE_TRANSIENT ),
-					'upeBnplClassicCartAppearance' => get_transient( WC_Payment_Gateway_WCPay::UPE_BNPL_CLASSIC_CART_APPEARANCE_TRANSIENT ),
-				]
-			)
-		);
-		wp_add_inline_script(
-			'WCPAY_PRODUCT_DETAILS',
-			"
-			var wcpayConfig = wcpayConfig || JSON.parse( decodeURIComponent( '" . esc_js( $wcpay_config ) . "' ) );
-			",
-			'before'
 		);
 
 		if ( ! $is_cart_block ) {

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1328,90 +1328,6 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Extract the REST route from the current request URL.
-	 *
-	 * @return string The REST route, or empty string if not found.
-	 */
-	private static function extract_rest_route_from_url(): string {
-		// Extract the request path from the request URL.
-		$url_parts = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		if ( empty( $url_parts['path'] ) ) {
-			return '';
-		}
-
-		$request_path = rtrim( $url_parts['path'], '/' );
-		if ( empty( $request_path ) ) {
-			return '';
-		}
-
-		// Remove the REST API prefix from the request path to end up with the route.
-		$rest_prefix = trailingslashit( rest_get_url_prefix() );
-
-		// For multisite subdirectory setups, we need to handle the subdirectory prefix.
-		// Look for the wp-json prefix in the path and extract everything after it.
-		$wp_json_pos = strpos( $request_path, '/' . rtrim( $rest_prefix, '/' ) );
-		if ( false !== $wp_json_pos ) {
-			return substr( $request_path, $wp_json_pos + strlen( $rest_prefix ) );
-		}
-
-		// Fallback: simple prefix replacement for non-multisite cases.
-		return str_replace( $rest_prefix, '', $request_path );
-	}
-
-	/**
-	 * Gets the current active theme transient for a given location
-	 * Falls back to 'stripe' if no transients are set.
-	 *
-	 * @param string $location The theme location.
-	 * @param string $context The theme location to fall back to if both transients are set.
-	 * @return string
-	 */
-	public static function get_active_upe_theme_transient_for_location( string $location = 'checkout', string $context = 'blocks' ) {
-		$themes       = \WC_Payment_Gateway_WCPay::APPEARANCE_THEME_TRANSIENTS;
-		$active_theme = false;
-
-		// If an invalid location is sent, we fallback to trying $themes[ 'checkout' ][ 'block' ].
-		if ( ! isset( $themes[ $location ] ) ) {
-			$active_theme = get_transient( $themes['checkout']['blocks'] );
-		} elseif ( ! isset( $themes[ $location ][ $context ] ) ) {
-			// If the location is valid but the context is invalid, we fallback to trying $themes[ $location ][ 'block' ].
-			$active_theme = get_transient( $themes[ $location ]['blocks'] );
-		} else {
-			$active_theme = get_transient( $themes[ $location ][ $context ] );
-		}
-
-		// If $active_theme is still false here, that means that $themes[ $location ][ $context ] is not set, so we try $themes[ $location ][ 'classic' ].
-		if ( ! $active_theme ) {
-			$active_theme = get_transient( $themes[ $location ][ 'blocks' === $context ? 'classic' : 'blocks' ] );
-		}
-
-		// If $active_theme is still false here, nothing at the location is set so we'll try all locations.
-		if ( ! $active_theme ) {
-			foreach ( $themes as $location_const => $contexts ) {
-				// We don't need to check the same location again.
-				if ( $location_const === $location ) {
-					continue;
-				}
-
-				foreach ( $contexts as $context => $transient ) {
-					$active_theme = get_transient( $transient );
-					if ( $active_theme ) {
-						break 2; // This will break both loops.
-					}
-				}
-			}
-		}
-
-		// If $active_theme is still false, we don't have any theme set in the transients, so we fallback to 'stripe'.
-		if ( $active_theme ) {
-			return $active_theme;
-		}
-
-		// Fallback to 'stripe' if no transients are set.
-		return 'stripe';
-	}
-
-	/**
 	 * Returns the list of countries in the European Economic Area (EEA).
 	 *
 	 * Based on the list documented at https://www.gov.uk/eu-eea.
@@ -1470,5 +1386,81 @@ class WC_Payments_Utils {
 			$logger = wc_get_logger();
 			$logger->$level( $message, [ 'source' => 'woopayments' ] );
 		}
+	}
+
+	/**
+	 * Returns the styles cache version string used to invalidate localStorage
+	 * appearance caches. Reads from a stored WP option; if missing, computes
+	 * and stores it.
+	 *
+	 * @return string MD5 hash representing the current styles version.
+	 */
+	public static function get_styles_cache_version(): string {
+		$version = get_option( 'wcpay_styles_cache_version' );
+		if ( ! empty( $version ) ) {
+			return $version;
+		}
+
+		$version = self::compute_styles_cache_version();
+		update_option( 'wcpay_styles_cache_version', $version, true );
+		return $version;
+	}
+
+	/**
+	 * Deletes the stored cache version so it recomputes on the next page load.
+	 * Hooked to after_switch_theme, save_post_wp_global_styles, and customize_save_after.
+	 */
+	public static function invalidate_styles_cache_version(): void {
+		delete_option( 'wcpay_styles_cache_version' );
+	}
+
+	/**
+	 * Extract the REST route from the current request URL.
+	 *
+	 * @return string The REST route, or empty string if not found.
+	 */
+	private static function extract_rest_route_from_url(): string {
+		// Extract the request path from the request URL.
+		$url_parts = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		if ( empty( $url_parts['path'] ) ) {
+			return '';
+		}
+
+		$request_path = rtrim( $url_parts['path'], '/' );
+		if ( empty( $request_path ) ) {
+			return '';
+		}
+
+		// Remove the REST API prefix from the request path to end up with the route.
+		$rest_prefix = trailingslashit( rest_get_url_prefix() );
+
+		// For multisite subdirectory setups, we need to handle the subdirectory prefix.
+		// Look for the wp-json prefix in the path and extract everything after it.
+		$wp_json_pos = strpos( $request_path, '/' . rtrim( $rest_prefix, '/' ) );
+		if ( false !== $wp_json_pos ) {
+			return substr( $request_path, $wp_json_pos + strlen( $rest_prefix ) );
+		}
+
+		// Fallback: simple prefix replacement for non-multisite cases.
+		return str_replace( $rest_prefix, '', $request_path );
+	}
+
+	/**
+	 * Computes a fresh styles cache version hash from plugin version,
+	 * theme stylesheet, and global styles (color palettes, style variations).
+	 *
+	 * @return string MD5 hash.
+	 */
+	private static function compute_styles_cache_version(): string {
+		$parts = WCPAY_VERSION_NUMBER . wp_get_theme()->get_stylesheet();
+
+		if ( function_exists( 'wp_get_global_styles' ) ) {
+			$parts .= wp_json_encode( wp_get_global_styles() );
+		}
+
+		// Theme mods capture Customizer changes (classic themes).
+		$parts .= wp_json_encode( get_theme_mods() );
+
+		return md5( $parts );
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -360,6 +360,11 @@ class WC_Payments {
 		add_action( 'admin_init', [ __CLASS__, 'remove_deprecated_notes' ] );
 		add_action( 'init', [ __CLASS__, 'install_actions' ] );
 
+		// Invalidate the styles cache version when theme or styles change.
+		add_action( 'after_switch_theme', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] );
+		add_action( 'save_post_wp_global_styles', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] );
+		add_action( 'customize_save_after', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] );
+
 		add_action( 'woocommerce_blocks_payment_method_type_registration', [ __CLASS__, 'register_checkout_gateway' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'disable_express_checkout_in_block_editor' ], 1 );
 
@@ -709,6 +714,7 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-migrate-payment-request-to-express-checkout-enabled.php';
 		require_once __DIR__ . '/migrations/class-migrate-express-checkout-locations.php';
 		require_once __DIR__ . '/migrations/class-add-amazon-pay-to-express-checkout-locations.php';
+		require_once __DIR__ . '/migrations/class-delete-appearance-transients.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Allowed_Payment_Request_Button_Sizes_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
@@ -724,6 +730,8 @@ class WC_Payments {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Migrate_Payment_Request_To_Express_Checkout_Enabled(), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Migrate_Express_Checkout_Locations(), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Add_Amazon_Pay_To_Express_Checkout_Locations(), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Delete_Appearance_Transients(), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] );
 
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-explicit-price-formatter.php';
 		WC_Payments_Explicit_Price_Formatter::init();

--- a/includes/migrations/class-delete-appearance-transients.php
+++ b/includes/migrations/class-delete-appearance-transients.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class Delete_Appearance_Transients
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Migrations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Delete_Appearance_Transients
+ *
+ * Removes stale UPE appearance transients that were previously used to cache
+ * Stripe Elements appearance data. The server-side transient caching mechanism
+ * has been removed to prevent cache poisoning attacks.
+ *
+ * @since 10.6.0
+ */
+class Delete_Appearance_Transients {
+	/**
+	 * Checks whether it's worth doing the migration.
+	 */
+	public function maybe_migrate() {
+		$previous_version = get_option( 'woocommerce_woocommerce_payments_version' );
+		if ( version_compare( '10.6.0', $previous_version, '>' ) ) {
+			$this->migrate();
+		}
+	}
+
+	/**
+	 * Does the actual migration — deletes all appearance transients.
+	 */
+	private function migrate() {
+		$transient_names = [
+			'wcpay_upe_appearance',
+			'wcpay_upe_add_payment_method_appearance',
+			'wcpay_wc_blocks_upe_appearance',
+			'wcpay_upe_bnpl_product_page_appearance',
+			'wcpay_upe_bnpl_classic_cart_appearance',
+			'wcpay_upe_bnpl_cart_block_appearance',
+			'wcpay_upe_appearance_theme',
+			'wcpay_upe_add_payment_method_appearance_theme',
+			'wcpay_wc_blocks_upe_appearance_theme',
+			'wcpay_upe_bnpl_product_page_appearance_theme',
+			'wcpay_upe_bnpl_classic_cart_appearance_theme',
+			'wcpay_upe_bnpl_cart_block_appearance_theme',
+		];
+
+		foreach ( $transient_names as $transient ) {
+			delete_transient( $transient );
+		}
+	}
+}

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -373,24 +373,6 @@ class UPE_Payment_Method {
 	}
 
 	/**
-	 * Gets the theme appropriate icon for the payment method for a given location and context.
-	 *
-	 * @param string  $location The location to get the icon for.
-	 * @param boolean $is_blocks Whether the icon is for blocks.
-	 * @param string  $account_country Optional account country.
-	 * @return string
-	 */
-	public function get_payment_method_icon_for_location( string $location = 'checkout', bool $is_blocks = true, ?string $account_country = null ) {
-		$appearance_theme = WC_Payments_Utils::get_active_upe_theme_transient_for_location( $location, $is_blocks ? 'blocks' : 'classic' );
-
-		if ( 'night' === $appearance_theme ) {
-			return $this->get_dark_icon( $account_country );
-		}
-
-		return $this->get_icon( $account_country );
-	}
-
-	/**
 	 * Returns payment method supported countries
 	 *
 	 * @return array

--- a/tests/unit/test-class-wc-payments-checkout.php
+++ b/tests/unit/test-class-wc-payments-checkout.php
@@ -545,35 +545,6 @@ class WC_Payments_Checkout_Test extends WP_UnitTestCase {
 			$this->assertSame( true, $this->system_under_test->get_payment_fields_js_config()['paymentMethodsConfig'][ Payment_Method::CARD ]['showSaveOption'] );
 	}
 
-	public function test_upe_appearance_transients() {
-		$this->mock_wcpay_account
-			->method( 'get_account_country' )
-			->willReturn( 'US' );
-		$this->mock_wcpay_gateway
-			->expects( $this->any() )
-			->method( 'get_payment_method_ids_enabled_at_checkout' )
-			->willReturn(
-				[
-					Payment_Method::CARD,
-				]
-			);
-		$this->mock_wcpay_gateway
-			->method( 'wc_payments_get_payment_method_by_id' )
-			->willReturn(
-				new CC_Payment_Method( $this->mock_token_service )
-			);
-
-		set_transient( WC_Payment_Gateway_WCPay::UPE_APPEARANCE_TRANSIENT, '{}', DAY_IN_SECONDS );
-		set_transient( WC_Payment_Gateway_WCPay::WC_BLOCKS_UPE_APPEARANCE_THEME_TRANSIENT, 'night', DAY_IN_SECONDS );
-		delete_transient( WC_Payment_Gateway_WCPay::UPE_ADD_PAYMENT_METHOD_APPEARANCE_TRANSIENT );
-
-		$js_config = $this->system_under_test->get_payment_fields_js_config();
-
-		$this->assertSame( '{}', $js_config['upeAppearance'] );
-		$this->assertSame( 'night', $js_config['wcBlocksUPEAppearanceTheme'] );
-		$this->assertFalse( $js_config['upeAddPaymentMethodAppearance'] );
-	}
-
 	/**
 	 * Data provider for testing different country card numbers
 	 */

--- a/tests/unit/test-class-wc-payments-order-success-page.php
+++ b/tests/unit/test-class-wc-payments-order-success-page.php
@@ -104,7 +104,8 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$payment_method = $this->createMock( UPE_Payment_Method::class );
 		$payment_method->method( 'get_title' )->willReturn( 'GrabPay' );
 		$payment_method->method( 'get_id' )->willReturn( 'grabpay' );
-		$payment_method->method( 'get_payment_method_icon_for_location' )->willReturn( '/grabpay.svg' );
+		$payment_method->method( 'get_icon' )->willReturn( '/grabpay.svg' );
+		$payment_method->method( 'get_dark_icon' )->willReturn( '/grabpay.svg' );
 
 		$result = $this->payments_order_success_page->show_lpm_payment_method_name( $gateway, $payment_method );
 
@@ -114,6 +115,22 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'src="/grabpay.svg"', $result );
 	}
 
+	public function test_show_lpm_payment_method_name_with_dark_icon() {
+		$gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$gateway->method( 'get_account_country' )->willReturn( 'NL' );
+
+		$payment_method = $this->createMock( UPE_Payment_Method::class );
+		$payment_method->method( 'get_title' )->willReturn( 'iDEAL' );
+		$payment_method->method( 'get_id' )->willReturn( 'ideal' );
+		$payment_method->method( 'get_icon' )->willReturn( '/ideal.svg' );
+		$payment_method->method( 'get_dark_icon' )->willReturn( '/ideal-dark.svg' );
+
+		$result = $this->payments_order_success_page->show_lpm_payment_method_name( $gateway, $payment_method );
+
+		$this->assertStringContainsString( 'src="/ideal.svg"', $result );
+		$this->assertStringContainsString( 'data-dark-src="/ideal-dark.svg"', $result );
+	}
+
 	public function test_show_lpm_payment_method_name_icon_not_found() {
 		$gateway = $this->createMock( WC_Payment_Gateway_WCPay::class );
 		$gateway->method( 'get_account_country' )->willReturn( 'SG' );
@@ -121,7 +138,8 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$payment_method = $this->createMock( UPE_Payment_Method::class );
 		$payment_method->method( 'get_title' )->willReturn( 'GrabPay' );
 		$payment_method->method( 'get_id' )->willReturn( 'grabpay' );
-		$payment_method->method( 'get_payment_method_icon_for_location' )->willReturn( '' );
+		$payment_method->method( 'get_icon' )->willReturn( '' );
+		$payment_method->method( 'get_dark_icon' )->willReturn( '' );
 
 		$result = $this->payments_order_success_page->show_lpm_payment_method_name( $gateway, $payment_method, true );
 

--- a/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
+++ b/tests/unit/test-class-wc-payments-payment-method-messaging-element.php
@@ -215,32 +215,19 @@ class WC_Payments_Payment_Method_Messaging_Element_Test extends WCPAY_UnitTestCa
 	}
 
 	/**
-	 * Test that inline script contains only minimal config keys, not the full checkout config.
+	 * Test that no wcpayConfig inline script is injected, to avoid claiming the global
+	 * before WooPay's full config can load on product pages.
 	 */
-	public function test_init_inline_script_contains_only_minimal_config() {
+	public function test_init_does_not_inject_wcpay_config_inline_script() {
 		$this->setup_gateway_mocks();
 
 		$this->messaging_element->init();
 
-		// Get the inline script added before WCPAY_PRODUCT_DETAILS.
+		// No inline script should be added before WCPAY_PRODUCT_DETAILS.
 		$registered = wp_scripts()->registered['WCPAY_PRODUCT_DETAILS'];
 		$before     = $registered->extra['before'] ?? [];
 		$inline_js  = implode( '', $before );
 
-		// Extract the JSON from the inline script.
-		preg_match( "/decodeURIComponent\(\s*'([^']+)'\s*\)/", $inline_js, $matches );
-		$this->assertNotEmpty( $matches[1], 'Inline script should contain encoded config' );
-
-		$config = json_decode( urldecode( $matches[1] ), true );
-		$this->assertIsArray( $config );
-
-		// Should contain only the 4 minimal keys.
-		$expected_keys = [ 'ajaxUrl', 'saveUPEAppearanceNonce', 'upeBnplProductPageAppearance', 'upeBnplClassicCartAppearance' ];
-		$this->assertEqualsCanonicalizing( $expected_keys, array_keys( $config ) );
-
-		// Should NOT contain keys from the full checkout config.
-		$this->assertArrayNotHasKey( 'fraudServices', $config );
-		$this->assertArrayNotHasKey( 'paymentMethodsConfig', $config );
-		$this->assertArrayNotHasKey( 'woopayMinimumSessionData', $config );
+		$this->assertStringNotContainsString( 'wcpayConfig', $inline_js, 'No wcpayConfig inline script should be injected — it would break the WooPay button on product pages.' );
 	}
 }

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -1042,55 +1042,6 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 400, WC_Payments_Utils::get_filtered_error_status_code( new \WCPay\Exceptions\API_Exception( 'Error: Your card was declined.', 'card_declined', 402 ) ) );
 	}
 
-	private function delete_appearance_theme_transients( $transients ) {
-		foreach ( $transients as $location => $contexts ) {
-			foreach ( $contexts as $context => $transient ) {
-				delete_transient( $transient );
-			}
-		}
-	}
-
-	private function set_appearance_theme_transients( $transients ) {
-		foreach ( $transients as $location => $contexts ) {
-			foreach ( $contexts as $context => $transient ) {
-				set_transient( $transient, $location . '_' . $context . '_value', DAY_IN_SECONDS );
-			}
-		}
-	}
-
-	public function test_get_active_upe_theme_transient_for_location() {
-		$theme_transients = \WC_Payment_Gateway_WCPay::APPEARANCE_THEME_TRANSIENTS;
-
-		// Test with no transients set.
-		$this->assertSame( 'stripe', WC_Payments_Utils::get_active_upe_theme_transient_for_location( 'checkout', 'blocks' ) );
-
-		// Set the transients.
-		$this->set_appearance_theme_transients( $theme_transients );
-
-		// Test with transients set.
-		// Test with invalid location.
-		$this->assertSame( 'checkout_blocks_value', WC_Payments_Utils::get_active_upe_theme_transient_for_location( 'invalid_location', 'blocks' ) );
-
-		// Test with valid location and invalid context.
-		$this->assertSame( 'checkout_blocks_value', WC_Payments_Utils::get_active_upe_theme_transient_for_location( 'checkout', 'invalid_context' ) );
-
-		// Test with valid location and context.
-		foreach ( $theme_transients as $location => $contexts ) {
-			foreach ( $contexts as $context => $transient ) {
-				// Our transient for the product page is the same transient for both block and classic.
-				if ( 'product_page' === $location ) {
-					$this->assertSame( 'product_page_classic_value', WC_Payments_Utils::get_active_upe_theme_transient_for_location( $location, 'blocks' ) );
-					$this->assertSame( 'product_page_classic_value', WC_Payments_Utils::get_active_upe_theme_transient_for_location( $location, 'classic' ) );
-				} else {
-					$this->assertSame( $location . '_' . $context . '_value', WC_Payments_Utils::get_active_upe_theme_transient_for_location( $location, $context ) );
-				}
-			}
-		}
-
-		// Remove the transients.
-		$this->delete_appearance_theme_transients( $theme_transients );
-	}
-
 	public function test_is_store_api_request_with_store_api_request() {
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_REQUEST['rest_route'] = '/wc/store/v1/checkout';
@@ -1274,5 +1225,64 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 			'general'                   => [ 'general', 'General' ],
 			'default case'              => [ 'unknown_reason', 'General' ],
 		];
+	}
+
+	public function test_get_styles_cache_version_returns_md5_string() {
+		delete_option( 'wcpay_styles_cache_version' );
+		$version = WC_Payments_Utils::get_styles_cache_version();
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $version );
+	}
+
+	public function test_get_styles_cache_version_stores_in_option() {
+		delete_option( 'wcpay_styles_cache_version' );
+		$version = WC_Payments_Utils::get_styles_cache_version();
+		$this->assertEquals( $version, get_option( 'wcpay_styles_cache_version' ) );
+	}
+
+	public function test_get_styles_cache_version_reads_from_option() {
+		update_option( 'wcpay_styles_cache_version', 'cached_hash_value' );
+		$version = WC_Payments_Utils::get_styles_cache_version();
+		$this->assertEquals( 'cached_hash_value', $version );
+		delete_option( 'wcpay_styles_cache_version' );
+	}
+
+	public function test_invalidate_styles_cache_version_deletes_option() {
+		update_option( 'wcpay_styles_cache_version', 'some_hash' );
+		WC_Payments_Utils::invalidate_styles_cache_version();
+		$this->assertFalse( get_option( 'wcpay_styles_cache_version' ) );
+	}
+
+	public function test_styles_cache_invalidation_hooks_registered() {
+		$this->assertNotFalse(
+			has_action( 'after_switch_theme', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] ),
+			'after_switch_theme hook not registered.'
+		);
+		$this->assertNotFalse(
+			has_action( 'save_post_wp_global_styles', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] ),
+			'save_post_wp_global_styles hook not registered.'
+		);
+		$this->assertNotFalse(
+			has_action( 'customize_save_after', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] ),
+			'customize_save_after hook not registered.'
+		);
+		$this->assertNotFalse(
+			has_action( 'woocommerce_woocommerce_payments_updated', [ 'WC_Payments_Utils', 'invalidate_styles_cache_version' ] ),
+			'woocommerce_woocommerce_payments_updated hook not registered.'
+		);
+	}
+
+	public function test_get_styles_cache_version_recomputes_after_invalidation() {
+		// Populate the cache.
+		delete_option( 'wcpay_styles_cache_version' );
+		$first_version = WC_Payments_Utils::get_styles_cache_version();
+
+		// Invalidate.
+		WC_Payments_Utils::invalidate_styles_cache_version();
+		$this->assertFalse( get_option( 'wcpay_styles_cache_version' ) );
+
+		// Recompute — should get a new stored value.
+		$second_version = WC_Payments_Utils::get_styles_cache_version();
+		$this->assertNotEmpty( get_option( 'wcpay_styles_cache_version' ) );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $second_version );
 	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-5806
Fixes WOOPMNT-4062

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Refactoring the UPE styles to be managed through the front-end.

- Styles are now cached in localStorage on each client's browser
- Removed the `wcpay_elements_appearance` in favor of a new client-side filter
**Old (PHP filter — removed):**
```php
add_filter( 'wcpay_elements_appearance', function( $appearance, $elements_location ) {
    $appearance['rules']['.Input']['color'] = '#333333';
    return $appearance;
}, 10, 2 );
```

**New (JS CustomEvent):**
```js
document.addEventListener( 'wcpay_elements_appearance', ( event ) => {
    const { appearance, elementsLocation } = event.detail;
    appearance.rules['.Input'].color = '#333333';
} );
```

The event fires at all 4 entry points (blocks checkout, classic checkout, BNPL product page, cart block) on cache miss only — same timing as the old filter. The object is passed by reference, so listeners mutate it in place before it's stored in localStorage.

The external docs page will need updating to reflect the new approach: https://woocommerce.com/document/woopayments/customization-and-translation/customize-payments-appearance/

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
