### PR TITLE
Adjust button sizes in the review prompt

### DIFF
--- a/changelog/fix-review-prompt-button-size
+++ b/changelog/fix-review-prompt-button-size
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix the size of the review prompt buttons. The prompt will be released with this WooPayments version.
+
+

--- a/client/components/spotlight/index.tsx
+++ b/client/components/spotlight/index.tsx
@@ -213,6 +213,7 @@ const Spotlight: React.FC< SpotlightProps > = ( {
 			className="wcpay-spotlight__primary-btn"
 			variant="secondary"
 			onClick={ handlePrimaryClick }
+			size="compact"
 		>
 			{ primaryButtonLabel }
 		</Button>
@@ -223,6 +224,7 @@ const Spotlight: React.FC< SpotlightProps > = ( {
 			className="wcpay-spotlight__secondary-btn"
 			variant="tertiary"
 			onClick={ onSecondaryClick }
+			size="compact"
 		>
 			{ secondaryButtonLabel }
 		</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After a discussion with Lucy after her AFK (hence the late PR), change the button size on the review prompt:

| Before | This PR |
| - | - |
| <img width="323" height="245" alt="Screenshot 2026-03-06 at 12 50 01" src="https://github.com/user-attachments/assets/171f390f-2f64-45ad-8510-a7acf9cb63c7" /> | <img width="327" height="239" alt="image" src="https://github.com/user-attachments/assets/7503ab85-2c3d-4cca-9085-9b9610381a61" /> |

#### Testing instructions

It's such a minor change, not needed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You 