### PR TITLE
Harden public multi-currency config REST endpoint

### DIFF
--- a/changelog/woopmnt-5827
+++ b/changelog/woopmnt-5827
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Harden public multi-currency config REST endpoint with permission callback

--- a/includes/multi-currency/RestController.php
+++ b/includes/multi-currency/RestController.php
@@ -53,14 +53,18 @@ class RestController extends \WP_REST_Controller {
 	 * Configure REST API routes.
 	 */
 	public function register_routes() {
-		if ( \WC_Payments_Features::is_mc_cache_optimized_enabled() ) {
+		// Public endpoint for the async price renderer. Only registered when
+		// cache-optimized mode is active.
+		// Intentionally unauthenticated: it serves anonymous visitors so the
+		// client-side JS can convert prices without a WC session.
+		if ( $this->multi_currency->is_cache_optimized_mode() ) {
 			register_rest_route(
 				$this->namespace,
 				'/' . $this->rest_base . '/public/config',
 				[
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_public_config' ],
-					'permission_callback' => [ $this, 'check_public_config_permission' ],
+					'permission_callback' => '__return_true',
 				]
 			);
 		}
@@ -284,26 +288,6 @@ class RestController extends \WP_REST_Controller {
 		// browser caching avoids repeated requests during a single browsing session.
 		$response->header( 'Cache-Control', 'private, max-age=300' );
 		return $response;
-	}
-
-	/**
-	 * Checks whether the public config endpoint should be accessible.
-	 *
-	 * The endpoint is only meaningful when the cache-optimized rendering mode
-	 * is active. Otherwise it returns a 403 to reduce the attack surface.
-	 *
-	 * @return true|\WP_Error
-	 */
-	public function check_public_config_permission() {
-		if ( ! $this->multi_currency->is_cache_optimized_mode() ) {
-			return new \WP_Error(
-				'wcpay_mc_public_config_not_available',
-				__( 'This endpoint is not available in the current configuration.', 'woocommerce-payments' ),
-				[ 'status' => 403 ]
-			);
-		}
-
-		return true;
 	}
 
 	/**

--- a/includes/multi-currency/RestController.php
+++ b/includes/multi-currency/RestController.php
@@ -60,7 +60,7 @@ class RestController extends \WP_REST_Controller {
 				[
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_public_config' ],
-					'permission_callback' => '__return_true',
+					'permission_callback' => [ $this, 'check_public_config_permission' ],
 				]
 			);
 		}
@@ -284,6 +284,26 @@ class RestController extends \WP_REST_Controller {
 		// browser caching avoids repeated requests during a single browsing session.
 		$response->header( 'Cache-Control', 'private, max-age=300' );
 		return $response;
+	}
+
+	/**
+	 * Checks whether the public config endpoint should be accessible.
+	 *
+	 * The endpoint is only meaningful when the cache-optimized rendering mode
+	 * is active. Otherwise it returns a 403 to reduce the attack surface.
+	 *
+	 * @return true|\WP_Error
+	 */
+	public function check_public_config_permission() {
+		if ( ! $this->multi_currency->is_cache_optimized_mode() ) {
+			return new \WP_Error(
+				'wcpay_mc_public_config_not_available',
+				__( 'This endpoint is not available in the current configuration.', 'woocommerce-payments' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/unit/multi-currency/test-class-rest-controller.php
+++ b/tests/unit/multi-currency/test-class-rest-controller.php
@@ -98,6 +98,8 @@ class WCPay_Multi_Currency_Rest_Controller_Tests extends WCPAY_UnitTestCase {
 	public function tear_down() {
 		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
 		delete_option( '_wcpay_feature_mc_cache_optimized' );
+		delete_option( 'wcpay_multi_currency_rendering_mode' );
+
 		parent::tear_down();
 	}
 
@@ -411,6 +413,44 @@ class WCPay_Multi_Currency_Rest_Controller_Tests extends WCPAY_UnitTestCase {
 
 		// Assert: Confirm the response is what we expected.
 		$this->assertEquals( $expected, $response );
+	}
+
+	public function test_get_public_config_permission_denied_when_cache_mode_inactive() {
+		// Arrange: Feature flag on, but rendering mode = speed (default).
+		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
+		delete_option( 'wcpay_multi_currency_rendering_mode' );
+
+		// Act.
+		$result = $this->controller->check_public_config_permission();
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'wcpay_mc_public_config_not_available', $result->get_error_code() );
+	}
+
+	public function test_get_public_config_permission_denied_when_feature_flag_off() {
+		// Arrange: Feature flag off, rendering mode = cache.
+		delete_option( '_wcpay_feature_mc_cache_optimized' );
+		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
+
+		// Act.
+		$result = $this->controller->check_public_config_permission();
+
+		// Assert.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'wcpay_mc_public_config_not_available', $result->get_error_code() );
+	}
+
+	public function test_get_public_config_permission_granted_when_cache_mode_active() {
+		// Arrange: Both feature flag and cache rendering mode active.
+		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
+		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
+
+		// Act.
+		$result = $this->controller->check_public_config_permission();
+
+		// Assert.
+		$this->assertTrue( $result );
 	}
 
 	private function get_mock_available_currencies() {

--- a/tests/unit/multi-currency/test-class-rest-controller.php
+++ b/tests/unit/multi-currency/test-class-rest-controller.php
@@ -98,8 +98,6 @@ class WCPay_Multi_Currency_Rest_Controller_Tests extends WCPAY_UnitTestCase {
 	public function tear_down() {
 		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
 		delete_option( '_wcpay_feature_mc_cache_optimized' );
-		delete_option( 'wcpay_multi_currency_rendering_mode' );
-
 		parent::tear_down();
 	}
 
@@ -413,44 +411,6 @@ class WCPay_Multi_Currency_Rest_Controller_Tests extends WCPAY_UnitTestCase {
 
 		// Assert: Confirm the response is what we expected.
 		$this->assertEquals( $expected, $response );
-	}
-
-	public function test_get_public_config_permission_denied_when_cache_mode_inactive() {
-		// Arrange: Feature flag on, but rendering mode = speed (default).
-		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
-		delete_option( 'wcpay_multi_currency_rendering_mode' );
-
-		// Act.
-		$result = $this->controller->check_public_config_permission();
-
-		// Assert.
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertEquals( 'wcpay_mc_public_config_not_available', $result->get_error_code() );
-	}
-
-	public function test_get_public_config_permission_denied_when_feature_flag_off() {
-		// Arrange: Feature flag off, rendering mode = cache.
-		delete_option( '_wcpay_feature_mc_cache_optimized' );
-		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
-
-		// Act.
-		$result = $this->controller->check_public_config_permission();
-
-		// Assert.
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertEquals( 'wcpay_mc_public_config_not_available', $result->get_error_code() );
-	}
-
-	public function test_get_public_config_permission_granted_when_cache_mode_active() {
-		// Arrange: Both feature flag and cache rendering mode active.
-		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
-		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
-
-		// Act.
-		$result = $this->controller->check_public_config_permission();
-
-		// Assert.
-		$this->assertTrue( $result );
 	}
 
 	private function get_mock_available_currencies() {


### PR DESCRIPTION
Fixes WOOPMNT-5827

#### Changes proposed in this Pull Request

The public REST endpoint `GET /wc/v3/payments/multi-currency/public/config` previously used `permission_callback => '__return_true'`, making it unconditionally accessible whenever the feature flag was enabled. This PR adds a real permission callback for defense-in-depth:

**Replace `__return_true` with `check_public_config_permission()`**. Verifies that the cache-optimized rendering mode is actually active (not just the feature flag). Returns 403 when the mode is `'speed'` (default), reducing the attack surface to only when the endpoint is needed. The check is a single `get_option` call, likely served from WP object cache, zero additional DB overhead.

**Intentionally not included:**

| Measure | Why? |
|---------|-----------|
| Per-IP rate limiting (`WC_Rate_Limiter`) | `WC_Rate_Limiter::set_rate_limit()` does an unconditional `REPLACE INTO` (DB write) on every successful request. This contradicts the endpoint's purpose of improving performance for cache-optimized sites. The browser already caches for 5 minutes (`Cache-Control: private, max-age=300`), so real visitors never hit it repeatedly. Automated abuse is better handled at the infrastructure layer (nginx/Cloudflare).
| `X-Robots-Tag` header | WP core's `WP_REST_Server` already sends `noindex` on all REST responses. |
| CORS origin restriction | Only affects browsers (curl/server-side ignores it), and the data is already public. |
| Response JSON Schema | Reduces discoverability; can be added later if needed. |
| Client-side sessionStorage caching | Depends on async renderer JS (not yet merged), tracked as follow-up. |

#### Testing instructions

* Enable the multi-currency feature flag: `wp option update _wcpay_feature_mc_cache_optimized 1`
* With rendering mode = `speed` (default), verify `GET /wp-json/wc/v3/payments/multi-currency/public/config` returns 403.
* Set rendering mode to `cache`: `wp option update wcpay_multi_currency_rendering_mode cache`
* Verify the endpoint returns 200 with currency config data.
* Disable the feature flag and verify the route is not registered at all (404).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_ (behind feature flag, no user-facing change)
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.