### PR TITLE
fix: Support WooPay Direct Checkout in iAPI mini-cart (WC 10.4+)

### DIFF
--- a/changelog/fix-woopay-direct-checkout-iapi-mini-cart
+++ b/changelog/fix-woopay-direct-checkout-iapi-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay Direct Checkout not working in iAPI mini-cart (WooCommerce 10.4+)

--- a/client/checkout/woopay/direct-checkout/__tests__/index.test.js
+++ b/client/checkout/woopay/direct-checkout/__tests__/index.test.js
@@ -27,8 +27,16 @@ jest.mock(
 		isUserLoggedIn: jest.fn(),
 		maybePrefetchEncryptedSessionData: jest.fn(),
 		getClassicProceedToCheckoutButton: jest.fn(),
+		getMiniCartProceedToCheckoutButton: jest.fn(),
+		getFooterMiniCartProceedToCheckoutButton: jest.fn(),
 		addRedirectToWooPayEventListener: jest.fn(),
 		setEncryptedSessionDataAsNotPrefetched: jest.fn(),
+		redirectElements: {
+			BLOCKS_MINI_CART_PROCEED_BUTTON:
+				'a.wp-block-woocommerce-mini-cart-checkout-button-block',
+			BLOCKS_FOOTER_MINI_CART_PROCEED_BUTTON:
+				'a.wc-block-mini-cart__footer-checkout',
+		},
 	} )
 );
 
@@ -206,5 +214,73 @@ describe( 'WooPay direct checkout cart item listeners', () => {
 		expect(
 			WooPayDirectCheckout.setEncryptedSessionDataAsNotPrefetched
 		).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'WooPay direct checkout iAPI mini-cart', () => {
+	let miniCartWidget;
+	let miniCartButton;
+	let footerButton;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		// Set up iAPI mini-cart widget element.
+		miniCartWidget = document.createElement( 'div' );
+		miniCartWidget.setAttribute(
+			'data-wp-interactive',
+			'woocommerce/mini-cart'
+		);
+		document.body.appendChild( miniCartWidget );
+
+		// Set up SSR'd checkout button inside the overlay.
+		miniCartButton = document.createElement( 'a' );
+		miniCartButton.classList.add(
+			'wp-block-woocommerce-mini-cart-checkout-button-block'
+		);
+		document.body.appendChild( miniCartButton );
+
+		// Set up SSR'd footer checkout button.
+		footerButton = document.createElement( 'a' );
+		footerButton.classList.add( 'wc-block-mini-cart__footer-checkout' );
+		document.body.appendChild( footerButton );
+	} );
+
+	afterEach( () => {
+		miniCartWidget.remove();
+		miniCartButton.remove();
+		footerButton.remove();
+	} );
+
+	it( "attaches event listeners directly to SSR'd mini-cart buttons on window load", async () => {
+		WooPayDirectCheckout.isWooPayThirdPartyCookiesEnabled.mockResolvedValue(
+			false
+		);
+		WooPayDirectCheckout.getCheckoutButtonElements.mockReturnValue( [] );
+		WooPayDirectCheckout.getMiniCartProceedToCheckoutButton.mockReturnValue(
+			miniCartButton
+		);
+		WooPayDirectCheckout.getFooterMiniCartProceedToCheckoutButton.mockReturnValue(
+			footerButton
+		);
+
+		fireEvent.load( window );
+
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+
+		// Should be called 3 times: mini-cart button, footer button, and main checkout buttons.
+		expect(
+			WooPayDirectCheckout.addRedirectToWooPayEventListener
+		).toHaveBeenCalledTimes( 3 );
+
+		// Verify mini-cart button got a listener.
+		expect(
+			WooPayDirectCheckout.addRedirectToWooPayEventListener
+		).toHaveBeenCalledWith( [ miniCartButton ], false );
+
+		// Verify footer button got a listener.
+		expect(
+			WooPayDirectCheckout.addRedirectToWooPayEventListener
+		).toHaveBeenCalledWith( [ footerButton ], false );
 	} );
 } );

