### PR TITLE
fix: amazon pay manual capture settings compatibility

### DIFF
--- a/changelog/fix-amazon-pay-manual-capture-support
+++ b/changelog/fix-amazon-pay-manual-capture-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: amazon pay manual capture compatibility

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -11,6 +11,8 @@ use WCPay\Fraud_Prevention\Fraud_Risk_Tools;
 use WCPay\Constants\Track_Events;
 use WCPay\Fraud_Prevention\Models\Rule;
 use WCPay\Logger;
+use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
+use WCPay\PaymentMethods\Configs\Utils\PaymentMethodUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -681,9 +683,25 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
 		$available_payment_methods    = $this->wcpay_gateway->get_upe_available_payment_methods();
 
-		// Only 'card' and 'link' support manual capture. Leave them enabled if they're already enabled.
+		// Filter out payment methods that don't support manual capture when it's enabled.
 		if ( $request->has_param( 'is_manual_capture_enabled' ) && $request->get_param( 'is_manual_capture_enabled' ) ) {
-			$payment_method_ids_to_enable = array_intersect( $payment_method_ids_to_enable, [ Payment_Method::CARD, Payment_Method::LINK ] );
+			$registry                     = PaymentMethodDefinitionRegistry::instance();
+			$all_definitions              = $registry->get_all_payment_method_definitions();
+			$payment_method_ids_to_enable = array_values(
+				array_filter(
+					$payment_method_ids_to_enable,
+					function ( $payment_method_id ) use ( $all_definitions ) {
+						// Always allow Link since it follows the card's capture behavior.
+						if ( Payment_Method::LINK === $payment_method_id ) {
+							return true;
+						}
+						if ( isset( $all_definitions[ $payment_method_id ] ) ) {
+							return PaymentMethodUtils::allows_manual_capture( $all_definitions[ $payment_method_id ] );
+						}
+						return false;
+					}
+				)
+			);
 		}
 
 		$payment_method_ids_to_enable = array_values(

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -19,6 +19,7 @@ use WCPay\PaymentMethods\Configs\Definitions\AmazonPayDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\ApplePayDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\BancontactDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\BecsDefinition;
+use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\EpsDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\GiropayDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\GooglePayDefinition;

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -27,6 +27,7 @@ use WCPay\PaymentMethods\Configs\Definitions\LinkDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\P24Definition;
 use WCPay\PaymentMethods\Configs\Definitions\SepaDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\SofortDefinition;
+use WCPay\PaymentMethods\Configs\Definitions\AmazonPayDefinition;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 use WCPay\Session_Rate_Limiter;
 
@@ -162,6 +163,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		$payment_method_definitions = [
 			CardDefinition::class,
+			AmazonPayDefinition::class,
 			ApplePayDefinition::class,
 			BancontactDefinition::class,
 			BecsDefinition::class,
@@ -288,6 +290,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$available_method_ids = $response->get_data()['available_payment_method_ids'];
 
 		$expected_method_ids = [
+			Payment_Method::AMAZON_PAY,
 			Payment_Method::CARD,
 			Payment_Method::BECS,
 			Payment_Method::BANCONTACT,
@@ -509,6 +512,26 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->controller->update_settings( $request );
 
 		$this->assertEquals( 'yes', $this->gateway->get_option( 'manual_capture' ) );
+	}
+
+	public function test_update_settings_manual_capture_keeps_payment_methods_with_capture_later_capability() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_manual_capture_enabled', true );
+		$request->set_param(
+			'enabled_payment_method_ids',
+			[ Payment_Method::CARD, Payment_Method::GOOGLE_PAY, Payment_Method::AMAZON_PAY, Payment_Method::IDEAL ]
+		);
+
+		$this->controller->update_settings( $request );
+
+		$enabled = WC_Payments::get_gateway()->get_option( 'upe_enabled_payment_method_ids' );
+
+		// Card, Google Pay, and Amazon Pay have CAPTURE_LATER capability and should remain enabled.
+		$this->assertContains( Payment_Method::CARD, $enabled );
+		$this->assertContains( Payment_Method::GOOGLE_PAY, $enabled );
+		$this->assertContains( Payment_Method::AMAZON_PAY, $enabled );
+		// iDEAL does not support manual capture and should be filtered out.
+		$this->assertNotContains( Payment_Method::IDEAL, $enabled );
 	}
 
 	public function test_update_settings_disables_manual_capture() {

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -15,7 +15,7 @@ use WCPay\Database_Cache;
 use WCPay\Duplicate_Payment_Prevention_Service;
 use WCPay\Duplicates_Detection_Service;
 use WCPay\Payment_Methods\UPE_Payment_Method;
-use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
+use WCPay\PaymentMethods\Configs\Definitions\AmazonPayDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\ApplePayDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\BancontactDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\BecsDefinition;
@@ -27,7 +27,6 @@ use WCPay\PaymentMethods\Configs\Definitions\LinkDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\P24Definition;
 use WCPay\PaymentMethods\Configs\Definitions\SepaDefinition;
 use WCPay\PaymentMethods\Configs\Definitions\SofortDefinition;
-use WCPay\PaymentMethods\Configs\Definitions\AmazonPayDefinition;
 use WCPay\PaymentMethods\Configs\Registry\PaymentMethodDefinitionRegistry;
 use WCPay\Session_Rate_Limiter;
 


### PR DESCRIPTION
Fixes WOOPMNT-5933

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Amazon Pay is defined in the codebase to support "manual capture".
However, in the settings, when "manual capture" gets enabled, Amazon Pay gets disabled.

The issue is that there's a hardcoded list of payment methods that support manual capture in the settings controller, which should instead be honoring the payment methods definitions.

This PR only fixes the settings UI - a separate PR aims to fix the actual behavior of amazon pay w/ manual capture: https://github.com/Automattic/woocommerce-payments/pull/11446


Before:

https://github.com/user-attachments/assets/ac5efbbb-6923-418e-9a6a-8114b37ad9b8


After:

https://github.com/user-attachments/assets/b61d19c0-3c19-4509-b39c-066fff4826af



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to Payments > Settings
- Make sure you have "Enable manual capture" disabled
- Make sure you have Amazon Pay enabled
- Now, enable "Enable manual capture"
- Save the settings
- Refresh the page
- Amazon Pay should stay enabled

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
