### PR TITLE
fix: ECE shipping for subscriptions with free trial

### DIFF
--- a/changelog/fix-ece-subscriptions-shipping-tweaks
+++ b/changelog/fix-ece-subscriptions-shipping-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: shipping rates on ECE for subscriptions with free trial

--- a/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
+++ b/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
@@ -162,23 +162,24 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 		).toBe( cart );
 	} );
 
-	it( 'all filters pass through for subscriptions with sign-up fees', () => {
-		// Sign-up fees are charged immediately, so the item is not a
-		// "free trial" even though it has trial_length > 0.
+	it( 'total-amount and eligibility filters pass through for subscriptions with sign-up fees (non-zero cart total)', () => {
+		// Sign-up fees produce a non-zero cart total, so the $0-cart
+		// overrides (total-amount, eligibility) don't activate.
 		const cart = buildTrialCart( {
 			items: [ buildTrialSubscriptionItem( { signUpFees: '500' } ) ],
+			totalPrice: '500',
 		} );
 
 		expect(
-			applyFilters( 'wcpay.express-checkout.total-amount', 0, cart )
-		).toBe( 0 );
+			applyFilters( 'wcpay.express-checkout.total-amount', 500, cart )
+		).toBe( 500 );
 		expect(
 			applyFilters(
 				'wcpay.express-checkout.is-cart-eligible',
-				false,
+				true,
 				cart
 			)
-		).toBe( false );
+		).toBe( true );
 	} );
 
 	describe( 'total-amount filter', () => {
@@ -322,6 +323,36 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 				)
 			).toEqual( subscriptionRates );
 		} );
+
+		it( 'falls back to subscription shipping rates for trial with sign-up fee', () => {
+			const subscriptionRates = [
+				{
+					rate_id: 'free_shipping:1',
+					name: 'Free shipping',
+					price: '0',
+				},
+				{
+					rate_id: 'flat_rate:5',
+					name: 'Express shipping',
+					price: '1000',
+				},
+			];
+			const cart = buildTrialCart( {
+				items: [ buildTrialSubscriptionItem( { signUpFees: '200' } ) ],
+				totalPrice: '217',
+				subscriptions: [
+					subscriptionWithShipping( subscriptionRates ),
+				],
+			} );
+
+			expect(
+				applyFilters(
+					'wcpay.express-checkout.shipping-rates',
+					[],
+					cart
+				)
+			).toEqual( subscriptionRates );
+		} );
 	} );
 
 	describe( 'shipping-package-id filter', () => {
@@ -368,6 +399,26 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 					'unknown_rate:99'
 				)
 			).toBe( 0 );
+		} );
+
+		it( 'returns the subscription package ID for trial with sign-up fee', () => {
+			const cart = {
+				...cartWithShippingPackage( 'sub_month_0', [
+					{ rate_id: 'flat_rate:1' },
+					{ rate_id: 'flat_rate:2' },
+				] ),
+				items: [ buildTrialSubscriptionItem( { signUpFees: '200' } ) ],
+			};
+			cart.totals.total_price = '217';
+
+			expect(
+				applyFilters(
+					'wcpay.express-checkout.shipping-package-id',
+					0,
+					cart,
+					'flat_rate:2'
+				)
+			).toBe( 'sub_month_0' );
 		} );
 	} );
 

