### PR TITLE
fix: update QIT workflow for CLI v1.0.0 exit code changes

### DIFF
--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -42,7 +42,10 @@ jobs:
           # 1 = invalid (bad arguments/config)
           # 2 = failed (critical security errors)
           # 3 = warning (non-critical issues)
-          if [ $EXIT_CODE -eq 2 ]; then
+          if [ $EXIT_CODE -eq 1 ]; then
+            echo "Security test failed: invalid arguments or configuration."
+            exit 1
+          elif [ $EXIT_CODE -eq 2 ]; then
             echo "Security test failed with critical errors."
             exit 1
           elif [ $EXIT_CODE -eq 3 ]; then
@@ -64,7 +67,10 @@ jobs:
           # 1 = invalid (bad arguments/config)
           # 2 = failed (critical malware detected)
           # 3 = warning
-          if [ $EXIT_CODE -eq 2 ]; then
+          if [ $EXIT_CODE -eq 1 ]; then
+            echo "Malware test failed: invalid arguments or configuration."
+            exit 1
+          elif [ $EXIT_CODE -eq 2 ]; then
             echo "Malware test failed."
             exit 1
           elif [ $EXIT_CODE -eq 3 ]; then

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y php-cli php-zip unzip
 
       - name: Install QIT CLI
-        run: composer global require woocommerce/qit-cli
+        run: composer global require woocommerce/qit-cli:^1.0
 
       - name: Authenticate QIT
         run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'
@@ -35,16 +35,17 @@ jobs:
       - name: Run Security Test
         run: |
           set +e
-          qit run:security woocommerce-payments --zip=woocommerce-payments.zip --wait
+          qit run:security woocommerce-payments --zip=woocommerce-payments.zip
           EXIT_CODE=$?
-          # QIT exit codes (v0.10.0):
+          # QIT exit codes (v1.0.0):
           # 0 = success
-          # 1 = failed (critical security errors)
-          # 2 = warning (non-critical issues)
-          if [ $EXIT_CODE -eq 1 ]; then
+          # 1 = invalid (bad arguments/config)
+          # 2 = failed (critical security errors)
+          # 3 = warning (non-critical issues)
+          if [ $EXIT_CODE -eq 2 ]; then
             echo "Security test failed with critical errors."
             exit 1
-          elif [ $EXIT_CODE -eq 2 ]; then
+          elif [ $EXIT_CODE -eq 3 ]; then
             echo "Security test completed with warnings (non-critical issues). CI will pass."
             exit 0
           elif [ $EXIT_CODE -ne 0 ]; then
@@ -56,16 +57,17 @@ jobs:
       - name: Run Malware Test
         run: |
           set +e
-          qit run:malware woocommerce-payments --zip=woocommerce-payments.zip --wait
+          qit run:malware woocommerce-payments --zip=woocommerce-payments.zip
           EXIT_CODE=$?
-          # QIT exit codes (v0.10.0):
+          # QIT exit codes (v1.0.0):
           # 0 = success
-          # 1 = failed (critical malware detected)
-          # 2 = warning
-          if [ $EXIT_CODE -eq 1 ]; then
+          # 1 = invalid (bad arguments/config)
+          # 2 = failed (critical malware detected)
+          # 3 = warning
+          if [ $EXIT_CODE -eq 2 ]; then
             echo "Malware test failed."
             exit 1
-          elif [ $EXIT_CODE -eq 2 ]; then
+          elif [ $EXIT_CODE -eq 3 ]; then
             echo "Malware test completed with warnings. CI will pass."
             exit 0
           elif [ $EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
## Summary

- QIT CLI 1.0.0 (released 2026-03-17 08:10 UTC) changed exit codes, breaking all QIT CI runs across every branch since ~08:49 UTC
- **Old codes (v0.x):** 0=success, 1=failed, 2=warning
- **New codes (v1.0.0):** 0=success, 1=invalid, 2=failed, 3=warning
- The workflow was unpinned and picked up the new version automatically, causing "warning" results (exit code 3) to be treated as unexpected failures

### Changes
- Update exit code handling to match QIT CLI v1.0.0
- Pin QIT CLI to `^1.0` to prevent future major-version breaks
- Remove deprecated `--wait` flag (tests now wait by default in v1.0.0)

## Test plan

- [ ] QIT Security test passes in this PR's CI (previously failing with exit code 3)
- [ ] QIT Malware test passes in this PR's CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)