### PR TITLE
feat: Themed WooPay checkout preview in merchant settings

### DIFF
--- a/assets/images/woopay-preview-beanie.jpg
+++ b/assets/images/woopay-preview-beanie.jpg
@@ -1,1 +1,0 @@
-404: Not Found

--- a/assets/images/woopay-preview-beanie.jpg
+++ b/assets/images/woopay-preview-beanie.jpg
@@ -1,0 +1,1 @@
+404: Not Found

--- a/assets/images/woopay-preview-product.svg
+++ b/assets/images/woopay-preview-product.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 60 60">
+  <rect width="60" height="60" rx="8" fill="#F2E6D9"/>
+  <ellipse cx="30" cy="44" rx="16" ry="10" fill="#D4836A"/>
+  <path d="M14 44c0-11 7-22 16-22s16 11 16 22" fill="#E8976E"/>
+  <path d="M14 44c0-2 7-4 16-4s16 2 16 4" fill="#D4836A"/>
+  <circle cx="30" cy="18" r="4" fill="#E8976E"/>
+  <path d="M18 38c4-8 8-12 12-12s8 4 12 12" fill="none" stroke="#D4836A" stroke-width="1" opacity="0.5"/>
+  <path d="M20 36c3-6 6-10 10-10s7 4 10 10" fill="none" stroke="#D4836A" stroke-width="1" opacity="0.5"/>
+</svg>

--- a/changelog/feat-woopay-settings-preview-themed
+++ b/changelog/feat-woopay-settings-preview-themed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Send merchant font CDN stylesheet URLs to WooPay so checkout renders the merchant's actual web fonts.

--- a/client/checkout/api/__tests__/index.test.js
+++ b/client/checkout/api/__tests__/index.test.js
@@ -158,8 +158,12 @@ describe( 'WCPayAPI', () => {
 		expect( request ).toHaveBeenLastCalledWith( 'https://example.org/', {
 			_wpnonce: 'foo',
 			appearance: null,
+			font_rules: null,
 			email: 'foo@bar.com',
 			user_session: 'qwerty123',
+			order_id: undefined,
+			key: undefined,
+			billing_email: undefined,
 		} );
 	} );
 } );

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -8,7 +8,7 @@ import {
 	getExpressCheckoutConfig,
 	buildAjaxURL,
 } from 'wcpay/utils/express-checkout';
-import { getAppearance } from 'checkout/upe-styles';
+import { getAppearance, getFontRulesFromPage } from 'checkout/upe-styles';
 import { getAppearanceType } from '../utils';
 import { isShortcodeCheckout } from 'wcpay/checkout/woopay/utils';
 
