### PR TITLE
chore: update changelog entry to avoid code freeze action breakage

### DIFF
--- a/changelog/fix-ideal-logo-stroke
+++ b/changelog/fix-ideal-logo-stroke
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixed iDEAL | Wero logo: removed baked-in stroke causing double border in admin, fixed missing rounded corners on checkout, consolidated into a single SVG file, and added dark mode icon for night theme checkout
+Fixed iDEAL / Wero logo: removed baked-in stroke causing double border in admin, fixed missing rounded corners on checkout, consolidated into a single SVG file, and added dark mode icon for night theme checkout


### PR DESCRIPTION
The changelog entry contains a `|`, which doesn't work well with the code freeze action.