### PR TITLE
Build WCPay Dev Tools plugin after pulling updates in post-merge hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ project.properties
 CLAUDE.local.md
 **/.claude/**/*.local.*
 .claude/local/
+.claude/docs/analysis/
+.claude/docs/plans/
+.claude/tmp/
 .serena/
 .zed/
 .phpactor.json

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -30,29 +30,29 @@ if [ -z "$DEV_TOOLS_PLUGIN_PATH" ]; then
 fi
 
 if [ -n "$DEV_TOOLS_PLUGIN_PATH" ] && [ -d "$DEV_TOOLS_PLUGIN_PATH" ]; then
-	if [ "$(cd $DEV_TOOLS_PLUGIN_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd $DEV_TOOLS_PLUGIN_PATH && pwd)" ]; then
+	if [ "$(cd "$DEV_TOOLS_PLUGIN_PATH" && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$DEV_TOOLS_PLUGIN_PATH" && pwd)" ]; then
 		echo
 		echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
 
-		DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PLUGIN_PATH && git branch --show-current)
+		DEV_TOOLS_BRANCH=$(cd "$DEV_TOOLS_PLUGIN_PATH" && git branch --show-current)
 		if [ "$DEV_TOOLS_BRANCH" = "trunk" ]; then
 			echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
-			if [ "$(cd $DEV_TOOLS_PLUGIN_PATH && git status --porcelain)" ]; then
+			if [ "$(cd "$DEV_TOOLS_PLUGIN_PATH" && git status --porcelain)" ]; then
 				echo "\033[33m  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it.\033[0m"
 			else
 				echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
-				DEV_TOOLS_HEAD_BEFORE=$(cd $DEV_TOOLS_PLUGIN_PATH && git rev-parse HEAD)
-				cd $DEV_TOOLS_PLUGIN_PATH && git pull
-				DEV_TOOLS_HEAD_AFTER=$(cd $DEV_TOOLS_PLUGIN_PATH && git rev-parse HEAD)
+				DEV_TOOLS_HEAD_BEFORE=$(cd "$DEV_TOOLS_PLUGIN_PATH" && git rev-parse HEAD)
+				(cd "$DEV_TOOLS_PLUGIN_PATH" && git pull)
+				DEV_TOOLS_HEAD_AFTER=$(cd "$DEV_TOOLS_PLUGIN_PATH" && git rev-parse HEAD)
 				# Install dependencies and build only when new changes were pulled
 				if [ "$DEV_TOOLS_HEAD_BEFORE" != "$DEV_TOOLS_HEAD_AFTER" ]; then
 					if [ -f "$DEV_TOOLS_PLUGIN_PATH/composer.json" ]; then
 						echo "  \033[32mInstalling WCPay Dev Tools Composer dependencies...\033[0m"
-						cd $DEV_TOOLS_PLUGIN_PATH && composer install
+						(cd "$DEV_TOOLS_PLUGIN_PATH" && composer install)
 					fi
 					if [ -f "$DEV_TOOLS_PLUGIN_PATH/package.json" ]; then
 						echo "  \033[32mBuilding WCPay Dev Tools...\033[0m"
-						cd $DEV_TOOLS_PLUGIN_PATH && npm install && npm run build
+						(cd "$DEV_TOOLS_PLUGIN_PATH" && npm install && npm run build)
 					fi
 				fi
 			fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -41,7 +41,20 @@ if [ -n "$DEV_TOOLS_PLUGIN_PATH" ] && [ -d "$DEV_TOOLS_PLUGIN_PATH" ]; then
 				echo "\033[33m  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it.\033[0m"
 			else
 				echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
+				DEV_TOOLS_HEAD_BEFORE=$(cd $DEV_TOOLS_PLUGIN_PATH && git rev-parse HEAD)
 				cd $DEV_TOOLS_PLUGIN_PATH && git pull
+				DEV_TOOLS_HEAD_AFTER=$(cd $DEV_TOOLS_PLUGIN_PATH && git rev-parse HEAD)
+				# Install dependencies and build only when new changes were pulled
+				if [ "$DEV_TOOLS_HEAD_BEFORE" != "$DEV_TOOLS_HEAD_AFTER" ]; then
+					if [ -f "$DEV_TOOLS_PLUGIN_PATH/composer.json" ]; then
+						echo "  \033[32mInstalling WCPay Dev Tools Composer dependencies...\033[0m"
+						cd $DEV_TOOLS_PLUGIN_PATH && composer install
+					fi
+					if [ -f "$DEV_TOOLS_PLUGIN_PATH/package.json" ]; then
+						echo "  \033[32mBuilding WCPay Dev Tools...\033[0m"
+						cd $DEV_TOOLS_PLUGIN_PATH && npm install && npm run build
+					fi
+				fi
 			fi
 		else
 			echo "\033[33m  The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it.\033[0m"

--- a/changelog/update-post-merge-build-dev-tools
+++ b/changelog/update-post-merge-build-dev-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Build dev-tools plugin after pulling updates in post-merge hook

--- a/changelog/update-post-merge-build-dev-tools
+++ b/changelog/update-post-merge-build-dev-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Build dev-tools plugin after pulling updates in post-merge hook
+Build WCPay Dev Tools plugin after pulling updates in post-merge hook


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The post-merge hook already pulls the latest WCPay Dev Tools plugin from trunk when it detects a local clone, but it doesn't install dependencies or build afterwards. This means the plugin can have stale assets until someone manually rebuilds.

This adds `composer install` and `npm install && npm run build` steps that run **only when `git pull` actually fetched new changes** (by comparing HEAD before and after), to avoid unnecessary work on every merge.

#### Testing instructions

- Have a local clone of the WCPay Dev Tools plugin configured via `LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH` in `local.env` (or at the legacy Docker path)
- Ensure the dev-tools clone is on `trunk` with no uncommitted changes
- [ ] Verify that after a `git pull` on WooPayments that triggers post-merge, the WCPay Dev Tools plugin's dependencies are installed and assets are built (when there are upstream changes on dev-tools trunk)
- [ ] Verify that when WCPay Dev Tools is already up to date (no new commits pulled), the install/build steps are skipped

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — dev tooling change, no product code affected
- [x] Tested on mobile (or does not apply) — does not apply

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_

---

🤖 Generated with [Claude Code](https://claude.ai/code)
