### PR TITLE
fix: guard against empty currency in express checkout canMakePayment

### DIFF
--- a/changelog/fix-ece-invalid-currency-on-canmakepayment
+++ b/changelog/fix-ece-invalid-currency-on-canmakepayment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Stripe IntegrationError for invalid currency when canMakePayment is called during WC Blocks store hydration

--- a/client/express-checkout/utils/__tests__/checkPaymentMethodIsAvailable.test.js
+++ b/client/express-checkout/utils/__tests__/checkPaymentMethodIsAvailable.test.js
@@ -194,6 +194,20 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 		expect( onReadySpy ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'should return false immediately when currency code is empty', async () => {
+		onReadySpy.mockClear();
+		ExpressCheckoutElement.mockClear();
+
+		const result = await checkPaymentMethodIsAvailable(
+			'applePay',
+			createCart( '100.00', '' ),
+			mockApi
+		);
+
+		expect( result ).toBe( false );
+		expect( ExpressCheckoutElement ).not.toHaveBeenCalled();
+	} );
+
 	it( 'should handle cases where payment method is not available', async () => {
 		ExpressCheckoutElement.mockImplementation( ( { onReady } ) => {
 			React.useEffect( () => {

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.tsx
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.tsx
@@ -69,6 +69,16 @@ const checkPaymentMethodIsAvailableInternal = (
 	currencyCode: string,
 	api: WCPayAPI
 ): Promise< boolean > => {
+	// Guard against empty currency code during WooCommerce Blocks store
+	// hydration. The cart store initialises with currency_code: '' before
+	// server-side preloaded data is applied. Passing an empty string to
+	// Stripe Elements throws: "Invalid value for elements(): currency should
+	// be one of ...". Returning false here lets WC Blocks re-evaluate once
+	// the cart data (and currency) is properly loaded.
+	if ( ! currencyCode ) {
+		return Promise.resolve( false );
+	}
+
 	return new Promise( ( resolve ) => {
 		const bodyElement = document.querySelector( 'body' );
 		if ( ! bodyElement ) {


### PR DESCRIPTION
Fixes WCCOM-2290

During WC Blocks store hydration, the cart store initialises with currency_code empty before server-side preloaded data is applied. checkPaymentMethodIsAvailable was passing this empty string to Stripe Elements as the currency option, triggering the IntegrationError about invalid currency.

The fix adds an early return of false when currencyCode is empty. WC Blocks re-calls canMakePayment once cart data is properly loaded.

#### Testing instructions

* Load checkout with express checkout buttons (Apple Pay / Google Pay / Amazon Pay) in Firefox
* Confirm the Stripe IntegrationError for invalid currency no longer appears in the console
* Confirm express checkout buttons still appear and function correctly

Tested on WCCOM sandbox, both Mozilla and Firefox. See video recording on Linear.

- [x] Changelog added
- [ ] Covered with tests
- [ ] Tested on mobile