### PR TITLE
chore: Bump WC tested up to version to 10.6.0

### DIFF
--- a/changelog/dev-bump-wc-tested-up-to-10.6.0
+++ b/changelog/dev-bump-wc-tested-up-to-10.6.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 10.6.0

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 10.5.0
+ * WC tested up to: 10.6.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 10.5.1


### PR DESCRIPTION
## Summary

Bumps the "WC tested up to" header from 10.5.0 to 10.6.0, ahead of the WooCommerce 10.6.0 release on March 10.

## Test plan

- [ ] Verify `woocommerce-payments.php` header shows `WC tested up to: 10.6.0`
- [ ] Changelog entry present

🤖 Generated with [Claude Code](https://claude.com/claude-code)