--- a/client/express-checkout/compatibility/wc-subscriptions.js
+++ b/client/express-checkout/compatibility/wc-subscriptions.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { transformPrice } from '../transformers/wc-to-stripe';
 
 /**
- * Checks if a cart item is a subscription with a free trial (no sign-up fee).
+ * Checks if a cart item is a subscription with a free trial.
  *
  * @param {Object} item Cart item from Store API.
  * @return {boolean} True if the item is a trial subscription.
@@ -26,10 +26,59 @@ const isTrialSubscriptionItem = ( item ) => {
 		return false;
 	}
 
-	return (
-		subscriptionData.trial_length > 0 &&
-		parseInt( subscriptionData.sign_up_fees || '0', 10 ) === 0
-	);
+	return subscriptionData.trial_length > 0;
+};
+
+/**
+ * Gets shipping rates from subscription extensions for trial subscriptions.
+ * During free trials, shipping is deferred so rates only exist in the
+ * subscription extensions, not in the main cart shipping packages.
+ *
+ * @param {Object} cartData Cart data from Store API.
+ * @return {Array|null} Array of shipping rates or null if none available.
+ */
+const getSubscriptionShippingRates = ( cartData ) => {
+	const subscriptions = cartData?.extensions?.subscriptions;
+	if ( ! subscriptions || ! Array.isArray( subscriptions ) ) {
+		return null;
+	}
+
+	for ( const subscription of subscriptions ) {
+		const rates = subscription.shipping_rates?.[ 0 ]?.shipping_rates;
+		if ( rates?.length > 0 ) {
+			return rates;
+		}
+	}
+
+	return null;
+};
+
+/**
+ * Checks if the cart contains any trial subscriptions (with or without sign-up fee)
+ * that have deferred shipping. During free trials, WooCommerce Subscriptions moves
+ * shipping rates from the main cart to the subscription extensions.
+ *
+ * @param {Object} cartData Cart data from Store API.
+ * @return {boolean} True if cart has trial subscriptions with deferred shipping.
+ */
+const hasTrialSubscriptionWithDeferredShipping = ( cartData ) => {
+	if ( ! cartData?.items || ! cartData?.extensions?.subscriptions ) {
+		return false;
+	}
+
+	const hasTrialItems = cartData.items.some( isTrialSubscriptionItem );
+	if ( ! hasTrialItems ) {
+		return false;
+	}
+
+	// Check that top-level shipping_rates is empty but subscription extensions have rates.
+	const hasMainShippingRates =
+		cartData.shipping_rates?.[ 0 ]?.shipping_rates?.length > 0;
+	if ( hasMainShippingRates ) {
+		return false;
+	}
+
+	return getSubscriptionShippingRates( cartData ) !== null;
 };
 
 /**
@@ -187,30 +236,6 @@ addFilter(
 );
 
 /**
- * Gets shipping rates from subscription extensions for trial subscriptions.
- * During free trials, shipping is deferred so rates only exist in the
- * subscription extensions, not in the main cart shipping packages.
- *
- * @param {Object} cartData Cart data from Store API.
- * @return {Array|null} Array of shipping rates or null if none available.
- */
-const getSubscriptionShippingRates = ( cartData ) => {
-	const subscriptions = cartData?.extensions?.subscriptions;
-	if ( ! subscriptions || ! Array.isArray( subscriptions ) ) {
-		return null;
-	}
-
-	for ( const subscription of subscriptions ) {
-		const rates = subscription.shipping_rates?.[ 0 ]?.shipping_rates;
-		if ( rates?.length > 0 ) {
-			return rates;
-		}
-	}
-
-	return null;
-};
-
-/**
  * Filter: wcpay.express-checkout.shipping-rates
  *
  * For trial subscriptions, falls back to shipping rates from subscription
@@ -228,7 +253,7 @@ addFilter(
 			return shippingRates;
 		}
 
-		if ( ! hasTrialSubscriptionInCart( cartData ) ) {
+		if ( ! hasTrialSubscriptionWithDeferredShipping( cartData ) ) {
 			return shippingRates;
 		}
 
@@ -251,7 +276,7 @@ addFilter(
 	'wcpay.express-checkout.shipping-package-id',
 	'automattic/wcpay/express-checkout/wc-subscriptions',
 	( packageId, cartData, rateId ) => {
-		if ( ! hasTrialSubscriptionInCart( cartData ) ) {
+		if ( ! hasTrialSubscriptionWithDeferredShipping( cartData ) ) {
 			return packageId;
 		}
 


### PR DESCRIPTION
Fixes WOOPRD-2948

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

ECE buttons were not showing shipping rates for physical subscriptions with a free trial **and** a sign-up fee.

There was a `hasTrialSubscriptionInCart` check that required both a $0 cart total and no sign-up fees before falling back to subscription extension shipping rates.
For subscriptions with a sign-up fee, the cart total is non-zero (sign-up fee + tax), so the shipping-related filters never activated, even though WooCommerce Subscriptions defers shipping to the subscription extensions for *all* trial subscriptions regardless of sign-up fees.

The result was that `shipping_rates` at the top level of the Store API response was `[]`, the fallback to `extensions.subscriptions[].shipping_rates` was skipped, and the express checkout dialog showed no shipping options (causing it to reject).
<img width="991" height="641" alt="Screenshot 2026-03-06 at 2 47 41 PM" src="https://github.com/user-attachments/assets/d7a392f7-9c89-4b5b-84f8-7831adc91aed" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a physical subscription product with:
  - A recurring price (e.g., $7.00/month)
  - A free trial period (e.g., 1 month)
  - A sign-up fee (e.g., $2.00)
* Configure at least two shipping methods (e.g., Free Shipping and a Flat Rate)
* As a customer, go to the product page of said subscription
* Click on the Google Pay button
* You should be able to purchase the product
<img width="965" height="617" alt="Screenshot 2026-03-06 at 2 49 53 PM" src="https://github.com/user-attachments/assets/925ba64c-f3ea-40fd-b0dd-f2abe44ff967" />

* Also verify that the following scenarios still work correctly:
  - Free trial subscription **without** sign-up fee (pure $0 cart) should show recurring total and subscription shipping rates
  - Regular (non-subscription) physical product should show normal shipping rates
  - Virtual subscriptions should not prompt for shipping

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