@@ -344,18 +344,22 @@ export default class WCPayAPI {
 			const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
 			const nonce = getConfig( 'initWooPayNonce' );
 			let appearance = null;
+			let fontRules = null;
 			if ( getConfig( 'isWooPayGlobalThemeSupportEnabled' ) ) {
 				if ( isShortcodeCheckout() ) {
 					const appearanceType = getAppearanceType();
 					appearance = getAppearance( appearanceType, true );
+					fontRules = getFontRulesFromPage();
 				} else {
 					appearance = getConfig( 'woopayAppearance' );
+					fontRules = getConfig( 'woopayFontRules' );
 				}
 			}
 
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 				_wpnonce: nonce,
 				appearance,
+				font_rules: fontRules,
 				email: userEmail,
 				user_session: woopayUserSession,
 				order_id: getConfig( 'order_id' ),

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -85,7 +85,7 @@ describe( 'Getting styles for automated theming', () => {
 
 	test( 'getFontRulesFromPage returns font rules from allowed font providers', () => {
 		const mockStyleSheets = {
-			length: 3,
+			length: 4,
 			0: {
 				href:
 					'https://not-supported-fonts-domain.com/style.css?ver=1.1.1',
@@ -95,6 +95,9 @@ describe( 'Getting styles for automated theming', () => {
 				href:
 					// eslint-disable-next-line max-len
 					'https://fonts.googleapis.com/css?family=Source+Sans+Pro%3A400%2C300%2C300italic%2C400italic%2C600%2C700%2C900&subset=latin%2Clatin-ext&ver=3.6.0',
+			},
+			3: {
+				href: 'https://fonts.bunny.net/css?family=Inter:400,700',
 			},
 		};
 		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
@@ -108,6 +111,7 @@ describe( 'Getting styles for automated theming', () => {
 					// eslint-disable-next-line max-len
 					'https://fonts.googleapis.com/css?family=Source+Sans+Pro%3A400%2C300%2C300italic%2C400italic%2C600%2C700%2C900&subset=latin%2Clatin-ext&ver=3.6.0',
 			},
+			{ cssSrc: 'https://fonts.bunny.net/css?family=Inter:400,700' },
 		] );
 	} );
 

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -605,7 +605,6 @@ export const getFontRulesFromPage = ( scope = document ) => {
 		fontDomains = [
 			'fonts.googleapis.com',
 			'fonts.gstatic.com',
-			'fast.fonts.com',
 			'use.typekit.net',
 			'fonts.bunny.net',
 		];

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -607,6 +607,7 @@ export const getFontRulesFromPage = ( scope = document ) => {
 			'fonts.gstatic.com',
 			'fast.fonts.com',
 			'use.typekit.net',
+			'fonts.bunny.net',
 		];
 	for ( let i = 0; i < sheets.length; i++ ) {
 		if ( ! sheets[ i ].href ) {

--- a/client/checkout/woopay/appearance/__tests__/persist-admin.test.js
+++ b/client/checkout/woopay/appearance/__tests__/persist-admin.test.js
@@ -1,5 +1,6 @@
 let mockGetConfig;
 let mockGetAppearance;
+let mockGetFontRulesFromPage;
 let mockGetAppearanceType;
 let mockIsPreviewing;
 
@@ -8,6 +9,7 @@ jest.mock( 'wcpay/utils/checkout', () => ( {
 } ) );
 jest.mock( 'wcpay/checkout/upe-styles', () => ( {
 	getAppearance: ( ...args ) => mockGetAppearance( ...args ),
+	getFontRulesFromPage: ( ...args ) => mockGetFontRulesFromPage( ...args ),
 } ) );
 jest.mock( 'wcpay/checkout/utils', () => ( {
 	getAppearanceType: ( ...args ) => mockGetAppearanceType( ...args ),
@@ -32,6 +34,9 @@ const setupDefaults = () => {
 	mockIsPreviewing = jest.fn( () => true );
 	mockGetAppearanceType = jest.fn( () => 'stripe' );
 	mockGetAppearance = jest.fn( () => MOCK_APPEARANCE );
+	mockGetFontRulesFromPage = jest.fn( () => [
+		{ cssSrc: 'https://fonts.googleapis.com/css?family=Roboto' },
+	] );
 	global.fetch = jest.fn( () => Promise.resolve() );
 };
 
@@ -110,7 +115,7 @@ describe( 'maybePersistAdminAppearance', () => {
 			expect( options.credentials ).toBe( 'same-origin' );
 		} );
 
-		it( 'includes action, nonce, and appearance in FormData', () => {
+		it( 'includes action, nonce, appearance, and font_rules in FormData', () => {
 			const persist = loadModule();
 
 			persist();
@@ -124,6 +129,11 @@ describe( 'maybePersistAdminAppearance', () => {
 			expect( body.get( 'appearance[variables][colorBackground]' ) ).toBe(
 				'#ffffff'
 			);
+			expect( JSON.parse( body.get( 'font_rules' ) ) ).toEqual( [
+				{
+					cssSrc: 'https://fonts.googleapis.com/css?family=Roboto',
+				},
+			] );
 		} );
 	} );
 

--- a/client/checkout/woopay/appearance/persist-admin.js
+++ b/client/checkout/woopay/appearance/persist-admin.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getConfig } from 'wcpay/utils/checkout';
-import { getAppearance } from 'wcpay/checkout/upe-styles';
+import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
 import { getAppearanceType } from 'wcpay/checkout/utils';
 import { isPreviewing } from 'wcpay/checkout/preview';
 import { appendObjectToFormData } from './form-data';
@@ -31,10 +31,13 @@ const persistAppearanceFromDOM = () => {
 		return;
 	}
 
+	const fontRules = getFontRulesFromPage();
+
 	const body = new FormData();
 	body.append( 'action', 'wcpay_admin_set_woopay_appearance' );
 	body.append( '_ajax_nonce', nonce );
 	appendObjectToFormData( body, appearance );
+	body.append( 'font_rules', JSON.stringify( fontRules ) );
 
 	// Fire-and-forget — admin write always overwrites.
 	fetch( ajaxUrl, {

--- a/client/checkout/woopay/appearance/persist.js
+++ b/client/checkout/woopay/appearance/persist.js
@@ -3,6 +3,7 @@
  */
 import { getConfig } from 'wcpay/utils/checkout';
 import { buildAjaxURL } from 'wcpay/utils/express-checkout';
+import { getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
 import { appendObjectToFormData } from './form-data';
 
 let persistAttempted = false;
@@ -28,9 +29,12 @@ export const maybePersistAppearance = ( appearance ) => {
 
 	const url = buildAjaxURL( wcAjaxUrl, 'shopper_set_woopay_appearance' );
 
+	const fontRules = getFontRulesFromPage();
+
 	const body = new FormData();
 	body.append( '_ajax_nonce', getConfig( 'woopaySessionNonce' ) );
 	appendObjectToFormData( body, appearance );
+	body.append( 'font_rules', JSON.stringify( fontRules ) );
 
 	// Fire-and-forget — we don't need the response.
 	fetch( url, {

--- a/client/settings/express-checkout-settings/__tests__/color-utils.test.js
+++ b/client/settings/express-checkout-settings/__tests__/color-utils.test.js
@@ -1,0 +1,113 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import {
+	darkenColor,
+	lightenColor,
+	isDarkColor,
+	getCardBorderColor,
+} from '../color-utils';
+
+describe( 'darkenColor', () => {
+	it( 'darkens white by 50% to #808080', () => {
+		expect( darkenColor( '#ffffff', 50 ) ).toBe( '#808080' );
+	} );
+
+	it( 'returns black when darkened by 100%', () => {
+		expect( darkenColor( '#ff8800', 100 ) ).toBe( '#000000' );
+	} );
+
+	it( 'returns the same color when darkened by 0%', () => {
+		expect( darkenColor( '#abcdef', 0 ) ).toBe( '#abcdef' );
+	} );
+
+	it( 'clamps negative percentage to 0', () => {
+		expect( darkenColor( '#abcdef', -10 ) ).toBe( '#abcdef' );
+	} );
+
+	it( 'handles hex without hash prefix', () => {
+		expect( darkenColor( 'ffffff', 50 ) ).toBe( '#808080' );
+	} );
+} );
+
+describe( 'lightenColor', () => {
+	it( 'lightens black by 50% to #808080', () => {
+		expect( lightenColor( '#000000', 50 ) ).toBe( '#808080' );
+	} );
+
+	it( 'returns white when lightened by 100%', () => {
+		expect( lightenColor( '#003366', 100 ) ).toBe( '#ffffff' );
+	} );
+
+	it( 'returns the same color when lightened by 0%', () => {
+		expect( lightenColor( '#abcdef', 0 ) ).toBe( '#abcdef' );
+	} );
+
+	it( 'clamps percentage above 100 to 100', () => {
+		expect( lightenColor( '#000000', 200 ) ).toBe( '#ffffff' );
+	} );
+} );
+
+describe( 'isDarkColor', () => {
+	it( 'returns true for black', () => {
+		expect( isDarkColor( '#000000' ) ).toBe( true );
+	} );
+
+	it( 'returns false for white', () => {
+		expect( isDarkColor( '#ffffff' ) ).toBe( false );
+	} );
+
+	it( 'returns true for dark blue', () => {
+		expect( isDarkColor( '#003366' ) ).toBe( true );
+	} );
+
+	it( 'returns false for light yellow', () => {
+		expect( isDarkColor( '#ffff00' ) ).toBe( false );
+	} );
+
+	it( 'handles boundary at luminance 128', () => {
+		// YIQ luminance for #808080: (128*299 + 128*587 + 128*114)/1000 = 128
+		// < 128 is false at exactly 128, so #808080 is not dark
+		expect( isDarkColor( '#808080' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getCardBorderColor', () => {
+	it( 'returns undefined for undefined input', () => {
+		expect( getCardBorderColor( undefined ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for null input', () => {
+		expect( getCardBorderColor( null ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for empty string', () => {
+		expect( getCardBorderColor( '' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for 3-digit hex shorthand', () => {
+		expect( getCardBorderColor( '#fff' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for invalid hex', () => {
+		expect( getCardBorderColor( '#gggggg' ) ).toBeUndefined();
+	} );
+
+	it( 'darkens a light background by 6%', () => {
+		const result = getCardBorderColor( '#ffffff' );
+		// darkenColor('#ffffff', 6) = #f0f0f0
+		expect( result ).toBe( '#f0f0f0' );
+	} );
+
+	it( 'lightens a dark background by 6%', () => {
+		const result = getCardBorderColor( '#000000' );
+		// lightenColor('#000000', 6) = #0f0f0f
+		expect( result ).toBe( '#0f0f0f' );
+	} );
+
+	it( 'accepts uppercase hex', () => {
+		expect( getCardBorderColor( '#FFFFFF' ) ).toBe( '#f0f0f0' );
+	} );
+} );

--- a/client/settings/express-checkout-settings/__tests__/color-utils.test.js
+++ b/client/settings/express-checkout-settings/__tests__/color-utils.test.js
@@ -87,8 +87,14 @@ describe( 'getCardBorderColor', () => {
 		expect( getCardBorderColor( '' ) ).toBeUndefined();
 	} );
 
-	it( 'returns undefined for 3-digit hex shorthand', () => {
-		expect( getCardBorderColor( '#fff' ) ).toBeUndefined();
+	it( 'normalizes 3-digit hex shorthand and applies border', () => {
+		// #fff → #ffffff → darkenColor('#ffffff', 6) = #f0f0f0
+		expect( getCardBorderColor( '#fff' ) ).toBe( '#f0f0f0' );
+	} );
+
+	it( 'normalizes 3-digit dark hex shorthand', () => {
+		// #000 → #000000 → lightenColor('#000000', 6) = #0f0f0f
+		expect( getCardBorderColor( '#000' ) ).toBe( '#0f0f0f' );
 	} );
 
 	it( 'returns undefined for invalid hex', () => {

--- a/client/settings/express-checkout-settings/__tests__/woopay-preview.test.js
+++ b/client/settings/express-checkout-settings/__tests__/woopay-preview.test.js
@@ -184,4 +184,149 @@ describe( 'WooPayPreview', () => {
 		const root = container.querySelector( '.preview-layout' );
 		expect( root.style.fontFamily ).toBe( 'Georgia, serif' );
 	} );
+
+	it( 'applies themed footer colors', () => {
+		const appearance = {
+			variables: {},
+			rules: {
+				'.Footer': {
+					backgroundColor: '#222222',
+					color: '#cccccc',
+				},
+				'.Footer-link': { color: '#aaaaaa' },
+			},
+		};
+
+		const { container } = render(
+			<WooPayPreview
+				storeName="Test Store"
+				storeLogo=""
+				customMessage=""
+				appearance={ appearance }
+			/>
+		);
+
+		const footer = container.querySelector( '.preview-layout__footer' );
+		expect( footer.style.backgroundColor ).toBe( 'rgb(34, 34, 34)' );
+		expect( footer.style.color ).toBe( 'rgb(204, 204, 204)' );
+	} );
+
+	it( 'applies card border color derived from background', () => {
+		const appearance = {
+			variables: { colorBackground: '#ffffff' },
+			rules: {},
+		};
+
+		const { container } = render(
+			<WooPayPreview
+				storeName="Test Store"
+				storeLogo=""
+				customMessage=""
+				appearance={ appearance }
+			/>
+		);
+
+		const rightColumn = container.querySelector(
+			'.preview-layout__right-column'
+		);
+		// darkenColor('#ffffff', 6) = #f0f0f0
+		expect( rightColumn.style.borderColor ).toBe( '#f0f0f0' );
+	} );
+
+	it( 'applies text color to field values', () => {
+		const appearance = {
+			variables: { colorText: '#112233' },
+			rules: {},
+		};
+
+		const { container } = render(
+			<WooPayPreview
+				storeName="Test Store"
+				storeLogo=""
+				customMessage=""
+				appearance={ appearance }
+			/>
+		);
+
+		const fieldValue = container.querySelector(
+			'.preview-layout__field-value'
+		);
+		expect( fieldValue.style.color ).toBe( 'rgb(17, 34, 51)' );
+	} );
+
+	it( 'sets link color CSS custom property on custom message', () => {
+		const appearance = {
+			variables: {},
+			rules: {
+				'.Link': { color: '#ff6600' },
+			},
+		};
+
+		const { container } = render(
+			<WooPayPreview
+				storeName="Test Store"
+				storeLogo=""
+				customMessage="<a>Terms</a>"
+				appearance={ appearance }
+			/>
+		);
+
+		const textBox = container.querySelector( '.preview-layout__text-box' );
+		expect( textBox.style.getPropertyValue( '--preview-link-color' ) ).toBe(
+			'#ff6600'
+		);
+	} );
+
+	it( 'handles appearance with empty variables and rules', () => {
+		const appearance = {
+			variables: {},
+			rules: {},
+		};
+
+		const { container } = render(
+			<WooPayPreview
+				storeName="Test Store"
+				storeLogo=""
+				customMessage=""
+				appearance={ appearance }
+			/>
+		);
+
+		// Should render without errors and not apply any themed styles.
+		const root = container.querySelector( '.preview-layout' );
+		expect( root ).toBeInTheDocument();
+		expect( root.style.fontFamily ).toBe( '' );
+	} );
+
+	it( 'handles partial appearance with only some rules', () => {
+		const appearance = {
+			variables: {},
+			rules: {
+				'.Header': { backgroundColor: '#112233' },
+				// No .Label, .Footer, .Link, etc.
+			},
+		};
+
+		const { container } = render(
+			<WooPayPreview
+				storeName="Test Store"
+				storeLogo=""
+				customMessage=""
+				appearance={ appearance }
+			/>
+		);
+
+		const storeHeader = container.querySelector(
+			'.preview-layout__store-header'
+		);
+		expect( storeHeader.style.backgroundColor ).toBe( 'rgb(17, 34, 51)' );
+
+		// Section headers should have no inline color.
+		const sectionHeaders = container.querySelectorAll(
+			'.preview-layout__section-header'
+		);
+		sectionHeaders.forEach( ( header ) => {
+			expect( header.style.color ).toBe( '' );
+		} );
+	} );
 } );

--- a/client/settings/express-checkout-settings/color-utils.js
+++ b/client/settings/express-checkout-settings/color-utils.js
@@ -66,8 +66,19 @@ export const isDarkColor = ( hex ) => {
  * @return {string|undefined} The derived border colour, or undefined.
  */
 export const getCardBorderColor = ( bg ) => {
-	if ( ! bg || ! /^#[0-9a-f]{6}$/i.test( bg ) ) {
+	if ( ! bg ) {
 		return undefined;
 	}
-	return isDarkColor( bg ) ? lightenColor( bg, 6 ) : darkenColor( bg, 6 );
+
+	// Normalize 3-digit hex (#RGB) to 6-digit (#RRGGBB).
+	let hex = bg;
+	const shortMatch = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec( hex );
+	if ( shortMatch ) {
+		hex = `#${ shortMatch[ 1 ] }${ shortMatch[ 1 ] }${ shortMatch[ 2 ] }${ shortMatch[ 2 ] }${ shortMatch[ 3 ] }${ shortMatch[ 3 ] }`;
+	}
+
+	if ( ! /^#[0-9a-f]{6}$/i.test( hex ) ) {
+		return undefined;
+	}
+	return isDarkColor( hex ) ? lightenColor( hex, 6 ) : darkenColor( hex, 6 );
 };

--- a/client/settings/express-checkout-settings/color-utils.js
+++ b/client/settings/express-checkout-settings/color-utils.js
@@ -1,0 +1,73 @@
+/**
+ * Darkens a hex colour by a percentage (matching WooPay's PHP darken_color).
+ *
+ * @param {string} hex   A hex colour string (e.g. "#ffffff").
+ * @param {number} pct   Percentage to darken (0–100).
+ * @return {string} The darkened hex colour.
+ */
+export const darkenColor = ( hex, pct ) => {
+	const h = hex.replace( '#', '' );
+	const factor = 1 - Math.max( 0, Math.min( 100, pct ) ) / 100;
+	const r = Math.round( parseInt( h.substring( 0, 2 ), 16 ) * factor );
+	const g = Math.round( parseInt( h.substring( 2, 4 ), 16 ) * factor );
+	const b = Math.round( parseInt( h.substring( 4, 6 ), 16 ) * factor );
+	return `#${ r.toString( 16 ).padStart( 2, '0' ) }${ g
+		.toString( 16 )
+		.padStart( 2, '0' ) }${ b.toString( 16 ).padStart( 2, '0' ) }`;
+};
+
+/**
+ * Lightens a hex colour by a percentage (matching WooPay's PHP lighten_color).
+ *
+ * @param {string} hex   A hex colour string (e.g. "#000000").
+ * @param {number} pct   Percentage to lighten (0–100).
+ * @return {string} The lightened hex colour.
+ */
+export const lightenColor = ( hex, pct ) => {
+	const h = hex.replace( '#', '' );
+	const factor = Math.max( 0, Math.min( 100, pct ) ) / 100;
+	const r = Math.round(
+		parseInt( h.substring( 0, 2 ), 16 ) +
+			( 255 - parseInt( h.substring( 0, 2 ), 16 ) ) * factor
+	);
+	const g = Math.round(
+		parseInt( h.substring( 2, 4 ), 16 ) +
+			( 255 - parseInt( h.substring( 2, 4 ), 16 ) ) * factor
+	);
+	const b = Math.round(
+		parseInt( h.substring( 4, 6 ), 16 ) +
+			( 255 - parseInt( h.substring( 4, 6 ), 16 ) ) * factor
+	);
+	return `#${ r.toString( 16 ).padStart( 2, '0' ) }${ g
+		.toString( 16 )
+		.padStart( 2, '0' ) }${ b.toString( 16 ).padStart( 2, '0' ) }`;
+};
+
+/**
+ * Returns true if the hex colour is considered "dark" (luminance < 128).
+ *
+ * @param {string} hex A hex colour string.
+ * @return {boolean} Whether the colour is dark.
+ */
+export const isDarkColor = ( hex ) => {
+	const h = hex.replace( '#', '' );
+	const r = parseInt( h.substring( 0, 2 ), 16 );
+	const g = parseInt( h.substring( 2, 4 ), 16 );
+	const b = parseInt( h.substring( 4, 6 ), 16 );
+	return ( r * 299 + g * 587 + b * 114 ) / 1000 < 128;
+};
+
+/**
+ * Derives the card border colour from a background hex value.
+ * Matches WooPay's PHP logic: lighten 6 % for dark (night) backgrounds,
+ * darken 6 % for light (day) backgrounds.
+ *
+ * @param {string|undefined} bg  A hex colour string, or undefined.
+ * @return {string|undefined} The derived border colour, or undefined.
+ */
+export const getCardBorderColor = ( bg ) => {
+	if ( ! bg || ! /^#[0-9a-f]{6}$/i.test( bg ) ) {
+		return undefined;
+	}
+	return isDarkColor( bg ) ? lightenColor( bg, 6 ) : darkenColor( bg, 6 );
+};

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -119,6 +119,8 @@
 			box-shadow: 0 2px 6px 0 rgba( 0, 0, 0, 0.05 );
 			padding: 0;
 			position: relative;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+				'Arial', sans-serif;
 
 			&__v-spacer {
 				background-color: #0000;
@@ -141,31 +143,62 @@
 
 			&__store-header {
 				width: 100%;
+				height: 32px;
 				display: flex;
-				justify-content: center;
-				position: relative;
+				justify-content: space-between;
+				align-items: center;
+				background-color: $studio-white;
+				box-shadow: 0 1px 0 $studio-gray-5;
+				padding: 0 3.797%;
+				box-sizing: border-box;
+				border-radius: $grid-unit-05 $grid-unit-05 0 0;
 
 				.header-text {
-					color: $studio-gray-60;
-					font-size: 1.125rem;
-					letter-spacing: 0.1rem;
+					color: #404040;
+					font-size: 0.4375rem;
+					font-weight: 400;
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
+				}
 
-					@media screen and ( max-width: $break-mobile ) {
-						// The chevronLeft icon is 5.66% from the left and
-						// has a width of 1.5rem. This padding is to ensure
-						// the text doesn't overlap with the icon.
-						padding-left: calc( 5.66% + 1.5rem );
-					}
+				img {
+					max-height: 0.875rem;
+					width: auto;
+					display: block;
 				}
 			}
 
-			&__chevron-left {
-				position: absolute;
-				left: 5.66%;
-				top: 0;
+			&__back-button {
+				display: flex;
+				align-items: center;
+				gap: 0.0625rem;
+				flex-shrink: 0;
+
+				svg {
+					width: 0.5rem;
+					height: 0.5rem;
+				}
+			}
+
+			&__back-button-label {
+				font-size: 0.25rem;
+				color: $studio-gray-40;
+				white-space: nowrap;
+			}
+
+			&__store-branding {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				flex: 1;
+				min-width: 0;
+			}
+
+			&__store-header-spacer {
+				flex-shrink: 0;
+				// Match back-button width to keep branding centered.
+				width: 2rem;
 			}
 
 			&__container {
@@ -184,6 +217,7 @@
 
 			&__left-column {
 				width: 59.08%;
+				max-width: 242px;
 			}
 
 			&__contact-section {
@@ -192,7 +226,7 @@
 			}
 
 			&__contact-field {
-				padding: 0.5rem;
+				padding: 0.375rem;
 
 				&:not( :last-child ) {
 					border-bottom: 0.03125rem solid #11111121;
@@ -201,19 +235,35 @@
 
 			&__right-column {
 				width: 35.59%;
+				max-width: 146px;
+				border: 0.03125rem solid #11111121;
+				border-radius: 0.25rem;
+				padding: 0.3125rem;
+				align-self: flex-start;
 			}
 
 			&__columns-container {
-				padding: 0 3.797% 0 3.797%;
+				padding: 0 3.797%;
 				display: flex;
-				justify-content: space-between;
+				justify-content: center;
+				gap: 28px;
+			}
+
+			&__woopay-logo {
+				display: flex;
+				align-items: center;
+
+				svg {
+					height: 0.375rem;
+					width: auto;
+				}
 			}
 
 			&__section-header {
 				font-weight: 500;
-				font-size: 0.5rem;
+				font-size: 0.4375rem;
 				color: $studio-gray-80;
-				line-height: 0.74669rem;
+				line-height: 0.625rem;
 				letter-spacing: 0.01rem;
 				display: flex;
 				justify-content: space-between;
@@ -221,63 +271,172 @@
 
 			&__loading-box {
 				background-color: $studio-gray-0;
-				border-radius: 0.25rem;
+				border-radius: 0.1875rem;
 				width: 100%;
 			}
 
 			&__field-value {
-				font-size: 0.5rem;
+				font-size: 0.375rem;
 				color: $studio-gray-80;
 				line-height: 1.4;
-				padding-top: 0.125rem;
+				padding-top: 0.375rem;
+			}
+
+			&__pay-with-value {
+				display: flex;
+				align-items: center;
+				gap: 0.1875rem;
+			}
+
+			&__visa-icon {
+				display: flex;
+				flex-shrink: 0;
+
+				svg {
+					width: 1.25rem;
+					height: auto;
+				}
 			}
 
 			&__chevron-down {
-				font-size: 0.625rem;
+				font-size: 0.4375rem;
 				color: $studio-gray-40;
 				transform: rotate( 90deg );
 				display: inline-block;
 			}
 
-			&__order-item {
-				display: flex;
-				align-items: center;
-				gap: 0.25rem;
+			&__chevron-up {
 				font-size: 0.4375rem;
+				transform: rotate( -90deg );
+				display: inline-block;
+			}
+
+			&__cart-header {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				font-size: 0.375rem;
 				color: $studio-gray-80;
 
-				&-box {
+				&-text {
+					font-weight: 400;
+				}
+
+				&-toggle {
+					display: flex;
+					align-items: center;
+					gap: 0.0625rem;
+					color: $studio-woocommerce-purple-50;
+					font-weight: 500;
+					font-size: 0.3125rem;
+				}
+			}
+
+			&__order-item {
+				display: grid;
+				grid-template-columns: max-content 1fr max-content;
+				grid-template-rows: 1fr 1fr;
+				height: 1.25rem;
+				column-gap: 0.375rem;
+				row-gap: 0;
+				font-size: 0.375rem;
+				color: $studio-gray-80;
+
+				&-image {
+					position: relative;
 					width: 1.25rem;
 					height: 1.25rem;
-					background-color: $studio-gray-0;
-					border-radius: 0.125rem;
 					flex-shrink: 0;
+					grid-row: 1 / 3;
+				}
+
+				&-img {
+					width: 100%;
+					height: 100%;
+					border-radius: 0.1875rem;
+					object-fit: cover;
+					display: block;
+					background-color: #f2e6d9;
+				}
+
+				&-qty {
+					position: absolute;
+					top: -0.125rem;
+					right: -0.125rem;
+					background: $studio-woocommerce-purple-90;
+					color: $studio-white;
+					font-size: 0.25rem;
+					line-height: 1;
+					min-width: 0.4375rem;
+					min-height: 0.4375rem;
+					border-radius: 0.4375rem;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					z-index: 1;
+				}
+
+				&-details {
+					display: contents;
+					min-width: 0;
 				}
 
 				&-name {
-					flex: 1;
+					font-weight: 400;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					grid-column: 2;
+					grid-row: 1;
+					align-self: start;
+				}
+
+				&-unit-price {
+					font-size: 0.3125rem;
+					color: $studio-gray-50;
+					grid-column: 2;
+					grid-row: 2;
+					align-self: end;
 				}
 
 				&-price {
 					white-space: nowrap;
+					grid-row: 1 / 3;
+					text-align: right;
+				}
+			}
+
+			&__add-coupon {
+				display: flex;
+				align-items: center;
+				gap: 0.0625rem;
+				font-size: 0.3125rem;
+				color: $studio-woocommerce-purple-50;
+				font-weight: 500;
+
+				&-icon {
+					width: 0.375rem;
+					height: 0.375rem;
 				}
 			}
 
 			&__order-row {
 				display: flex;
 				justify-content: space-between;
-				font-size: 0.4375rem;
+				font-size: 0.3125rem;
 				color: $studio-gray-80;
-				line-height: 1.6;
+				line-height: 1.8;
 			}
 
 			&__hr--dotted {
 				border-style: dotted;
+				border-color: $studio-gray-10;
 			}
 
 			&__footer {
 				background-color: $studio-white;
-				padding: 0.375rem 3.797%;
+				height: 24px;
+				padding: 0 3.797%;
 				border-radius: 0 0 $grid-unit-05 $grid-unit-05;
 				box-shadow: 0 -1px 0 $studio-gray-5;
 				display: flex;
@@ -288,8 +447,8 @@
 			&__footer-links {
 				display: flex;
 				align-items: center;
-				gap: 0.1875rem;
-				font-size: 0.375rem;
+				gap: 0.125rem;
+				font-size: 0.25rem;
 				color: $studio-gray-50;
 			}
 
@@ -300,7 +459,7 @@
 
 			&__footer-dot {
 				color: #72767c;
-				font-size: 0.25rem;
+				font-size: 0.1875rem;
 			}
 
 			&__footer-cards {
@@ -309,14 +468,14 @@
 				flex-shrink: 0;
 
 				svg {
-					height: 0.75rem;
+					height: 0.5rem;
 					width: auto;
 				}
 			}
 
 			&__text-box {
 				width: 100%;
-				font-size: 0.625rem;
+				font-size: 0.375rem;
 				color: $studio-gray-50;
 				text-align: center;
 				font-weight: 400;
@@ -325,7 +484,10 @@
 			}
 
 			&__shortcode-link {
-				color: $studio-woocommerce-purple-60;
+				color: var(
+					--preview-link-color,
+					$studio-woocommerce-purple-60
+				);
 			}
 
 			&__checkout-button {
@@ -336,9 +498,9 @@
 				justify-content: center;
 
 				color: $studio-white;
-				font-size: 0.625em;
+				font-size: 0.5rem;
 				font-weight: 600;
-				line-height: 0.56rem;
+				line-height: 0.5rem;
 				letter-spacing: 0.0125rem;
 			}
 		}

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -4,6 +4,7 @@
  */
 import React, { useMemo } from 'react';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -116,7 +117,7 @@ const BackButton = ( { themedStyle } ) => {
 				className="preview-layout__back-button-label"
 				style={ themedStyle }
 			>
-				Return to cart
+				{ __( 'Return to cart', 'woocommerce-payments' ) }
 			</span>
 		</div>
 	);
@@ -314,7 +315,7 @@ const WooPayLogo = () => {
 const CheckoutButton = ( { height } ) => {
 	return (
 		<div className="preview-layout__checkout-button" style={ { height } }>
-			Place order
+			{ __( 'Place order', 'woocommerce-payments' ) }
 		</div>
 	);
 };
@@ -440,7 +441,10 @@ export default ( {
 										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
-										Ship to
+										{ __(
+											'Ship to',
+											'woocommerce-payments'
+										) }
 										<ChevronDown />
 									</SectionHeader>
 									<FieldValue themedStyle={ themed.textBox }>
@@ -453,11 +457,24 @@ export default ( {
 										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
-										Shipping method
+										{ __(
+											'Shipping method',
+											'woocommerce-payments'
+										) }
 										<ChevronDown />
 									</SectionHeader>
 									<FieldValue themedStyle={ themed.textBox }>
-										Free shipping — Free
+										{ sprintf(
+											/* translators: %s: shipping method name */
+											__(
+												'%s — Free',
+												'woocommerce-payments'
+											),
+											__(
+												'Free shipping',
+												'woocommerce-payments'
+											)
+										) }
 									</FieldValue>
 								</ContactField>
 								<ContactField>
@@ -465,7 +482,10 @@ export default ( {
 										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
-										Pay with
+										{ __(
+											'Pay with',
+											'woocommerce-payments'
+										) }
 										<ChevronDown />
 									</SectionHeader>
 									<FieldValue themedStyle={ themed.textBox }>
@@ -507,7 +527,10 @@ export default ( {
 								height="0.625rem"
 								themedStyle={ themed.sectionHeader }
 							>
-								Order summary
+								{ __(
+									'Order summary',
+									'woocommerce-payments'
+								) }
 							</SectionHeader>
 							<VerticalSpacer height="0.6rem" />
 							<div
@@ -515,13 +538,17 @@ export default ( {
 								style={ themed.textBox }
 							>
 								<span className="preview-layout__cart-header-text">
-									1 item
+									{ sprintf(
+										/* translators: %d: number of items in cart */
+										__( '%d item', 'woocommerce-payments' ),
+										1
+									) }
 								</span>
 								<span
 									className="preview-layout__cart-header-toggle"
 									style={ themed.link }
 								>
-									Hide
+									{ __( 'Hide', 'woocommerce-payments' ) }
 									<span className="preview-layout__chevron-up">
 										›
 									</span>
@@ -562,7 +589,7 @@ export default ( {
 										fill="currentColor"
 									/>
 								</svg>
-								Add a coupon
+								{ __( 'Add a coupon', 'woocommerce-payments' ) }
 							</div>
 							<VerticalSpacer height="0.108rem" />
 							<div
@@ -601,22 +628,31 @@ export default ( {
 										strokeWidth="1.5"
 									/>
 								</svg>
-								Add a gift card
+								{ __(
+									'Add a gift card',
+									'woocommerce-payments'
+								) }
 							</div>
 							<VerticalSpacer height="0.24rem" />
 							<OrderRow
-								label="Subtotal"
+								label={ __(
+									'Subtotal',
+									'woocommerce-payments'
+								) }
 								value="$ 18.00"
 								themedStyle={ themed.textBox }
 							/>
 							<OrderRow
-								label="Shipping"
-								value="Free"
+								label={ __(
+									'Shipping',
+									'woocommerce-payments'
+								) }
+								value={ __( 'Free', 'woocommerce-payments' ) }
 								themedStyle={ themed.textBox }
 							/>
 							<VerticalSpacer height="0.5rem" />
 							<OrderRow
-								label="Total"
+								label={ __( 'Total', 'woocommerce-payments' ) }
 								value="$ 18.00"
 								themedStyle={ {
 									...themed.textBox,

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -4,12 +4,86 @@
  */
 import React, { useMemo } from 'react';
 import { decodeEntities } from '@wordpress/html-entities';
-import { chevronLeft, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
 import { NAMESPACE } from 'wcpay/data/constants';
+import PreviewProductImage from 'assets/images/woopay-preview-product.svg?asset';
+
+/**
+ * Darkens a hex colour by a percentage (matching WooPay's PHP darken_color).
+ *
+ * @param {string} hex   A hex colour string (e.g. "#ffffff").
+ * @param {number} pct   Percentage to darken (0–100).
+ * @return {string} The darkened hex colour.
+ */
+const darkenColor = ( hex, pct ) => {
+	const h = hex.replace( '#', '' );
+	const factor = 1 - Math.max( 0, Math.min( 100, pct ) ) / 100;
+	const r = Math.round( parseInt( h.substring( 0, 2 ), 16 ) * factor );
+	const g = Math.round( parseInt( h.substring( 2, 4 ), 16 ) * factor );
+	const b = Math.round( parseInt( h.substring( 4, 6 ), 16 ) * factor );
+	return `#${ r.toString( 16 ).padStart( 2, '0' ) }${ g
+		.toString( 16 )
+		.padStart( 2, '0' ) }${ b.toString( 16 ).padStart( 2, '0' ) }`;
+};
+
+/**
+ * Lightens a hex colour by a percentage (matching WooPay's PHP lighten_color).
+ *
+ * @param {string} hex   A hex colour string (e.g. "#000000").
+ * @param {number} pct   Percentage to lighten (0–100).
+ * @return {string} The lightened hex colour.
+ */
+const lightenColor = ( hex, pct ) => {
+	const h = hex.replace( '#', '' );
+	const factor = Math.max( 0, Math.min( 100, pct ) ) / 100;
+	const r = Math.round(
+		parseInt( h.substring( 0, 2 ), 16 ) +
+			( 255 - parseInt( h.substring( 0, 2 ), 16 ) ) * factor
+	);
+	const g = Math.round(
+		parseInt( h.substring( 2, 4 ), 16 ) +
+			( 255 - parseInt( h.substring( 2, 4 ), 16 ) ) * factor
+	);
+	const b = Math.round(
+		parseInt( h.substring( 4, 6 ), 16 ) +
+			( 255 - parseInt( h.substring( 4, 6 ), 16 ) ) * factor
+	);
+	return `#${ r.toString( 16 ).padStart( 2, '0' ) }${ g
+		.toString( 16 )
+		.padStart( 2, '0' ) }${ b.toString( 16 ).padStart( 2, '0' ) }`;
+};
+
+/**
+ * Returns true if the hex colour is considered "dark" (luminance < 128).
+ *
+ * @param {string} hex A hex colour string.
+ * @return {boolean} Whether the colour is dark.
+ */
+const isDarkColor = ( hex ) => {
+	const h = hex.replace( '#', '' );
+	const r = parseInt( h.substring( 0, 2 ), 16 );
+	const g = parseInt( h.substring( 2, 4 ), 16 );
+	const b = parseInt( h.substring( 4, 6 ), 16 );
+	return ( r * 299 + g * 587 + b * 114 ) / 1000 < 128;
+};
+
+/**
+ * Derives the card border colour from a background hex value.
+ * Matches WooPay's PHP logic: lighten 6 % for dark (night) backgrounds,
+ * darken 6 % for light (day) backgrounds.
+ *
+ * @param {string|undefined} bg  A hex colour string, or undefined.
+ * @return {string|undefined} The derived border colour, or undefined.
+ */
+const getCardBorderColor = ( bg ) => {
+	if ( ! bg || ! /^#[0-9a-f]{6}$/i.test( bg ) ) {
+		return undefined;
+	}
+	return isDarkColor( bg ) ? lightenColor( bg, 6 ) : darkenColor( bg, 6 );
+};
 
 /**
  * Derives inline style objects from a WooPay appearance object.
@@ -27,6 +101,7 @@ const getThemedStyles = ( appearance ) => {
 	const rules = appearance.rules || {};
 
 	const headerBg = rules[ '.Header' ]?.backgroundColor || undefined;
+	const cardBorderColor = getCardBorderColor( vars.colorBackground );
 
 	return {
 		root: {
@@ -49,9 +124,6 @@ const getThemedStyles = ( appearance ) => {
 		chevron: {
 			color: rules[ '.Header' ]?.color || undefined,
 		},
-		hr: {
-			color: vars.colorText ? `${ vars.colorText }33` : undefined,
-		},
 		sectionHeader: {
 			color: rules[ '.Label' ]?.color || undefined,
 		},
@@ -60,6 +132,9 @@ const getThemedStyles = ( appearance ) => {
 		},
 		textBox: {
 			color: vars.colorText || undefined,
+		},
+		card: {
+			borderColor: cardBorderColor,
 		},
 		link: {
 			color: rules[ '.Link' ]?.color || undefined,
@@ -95,24 +170,48 @@ const PreviewContainer = ( { height, themedStyle, children } ) => {
 	);
 };
 
-const ChevronLeft = () => {
+const BackButton = ( { themedStyle } ) => {
+	const strokeColor = themedStyle?.color || '#2C3338';
 	return (
-		<Icon
-			className="preview-layout__chevron-left"
-			icon={ chevronLeft }
-			size={ 24 }
-		/>
+		<div className="preview-layout__back-button">
+			<svg
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					d="M14 6.50002L9 12L14 17.5"
+					stroke={ strokeColor }
+					strokeWidth="1.5"
+				/>
+			</svg>
+			<span
+				className="preview-layout__back-button-label"
+				style={ themedStyle }
+			>
+				Return to cart
+			</span>
+		</div>
 	);
 };
 
-const StoreHeader = ( { height, variant = 'test', themedStyle, children } ) => {
+const StoreHeader = ( {
+	variant = 'test',
+	themedStyle,
+	chevronStyle,
+	children,
+} ) => {
 	return (
 		<div
 			className="preview-layout__store-header"
 			variant={ variant }
-			style={ { height, ...themedStyle } }
+			style={ themedStyle }
 		>
-			{ children }
+			<BackButton themedStyle={ chevronStyle } />
+			<div className="preview-layout__store-branding">{ children }</div>
+			<div className="preview-layout__store-header-spacer" />
 		</div>
 	);
 };
@@ -149,9 +248,12 @@ const ContactField = ( { children } ) => {
 	return <div className="preview-layout__contact-field">{ children }</div>;
 };
 
-const RightColumn = ( { height, children } ) => {
+const RightColumn = ( { height, themedStyle, children } ) => {
 	return (
-		<div className="preview-layout__right-column" style={ { height } }>
+		<div
+			className="preview-layout__right-column"
+			style={ { height, ...themedStyle } }
+		>
 			{ children }
 		</div>
 	);
@@ -180,11 +282,40 @@ const ChevronDown = () => {
 	return <span className="preview-layout__chevron-down">›</span>;
 };
 
-const OrderItem = ( { name, price, themedStyle } ) => {
+// Small Visa card icon for the "Pay with" field value.
+const VISA_ICON_SVG =
+	'<svg width="20" height="13" viewBox="0 0 64 40" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="64" height="40" rx="3" fill="white" stroke="#ddd" stroke-width="1"/><path d="M28.6564 27.2545H24.7949L27.2102 13.2538H31.0714L28.6564 27.2545Z" fill="#1C34C3"/><path d="M42.6537 13.5961C41.8921 13.3128 40.684 13 39.1903 13C35.3769 13 32.6916 14.9064 32.6751 17.6319C32.6435 19.6428 34.5977 20.7597 36.0594 21.4302C37.5534 22.1154 38.0612 22.5626 38.0612 23.1733C38.046 24.1112 36.854 24.5436 35.7422 24.5436C34.2006 24.5436 33.3745 24.3207 32.1191 23.7989L31.6107 23.5752L31.0703 26.718C31.976 27.1048 33.6446 27.4481 35.3769 27.4631C39.4287 27.4631 42.0665 25.5863 42.0977 22.6818C42.1131 21.088 41.0812 19.8667 38.8564 18.8688C37.5058 18.2282 36.6787 17.7962 36.6787 17.1408C36.6946 16.5449 37.3783 15.9346 38.9029 15.9346C40.1582 15.9047 41.0806 16.1876 41.7793 16.4707L42.1286 16.6194L42.6537 13.5961Z" fill="#1C34C3"/><path fill-rule="evenodd" clip-rule="evenodd" d="M49.5665 13.2538H52.5534L55.6686 27.2543H52.0933C52.0933 27.2543 51.7434 25.6456 51.6325 25.1541H46.6747C46.5313 25.5263 45.8642 27.2543 45.8642 27.2543H41.8125L47.5482 14.4154C47.9456 13.5068 48.6454 13.2538 49.5665 13.2538ZM49.3285 18.3773C49.3285 18.3773 48.1049 21.4902 47.7869 22.2945H50.9965C50.8377 21.5945 50.1064 18.2432 50.1064 18.2432L49.8366 17.0368C49.7229 17.3475 49.5586 17.7746 49.4478 18.0626C49.3726 18.2579 49.322 18.3893 49.3285 18.3773Z" fill="#1C34C3"/><path fill-rule="evenodd" clip-rule="evenodd" d="M8.06356 13.2538H14.2763C15.1184 13.2833 15.8017 13.5365 16.0241 14.4307L17.3743 20.8634C17.3744 20.8638 17.3745 20.8643 17.3747 20.8647L17.7879 22.8009L21.5696 13.2538H25.6528L19.5832 27.2396H15.4998L12.058 15.0743C10.8705 14.4234 9.51527 13.8999 8 13.5367L8.06356 13.2538Z" fill="#1C34C3"/></svg>';
+
+const OrderItem = ( {
+	name,
+	price,
+	unitPrice,
+	quantity,
+	imageSrc,
+	themedStyle,
+} ) => {
 	return (
 		<div className="preview-layout__order-item" style={ themedStyle }>
-			<div className="preview-layout__order-item-box" />
-			<span className="preview-layout__order-item-name">{ name }</span>
+			<div className="preview-layout__order-item-image">
+				<img
+					src={ imageSrc }
+					alt={ name }
+					className="preview-layout__order-item-img"
+				/>
+				<span className="preview-layout__order-item-qty">
+					{ quantity }
+				</span>
+			</div>
+			<div className="preview-layout__order-item-details">
+				<span className="preview-layout__order-item-name">
+					{ name }
+				</span>
+				{ unitPrice && (
+					<span className="preview-layout__order-item-unit-price">
+						{ unitPrice }
+					</span>
+				) }
+			</div>
 			<span className="preview-layout__order-item-price">{ price }</span>
 		</div>
 	);
@@ -246,6 +377,20 @@ const TextBox = ( { children, maxHeight, themedStyle } ) => {
 			dangerouslySetInnerHTML={ {
 				__html: children,
 			} }
+		/>
+	);
+};
+
+// WooPay logo SVG (dark variant) from woopay-svgs.svg.
+// Uses dangerouslySetInnerHTML to preserve the original SVG markup.
+const WOOPAY_LOGO_SVG =
+	'<svg viewBox="0 0 124 26" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M79.453 1.044v18.902h3.184v-7.113h5.031c1.27 0 2.369-.265 3.297-.794.929-.529 1.64-1.237 2.132-2.125.493-.907.74-1.899.74-2.976 0-1.076-.247-2.059-.74-2.947a5.426 5.426 0 0 0-2.132-2.153c-.91-.53-2.008-.794-3.297-.794h-8.215Zm3.184 8.983h4.605c.644 0 1.212-.122 1.705-.368.512-.265.91-.633 1.194-1.105.284-.473.426-1.011.426-1.616 0-.604-.142-1.143-.426-1.615a2.747 2.747 0 0 0-1.194-1.077c-.493-.264-1.061-.396-1.705-.396h-4.605v6.177ZM100.7 20.286c-1.175 0-2.227-.284-3.155-.85-.929-.586-1.658-1.417-2.189-2.494-.512-1.077-.767-2.352-.767-3.826 0-1.454.255-2.72.767-3.797.53-1.096 1.26-1.937 2.189-2.522.928-.586 1.98-.879 3.155-.879.947 0 1.838.236 2.672.709a5.492 5.492 0 0 1 1.791 1.556V6.258h2.842v13.688h-2.842v-1.92a6.027 6.027 0 0 1-1.791 1.58 5.405 5.405 0 0 1-2.672.68Zm3.098-11.137c.61.358 1.065.774 1.365 1.248v5.476c-.3.486-.755.909-1.365 1.267-.739.416-1.497.624-2.274.624-1.213 0-2.179-.425-2.9-1.276-.7-.869-1.05-1.993-1.05-3.372 0-.907.15-1.71.454-2.409a3.83 3.83 0 0 1 1.393-1.643c.606-.397 1.307-.595 2.103-.595.777 0 1.535.226 2.274.68Zm7.392 13.602c.133.076.313.132.54.17.228.038.455.057.683.057.454 0 .833-.095 1.137-.284.303-.188.549-.5.739-.935l.719-1.66-5.637-13.84h3.042l4.093 10.4 4.093-10.4h3.07l-6.68 16.237c0 .019-.01.029-.028.029v.056c-.304.7-.673 1.266-1.109 1.7a3.855 3.855 0 0 1-1.478.936c-.55.189-1.175.283-1.876.283a8.05 8.05 0 0 1-.938-.057 6.725 6.725 0 0 1-.825-.141l.455-2.55Z" fill="#000"/><path fill-rule="evenodd" clip-rule="evenodd" d="M9.803 20.275c2.208 0 3.98-1.088 5.316-3.588l2.972-5.546v4.703c0 2.772 1.8 4.43 4.581 4.43 2.181 0 3.79-.95 5.344-3.588L34.86 5.161c1.5-2.528.436-4.43-2.863-4.43-1.772 0-2.917.57-3.953 2.5l-4.718 8.835V4.21c0-2.338-1.117-3.48-3.19-3.48-1.636 0-2.944.707-3.953 2.664l-4.445 8.671V4.292c0-2.5-1.036-3.56-3.544-3.56H3.068C1.132.73.15 1.626.15 3.284c0 1.659 1.037 2.61 2.918 2.61h2.1v9.922c0 2.8 1.88 4.458 4.635 4.458ZM44.868.73c-5.59 0-9.87 4.16-9.87 9.786 0 5.627 4.308 9.759 9.87 9.759 5.562 0 9.816-4.16 9.843-9.759 0-5.627-4.28-9.786-9.843-9.786Zm0 13.537c-2.1 0-3.545-1.576-3.545-3.751s1.445-3.778 3.545-3.778c2.1 0 3.544 1.603 3.544 3.778s-1.417 3.751-3.544 3.751ZM56.1 10.516C56.1 4.889 60.381.73 65.943.73c5.563 0 9.843 4.186 9.843 9.786s-4.28 9.759-9.843 9.759c-5.562 0-9.843-4.132-9.843-9.759Zm6.326 0c0 2.175 1.39 3.751 3.517 3.751 2.1 0 3.545-1.576 3.545-3.751s-1.445-3.778-3.545-3.778c-2.1 0-3.517 1.603-3.517 3.778Z" fill="#873EFF"/></svg>';
+
+const WooPayLogo = () => {
+	return (
+		<div
+			className="preview-layout__woopay-logo"
+			dangerouslySetInnerHTML={ { __html: WOOPAY_LOGO_SVG } }
 		/>
 	);
 };
@@ -357,30 +502,20 @@ export default ( {
 				// <PreviewButton />
 			 }
 			<PreviewContainer themedStyle={ themed.container }>
-				<VerticalSpacer height="0.75rem" />
 				<StoreHeader
-					className="preview-layout__store-header"
 					variant={ storeLogo ? 'logo' : 'text' }
-					height={ storeLogo ? '2rem' : '1.5rem' }
 					themedStyle={ themed.storeHeader }
+					chevronStyle={ themed.chevron }
 				>
-					<ChevronLeft />
 					{ storeHeader }
 				</StoreHeader>
-				<VerticalSpacer height={ storeLogo ? '0.4rem' : '0.75rem' } />
-				<hr className="preview-layout__hr" style={ themed.hr } />
 				<PreviewBody themedStyle={ themed.body }>
-					<VerticalSpacer height="1.5rem" />
+					<VerticalSpacer height="2rem" />
 					<ColumnsContainer>
 						<LeftColumn>
 							<ContactSection>
 								<ContactField>
-									<SectionHeader
-										height="0.75rem"
-										themedStyle={ themed.sectionHeader }
-									>
-										CONTACT
-									</SectionHeader>
+									<WooPayLogo />
 									<FieldValue themedStyle={ themed.textBox }>
 										jane@example.com
 									</FieldValue>
@@ -388,25 +523,24 @@ export default ( {
 								<ContactField>
 									<SectionHeader
 										isDropdownIncluded
-										height="0.75rem"
+										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
-										SHIP TO
+										Ship to
 										<ChevronDown />
 									</SectionHeader>
 									<FieldValue themedStyle={ themed.textBox }>
-										Jane Smith, 123 Main St,
-										<br />
-										San Francisco, CA 94105
+										Jane Smith, 123 Main St, San Francisco,
+										CA 94105
 									</FieldValue>
 								</ContactField>
 								<ContactField>
 									<SectionHeader
 										isDropdownIncluded
-										height="0.75rem"
+										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
-										SHIPPING METHOD
+										Shipping method
 										<ChevronDown />
 									</SectionHeader>
 									<FieldValue themedStyle={ themed.textBox }>
@@ -416,50 +550,148 @@ export default ( {
 								<ContactField>
 									<SectionHeader
 										isDropdownIncluded
-										height="0.75rem"
+										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
-										PAY WITH
+										Pay with
 										<ChevronDown />
 									</SectionHeader>
 									<FieldValue themedStyle={ themed.textBox }>
-										Visa ···· 4242 Exp. 12/29
+										<span className="preview-layout__pay-with-value">
+											<span
+												className="preview-layout__visa-icon"
+												dangerouslySetInnerHTML={ {
+													__html: VISA_ICON_SVG,
+												} }
+											/>
+											Visa ···· 4242 Exp. 12/29
+										</span>
 									</FieldValue>
 								</ContactField>
 							</ContactSection>
 
-							<VerticalSpacer height="1.244rem" />
+							<VerticalSpacer height="1.25rem" />
+							<CheckoutButton height="1.5rem" />
 							{ preparedCustomMessage && (
 								<>
+									<VerticalSpacer height="0.25rem" />
 									<TextBox
-										maxHeight="2.5rem"
-										themedStyle={ themed.textBox }
+										maxHeight="1.5rem"
+										themedStyle={ {
+											...themed.textBox,
+											'--preview-link-color':
+												themed.link?.color,
+										} }
 									>
 										{ preparedCustomMessage }
 									</TextBox>
-									<VerticalSpacer height="0.75rem" />
 								</>
 							) }
-							<CheckoutButton height="1.875rem" />
 
-							<VerticalSpacer height="0.498rem" />
+							<VerticalSpacer height="0.75rem" />
 						</LeftColumn>
-						<RightColumn>
+						<RightColumn themedStyle={ themed.card }>
 							<SectionHeader
-								height="0.75rem"
+								height="0.625rem"
 								themedStyle={ themed.sectionHeader }
 							>
-								ORDER SUMMARY
+								Order summary
 							</SectionHeader>
-							<VerticalSpacer height="0.498rem" />
+							<VerticalSpacer height="0.6rem" />
+							<div
+								className="preview-layout__cart-header"
+								style={ themed.textBox }
+							>
+								<span className="preview-layout__cart-header-text">
+									1 item
+								</span>
+								<span
+									className="preview-layout__cart-header-toggle"
+									style={ themed.link }
+								>
+									Hide
+									<span className="preview-layout__chevron-up">
+										›
+									</span>
+								</span>
+							</div>
+							<VerticalSpacer height="0.5625rem" />
 							<OrderItem
 								name="Beanie"
+								unitPrice="$ 18.00"
 								price="$ 18.00"
+								quantity={ 1 }
+								imageSrc={ PreviewProductImage }
 								themedStyle={ themed.textBox }
 							/>
-							<VerticalSpacer height="0.25rem" />
+							<VerticalSpacer height="0.75rem" />
 							<hr className="preview-layout__hr preview-layout__hr--dotted" />
-							<VerticalSpacer height="0.25rem" />
+							<VerticalSpacer height="0.15rem" />
+							<div
+								className="preview-layout__add-coupon"
+								style={ themed.link }
+							>
+								{ /* Exact coupon-discount icon from WooPay SVG sprite */ }
+								<svg
+									className="preview-layout__add-coupon-icon"
+									viewBox="0 0 24 24"
+									fill="none"
+								>
+									<path
+										d="M4.41387 11.8743L11.442 4.84616L18.8667 4.84616L18.8667 12.2708L11.8385 19.299L4.41387 11.8743Z"
+										stroke="currentColor"
+										strokeWidth="1.5"
+									/>
+									<circle
+										cx="14.667"
+										cy="9.04605"
+										r="1"
+										transform="rotate(45 14.667 9.04605)"
+										fill="currentColor"
+									/>
+								</svg>
+								Add a coupon
+							</div>
+							<VerticalSpacer height="0.108rem" />
+							<div
+								className="preview-layout__add-coupon"
+								style={ themed.link }
+							>
+								{ /* Exact gift-cards-purple icon from WooPay SVG sprite */ }
+								<svg
+									className="preview-layout__add-coupon-icon"
+									viewBox="0 0 24 24"
+									fill="none"
+								>
+									<rect
+										x="-0.75"
+										y="-0.75"
+										width="9.5"
+										height="14.5"
+										transform="matrix(3.97376e-08 -1 -1 -4.80825e-08 18.5 18.5)"
+										stroke="currentColor"
+										strokeWidth="1.5"
+									/>
+									<path
+										fillRule="evenodd"
+										clipRule="evenodd"
+										d="M13 19L13 9L11.5 9L11.5 19L13 19Z"
+										fill="currentColor"
+									/>
+									<path
+										d="M16.5 6.5C16.5 7.4665 15.7165 8.25 14.75 8.25H13V6.5C13 5.5335 13.7835 4.75 14.75 4.75C15.7165 4.75 16.5 5.5335 16.5 6.5Z"
+										stroke="currentColor"
+										strokeWidth="1.5"
+									/>
+									<path
+										d="M8 6.5C8 7.4665 8.7835 8.25 9.75 8.25H11.5V6.5C11.5 5.5335 10.7165 4.75 9.75 4.75C8.7835 4.75 8 5.5335 8 6.5Z"
+										stroke="currentColor"
+										strokeWidth="1.5"
+									/>
+								</svg>
+								Add a gift card
+							</div>
+							<VerticalSpacer height="0.24rem" />
 							<OrderRow
 								label="Subtotal"
 								value="$ 18.00"
@@ -470,7 +702,7 @@ export default ( {
 								value="Free"
 								themedStyle={ themed.textBox }
 							/>
-							<hr className="preview-layout__hr" />
+							<VerticalSpacer height="0.5rem" />
 							<OrderRow
 								label="Total"
 								value="$ 18.00"
@@ -479,9 +711,10 @@ export default ( {
 									fontWeight: 600,
 								} }
 							/>
-							<VerticalSpacer height="0.498rem" />
+							<VerticalSpacer height="0.25rem" />
 						</RightColumn>
 					</ColumnsContainer>
+					<VerticalSpacer height="1.15rem" />
 				</PreviewBody>
 			</PreviewContainer>
 			<PreviewFooter

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -388,17 +388,22 @@ export default ( {
 			if ( ! rule.cssSrc ) {
 				return;
 			}
+			let validUrl;
 			try {
 				const url = new URL( rule.cssSrc );
-				if ( ! ALLOWED_FONT_DOMAINS.includes( url.hostname ) ) {
+				if (
+					url.protocol !== 'https:' ||
+					! ALLOWED_FONT_DOMAINS.includes( url.hostname )
+				) {
 					return;
 				}
+				validUrl = url.href;
 			} catch {
 				return;
 			}
 			const link = document.createElement( 'link' );
 			link.rel = 'stylesheet';
-			link.href = rule.cssSrc;
+			link.href = validUrl;
 			link.id = `woopay-preview-font-${ index }`;
 			document.head.appendChild( link );
 			links.push( link );

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -11,79 +11,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { NAMESPACE } from 'wcpay/data/constants';
 import PreviewProductImage from 'assets/images/woopay-preview-product.svg?asset';
 
-/**
- * Darkens a hex colour by a percentage (matching WooPay's PHP darken_color).
- *
- * @param {string} hex   A hex colour string (e.g. "#ffffff").
- * @param {number} pct   Percentage to darken (0–100).
- * @return {string} The darkened hex colour.
- */
-const darkenColor = ( hex, pct ) => {
-	const h = hex.replace( '#', '' );
-	const factor = 1 - Math.max( 0, Math.min( 100, pct ) ) / 100;
-	const r = Math.round( parseInt( h.substring( 0, 2 ), 16 ) * factor );
-	const g = Math.round( parseInt( h.substring( 2, 4 ), 16 ) * factor );
-	const b = Math.round( parseInt( h.substring( 4, 6 ), 16 ) * factor );
-	return `#${ r.toString( 16 ).padStart( 2, '0' ) }${ g
-		.toString( 16 )
-		.padStart( 2, '0' ) }${ b.toString( 16 ).padStart( 2, '0' ) }`;
-};
-
-/**
- * Lightens a hex colour by a percentage (matching WooPay's PHP lighten_color).
- *
- * @param {string} hex   A hex colour string (e.g. "#000000").
- * @param {number} pct   Percentage to lighten (0–100).
- * @return {string} The lightened hex colour.
- */
-const lightenColor = ( hex, pct ) => {
-	const h = hex.replace( '#', '' );
-	const factor = Math.max( 0, Math.min( 100, pct ) ) / 100;
-	const r = Math.round(
-		parseInt( h.substring( 0, 2 ), 16 ) +
-			( 255 - parseInt( h.substring( 0, 2 ), 16 ) ) * factor
-	);
-	const g = Math.round(
-		parseInt( h.substring( 2, 4 ), 16 ) +
-			( 255 - parseInt( h.substring( 2, 4 ), 16 ) ) * factor
-	);
-	const b = Math.round(
-		parseInt( h.substring( 4, 6 ), 16 ) +
-			( 255 - parseInt( h.substring( 4, 6 ), 16 ) ) * factor
-	);
-	return `#${ r.toString( 16 ).padStart( 2, '0' ) }${ g
-		.toString( 16 )
-		.padStart( 2, '0' ) }${ b.toString( 16 ).padStart( 2, '0' ) }`;
-};
-
-/**
- * Returns true if the hex colour is considered "dark" (luminance < 128).
- *
- * @param {string} hex A hex colour string.
- * @return {boolean} Whether the colour is dark.
- */
-const isDarkColor = ( hex ) => {
-	const h = hex.replace( '#', '' );
-	const r = parseInt( h.substring( 0, 2 ), 16 );
-	const g = parseInt( h.substring( 2, 4 ), 16 );
-	const b = parseInt( h.substring( 4, 6 ), 16 );
-	return ( r * 299 + g * 587 + b * 114 ) / 1000 < 128;
-};
-
-/**
- * Derives the card border colour from a background hex value.
- * Matches WooPay's PHP logic: lighten 6 % for dark (night) backgrounds,
- * darken 6 % for light (day) backgrounds.
- *
- * @param {string|undefined} bg  A hex colour string, or undefined.
- * @return {string|undefined} The derived border colour, or undefined.
- */
-const getCardBorderColor = ( bg ) => {
-	if ( ! bg || ! /^#[0-9a-f]{6}$/i.test( bg ) ) {
-		return undefined;
-	}
-	return isDarkColor( bg ) ? lightenColor( bg, 6 ) : darkenColor( bg, 6 );
-};
+import { getCardBorderColor } from './color-utils';
 
 /**
  * Derives inline style objects from a WooPay appearance object.
@@ -126,9 +54,6 @@ const getThemedStyles = ( appearance ) => {
 		},
 		sectionHeader: {
 			color: rules[ '.Label' ]?.color || undefined,
-		},
-		loadingBox: {
-			backgroundColor: rules[ '.Input' ]?.backgroundColor || undefined,
 		},
 		textBox: {
 			color: vars.colorText || undefined,
@@ -197,18 +122,9 @@ const BackButton = ( { themedStyle } ) => {
 	);
 };
 
-const StoreHeader = ( {
-	variant = 'test',
-	themedStyle,
-	chevronStyle,
-	children,
-} ) => {
+const StoreHeader = ( { themedStyle, chevronStyle, children } ) => {
 	return (
-		<div
-			className="preview-layout__store-header"
-			variant={ variant }
-			style={ themedStyle }
-		>
+		<div className="preview-layout__store-header" style={ themedStyle }>
 			<BackButton themedStyle={ chevronStyle } />
 			<div className="preview-layout__store-branding">{ children }</div>
 			<div className="preview-layout__store-header-spacer" />
@@ -503,7 +419,6 @@ export default ( {
 			 }
 			<PreviewContainer themedStyle={ themed.container }>
 				<StoreHeader
-					variant={ storeLogo ? 'logo' : 'text' }
 					themedStyle={ themed.storeHeader }
 					chevronStyle={ themed.chevron }
 				>
@@ -522,7 +437,6 @@ export default ( {
 								</ContactField>
 								<ContactField>
 									<SectionHeader
-										isDropdownIncluded
 										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
@@ -536,7 +450,6 @@ export default ( {
 								</ContactField>
 								<ContactField>
 									<SectionHeader
-										isDropdownIncluded
 										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>
@@ -549,7 +462,6 @@ export default ( {
 								</ContactField>
 								<ContactField>
 									<SectionHeader
-										isDropdownIncluded
 										height="0.625rem"
 										themedStyle={ themed.sectionHeader }
 									>

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -49,12 +49,14 @@ const getThemedStyles = ( appearance ) => {
 		},
 		headerText: {
 			color: rules[ '.Header' ]?.color || undefined,
+			fontFamily: rules[ '.Heading' ]?.fontFamily || undefined,
 		},
 		chevron: {
 			color: rules[ '.Header' ]?.color || undefined,
 		},
 		sectionHeader: {
 			color: rules[ '.Label' ]?.color || undefined,
+			fontFamily: rules[ '.Heading' ]?.fontFamily || undefined,
 		},
 		textBox: {
 			color: vars.colorText || undefined,

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -358,11 +358,19 @@ function sanitizeHtmlForPreview( input ) {
 	} );
 }
 
+const ALLOWED_FONT_DOMAINS = [
+	'fonts.googleapis.com',
+	'fonts.gstatic.com',
+	'use.typekit.net',
+	'fonts.bunny.net',
+];
+
 export default ( {
 	storeName,
 	storeLogo,
 	customMessage,
 	appearance,
+	fontRules,
 	...props
 } ) => {
 	const { style, ...restProps } = props;
@@ -370,6 +378,34 @@ export default ( {
 	const themed = useMemo( () => getThemedStyles( appearance ), [
 		appearance,
 	] );
+
+	// Load merchant font stylesheets from stored font rules.
+	useEffect( () => {
+		const rules = fontRules || [];
+		const links = [];
+
+		rules.forEach( ( rule, index ) => {
+			if ( ! rule.cssSrc ) {
+				return;
+			}
+			try {
+				const url = new URL( rule.cssSrc );
+				if ( ! ALLOWED_FONT_DOMAINS.includes( url.hostname ) ) {
+					return;
+				}
+			} catch {
+				return;
+			}
+			const link = document.createElement( 'link' );
+			link.rel = 'stylesheet';
+			link.href = rule.cssSrc;
+			link.id = `woopay-preview-font-${ index }`;
+			document.head.appendChild( link );
+			links.push( link );
+		} );
+
+		return () => links.forEach( ( link ) => link.remove() );
+	}, [ fontRules ] );
 
 	const preparedCustomMessage = useMemo( () => {
 		let rawCustomMessage = ( customMessage || '' ).trim();

--- a/client/settings/express-checkout-settings/woopay-settings.js
+++ b/client/settings/express-checkout-settings/woopay-settings.js
@@ -333,6 +333,11 @@ const WooPaySettings = ( { section } ) => {
 									? wcpaySettings.woopayAppearance
 									: null
 							}
+							fontRules={
+								isWooPayGlobalThemeSupportEnabled
+									? wcpaySettings.woopayFontRules
+									: null
+							}
 						/>
 					</BaseControl>
 				</CardBody>

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1027,6 +1027,7 @@ class WC_Payments_Admin {
 			'defaultExpressCheckoutBorderRadius' => WC_Payments_Express_Checkout_Button_Handler::DEFAULT_BORDER_RADIUS_IN_PX,
 			'isWooPayGlobalThemeSupportEligible' => WC_Payments_Features::is_woopay_global_theme_support_eligible(),
 			'woopayAppearance'                   => WC_Payments_Styles_Cache::get_woopay_appearance(),
+			'woopayFontRules'                    => WC_Payments_Styles_Cache::get_woopay_font_rules(),
 			'dateFormat'                         => wc_date_format(),
 			'timeFormat'                         => get_option( 'time_format' ),
 			'formattedStoreAddress'              => WC()->countries->get_formatted_address(

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -116,7 +116,7 @@ class WC_Payments_Styles_Cache {
 				'font_rules' => $font_rules,
 				'version'    => self::get_styles_cache_version(),
 			],
-			true
+			false
 		);
 	}
 

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -276,9 +276,10 @@ class WC_Payments_Styles_Cache {
 			if ( empty( $style->src ) || ! is_string( $style->src ) ) {
 				continue;
 			}
-			$host = wp_parse_url( $style->src, PHP_URL_HOST );
+			$url  = esc_url_raw( $style->src, [ 'https' ] );
+			$host = wp_parse_url( $url, PHP_URL_HOST );
 			if ( $host && in_array( $host, self::ALLOWED_FONT_DOMAINS, true ) ) {
-				$font_rules[] = [ 'cssSrc' => $style->src ];
+				$font_rules[] = [ 'cssSrc' => $url ];
 			}
 		}
 		return array_slice( $font_rules, 0, 10 );

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -62,7 +62,8 @@ class WC_Payments_Styles_Cache {
 		if ( wp_is_block_theme() ) {
 			$appearance = self::compute_woopay_appearance_from_theme();
 			if ( null !== $appearance ) {
-				self::set_woopay_appearance( $appearance );
+				$font_rules = self::get_font_rules_from_registered_styles();
+				self::set_woopay_appearance( $appearance, $font_rules );
 				return $appearance;
 			}
 		}
@@ -71,15 +72,33 @@ class WC_Payments_Styles_Cache {
 	}
 
 	/**
-	 * Stores the WooPay checkout appearance alongside the current cache version.
+	 * Returns the stored WooPay font rules, or an empty array if not set or version mismatch.
+	 *
+	 * @return array The font rules array.
+	 */
+	public static function get_woopay_font_rules(): array {
+		$stored = get_option( 'wcpay_woopay_checkout_appearance' );
+		if ( ! empty( $stored ) && is_array( $stored ) ) {
+			if ( ( $stored['version'] ?? '' ) === self::get_styles_cache_version() ) {
+				return $stored['font_rules'] ?? [];
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Stores the WooPay checkout appearance and font rules alongside the current cache version.
 	 *
 	 * @param array $appearance The appearance object to store.
+	 * @param array $font_rules Font CDN stylesheet URLs.
 	 */
-	public static function set_woopay_appearance( array $appearance ): void {
+	public static function set_woopay_appearance( array $appearance, array $font_rules = [] ): void {
 		update_option(
 			'wcpay_woopay_checkout_appearance',
 			[
 				'appearance' => $appearance,
+				'font_rules' => $font_rules,
 				'version'    => self::get_styles_cache_version(),
 			],
 			true
@@ -227,19 +246,50 @@ class WC_Payments_Styles_Cache {
 	}
 
 	/**
+	 * Extracts font CDN stylesheet URLs from the WordPress registered styles queue.
+	 *
+	 * Scans wp_styles() for registered stylesheets from allowed font CDN domains.
+	 * Used as a server-side fallback for block themes where DOM extraction isn't available.
+	 *
+	 * @return array Array of font rules, each with a 'cssSrc' key. Capped at 10 entries.
+	 */
+	public static function get_font_rules_from_registered_styles(): array {
+		$wp_styles       = wp_styles();
+		$allowed_domains = [
+			'fonts.googleapis.com',
+			'fonts.gstatic.com',
+			'use.typekit.net',
+			'fonts.bunny.net',
+		];
+
+		$font_rules = [];
+		foreach ( $wp_styles->registered as $style ) {
+			if ( empty( $style->src ) || ! is_string( $style->src ) ) {
+				continue;
+			}
+			$host = wp_parse_url( $style->src, PHP_URL_HOST );
+			if ( $host && in_array( $host, $allowed_domains, true ) ) {
+				$font_rules[] = [ 'cssSrc' => $style->src ];
+			}
+		}
+		return array_slice( $font_rules, 0, 10 );
+	}
+
+	/**
 	 * Stores the WooPay appearance if no valid appearance exists for the current version.
 	 * Used by the shopper conditional write path.
 	 *
 	 * @param array $appearance The appearance object to store.
+	 * @param array $font_rules Font CDN stylesheet URLs.
 	 * @return bool True if stored, false if slot was already filled.
 	 */
-	public static function maybe_set_woopay_appearance( array $appearance ): bool {
+	public static function maybe_set_woopay_appearance( array $appearance, array $font_rules = [] ): bool {
 		$existing = self::get_woopay_appearance();
 		if ( null !== $existing ) {
 			return false;
 		}
 
-		self::set_woopay_appearance( $appearance );
+		self::set_woopay_appearance( $appearance, $font_rules );
 		return true;
 	}
 

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -20,6 +20,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Payments_Styles_Cache {
 
 	/**
+	 * Font CDN domains allowed for WooPay appearance font rules.
+	 *
+	 * Shared between server-side extraction (get_font_rules_from_registered_styles)
+	 * and client-submitted validation (WooPay_Session::sanitize_font_rules).
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_FONT_DOMAINS = [
+		'fonts.googleapis.com',
+		'fonts.gstatic.com',
+		'use.typekit.net',
+		'fonts.bunny.net',
+	];
+
+	/**
 	 * Returns the styles cache version string used to invalidate localStorage
 	 * appearance caches. Reads from a stored WP option; if missing, computes
 	 * and stores it.
@@ -254,13 +269,7 @@ class WC_Payments_Styles_Cache {
 	 * @return array Array of font rules, each with a 'cssSrc' key. Capped at 10 entries.
 	 */
 	public static function get_font_rules_from_registered_styles(): array {
-		$wp_styles       = wp_styles();
-		$allowed_domains = [
-			'fonts.googleapis.com',
-			'fonts.gstatic.com',
-			'use.typekit.net',
-			'fonts.bunny.net',
-		];
+		$wp_styles = wp_styles();
 
 		$font_rules = [];
 		foreach ( $wp_styles->registered as $style ) {
@@ -268,7 +277,7 @@ class WC_Payments_Styles_Cache {
 				continue;
 			}
 			$host = wp_parse_url( $style->src, PHP_URL_HOST );
-			if ( $host && in_array( $host, $allowed_domains, true ) ) {
+			if ( $host && in_array( $host, self::ALLOWED_FONT_DOMAINS, true ) ) {
 				$font_rules[] = [ 'cssSrc' => $style->src ];
 			}
 		}

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -105,8 +105,15 @@ class WC_Payments_Styles_Cache {
 	/**
 	 * Stores the WooPay checkout appearance and font rules alongside the current cache version.
 	 *
+	 * The stored option (`wcpay_woopay_checkout_appearance`) has the structure:
+	 *   [
+	 *       'appearance' => [ 'variables' => [...], 'rules' => [...] ],
+	 *       'font_rules' => [ [ 'cssSrc' => 'https://fonts.googleapis.com/...' ], ... ],
+	 *       'version'    => '<cache_version_hash>',
+	 *   ]
+	 *
 	 * @param array $appearance The appearance object to store.
-	 * @param array $font_rules Font CDN stylesheet URLs.
+	 * @param array $font_rules Font CDN stylesheet URLs, each as [ 'cssSrc' => string ].
 	 */
 	public static function set_woopay_appearance( array $appearance, array $font_rules = [] ): void {
 		update_option(

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -153,6 +153,9 @@ class WC_Payments_WooPay_Button_Handler {
 		$config['woopayAppearance']         = $this->gateway->is_woopay_global_theme_support_enabled()
 			? WC_Payments_Styles_Cache::get_woopay_appearance()
 			: null;
+		$config['woopayFontRules']          = $this->gateway->is_woopay_global_theme_support_enabled()
+			? WC_Payments_Styles_Cache::get_woopay_font_rules()
+			: [];
 
 		return $config;
 	}

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -478,7 +478,7 @@ class WooPay_Session {
 	 * @param string|null          $key Pay-for-order key.
 	 * @param string|null          $billing_email Pay-for-order billing email.
 	 * @param WP_REST_Request|null $woopay_request The WooPay request object.
-	 * @param array                $appearance Merchant appearance.
+	 * @param array|null           $appearance Merchant appearance, or null to use server-stored fallback.
 	 * @param array                $font_rules Font CDN stylesheet URLs.
 	 * @return array The initial session request data without email and user_session.
 	 */
@@ -651,7 +651,7 @@ class WooPay_Session {
 			if ( ! isset( $rule['cssSrc'] ) || ! is_string( $rule['cssSrc'] ) ) {
 				continue;
 			}
-			$url  = esc_url_raw( $rule['cssSrc'] );
+			$url  = esc_url_raw( $rule['cssSrc'], [ 'https' ] );
 			$host = wp_parse_url( $url, PHP_URL_HOST );
 			if ( $host && in_array( $host, \WC_Payments_Styles_Cache::ALLOWED_FONT_DOMAINS, true ) ) {
 				$sanitized[] = [ 'cssSrc' => $url ];

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -646,13 +646,6 @@ class WooPay_Session {
 			return [];
 		}
 
-		$allowed_domains = [
-			'fonts.googleapis.com',
-			'fonts.gstatic.com',
-			'use.typekit.net',
-			'fonts.bunny.net',
-		];
-
 		$sanitized = [];
 		foreach ( array_slice( $raw_rules, 0, 10 ) as $rule ) {
 			if ( ! isset( $rule['cssSrc'] ) || ! is_string( $rule['cssSrc'] ) ) {
@@ -660,7 +653,7 @@ class WooPay_Session {
 			}
 			$url  = esc_url_raw( $rule['cssSrc'] );
 			$host = wp_parse_url( $url, PHP_URL_HOST );
-			if ( $host && in_array( $host, $allowed_domains, true ) ) {
+			if ( $host && in_array( $host, \WC_Payments_Styles_Cache::ALLOWED_FONT_DOMAINS, true ) ) {
 				$sanitized[] = [ 'cssSrc' => $url ];
 			}
 		}

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -479,13 +479,20 @@ class WooPay_Session {
 	 * @param string|null          $billing_email Pay-for-order billing email.
 	 * @param WP_REST_Request|null $woopay_request The WooPay request object.
 	 * @param array                $appearance Merchant appearance.
+	 * @param array                $font_rules Font CDN stylesheet URLs.
 	 * @return array The initial session request data without email and user_session.
 	 */
-	public static function get_init_session_request( $order_id = null, $key = null, $billing_email = null, $woopay_request = null, $appearance = null ) {
+	public static function get_init_session_request( $order_id = null, $key = null, $billing_email = null, $woopay_request = null, $appearance = null, $font_rules = [] ) {
 		// Fall back to server-stored appearance when no appearance was provided,
 		// but only if global theme support is enabled.
 		if ( null === $appearance && WC_Payments::get_gateway()->is_woopay_global_theme_support_enabled() ) {
 			$appearance = \WC_Payments_Styles_Cache::get_woopay_appearance();
+			$font_rules = \WC_Payments_Styles_Cache::get_woopay_font_rules();
+		}
+
+		// Fall back to server-extracted font rules when none were provided by the client.
+		if ( empty( $font_rules ) && WC_Payments::get_gateway()->is_woopay_global_theme_support_enabled() ) {
+			$font_rules = \WC_Payments_Styles_Cache::get_woopay_font_rules();
 		}
 
 		$user             = wp_get_current_user();
@@ -571,6 +578,7 @@ class WooPay_Session {
 			],
 			'tracks_user_identity' => WC_Payments::woopay_tracker()->tracks_get_identity(),
 			'appearance'           => $appearance,
+			'font_rules'           => $font_rules,
 		];
 
 		$woopay_adapted_extensions = new WooPay_Adapted_Extensions();
@@ -625,6 +633,41 @@ class WooPay_Session {
 	}
 
 	/**
+	 * Sanitize font rules from the client.
+	 *
+	 * Validates each rule contains a cssSrc URL from an allowed font CDN domain.
+	 * Caps at 10 entries to prevent abuse.
+	 *
+	 * @param array $raw_rules Raw font rules array from the client.
+	 * @return array Sanitized font rules.
+	 */
+	private static function sanitize_font_rules( $raw_rules ): array {
+		if ( ! is_array( $raw_rules ) ) {
+			return [];
+		}
+
+		$allowed_domains = [
+			'fonts.googleapis.com',
+			'fonts.gstatic.com',
+			'use.typekit.net',
+			'fonts.bunny.net',
+		];
+
+		$sanitized = [];
+		foreach ( array_slice( $raw_rules, 0, 10 ) as $rule ) {
+			if ( ! isset( $rule['cssSrc'] ) || ! is_string( $rule['cssSrc'] ) ) {
+				continue;
+			}
+			$url  = esc_url_raw( $rule['cssSrc'] );
+			$host = wp_parse_url( $url, PHP_URL_HOST );
+			if ( $host && in_array( $host, $allowed_domains, true ) ) {
+				$sanitized[] = [ 'cssSrc' => $url ];
+			}
+		}
+		return $sanitized;
+	}
+
+	/**
 	 * Used to initialize woopay session.
 	 *
 	 * @return void
@@ -643,8 +686,9 @@ class WooPay_Session {
 		$key           = ! empty( $_POST['key'] ) ? sanitize_text_field( wp_unslash( $_POST['key'] ) ) : null;
 		$billing_email = ! empty( $_POST['billing_email'] ) ? sanitize_text_field( wp_unslash( $_POST['billing_email'] ) ) : null;
 		$appearance    = ! empty( $_POST['appearance'] ) ? self::array_map_recursive( array( __CLASS__, 'sanitize_string' ), $_POST['appearance'] ) : null; // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, Generic.Arrays.DisallowLongArraySyntax.Found
+		$font_rules    = ! empty( $_POST['font_rules'] ) ? self::sanitize_font_rules( wp_unslash( $_POST['font_rules'] ) ) : []; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized by sanitize_font_rules.
 
-		$body                 = self::get_init_session_request( $order_id, $key, $billing_email, null, $appearance );
+		$body                 = self::get_init_session_request( $order_id, $key, $billing_email, null, $appearance, $font_rules );
 		$body['user_session'] = isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null;
 
 		$args = [
@@ -1187,7 +1231,13 @@ class WooPay_Session {
 			);
 		}
 
-		\WC_Payments_Styles_Cache::set_woopay_appearance( $appearance );
+		$font_rules = [];
+		if ( ! empty( $_POST['font_rules'] ) ) {
+			$raw_font_rules = json_decode( sanitize_text_field( wp_unslash( $_POST['font_rules'] ) ), true );
+			$font_rules     = is_array( $raw_font_rules ) ? self::sanitize_font_rules( $raw_font_rules ) : [];
+		}
+
+		\WC_Payments_Styles_Cache::set_woopay_appearance( $appearance, $font_rules );
 
 		wp_send_json_success();
 	}
@@ -1234,7 +1284,13 @@ class WooPay_Session {
 			);
 		}
 
-		$stored = \WC_Payments_Styles_Cache::maybe_set_woopay_appearance( $appearance );
+		$font_rules = [];
+		if ( ! empty( $_POST['font_rules'] ) ) {
+			$raw_font_rules = json_decode( sanitize_text_field( wp_unslash( $_POST['font_rules'] ) ), true );
+			$font_rules     = is_array( $raw_font_rules ) ? self::sanitize_font_rules( $raw_font_rules ) : [];
+		}
+
+		$stored = \WC_Payments_Styles_Cache::maybe_set_woopay_appearance( $appearance, $font_rules );
 
 		if ( ! $stored ) {
 			wp_send_json_success( [ 'stored' => false ] );

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -635,11 +635,19 @@ class WooPay_Session {
 	/**
 	 * Sanitize font rules from the client.
 	 *
-	 * Validates each rule contains a cssSrc URL from an allowed font CDN domain.
-	 * Caps at 10 entries to prevent abuse.
+	 * Font rules are an array of external font CDN stylesheet references sent alongside
+	 * the WooPay appearance. Each rule is an associative array with a single key:
+	 *
+	 *   [ 'cssSrc' => 'https://fonts.googleapis.com/css2?family=...' ]
+	 *
+	 * Validation:
+	 * - Each entry must have a string `cssSrc` key.
+	 * - The URL must use HTTPS (enforced via esc_url_raw).
+	 * - The host must be in WC_Payments_Styles_Cache::ALLOWED_FONT_DOMAINS.
+	 * - Capped at 10 entries to prevent payload abuse.
 	 *
 	 * @param array $raw_rules Raw font rules array from the client.
-	 * @return array Sanitized font rules.
+	 * @return array Sanitized font rules, each as [ 'cssSrc' => string ].
 	 */
 	private static function sanitize_font_rules( $raw_rules ): array {
 		if ( ! is_array( $raw_rules ) ) {

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -253,4 +253,147 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assertNotEmpty( get_option( 'wcpay_styles_cache_version' ) );
 		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $second_version );
 	}
+
+	public function test_set_woopay_appearance_stores_font_rules() {
+		delete_option( 'wcpay_woopay_checkout_appearance' );
+		delete_option( 'wcpay_styles_cache_version' );
+
+		$appearance = [
+			'theme' => 'stripe',
+			'rules' => [ '.Input' => [ 'color' => '#333' ] ],
+		];
+		$font_rules = [
+			[ 'cssSrc' => 'https://fonts.googleapis.com/css?family=Roboto' ],
+			[ 'cssSrc' => 'https://fonts.bunny.net/css?family=Inter' ],
+		];
+
+		WC_Payments_Styles_Cache::set_woopay_appearance( $appearance, $font_rules );
+
+		$this->assertEquals( $appearance, WC_Payments_Styles_Cache::get_woopay_appearance() );
+		$this->assertEquals( $font_rules, WC_Payments_Styles_Cache::get_woopay_font_rules() );
+	}
+
+	public function test_get_woopay_font_rules_returns_empty_when_not_set() {
+		// Force a non-block theme so get_woopay_appearance() does not auto-compute.
+		$stylesheet_filter = function () {
+			return 'default';
+		};
+		add_filter( 'stylesheet', $stylesheet_filter );
+
+		try {
+			delete_option( 'wcpay_woopay_checkout_appearance' );
+
+			$result = WC_Payments_Styles_Cache::get_woopay_font_rules();
+			$this->assertEmpty( $result );
+		} finally {
+			remove_filter( 'stylesheet', $stylesheet_filter );
+		}
+	}
+
+	public function test_get_woopay_font_rules_returns_empty_on_version_mismatch() {
+		// Force a non-block theme so get_woopay_appearance() does not auto-compute.
+		$stylesheet_filter = function () {
+			return 'default';
+		};
+		add_filter( 'stylesheet', $stylesheet_filter );
+
+		try {
+			delete_option( 'wcpay_styles_cache_version' );
+
+			$appearance = [ 'theme' => 'stripe' ];
+			$font_rules = [
+				[ 'cssSrc' => 'https://fonts.googleapis.com/css?family=Roboto' ],
+			];
+			WC_Payments_Styles_Cache::set_woopay_appearance( $appearance, $font_rules );
+
+			// Invalidate the styles cache version so a new one is computed.
+			WC_Payments_Styles_Cache::invalidate_styles_cache_version();
+
+			// Manually set a different version to simulate a theme change.
+			update_option( 'wcpay_styles_cache_version', 'different_version' );
+
+			$result = WC_Payments_Styles_Cache::get_woopay_font_rules();
+			$this->assertEmpty( $result );
+		} finally {
+			remove_filter( 'stylesheet', $stylesheet_filter );
+		}
+	}
+
+	public function test_get_font_rules_from_registered_styles_extracts_cdn_urls() {
+		// phpcs:disable WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Test fixtures for CDN font stylesheets.
+		wp_register_style( 'test-google-font', 'https://fonts.googleapis.com/css?family=Roboto', [], null );
+		wp_register_style( 'test-bunny-font', 'https://fonts.bunny.net/css?family=Inter', [], null );
+		// phpcs:enable WordPress.WP.EnqueuedResourceParameters.MissingVersion
+
+		try {
+			$result = WC_Payments_Styles_Cache::get_font_rules_from_registered_styles();
+
+			$sources = array_column( $result, 'cssSrc' );
+			$this->assertContains( 'https://fonts.googleapis.com/css?family=Roboto', $sources );
+			$this->assertContains( 'https://fonts.bunny.net/css?family=Inter', $sources );
+		} finally {
+			wp_deregister_style( 'test-google-font' );
+			wp_deregister_style( 'test-bunny-font' );
+		}
+	}
+
+	public function test_get_font_rules_from_registered_styles_ignores_non_cdn_urls() {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Test fixture.
+		wp_register_style( 'test-non-cdn', 'https://example.com/styles.css', [], null );
+
+		try {
+			$result  = WC_Payments_Styles_Cache::get_font_rules_from_registered_styles();
+			$sources = array_column( $result, 'cssSrc' );
+			$this->assertNotContains( 'https://example.com/styles.css', $sources );
+		} finally {
+			wp_deregister_style( 'test-non-cdn' );
+		}
+	}
+
+	public function test_get_font_rules_from_registered_styles_caps_at_10() {
+		$handles = [];
+		// phpcs:disable WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Test fixtures.
+		for ( $i = 0; $i < 12; $i++ ) {
+			$handle    = 'test-font-cap-' . $i;
+			$handles[] = $handle;
+			wp_register_style( $handle, 'https://fonts.googleapis.com/css?family=Font' . $i, [], null );
+		}
+		// phpcs:enable WordPress.WP.EnqueuedResourceParameters.MissingVersion
+
+		try {
+			$result = WC_Payments_Styles_Cache::get_font_rules_from_registered_styles();
+			$this->assertCount( 10, $result );
+		} finally {
+			foreach ( $handles as $handle ) {
+				wp_deregister_style( $handle );
+			}
+		}
+	}
+
+	public function test_maybe_set_woopay_appearance_stores_font_rules() {
+		// Force a non-block theme so get_woopay_appearance() does not auto-compute.
+		$stylesheet_filter = function () {
+			return 'default';
+		};
+		add_filter( 'stylesheet', $stylesheet_filter );
+
+		try {
+			delete_option( 'wcpay_woopay_checkout_appearance' );
+			delete_option( 'wcpay_styles_cache_version' );
+
+			$appearance = [
+				'theme' => 'stripe',
+				'rules' => [ '.Input' => [ 'color' => '#333' ] ],
+			];
+			$font_rules = [
+				[ 'cssSrc' => 'https://fonts.googleapis.com/css?family=Roboto' ],
+			];
+
+			$result = WC_Payments_Styles_Cache::maybe_set_woopay_appearance( $appearance, $font_rules );
+			$this->assertTrue( $result );
+			$this->assertEquals( $font_rules, WC_Payments_Styles_Cache::get_woopay_font_rules() );
+		} finally {
+			remove_filter( 'stylesheet', $stylesheet_filter );
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Replaces the wireframe-style WooPay settings preview with a realistic checkout representation
- Applies themed styles (colors, fonts, backgrounds) from the store's appearance settings when global theme support is enabled
- Uses WooPay's default system font stack (`-apple-system, BlinkMacSystemFont, ...`) for the unthemed state
- Includes proper column scaling (41% of real WooPay), order summary layout, themed link colors, and footer with WooPay branding
- Preview is a realistic representation but it is not exact. The container width in WooPay settings is proportionately much wider than on the real WooPay checkout. To work within that constraint, spacing has been adapted.
- On shortcode, since it relies on DOM extraction, there may be cases where the computed values are null until the checkout page is loaded in the Customizer or a user lands on the checkout page. For now, this is an acceptable tradeoff and an improvement over the current preview that only shows WooPay's styles.

**Parent PR:** #11427
Closes https://github.com/Automattic/woopay/issues/3204

## Test plan

- [x] Enable WooPay and global theme support on a store with a block theme
- [x] Verify the preview reflects the store's theme colors and fonts
- [x] Disable global theme support and verify the preview uses default WooPay styling
- [x] Test with a classic theme to confirm unthemed defaults render correctly
- [x] Resize the viewport — columns should stay centered with max-width constraints


🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/7bcc3bd7-bd9e-4d90-b276-900ab83aa33d


https://github.com/user-attachments/assets/3950c00a-3542-43b0-8d98-d64db51b5d5a