### PR TITLE
docs: update AI knowledge from appearance cache compound analysis

### DIFF
--- a/.claude/docs/payment-flow.md
+++ b/.claude/docs/payment-flow.md
@@ -1,6 +1,6 @@
 # Payment Flow — Detailed Reference
 
-**Last updated:** 2026-02-20
+**Last updated:** 2026-03-04
 
 This documents the exact call chain for payment operations in WooPayments. Read this when working on payment processing, refunds, or API communication.
 
@@ -167,6 +167,20 @@ Key difference from shortcode path: The shortcode path uses `should_show_express
 | `List_Transactions` | `transactions` | GET | Admin transaction list |
 | `List_Disputes` | `disputes` | GET | Admin dispute list |
 | (direct) | `disputes/{id}/summary` | GET | Fetch dispute summary (webhook-only, no Request class) |
+
+## Stripe Elements Appearance Caching
+
+Appearance objects for Stripe Elements are cached **client-side in localStorage** (`wcpay_appearance_<location>`). The cache is versioned via `stylesCacheVersion` (MD5 hash of theme styles + plugin version), passed from PHP through `wcpayConfig`.
+
+**Locations:** `checkout`, `blocks_checkout`, `bnpl_product_page`, `bnpl_cart_block`, `add_payment_method`
+
+**Cache flow:** `getCachedAppearance()` → cache hit? return it : `getAppearance(location)` → `dispatchAppearanceEvent(appearance, location)` → `setCachedAppearance(location, version, appearance)`
+
+**CustomEvent hook:** `wcpay_elements_appearance` — synchronous CustomEvent dispatched before caching. Merchants modify `event.detail.appearance` in place. Replaces the removed PHP `apply_filters('wcpay_elements_appearance')`.
+
+**Dark icon detection (server-rendered pages):** The order success page uses `data-dark-src` on `<img>` tags + inline JS in `wp_footer` that computes background luminance via `getComputedStyle()` to swap icons for dark themes.
+
+**Key files:** `client/utils/appearance-cache.js`, `client/checkout/classic/payment-processing.js`, `client/checkout/blocks/payment-elements.js`, `includes/class-wc-payments-order-success-page.php`
 
 ## Plugin Initialization Chain
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,3 +296,6 @@ Skip persisting trivial lookups, single-file reads, simple Q&A.
 - PHP tests require Docker — ensure it's running before executing
 - Always push only current branch: `git push origin HEAD`
 - Always pull with rebase: `git pull origin $(git branch --show-current) --rebase`
+- **PHPCS class structure ordering:** `SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder` requires methods in order: public → protected → private. When adding new private methods, place them after all public methods. Run `vendor/bin/phpcbf --standard=phpcs.xml.dist <file>` to auto-fix ordering violations.
+- **Migration version_compare:** When adding a migration class in `includes/migrations/`, the `version_compare()` threshold must match the version in the `@since` tag (e.g., `version_compare('10.6.0', $previous_version, '>')` for `@since 10.6.0`). The version represents when the migration ships, not when the old behavior was introduced.
+- **Styles cache invalidation on plugin update:** `WC_Payments_Utils::compute_styles_cache_version()` uses `WCPAY_VERSION_NUMBER` in its hash, but the cached WP option persists across updates. Hook `invalidate_styles_cache_version` to `woocommerce_woocommerce_payments_updated` to clear stale caches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,6 @@ Skip persisting trivial lookups, single-file reads, simple Q&A.
 - PHP tests require Docker — ensure it's running before executing
 - Always push only current branch: `git push origin HEAD`
 - Always pull with rebase: `git pull origin $(git branch --show-current) --rebase`
-- **PHPCS class structure ordering:** `SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder` requires methods in order: public → protected → private. When adding new private methods, place them after all public methods. Run `vendor/bin/phpcbf --standard=phpcs.xml.dist <file>` to auto-fix ordering violations.
+- **PHPCS class structure ordering:** `SlevomatCodingStandard.Classes.ClassStructure.IncorrectGroupOrder` requires methods in order: public → protected → private. When adding new private methods, place them after all public and protected methods. Run `vendor/bin/phpcbf --standard=phpcs.xml.dist <file>` to auto-fix ordering violations.
 - **Migration version_compare:** When adding a migration class in `includes/migrations/`, the `version_compare()` threshold must match the version in the `@since` tag (e.g., `version_compare('10.6.0', $previous_version, '>')` for `@since 10.6.0`). The version represents when the migration ships, not when the old behavior was introduced.
 - **Styles cache invalidation on plugin update:** `WC_Payments_Utils::compute_styles_cache_version()` uses `WCPAY_VERSION_NUMBER` in its hash, but the cached WP option persists across updates. Hook `invalidate_styles_cache_version` to `woocommerce_woocommerce_payments_updated` to clear stale caches.

--- a/changelog/docs-compound-learnings-appearance-cache
+++ b/changelog/docs-compound-learnings-appearance-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Update AI knowledge docs from appearance cache compound analysis
+Comment: Update AI knowledge docs from appearance cache compound analysis

--- a/changelog/docs-compound-learnings-appearance-cache
+++ b/changelog/docs-compound-learnings-appearance-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update AI knowledge docs from appearance cache compound analysis


### PR DESCRIPTION
## Summary

- Add 3 new agent rules to `AGENTS.md`: PHPCS class structure ordering, migration `version_compare` pattern, and styles cache invalidation on plugin update
- Document the Stripe Elements appearance caching architecture in `.claude/docs/payment-flow.md` (localStorage cache flow, CustomEvent hook, dark icon detection for server-rendered pages)

These learnings were extracted from recent work.

## Test plan

- [ ] Verify AGENTS.md additions are accurate and non-duplicative
- [ ] Verify payment-flow.md new section matches actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)