### PR TITLE
chore: add title from charge details call on method definition

### DIFF
--- a/changelog/chore-add-title-from-charge-details-on-upe-method-definition
+++ b/changelog/chore-add-title-from-charge-details-on-upe-method-definition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: add `get_title_from_charge_details` call on payment method definition on UPE_Payment_Method
+
+

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -379,24 +379,6 @@ class UPE_Payment_Method {
 	}
 
 	/**
-	 * Gets the theme appropriate icon for the payment method for a given location and context.
-	 *
-	 * @param string  $location The location to get the icon for.
-	 * @param boolean $is_blocks Whether the icon is for blocks.
-	 * @param string  $account_country Optional account country.
-	 * @return string
-	 */
-	public function get_payment_method_icon_for_location( string $location = 'checkout', bool $is_blocks = true, ?string $account_country = null ) {
-		$appearance_theme = WC_Payments_Utils::get_active_upe_theme_transient_for_location( $location, $is_blocks ? 'blocks' : 'classic' );
-
-		if ( 'night' === $appearance_theme ) {
-			return $this->get_dark_icon( $account_country );
-		}
-
-		return $this->get_icon( $account_country );
-	}
-
-	/**
 	 * Returns payment method supported countries
 	 *
 	 * @return array

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -173,6 +173,12 @@ class UPE_Payment_Method {
 	 */
 	public function get_title( ?string $account_country = null, $payment_details = false ) {
 		if ( null !== $this->definition ) {
+			if ( is_array( $payment_details ) && ! empty( $payment_details ) ) {
+				$dynamic_title = $this->definition::get_title_from_charge_details( $account_country ?? '', $payment_details );
+				if ( null !== $dynamic_title ) {
+					return $dynamic_title;
+				}
+			}
 			return $this->definition::get_title( $account_country );
 		}
 		return $this->title;
@@ -370,6 +376,24 @@ class UPE_Payment_Method {
 			return $this->definition::get_dark_icon_url( $account_country );
 		}
 		return isset( $this->dark_icon_url ) ? $this->dark_icon_url : $this->get_icon( $account_country );
+	}
+
+	/**
+	 * Gets the theme appropriate icon for the payment method for a given location and context.
+	 *
+	 * @param string  $location The location to get the icon for.
+	 * @param boolean $is_blocks Whether the icon is for blocks.
+	 * @param string  $account_country Optional account country.
+	 * @return string
+	 */
+	public function get_payment_method_icon_for_location( string $location = 'checkout', bool $is_blocks = true, ?string $account_country = null ) {
+		$appearance_theme = WC_Payments_Utils::get_active_upe_theme_transient_for_location( $location, $is_blocks ? 'blocks' : 'classic' );
+
+		if ( 'night' === $appearance_theme ) {
+			return $this->get_dark_icon( $account_country );
+		}
+
+		return $this->get_icon( $account_country );
 	}
 
 	/**

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
@@ -35,6 +35,9 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+		if ( ! empty( $payment_details['dynamic_title'] ) ) {
+			return $payment_details['dynamic_title'];
+		}
 		return null;
 	}
 

--- a/tests/unit/payment-methods/test-class-upe-payment-method.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-method.php
@@ -9,6 +9,7 @@ namespace WCPay\Payment_Methods;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Country_Code;
+use WCPay\Tests\PaymentMethods\Configs\MockPaymentMethodDefinition;
 use WCPAY_UnitTestCase;
 use WC_Payments_Account;
 use WC_Payments_Token_Service;
@@ -289,5 +290,27 @@ class UPE_Payment_Method_Test extends WCPAY_UnitTestCase {
 
 		// Cleanup.
 		WC_Subscriptions::set_wcs_is_manual_renewal_enabled( null );
+	}
+
+	public function test_get_title_returns_dynamic_title_from_charge_details() {
+		$payment_method = new UPE_Payment_Method( $this->mock_token_service, MockPaymentMethodDefinition::class );
+
+		$payment_details = [ 'dynamic_title' => 'Dynamic Mock Title' ];
+
+		$this->assertSame( 'Dynamic Mock Title', $payment_method->get_title( 'US', $payment_details ) );
+	}
+
+	public function test_get_title_falls_back_to_default_when_charge_details_return_null() {
+		$payment_method = new UPE_Payment_Method( $this->mock_token_service, MockPaymentMethodDefinition::class );
+
+		$payment_details = [ 'some_key' => 'some_value' ];
+
+		$this->assertSame( 'Mock Method', $payment_method->get_title( 'US', $payment_details ) );
+	}
+
+	public function test_get_title_uses_default_when_no_payment_details() {
+		$payment_method = new UPE_Payment_Method( $this->mock_token_service, MockPaymentMethodDefinition::class );
+
+		$this->assertSame( 'Mock Method', $payment_method->get_title( 'US' ) );
 	}
 }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Part of https://github.com/Automattic/woocommerce-payments/pull/11225
The `PaymentMethodDefinitionInterface` has a `get_title_from_charge_details` method that is a replacement for when `get_title(?string $account_country = null, $payment_details = false)` is called on a `UPE_Payment_Method` object with a charge detail.

Ensuring that it gets called.

This PR does not make any changes to any code, since all the `get_title_from_charge_details` methods are currently returning `null`.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No change in behavior. All the `get_title_from_charge_details` methods return `null`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
