### PR TITLE
Add WooPay order tracking sync webhook

### DIFF
--- a/.claude/docs/test-patterns.md
+++ b/.claude/docs/test-patterns.md
@@ -209,28 +209,9 @@ npm run test:js -- --testPathPattern=settings  # Tests matching pattern
 npm run test:update-snapshots       # Update snapshots
 ```
 
-## Vanilla JS (Non-React) Storefront Tests
+### jsdom Style Normalization Gotcha
 
-Storefront JS that doesn't use React (e.g., `async-renderer/index.js`) uses plain Jest — no React Testing Library, no MSW.
-
-**Key patterns:**
-
-- **Mock `global.fetch`** directly, not via MSW:
-
-  ```js
-  beforeEach( () => { global.fetch = jest.fn(); } );
-  afterEach( () => { delete global.fetch; } );
-  ```
-
-- **Mock jQuery** with jest.fn() chains for WC event listener tests:
-
-  ```js
-  global.jQuery = jest.fn( () => ( { on: jest.fn().mockReturnThis(), off: jest.fn().mockReturnThis() } ) );
-  ```
-
-- **Reset DOM** state with `document.body.textContent = ''` in `beforeEach`.
-- **State leakage:** Always place global setup (`global.fetch`, `global.wcpayAsyncPriceConfig`) in `beforeEach`/`afterEach` — not at `describe` level — so state is cleaned even when assertions fail mid-test.
-- **Class under test:** Instantiate fresh in `beforeEach`. Set `.config` directly (not via `init()`) for unit tests that don't test the fetch path.
+jsdom normalizes `backgroundColor` and `color` to `rgb()` format (e.g. `'rgb(51, 51, 51)'`), but does **not** normalize `borderColor` — hex values stay as-is (e.g. `'#f0f0f0'`). Match assertions to the format jsdom actually returns, not what feels consistent.
 
 ## E2E Tests (Playwright)
 

--- a/changelog/add-woopay-order-tracking-sync
+++ b/changelog/add-woopay-order-tracking-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WooPay order tracking sync webhook to deliver shipment data to WooPay when fulfillments are created or updated

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -50,6 +50,7 @@ use WCPay\Fraud_Prevention\Fraud_Risk_Tools;
 use WCPay\Logger;
 use WCPay\Payment_Information;
 use WCPay\WooPay\WooPay_Order_Status_Sync;
+use WCPay\WooPay\WooPay_Order_Tracking_Sync;
 use WCPay\WooPay\WooPay_Utilities;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Tracker;
@@ -2764,6 +2765,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( ! $is_woopay_enabled ) {
 				WooPay_Order_Status_Sync::remove_webhook();
+				WooPay_Order_Tracking_Sync::remove_webhook();
 			}
 		}
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -18,6 +18,7 @@ use WCPay\PaymentMethods\Configs\Definitions\SofortDefinition;
 use WCPay\WooPay_Tracker;
 use WCPay\WooPay\WooPay_Utilities;
 use WCPay\WooPay\WooPay_Order_Status_Sync;
+use WCPay\WooPay\WooPay_Order_Tracking_Sync;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Database_Cache;
 use WCPay\WC_Payments_Checkout;
@@ -646,6 +647,7 @@ class WC_Payments {
 			'setup_theme',
 			function () {
 				add_action( 'woocommerce_payments_account_refreshed', [ WooPay_Order_Status_Sync::class, 'remove_webhook' ] );
+				add_action( 'woocommerce_payments_account_refreshed', [ WooPay_Order_Tracking_Sync::class, 'remove_webhook' ] );
 
 				self::maybe_register_woopay_hooks();
 				self::maybe_init_woopay_direct_checkout();
@@ -1727,6 +1729,7 @@ class WC_Payments {
 			}
 
 			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
+			new WooPay_Order_Tracking_Sync( self::$api_client, self::$account );
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -511,6 +511,7 @@ class WC_Payments {
 		include_once __DIR__ . '/woopay/class-woopay-store-api-token.php';
 		include_once __DIR__ . '/woopay/class-woopay-utilities.php';
 		include_once __DIR__ . '/woopay/class-woopay-order-status-sync.php';
+		include_once __DIR__ . '/woopay/class-woopay-order-tracking-sync.php';
 		include_once __DIR__ . '/woopay/class-woopay-store-api-session-handler.php';
 		include_once __DIR__ . '/woopay/class-woopay-scheduler.php';
 		include_once __DIR__ . '/woopay/class-woopay-adapted-extensions.php';

--- a/includes/woopay/class-woopay-order-tracking-sync.php
+++ b/includes/woopay/class-woopay-order-tracking-sync.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Class WooPay_Order_Tracking_Sync
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\WooPay;
+
+use WC_Payments_Account;
+use WC_Payments_API_Client;
+use WCPay\Exceptions\API_Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class introduces webhooks to deliver order tracking updates to the
+ * associated orders in WooPay.
+ *
+ * Listens for WooCommerce Fulfillment events and sends tracking data
+ * (carrier, tracking number, tracking URL) to WooPay via webhook.
+ */
+class WooPay_Order_Tracking_Sync {
+	const WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED = 'wcpay_webhook_platform_checkout_order_tracking_updated';
+
+	/**
+	 * WC_Payments_Account instance to get information about the account.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $account;
+
+	/**
+	 * Client for making requests to the WooCommerce Payments API.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	protected $payments_api_client;
+
+	/**
+	 * Setup webhook for the WooPay Order Tracking Sync.
+	 *
+	 * @param WC_Payments_API_Client $payments_api_client - WooCommerce Payments API client.
+	 * @param WC_Payments_Account    $account - WooCommerce Payments account.
+	 */
+	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account ) {
+
+		$this->payments_api_client = $payments_api_client;
+		$this->account             = $account;
+
+		add_filter( 'woocommerce_webhook_topic_hooks', [ __CLASS__, 'add_topics' ], 20, 2 );
+		add_filter( 'woocommerce_webhook_payload', [ __CLASS__, 'create_payload' ], 10, 4 );
+		add_filter( 'woocommerce_valid_webhook_resources', [ __CLASS__, 'add_resource' ], 10, 1 );
+		add_filter( 'woocommerce_valid_webhook_events', [ __CLASS__, 'add_event' ], 10, 1 );
+
+		add_action( 'woocommerce_fulfillment_after_create', [ __CLASS__, 'send_webhook' ], 10, 1 );
+		add_action( 'woocommerce_fulfillment_after_update', [ __CLASS__, 'send_webhook_on_update' ], 10, 3 );
+		add_action( 'woocommerce_fulfillment_after_fulfill', [ __CLASS__, 'send_webhook' ], 10, 1 );
+		add_action( 'woocommerce_fulfillment_after_delete', [ __CLASS__, 'send_webhook' ], 10, 1 );
+
+		add_action( 'admin_init', [ $this, 'maybe_create_woopay_tracking_webhook' ], 10 );
+	}
+
+	/**
+	 * Return the webhook name.
+	 *
+	 * @return string
+	 */
+	private static function get_webhook_name() {
+		return __( 'WooPayments woopay order tracking sync', 'woocommerce-payments' );
+	}
+
+	/**
+	 * Maybe create the WooPay tracking webhook under certain conditions.
+	 */
+	public function maybe_create_woopay_tracking_webhook() {
+		if ( ! current_user_can( 'manage_woocommerce' ) || self::is_webhook_created() ) {
+			return;
+		}
+
+		if ( ! $this->account->is_stripe_account_valid() || $this->account->is_account_under_review() || $this->account->is_account_rejected() ) {
+			return;
+		}
+
+		$this->register_webhook();
+	}
+
+	/**
+	 * Return true if webhook was already created.
+	 *
+	 * @return bool
+	 */
+	private static function is_webhook_created() {
+		return ! empty( self::get_webhook() );
+	}
+
+	/**
+	 * Return array with the webhook id for the woopay order tracking sync.
+	 *
+	 * @return array
+	 */
+	public static function get_webhook() {
+		$data_store = \WC_Data_Store::load( 'webhook' );
+
+		$args = [
+			'search' => self::get_webhook_name(),
+			'status' => 'active',
+			'limit'  => 1,
+		];
+
+		$webhooks = $data_store->search_webhooks( $args );
+		return $webhooks;
+	}
+
+	/**
+	 * Register the webhook on WooCommerce.
+	 *
+	 * @return void
+	 */
+	private function register_webhook() {
+		$webhook = new \WC_Webhook();
+		$webhook->set_name( self::get_webhook_name() );
+		$webhook->set_user_id( get_current_user_id() );
+		$webhook->set_topic( 'order.tracking_updated' );
+		$webhook->set_secret( wp_generate_password( 50, false ) );
+		$webhook->set_delivery_url( WooPay_Utilities::get_woopay_rest_url( 'merchant-notification' ) );
+		$webhook->set_status( 'active' );
+		$webhook->save();
+
+		try {
+			$this->payments_api_client->update_woopay( [ 'tracking_webhook_secret' => $webhook->get_secret() ] );
+		} catch ( API_Exception $e ) {
+			$webhook->delete();
+		}
+	}
+
+	/**
+	 * Add order tracking webhook topic.
+	 *
+	 * @param array $topic_hooks List of WooCommerce's standard webhook topics and hooks.
+	 * @return array
+	 */
+	public static function add_topics( $topic_hooks ) {
+		$topic_hooks['order.tracking_updated'][] = self::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED;
+
+		return $topic_hooks;
+	}
+
+	/**
+	 * Setup payload for the webhook delivery.
+	 *
+	 * @param array   $payload       Data to be sent out by the webhook.
+	 * @param string  $resource_name Type/name of the resource.
+	 * @param integer $resource_id   ID of the resource.
+	 * @param integer $id            ID of the webhook.
+	 * @return array
+	 */
+	public static function create_payload( $payload, $resource_name, $resource_id, $id ) {
+		$webhook = wc_get_webhook( $id );
+		if ( ! $webhook ) {
+			return $payload;
+		}
+
+		if ( 'order.tracking_updated' !== $webhook->get_topic() ) {
+			return $payload;
+		}
+
+		if ( 0 !== strpos( $webhook->get_delivery_url(), WooPay_Utilities::get_woopay_rest_url( 'merchant-notification' ) ) ) {
+			return $payload;
+		}
+
+		$order = wc_get_order( $resource_id );
+		if ( ! $order ) {
+			return $payload;
+		}
+
+		$shipments = self::get_order_shipments( $order );
+
+		return [
+			'blog_id'   => \Jetpack_Options::get_option( 'id' ),
+			'order_id'  => $resource_id,
+			'shipments' => $shipments,
+		];
+	}
+
+	/**
+	 * Get all shipment tracking data for an order from its fulfillments.
+	 *
+	 * @param \WC_Order $order The WooCommerce order.
+	 * @return array Array of shipment data.
+	 */
+	private static function get_order_shipments( $order ) {
+		$shipments = [];
+
+		if ( ! function_exists( 'wc_get_fulfillments' ) ) {
+			return $shipments;
+		}
+
+		$fulfillments = wc_get_fulfillments( [ 'entity_id' => $order->get_id() ] );
+
+		foreach ( $fulfillments as $fulfillment ) {
+			$tracking_number = $fulfillment->get_meta( '_tracking_number' );
+
+			if ( empty( $tracking_number ) ) {
+				continue;
+			}
+
+			$items = [];
+			foreach ( $fulfillment->get_items() as $item ) {
+				$items[] = [
+					'name'     => $item->get_name(),
+					'quantity' => $item->get_quantity(),
+				];
+			}
+
+			$shipments[] = [
+				'tracking_number' => $tracking_number,
+				'carrier_name'    => $fulfillment->get_meta( '_shipping_provider' ),
+				'tracking_url'    => $fulfillment->get_meta( '_tracking_url' ),
+				'date_shipped'    => $fulfillment->get_date_created() ? $fulfillment->get_date_created()->format( 'Y-m-d' ) : null,
+				'status'          => $fulfillment->get_status(),
+				'items'           => $items,
+			];
+		}
+
+		return $shipments;
+	}
+
+	/**
+	 * Add webhook resource for order.
+	 *
+	 * @param array $resources List of available resources.
+	 * @return array
+	 */
+	public static function add_resource( $resources ) {
+		$resources[] = 'order';
+
+		return $resources;
+	}
+
+	/**
+	 * Add tracking_updated as a valid webhook event.
+	 *
+	 * @param array $topic_events List of available topic events.
+	 * @return array
+	 */
+	public static function add_event( $topic_events ) {
+		$topic_events[] = 'tracking_updated';
+
+		return $topic_events;
+	}
+
+	/**
+	 * Trigger webhook delivery for a fulfillment event.
+	 *
+	 * @param object $fulfillment The WC_Fulfillment object.
+	 * @return void
+	 */
+	public static function send_webhook( $fulfillment ) {
+		$order_id = $fulfillment->get_entity_id();
+		$order    = wc_get_order( $order_id );
+
+		if ( ! $order || ! $order->get_meta( 'is_woopay' ) ) {
+			return;
+		}
+
+		do_action( self::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED, $order_id );
+	}
+
+	/**
+	 * Trigger webhook delivery on fulfillment update, only if tracking-relevant props changed.
+	 *
+	 * @param object $fulfillment  The WC_Fulfillment object.
+	 * @param array  $changed_props Properties that changed.
+	 * @param array  $old_state     Previous state.
+	 * @return void
+	 */
+	public static function send_webhook_on_update( $fulfillment, $changed_props, $old_state ) {
+		self::send_webhook( $fulfillment );
+	}
+
+	/**
+	 * Removes the tracking webhook if WooPay is disabled.
+	 *
+	 * @return void
+	 */
+	public static function remove_webhook() {
+
+		if ( self::is_webhook_created() ) {
+			$webhook_id = self::get_webhook()[0];
+			$webhook    = new \WC_Webhook( $webhook_id );
+			$webhook->delete();
+		}
+	}
+}

--- a/includes/woopay/class-woopay-order-tracking-sync.php
+++ b/includes/woopay/class-woopay-order-tracking-sync.php
@@ -7,6 +7,7 @@
 
 namespace WCPay\WooPay;
 
+use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
 use WC_Payments_Account;
 use WC_Payments_API_Client;
 use WCPay\Exceptions\API_Exception;
@@ -54,7 +55,7 @@ class WooPay_Order_Tracking_Sync {
 		add_filter( 'woocommerce_valid_webhook_events', [ __CLASS__, 'add_event' ], 10, 1 );
 
 		add_action( 'woocommerce_fulfillment_after_create', [ __CLASS__, 'send_webhook' ], 10, 1 );
-		add_action( 'woocommerce_fulfillment_after_update', [ __CLASS__, 'send_webhook_on_update' ], 10, 3 );
+		add_action( 'woocommerce_fulfillment_after_update', [ __CLASS__, 'send_webhook' ], 10, 1 );
 		add_action( 'woocommerce_fulfillment_after_fulfill', [ __CLASS__, 'send_webhook' ], 10, 1 );
 		add_action( 'woocommerce_fulfillment_after_delete', [ __CLASS__, 'send_webhook' ], 10, 1 );
 
@@ -118,20 +119,26 @@ class WooPay_Order_Tracking_Sync {
 	 * @return void
 	 */
 	private function register_webhook() {
+		// Reuse the secret from the existing order status webhook so WooPay
+		// can validate both webhooks with the same store-level HMAC secret.
+		$status_webhooks = WooPay_Order_Status_Sync::get_webhook();
+		if ( empty( $status_webhooks ) ) {
+			return;
+		}
+
+		$status_webhook = wc_get_webhook( $status_webhooks[0] );
+		if ( ! $status_webhook ) {
+			return;
+		}
+
 		$webhook = new \WC_Webhook();
 		$webhook->set_name( self::get_webhook_name() );
 		$webhook->set_user_id( get_current_user_id() );
 		$webhook->set_topic( 'order.tracking_updated' );
-		$webhook->set_secret( wp_generate_password( 50, false ) );
+		$webhook->set_secret( $status_webhook->get_secret() );
 		$webhook->set_delivery_url( WooPay_Utilities::get_woopay_rest_url( 'merchant-notification' ) );
 		$webhook->set_status( 'active' );
 		$webhook->save();
-
-		try {
-			$this->payments_api_client->update_woopay( [ 'tracking_webhook_secret' => $webhook->get_secret() ] );
-		} catch ( API_Exception $e ) {
-			$webhook->delete();
-		}
 	}
 
 	/**
@@ -192,32 +199,36 @@ class WooPay_Order_Tracking_Sync {
 	private static function get_order_shipments( $order ) {
 		$shipments = [];
 
-		if ( ! function_exists( 'wc_get_fulfillments' ) ) {
+		if ( ! class_exists( FulfillmentsDataStore::class ) ) {
 			return $shipments;
 		}
 
-		$fulfillments = wc_get_fulfillments( [ 'entity_id' => $order->get_id() ] );
+		$data_store   = wc_get_container()->get( FulfillmentsDataStore::class );
+		$fulfillments = $data_store->read_fulfillments( \WC_Order::class, '' . $order->get_id() );
 
 		foreach ( $fulfillments as $fulfillment ) {
-			$tracking_number = $fulfillment->get_meta( '_tracking_number' );
+			$tracking_number = $fulfillment->get_meta( '_tracking_number', true );
 
 			if ( empty( $tracking_number ) ) {
 				continue;
 			}
 
-			$items = [];
-			foreach ( $fulfillment->get_items() as $item ) {
-				$items[] = [
-					'name'     => $item->get_name(),
-					'quantity' => $item->get_quantity(),
+			$items             = [];
+			$fulfillment_items = $fulfillment->get_items();
+			foreach ( $fulfillment_items as $fulfillment_item ) {
+				$item_id    = $fulfillment_item['item_id'] ?? 0;
+				$order_item = $order->get_item( $item_id );
+				$items[]    = [
+					'name'     => $order_item ? $order_item->get_name() : '',
+					'quantity' => $fulfillment_item['qty'] ?? 0,
 				];
 			}
 
 			$shipments[] = [
 				'tracking_number' => $tracking_number,
-				'carrier_name'    => $fulfillment->get_meta( '_shipping_provider' ),
-				'tracking_url'    => $fulfillment->get_meta( '_tracking_url' ),
-				'date_shipped'    => $fulfillment->get_date_created() ? $fulfillment->get_date_created()->format( 'Y-m-d' ) : null,
+				'carrier_name'    => $fulfillment->get_meta( '_shipping_provider', true ),
+				'tracking_url'    => $fulfillment->get_meta( '_tracking_url', true ),
+				'date_shipped'    => $fulfillment->get_date_fulfilled(),
 				'status'          => $fulfillment->get_status(),
 				'items'           => $items,
 			];
@@ -265,18 +276,6 @@ class WooPay_Order_Tracking_Sync {
 		}
 
 		do_action( self::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED, $order_id );
-	}
-
-	/**
-	 * Trigger webhook delivery on fulfillment update, only if tracking-relevant props changed.
-	 *
-	 * @param object $fulfillment  The WC_Fulfillment object.
-	 * @param array  $changed_props Properties that changed.
-	 * @param array  $old_state     Previous state.
-	 * @return void
-	 */
-	public static function send_webhook_on_update( $fulfillment, $changed_props, $old_state ) {
-		self::send_webhook( $fulfillment );
 	}
 
 	/**

--- a/tests/unit/woopay/test-class-woopay-order-tracking-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-tracking-sync.php
@@ -109,8 +109,7 @@ class WooPay_Order_Tracking_Sync_Test extends WP_UnitTestCase {
 		$order->update_meta_data( 'is_woopay', true );
 		$order->save();
 
-		$fulfillment = $this->createMock( stdClass::class );
-		$fulfillment->method( 'get_entity_id' )->willReturn( $order->get_id() );
+		$fulfillment = $this->make_fulfillment_stub( $order->get_id() );
 
 		$action_fired = false;
 		$hook_name    = WooPay_Order_Tracking_Sync::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED;
@@ -136,8 +135,7 @@ class WooPay_Order_Tracking_Sync_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
-		$fulfillment = $this->createMock( stdClass::class );
-		$fulfillment->method( 'get_entity_id' )->willReturn( $order->get_id() );
+		$fulfillment = $this->make_fulfillment_stub( $order->get_id() );
 
 		$action_fired = false;
 		$hook_name    = WooPay_Order_Tracking_Sync::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED;
@@ -165,6 +163,16 @@ class WooPay_Order_Tracking_Sync_Test extends WP_UnitTestCase {
 		$this->account_mock->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->account_mock->method( 'is_account_under_review' )->willReturn( false );
 		$this->account_mock->method( 'is_account_rejected' )->willReturn( false );
+
+		// Create the status webhook first (tracking webhook depends on it for the shared secret).
+		$status_webhook = new \WC_Webhook();
+		$status_webhook->set_name( 'WooPayments woopay order status sync' );
+		$status_webhook->set_user_id( get_current_user_id() );
+		$status_webhook->set_topic( 'order.status_changed' );
+		$status_webhook->set_secret( wp_generate_password( 50, false ) );
+		$status_webhook->set_delivery_url( 'https://example.com/merchant-notification' );
+		$status_webhook->set_status( 'active' );
+		$status_webhook->save();
 
 		// Create the tracking webhook.
 		$this->tracking_sync->maybe_create_woopay_tracking_webhook();
@@ -195,6 +203,7 @@ class WooPay_Order_Tracking_Sync_Test extends WP_UnitTestCase {
 
 		$order->delete( true );
 		WooPay_Order_Tracking_Sync::remove_webhook();
+		$status_webhook->delete( true );
 	}
 
 	/**
@@ -237,5 +246,40 @@ class WooPay_Order_Tracking_Sync_Test extends WP_UnitTestCase {
 	 */
 	private function set_is_woopay_eligible( $is_woopay_eligible ) {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => $is_woopay_eligible ] );
+	}
+
+	/**
+	 * Creates a simple fulfillment stub with get_entity_id().
+	 *
+	 * @param int $order_id The order ID.
+	 * @return object
+	 */
+	private function make_fulfillment_stub( $order_id ) {
+		return new class( $order_id ) {
+			/**
+			 * Entity ID.
+			 *
+			 * @var string
+			 */
+			private $entity_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $id Order ID.
+			 */
+			public function __construct( $id ) {
+				$this->entity_id = (string) $id;
+			}
+
+			/**
+			 * Get the entity ID.
+			 *
+			 * @return string
+			 */
+			public function get_entity_id() {
+				return $this->entity_id;
+			}
+		};
 	}
 }

--- a/tests/unit/woopay/test-class-woopay-order-tracking-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-tracking-sync.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Class WooPay_Order_Tracking_Sync_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\WooPay\WooPay_Order_Tracking_Sync;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * WooPay_Order_Tracking_Sync unit tests.
+ */
+class WooPay_Order_Tracking_Sync_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_User
+	 */
+	protected static $admin_user;
+
+	/**
+	 * @var WC_Payments_Account|MockObject
+	 */
+	private $account_mock;
+
+	/**
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $api_client_mock;
+
+	/**
+	 * @var WooPay_Order_Tracking_Sync
+	 */
+	private $tracking_sync;
+
+	/**
+	 * @var WCPay\Database_Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var WCPay\Database_Cache|MockObject
+	 */
+	private $mock_cache;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->account_mock    = $this->createMock( WC_Payments_Account::class );
+		$this->api_client_mock = $this->createMock( WC_Payments_API_Client::class );
+		$this->tracking_sync   = new WooPay_Order_Tracking_Sync( $this->api_client_mock, $this->account_mock );
+
+		// Mock the main class's cache service.
+		$this->cache      = WC_Payments::get_database_cache();
+		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );
+		WC_Payments::set_database_cache( $this->mock_cache );
+
+		// Enable woopay.
+		$this->set_is_woopay_eligible( true );
+		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
+	}
+
+	public function tear_down() {
+		// Restore the cache service in the main class.
+		WC_Payments::set_database_cache( $this->cache );
+		parent::tear_down();
+	}
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_user = $factory->user->create_and_get( [ 'role' => 'administrator' ] );
+	}
+
+	/**
+	 * Tests that add_topics adds 'order.tracking_updated' to the topic hooks array.
+	 */
+	public function test_add_topics_registers_tracking_updated() {
+		$topic_hooks = WooPay_Order_Tracking_Sync::add_topics( [] );
+
+		$this->assertArrayHasKey( 'order.tracking_updated', $topic_hooks );
+		$this->assertContains(
+			WooPay_Order_Tracking_Sync::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED,
+			$topic_hooks['order.tracking_updated']
+		);
+	}
+
+	/**
+	 * Tests that add_event adds 'tracking_updated' to valid events.
+	 */
+	public function test_add_event_registers_tracking_updated() {
+		$events = WooPay_Order_Tracking_Sync::add_event( [] );
+
+		$this->assertContains( 'tracking_updated', $events );
+	}
+
+	/**
+	 * Tests that add_resource includes 'order'.
+	 */
+	public function test_add_resource_includes_order() {
+		$resources = WooPay_Order_Tracking_Sync::add_resource( [] );
+
+		$this->assertContains( 'order', $resources );
+	}
+
+	/**
+	 * Tests that send_webhook fires the custom action for WooPay orders.
+	 */
+	public function test_send_webhook_fires_action_for_woopay_orders() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( 'is_woopay', true );
+		$order->save();
+
+		$fulfillment = $this->createMock( stdClass::class );
+		$fulfillment->method( 'get_entity_id' )->willReturn( $order->get_id() );
+
+		$action_fired = false;
+		$hook_name    = WooPay_Order_Tracking_Sync::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED;
+
+		add_action(
+			$hook_name,
+			function () use ( &$action_fired ) {
+				$action_fired = true;
+			}
+		);
+
+		WooPay_Order_Tracking_Sync::send_webhook( $fulfillment );
+
+		$this->assertTrue( $action_fired );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Tests that send_webhook skips non-WooPay orders.
+	 */
+	public function test_send_webhook_skips_non_woopay_orders() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$fulfillment = $this->createMock( stdClass::class );
+		$fulfillment->method( 'get_entity_id' )->willReturn( $order->get_id() );
+
+		$action_fired = false;
+		$hook_name    = WooPay_Order_Tracking_Sync::WCPAY_WEBHOOK_WOOPAY_ORDER_TRACKING_UPDATED;
+
+		add_action(
+			$hook_name,
+			function () use ( &$action_fired ) {
+				$action_fired = true;
+			}
+		);
+
+		WooPay_Order_Tracking_Sync::send_webhook( $fulfillment );
+
+		$this->assertFalse( $action_fired );
+
+		$order->delete( true );
+	}
+
+	/**
+	 * Tests that create_payload returns the correct structure for a tracking webhook.
+	 */
+	public function test_create_payload_returns_shipments_for_tracking_webhook() {
+		wp_set_current_user( self::$admin_user->ID );
+
+		$this->account_mock->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->account_mock->method( 'is_account_under_review' )->willReturn( false );
+		$this->account_mock->method( 'is_account_rejected' )->willReturn( false );
+
+		// Create the tracking webhook.
+		$this->tracking_sync->maybe_create_woopay_tracking_webhook();
+
+		$webhook_ids = WooPay_Order_Tracking_Sync::get_webhook();
+		$this->assertNotEmpty( $webhook_ids );
+		$webhook_id = $webhook_ids[0];
+
+		// Create an order.
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$pre_processing_payload = [
+			'status' => 'processing',
+		];
+
+		$post_processing_payload = WooPay_Order_Tracking_Sync::create_payload(
+			$pre_processing_payload,
+			'order',
+			$order->get_id(),
+			$webhook_id
+		);
+
+		$this->assertArrayHasKey( 'order_id', $post_processing_payload );
+		$this->assertArrayHasKey( 'shipments', $post_processing_payload );
+		$this->assertArrayHasKey( 'blog_id', $post_processing_payload );
+		$this->assertEquals( $order->get_id(), $post_processing_payload['order_id'] );
+
+		$order->delete( true );
+		WooPay_Order_Tracking_Sync::remove_webhook();
+	}
+
+	/**
+	 * Tests that create_payload returns the original payload for non-tracking webhooks.
+	 */
+	public function test_create_payload_passes_through_for_non_tracking_webhook() {
+		wp_set_current_user( self::$admin_user->ID );
+
+		// Create a non-tracking webhook.
+		$webhook = new \WC_Webhook();
+		$webhook->set_name( 'Some other webhook' );
+		$webhook->set_user_id( get_current_user_id() );
+		$webhook->set_topic( 'order.status_changed' );
+		$webhook->set_secret( wp_generate_password( 50, false ) );
+		$webhook->set_delivery_url( 'https://example.com/webhook' );
+		$webhook->set_status( 'active' );
+		$webhook->save();
+
+		$pre_processing_payload = [
+			'status'   => 'processing',
+			'order_id' => 1,
+		];
+
+		$post_processing_payload = WooPay_Order_Tracking_Sync::create_payload(
+			$pre_processing_payload,
+			'order',
+			1,
+			$webhook->get_id()
+		);
+
+		$this->assertEquals( $pre_processing_payload, $post_processing_payload );
+
+		$webhook->delete( true );
+	}
+
+	/**
+	 * Cache account details.
+	 *
+	 * @param bool $is_woopay_eligible Whether WooPay is eligible.
+	 */
+	private function set_is_woopay_eligible( $is_woopay_eligible ) {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => $is_woopay_eligible ] );
+	}
+}


### PR DESCRIPTION
### * EXPERIMENTAL *

## Summary
- Adds a new `WooPay_Order_Tracking_Sync` class that listens to WooCommerce Fulfillment events and delivers tracking data (carrier, tracking number, URL) to WooPay via webhook
- Registers a custom `order.tracking_updated` webhook topic with WooCommerce
- Reuses the existing order status webhook's HMAC secret so WooPay validates both webhooks with the same store-level secret
- Only fires webhooks for orders placed through WooPay (`is_woopay` meta)

## Test plan
- [ ] Enable `woocommerce_feature_fulfillments_enabled` feature flag
- [ ] Place an order via WooPay
- [ ] Add tracking info to the order via WC admin fulfillment UI
- [ ] Verify the tracking webhook fires and WooPay receives shipment data
- [ ] Verify non-WooPay orders do not trigger the webhook
- [ ] Run `npm run test:php -- -- --filter WooPay_Order_Tracking_Sync_Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)