### PR TITLE
chore: replace CC_Payment_Method constant with CardDefinition::get_id()

### DIFF
--- a/changelog/chore-replace-card-method-constant-with-definition
+++ b/changelog/chore-replace-card-method-constant-with-definition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: updated CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID with CardDefinition::get_id()
+
+

--- a/includes/class-duplicates-detection-service.php
+++ b/includes/class-duplicates-detection-service.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WC_Payments;
-use WCPay\Payment_Methods\CC_Payment_Method;
+use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 
 /**
@@ -70,7 +70,7 @@ class Duplicates_Detection_Service {
 
 		foreach ( $this->get_enabled_gateways() as $gateway ) {
 			if ( $this->gateway_contains_keyword( $gateway->id, $keywords ) || in_array( $gateway->id, $special_keywords, true ) ) {
-				$this->gateways_qualified_by_duplicates_detector[ CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID ][] = $gateway->id;
+				$this->gateways_qualified_by_duplicates_detector[ CardDefinition::get_id() ][] = $gateway->id;
 			}
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -55,8 +55,8 @@ use WCPay\Session_Rate_Limiter;
 use WCPay\Tracker;
 use WCPay\Internal\Service\Level3Service;
 use WCPay\Internal\Service\OrderService;
-use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Payment_Methods\UPE_Payment_Method;
+use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\LinkDefinition;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 
@@ -4279,7 +4279,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// if credit card payment method is not enabled, we don't use stripe link.
 		if (
-			! in_array( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true ) &&
+			! in_array( CardDefinition::get_id(), $enabled_payment_methods, true ) &&
 			in_array( LinkDefinition::get_id(), $enabled_payment_methods, true ) ) {
 			$link_stripe_id          = LinkDefinition::get_id();
 			$enabled_payment_methods = array_filter(

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -608,7 +608,7 @@ class WC_Payments {
 
 		// Build the card gateway first so that WC_Payments::get_gateway() is available
 		// during construction of the other gateways (e.g. for settings checks).
-		$card_payment_method                                        = $payment_methods[ CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID ];
+		$card_payment_method                                        = $payment_methods[ \WCPay\PaymentMethods\Configs\Definitions\CardDefinition::get_id() ];
 		self::$payment_method_map[ $card_payment_method->get_id() ] = $card_payment_method;
 		self::$card_gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $card_payment_method, $payment_methods, self::$order_service, self::$duplicate_payment_prevention_service, self::$localization_service, self::$fraud_service, self::$duplicates_detection_service, self::$failed_transaction_rate_limiter );
 		self::$payment_gateway_map[ $card_payment_method->get_id() ] = self::$card_gateway;

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -7,8 +7,8 @@
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\LinkDefinition;
-use WCPay\Payment_Methods\CC_Payment_Method;
 
 
 defined( 'ABSPATH' ) || exit;
@@ -51,7 +51,7 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 		// Retrieve enabled payment methods at checkout.
 		$enabled_payment_methods = self::$gateway->get_payment_method_ids_enabled_at_checkout_filtered_by_fees( null, true );
 		// If card payment method is not enabled or Link payment method is enabled, skip.
-		if ( ! in_array( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true )
+		if ( ! in_array( CardDefinition::get_id(), $enabled_payment_methods, true )
 				|| in_array( LinkDefinition::get_id(), $enabled_payment_methods, true ) ) {
 			return false;
 		}

--- a/tests/unit/duplicate-detection/test-class-duplicates-detection-service.php
+++ b/tests/unit/duplicate-detection/test-class-duplicates-detection-service.php
@@ -6,7 +6,7 @@
  */
 
 use WCPay\Duplicates_Detection_Service;
-use WCPay\Payment_Methods\CC_Payment_Method;
+use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 
 /**
@@ -80,7 +80,7 @@ class Duplicates_Detection_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_two_cc_one_enabled() {
-		$this->set_duplicates( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, 'yes', 'no' );
+		$this->set_duplicates( CardDefinition::get_id(), 'yes', 'no' );
 
 		$result = $this->service->find_duplicates();
 
@@ -106,7 +106,7 @@ class Duplicates_Detection_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_two_prbs_enabled() {
-		$this->set_duplicates( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, 'yes', 'yes' );
+		$this->set_duplicates( CardDefinition::get_id(), 'yes', 'yes' );
 		$this->woopayments_gateway->is_payment_request_enabled_value = true;
 		$this->woopayments_gateway->enabled                          = 'yes';
 		$this->gateway_from_another_plugin->id                       = 'apple_pay';
@@ -133,7 +133,7 @@ class Duplicates_Detection_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_duplicate_not_enabled_in_woopayments() {
-		$this->set_duplicates( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, 'yes', 'yes' );
+		$this->set_duplicates( CardDefinition::get_id(), 'yes', 'yes' );
 		$this->woopayments_gateway->id = 'not_woopayments_card';
 
 		$result = $this->service->find_duplicates();


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Part of https://github.com/Automattic/woocommerce-payments/pull/11225 - just replacing `CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID` with `CardDefinition::get_id()` in various files.
Backwards-compatible change, it's just replacing a constant with the same value.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