--- a/client/checkout/woopay/direct-checkout/__tests__/index.test.js
+++ b/client/checkout/woopay/direct-checkout/__tests__/index.test.js
@@ -268,19 +268,15 @@ describe( 'WooPay direct checkout iAPI mini-cart', () => {
 
 		await new Promise( ( resolve ) => setImmediate( resolve ) );
 
-		// Should be called 3 times: mini-cart button, footer button, and main checkout buttons.
+		// All buttons (checkout + iAPI mini-cart) are merged into a single call
+		// to avoid concurrent isUserLoggedIn races via postMessage.
 		expect(
 			WooPayDirectCheckout.addRedirectToWooPayEventListener
-		).toHaveBeenCalledTimes( 3 );
+		).toHaveBeenCalledTimes( 1 );
 
-		// Verify mini-cart button got a listener.
+		// Verify both mini-cart buttons are included in the single call.
 		expect(
 			WooPayDirectCheckout.addRedirectToWooPayEventListener
-		).toHaveBeenCalledWith( [ miniCartButton ], false );
-
-		// Verify footer button got a listener.
-		expect(
-			WooPayDirectCheckout.addRedirectToWooPayEventListener
-		).toHaveBeenCalledWith( [ footerButton ], false );
+		).toHaveBeenCalledWith( [ miniCartButton, footerButton ], false );
 	} );
 } );

--- a/client/checkout/woopay/direct-checkout/index.js
+++ b/client/checkout/woopay/direct-checkout/index.js
@@ -71,27 +71,32 @@ const addFooterCartEventListener = () => {
  *
  * Supports two rendering modes:
  * - iAPI (WooCommerce 10.4+): The overlay and buttons are server-side rendered and already in the
- *   DOM at page load. We attach listeners directly — no MutationObserver needed.
+ *   DOM at page load. Returns the button elements so the caller can merge them into a single
+ *   handleWooPayDirectCheckout call (avoids concurrent isUserLoggedIn races).
  * - Legacy React: The drawer is dynamically injected into the DOM when opened, so we use a
  *   MutationObserver to detect insertion and then wait for the buttons to render.
+ *
+ * @return {HTMLElement[]} iAPI mini-cart buttons (empty array for legacy/absent mini-cart).
  */
 const maybeObserveMiniCart = () => {
 	// iAPI mini-cart (WC 10.4+): overlay & buttons are SSR'd, already in the DOM.
+	// Return them so the caller can batch all buttons into one handleWooPayDirectCheckout call.
 	if (
 		document.querySelector(
 			'[data-wp-interactive="woocommerce/mini-cart"]'
 		)
 	) {
-		addMiniCartEventListener();
-		addFooterCartEventListener();
-		return;
+		return [
+			WooPayDirectCheckout.getMiniCartProceedToCheckoutButton(),
+			WooPayDirectCheckout.getFooterMiniCartProceedToCheckoutButton(),
+		];
 	}
 
 	// Legacy React mini-cart: check if the widget is available on the page.
 	if (
 		! document.querySelector( '[data-block-name="woocommerce/mini-cart"]' )
 	) {
-		return;
+		return [];
 	}
 
 	// Create a MutationObserver to check when the mini cart drawer is added to the DOM.
@@ -125,6 +130,8 @@ const maybeObserveMiniCart = () => {
 	} );
 
 	observer.observe( document.body, { childList: true } );
+
+	return [];
 };
 
 /**
@@ -266,11 +273,13 @@ window.addEventListener( 'load', async () => {
 		removeItemCallback
 	);
 
-	// If the mini cart is available, check when it's opened so we can add the event listener to the mini cart's checkout button.
-	maybeObserveMiniCart();
+	// Collect iAPI mini-cart buttons (if present) and merge with checkout buttons
+	// into a single handleWooPayDirectCheckout call to avoid concurrent isUserLoggedIn races.
+	// Legacy React mini-cart sets up a MutationObserver internally and returns [].
+	const miniCartButtons = maybeObserveMiniCart();
 
 	const checkoutButtons = WooPayDirectCheckout.getCheckoutButtonElements();
-	handleWooPayDirectCheckout( checkoutButtons );
+	handleWooPayDirectCheckout( [ ...checkoutButtons, ...miniCartButtons ] );
 } );
 
 jQuery( ( $ ) => {

--- a/client/checkout/woopay/direct-checkout/index.js
+++ b/client/checkout/woopay/direct-checkout/index.js
@@ -64,14 +64,27 @@ const addFooterCartEventListener = () => {
 };
 
 /**
- * If the mini cart widget is available on the page, observe when the drawer element gets added to the DOM.
+ * If the mini cart widget is available on the page, attach event listeners to the checkout buttons.
  *
- * As of today, no window events are triggered when the mini cart is opened or closed,
- * nor there are attribute changes to the "open" button, so we have to rely on a MutationObserver
- * attached to the `document.body`, which is where the mini cart drawer element is added.
+ * Supports two rendering modes:
+ * - iAPI (WooCommerce 10.4+): The overlay and buttons are server-side rendered and already in the
+ *   DOM at page load. We attach listeners directly — no MutationObserver needed.
+ * - Legacy React: The drawer is dynamically injected into the DOM when opened, so we use a
+ *   MutationObserver to detect insertion and then wait for the buttons to render.
  */
 const maybeObserveMiniCart = () => {
-	// Check if the widget is available on the page.
+	// iAPI mini-cart (WC 10.4+): overlay & buttons are SSR'd, already in the DOM.
+	if (
+		document.querySelector(
+			'[data-wp-interactive="woocommerce/mini-cart"]'
+		)
+	) {
+		addMiniCartEventListener();
+		addFooterCartEventListener();
+		return;
+	}
+
+	// Legacy React mini-cart: check if the widget is available on the page.
 	if (
 		! document.querySelector( '[data-block-name="woocommerce/mini-cart"]' )
 	) {

--- a/client/checkout/woopay/direct-checkout/index.js
+++ b/client/checkout/woopay/direct-checkout/index.js
@@ -28,6 +28,9 @@ const handleWooPayDirectCheckout = async ( checkoutButtons ) => {
 		return;
 	}
 
+	// Filter out null/undefined elements (e.g. when a button getter returns null).
+	checkoutButtons = checkoutButtons.filter( Boolean );
+
 	if ( isThirdPartyCookieEnabled ) {
 		if ( await WooPayDirectCheckout.isUserLoggedIn() ) {
 			WooPayDirectCheckout.maybePrefetchEncryptedSessionData();


### PR DESCRIPTION
Fixes #11431

#### Changes proposed in this Pull Request

The WooPay Direct Checkout flow doesn't work in the mini-cart block after WooCommerce migrated it from React to the Interactivity API (iAPI), which became the default in WC 10.4 (Dec 2025).

Business Impacts:
1. Conversion - WooPay signed-in users are getting the guest checkout experience
2. Activation - New users that enrolled into WooPay and were cookied when they verified their email may not get into the flow that turns them into an activated user.

**Root cause — two compounding issues:**

1. **Widget detection fails:** `maybeObserveMiniCart()` checks for `[data-block-name="woocommerce/mini-cart"]`, but the iAPI version renders `data-wp-interactive="woocommerce/mini-cart"` instead. The function exits early.

4. **MutationObserver is incompatible:** The observer watches for `.wc-block-components-drawer__screen-overlay` being added to the DOM. In iAPI, the overlay is server-side rendered and always present — visibility toggles via CSS classes, not DOM insertion. The observer never fires.

**Fix:** Detect the iAPI mini-cart via `[data-wp-interactive="woocommerce/mini-cart"]` and attach click listeners directly to the SSR'd checkout buttons at page load. The legacy React mini-cart path (MutationObserver) is preserved for older WC versions.

#### Testing instructions

1. Use WooCommerce 10.4+ (iAPI mini-cart is default).
2. Enable WooPay and WooPay Direct Checkout.
5. Add a product to the cart.
6. Open the mini-cart drawer (click the cart icon in the header).
7. Click "Go to checkout".
8. **Expected:** User is redirected to WooPay checkout (or WooPay login if not logged in).
9. **Before fix:** User navigates to the normal WooCommerce checkout page.

**Backward compatibility:** Stores on older WC versions (or those that revert to React mini-cart via the `woocommerce_admin_get_feature_config` filter) continue to use the existing MutationObserver path, which is unchanged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/a296c9eb-4f7d-44b1-8602-24fcb11de6ac

