### PR TITLE
Fix currency reverting to default on session start in cache-optimized mode

### DIFF
--- a/changelog/woopmnt-5938
+++ b/changelog/woopmnt-5938
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix multi-currency cache mode: retain geolocation currency across session creation and Store API requests

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -311,7 +311,7 @@ class MultiCurrency {
 			$this->async_renderer->init_hooks();
 		}
 
-		if ( ! $this->is_cache_optimized_mode() || $this->has_active_session() || $has_pending_currency_switch || Utils::is_store_api_request() ) {
+		if ( ! $this->should_use_async_rendering() || $has_pending_currency_switch ) {
 			$this->frontend_prices->init_hooks();
 			$this->frontend_currencies->init_hooks();
 		}
@@ -757,13 +757,10 @@ class MultiCurrency {
 			return;
 		}
 
-		// In cache-optimized mode without an active session or Store API context,
-		// skip session/cookie for geolocation auto-switch (persist_change = false).
-		// This keeps catalog pages cacheable. Allow persistence when a session
-		// exists (e.g. after add-to-cart) or during Store API requests (which use
-		// Cart-Token sessions that bypass has_active_session).
-		// Explicit user switches (persist_change = true, e.g. ?currency=XXX) always set the session.
-		if ( $this->is_cache_optimized_mode() && ! $persist_change && ! $this->has_active_session() && ! Utils::is_store_api_request() ) {
+		// Don't create a session during async rendering for automatic
+		// currency switches (e.g. geolocation). Explicit user switches
+		// (persist_change = true) always persist.
+		if ( $this->should_use_async_rendering() && ! $persist_change ) {
 			return;
 		}
 
@@ -822,11 +819,9 @@ class MultiCurrency {
 			return;
 		}
 
-		// In cache-optimized mode without a session or Store API context,
-		// currency switching is handled client-side via the async renderer.
-		// Store API requests need server-side geolocation because they return
-		// prices directly (Cart-Token sessions bypass has_active_session).
-		if ( $this->is_cache_optimized_mode() && ! $this->has_active_session() && ! Utils::is_store_api_request() ) {
+		// When async rendering handles pricing, currency switching is done
+		// client-side via the JS renderer. Skip server-side geolocation.
+		if ( $this->should_use_async_rendering() ) {
 			return;
 		}
 
@@ -1113,6 +1108,24 @@ class MultiCurrency {
 	 */
 	public function has_active_session(): bool {
 		return isset( WC()->session ) && WC()->session->has_session();
+	}
+
+	/**
+	 * Whether the async (client-side) price renderer should handle pricing
+	 * instead of server-side FrontendPrices.
+	 *
+	 * Returns true only when all conditions are met:
+	 * - Cache-optimized rendering mode is enabled.
+	 * - No active WC session (cookie-based).
+	 * - Not a Store API request (uses Cart-Token JWT sessions that bypass
+	 *   has_active_session, but still needs server-side conversion).
+	 *
+	 * @return bool
+	 */
+	private function should_use_async_rendering(): bool {
+		return $this->is_cache_optimized_mode()
+			&& ! $this->has_active_session()
+			&& ! Utils::is_store_api_request();
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1107,7 +1107,9 @@ class MultiCurrency {
 	 * @return bool
 	 */
 	public function has_active_session(): bool {
-		return isset( WC()->session ) && WC()->session->has_session();
+		return isset( WC()->session )
+			&& is_callable( [ WC()->session, 'has_session' ] )
+			&& WC()->session->has_session();
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -311,7 +311,7 @@ class MultiCurrency {
 			$this->async_renderer->init_hooks();
 		}
 
-		if ( ! $this->is_cache_optimized_mode() || $this->has_active_session() || $has_pending_currency_switch ) {
+		if ( ! $this->is_cache_optimized_mode() || $this->has_active_session() || $has_pending_currency_switch || Utils::is_store_api_request() ) {
 			$this->frontend_prices->init_hooks();
 			$this->frontend_currencies->init_hooks();
 		}
@@ -757,12 +757,13 @@ class MultiCurrency {
 			return;
 		}
 
-		// In cache-optimized mode without an active session, skip session/cookie
-		// for geolocation auto-switch (persist_change = false). This keeps
-		// catalog pages cacheable. Once a session exists (e.g. after add-to-cart),
-		// allow persistence so the geolocation currency carries forward.
+		// In cache-optimized mode without an active session or Store API context,
+		// skip session/cookie for geolocation auto-switch (persist_change = false).
+		// This keeps catalog pages cacheable. Allow persistence when a session
+		// exists (e.g. after add-to-cart) or during Store API requests (which use
+		// Cart-Token sessions that bypass has_active_session).
 		// Explicit user switches (persist_change = true, e.g. ?currency=XXX) always set the session.
-		if ( $this->is_cache_optimized_mode() && ! $persist_change && ! $this->has_active_session() ) {
+		if ( $this->is_cache_optimized_mode() && ! $persist_change && ! $this->has_active_session() && ! Utils::is_store_api_request() ) {
 			return;
 		}
 
@@ -821,9 +822,11 @@ class MultiCurrency {
 			return;
 		}
 
-		// In cache-optimized mode, currency switching is handled client-side
-		// via the REST API. Skip server-side geolocation and notice.
-		if ( $this->is_cache_optimized_mode() && ! $this->has_active_session() ) {
+		// In cache-optimized mode without a session or Store API context,
+		// currency switching is handled client-side via the async renderer.
+		// Store API requests need server-side geolocation because they return
+		// prices directly (Cart-Token sessions bypass has_active_session).
+		if ( $this->is_cache_optimized_mode() && ! $this->has_active_session() && ! Utils::is_store_api_request() ) {
 			return;
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -297,21 +297,21 @@ class MultiCurrency {
 		$admin_notices->init_hooks();
 		$user_settings->init_hooks();
 
-		// In cache-optimized mode without an active session, use async rendering.
-		// Otherwise, use standard server-side price conversion.
-		// A ?currency= URL param means a session will be created (at init priority 11),
-		// so we use server-side conversion to show the correct currency immediately.
-		// Auto-switching is also required for the async renderer: without it, all
-		// session-less visitors always see the default currency, so skeletons add
-		// unnecessary JS latency with no benefit — PHP renders the default prices
-		// directly, which is still fully cacheable (same output for all visitors).
+		// Use async (client-side) rendering only when should_use_async_rendering()
+		// is true: cache-optimized mode, no active session, and not a Store API
+		// request. Otherwise, use server-side FrontendPrices/FrontendCurrencies.
+		// A ?currency= URL param forces server-side conversion (session will be
+		// created at init priority 11). Auto-switching is also required: without
+		// it, session-less visitors always see the default currency, so skeletons
+		// add unnecessary JS latency with no benefit.
 		$has_pending_currency_switch = isset( $_GET['currency'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		$use_async_rendering         = $this->should_use_async_rendering();
 
-		if ( ! $has_pending_currency_switch && $this->is_using_auto_currency_switching() ) {
+		if ( $use_async_rendering && ! $has_pending_currency_switch && $this->is_using_auto_currency_switching() ) {
 			$this->async_renderer->init_hooks();
 		}
 
-		if ( ! $this->should_use_async_rendering() || $has_pending_currency_switch ) {
+		if ( ! $use_async_rendering || $has_pending_currency_switch ) {
 			$this->frontend_prices->init_hooks();
 			$this->frontend_currencies->init_hooks();
 		}
@@ -779,8 +779,8 @@ class MultiCurrency {
 
 		if ( 0 === $user_id && WC()->session ) {
 			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->get_code() );
-			// Set the session cookie if is not yet to persist the selected currency.
-			if ( ! WC()->session->has_session() && ! headers_sent() && $persist_change ) {
+			// Set the session cookie if not yet set to persist the selected currency.
+			if ( ! $this->has_active_session() && ! headers_sent() && $persist_change ) {
 				$this->utils->set_customer_session_cookie( true );
 			}
 		} elseif ( $user_id ) {
@@ -1102,13 +1102,17 @@ class MultiCurrency {
 	}
 
 	/**
-	 * Checks if there is an active WooCommerce session.
+	 * Checks if there is an active cookie-based WooCommerce session.
+	 *
+	 * Returns false for Store API requests that use Cart-Token JWT sessions,
+	 * since WC's Store API SessionHandler does not implement has_session().
+	 * Use Utils::is_store_api_request() to detect those separately.
 	 *
 	 * @return bool
 	 */
 	public function has_active_session(): bool {
 		return isset( WC()->session )
-			&& is_callable( [ WC()->session, 'has_session' ] )
+			&& method_exists( WC()->session, 'has_session' )
 			&& WC()->session->has_session();
 	}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -757,10 +757,12 @@ class MultiCurrency {
 			return;
 		}
 
-		// In cache-optimized mode, skip session/cookie for geolocation auto-switch
-		// (persist_change = false). This keeps catalog pages cacheable.
-		// Explicit user switches (persist_change = true, e.g. ?currency=XXX) still set the session.
-		if ( $this->is_cache_optimized_mode() && ! $persist_change ) {
+		// In cache-optimized mode without an active session, skip session/cookie
+		// for geolocation auto-switch (persist_change = false). This keeps
+		// catalog pages cacheable. Once a session exists (e.g. after add-to-cart),
+		// allow persistence so the geolocation currency carries forward.
+		// Explicit user switches (persist_change = true, e.g. ?currency=XXX) always set the session.
+		if ( $this->is_cache_optimized_mode() && ! $persist_change && ! $this->has_active_session() ) {
 			return;
 		}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -587,6 +587,33 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		unset( $_COOKIE[ $cookie_name ] );
 	}
 
+	public function test_update_selected_currency_by_geolocation_persists_in_cache_mode_for_store_api_request() {
+		// Enable cache-optimized mode and auto currency switching.
+		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
+		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
+		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
+		$this->init_multi_currency();
+
+		// Simulate a Store API request (no session cookie, but Cart-Token based).
+		$original_request_uri   = $_SERVER['REQUEST_URI'] ?? '';
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/store/v1/batch';
+
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function () {
+				return 'CA';
+			}
+		);
+
+		$this->multi_currency->update_selected_currency_by_geolocation();
+
+		// Store API requests should persist geolocation currency even without a cookie session.
+		$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+
+		// Clean up.
+		$_SERVER['REQUEST_URI'] = $original_request_uri;
+	}
+
 	public function test_display_geolocation_currency_update_notice() {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'CAD' );
 		add_filter(

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -145,6 +145,8 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->remove_currency_settings_mock( 'GBP', [ 'price_charm', 'price_rounding', 'manual_rate', 'exchange_rate' ] );
 		delete_option( self::ENABLED_CURRENCIES_OPTION );
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'no' );
+		delete_option( '_wcpay_feature_mc_cache_optimized' );
+		delete_option( 'wcpay_multi_currency_rendering_mode' );
 
 		parent::tear_down();
 	}
@@ -536,6 +538,53 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		// Assert: Confirm the session does not have a currency key set, and that the update notice action was not added.
 		$this->assertNull( WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
 		$this->assertFalse( has_filter( 'wp_footer', [ $this->multi_currency, 'display_geolocation_currency_update_notice' ] ) );
+	}
+
+	public function test_update_selected_currency_by_geolocation_skips_persistence_in_cache_mode_without_session() {
+		// Enable cache-optimized mode and auto currency switching.
+		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
+		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
+		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
+		$this->init_multi_currency();
+
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function () {
+				return 'CA';
+			}
+		);
+
+		$this->multi_currency->update_selected_currency_by_geolocation();
+
+		// Without an active session, geolocation should be skipped entirely in cache mode.
+		$this->assertNull( WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+	}
+
+	public function test_update_selected_currency_by_geolocation_persists_in_cache_mode_with_active_session() {
+		// Enable cache-optimized mode and auto currency switching.
+		update_option( '_wcpay_feature_mc_cache_optimized', '1' );
+		update_option( 'wcpay_multi_currency_rendering_mode', 'cache' );
+		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
+		$this->init_multi_currency();
+
+		// Simulate an active session (e.g. after add-to-cart) by setting the session cookie.
+		$cookie_name             = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
+		$_COOKIE[ $cookie_name ] = 'test-session-id';
+
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function () {
+				return 'CA';
+			}
+		);
+
+		$this->multi_currency->update_selected_currency_by_geolocation();
+
+		// With an active session, geolocation should persist the currency.
+		$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+
+		// Clean up.
+		unset( $_COOKIE[ $cookie_name ] );
 	}
 
 	public function test_display_geolocation_currency_update_notice() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -137,6 +137,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
 		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
 		remove_all_filters( 'woocommerce_currency' );
+		remove_all_filters( 'woocommerce_geolocate_ip' );
 		remove_all_filters( 'stylesheet' );
 
 		delete_user_meta( self::LOGGED_IN_USER_ID, MultiCurrency::CURRENCY_META_KEY );
@@ -571,20 +572,21 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$cookie_name             = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
 		$_COOKIE[ $cookie_name ] = 'test-session-id';
 
-		add_filter(
-			'woocommerce_geolocate_ip',
-			function () {
-				return 'CA';
-			}
-		);
+		try {
+			add_filter(
+				'woocommerce_geolocate_ip',
+				function () {
+					return 'CA';
+				}
+			);
 
-		$this->multi_currency->update_selected_currency_by_geolocation();
+			$this->multi_currency->update_selected_currency_by_geolocation();
 
-		// With an active session, geolocation should persist the currency.
-		$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
-
-		// Clean up.
-		unset( $_COOKIE[ $cookie_name ] );
+			// With an active session, geolocation should persist the currency.
+			$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+		} finally {
+			unset( $_COOKIE[ $cookie_name ] );
+		}
 	}
 
 	public function test_update_selected_currency_by_geolocation_persists_in_cache_mode_for_store_api_request() {
@@ -594,24 +596,30 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
 		$this->init_multi_currency();
 
-		// Simulate a Store API request (no session cookie, but Cart-Token based).
-		$original_request_uri   = $_SERVER['REQUEST_URI'] ?? '';
-		$_SERVER['REQUEST_URI'] = '/wp-json/wc/store/v1/batch';
+		// Save state — WC()->is_store_api_request() may swap the session handler.
+		$original_request_uri = $_SERVER['REQUEST_URI'] ?? '';
+		$original_session     = WC()->session;
 
-		add_filter(
-			'woocommerce_geolocate_ip',
-			function () {
-				return 'CA';
-			}
-		);
+		try {
+			// Simulate a Store API request (no session cookie, but Cart-Token based).
+			$_SERVER['REQUEST_URI'] = '/wp-json/wc/store/v1/batch';
 
-		$this->multi_currency->update_selected_currency_by_geolocation();
+			add_filter(
+				'woocommerce_geolocate_ip',
+				function () {
+					return 'CA';
+				}
+			);
 
-		// Store API requests should persist geolocation currency even without a cookie session.
-		$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+			$this->multi_currency->update_selected_currency_by_geolocation();
 
-		// Clean up.
-		$_SERVER['REQUEST_URI'] = $original_request_uri;
+			// Store API requests should persist geolocation currency even without a cookie session.
+			$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+		} finally {
+			// Restore state to avoid polluting subsequent tests.
+			$_SERVER['REQUEST_URI'] = $original_request_uri;
+			WC()->session           = $original_session;
+		}
 	}
 
 	public function test_display_geolocation_currency_update_notice() {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPMNT-5938

#### Changes proposed in this Pull Request

In cache-optimized mode, the geolocation currency was lost during two transitions:

**1. Session creation (e.g. add-to-cart → checkout)**

When a visitor with no session browsed catalog pages, the async JS renderer correctly converted prices to their geolocation currency (e.g. EUR). But when a WC session was created (add-to-cart), the server had no record of the selected currency and reverted to the store default (USD).

**Root cause:** `update_selected_currency()` bailed in cache-optimized mode for all automatic currency switches (`persist_change = false`), even when a session already existed.

**2. Store API requests (block-based cart/checkout)**

The block-based cart and checkout use Store API requests (`/wc/store/v1/batch`) which authenticate via Cart-Token JWT headers instead of WC session cookies. `has_active_session()` only checks for cookies, so it returned `false` for these requests. This meant `FrontendPrices` and `FrontendCurrencies` were never hooked, and the Store API returned USD prices.

**The fix:**

Extract a `should_use_async_rendering()` method that encapsulates when client-side rendering should handle pricing vs server-side `FrontendPrices`/`FrontendCurrencies`. Returns `true` only when all conditions are met:
- Cache-optimized mode is enabled
- No active WC session (cookie-based)
- Not a Store API request

#### Testing instructions

**Setup:**

1. Go to **WooCommerce → Settings → Multi-Currency** and enable at least one non-default currency (e.g. EUR)
2. Enable **Automatically switch currency** (auto currency switching based on geolocation)
3. Enable the cache-optimized feature flag via WP-CLI:
   ```
   wp option update _wcpay_feature_mc_cache_optimized 1
   ```
4. Set the rendering mode to cache-optimized in the admin or via WP-CLI:
   ```
   wp option update wcpay_multi_currency_rendering_mode cache
   ```
5. Clear cookies / use incognito to ensure no WC session exists

**Scenario 1 — Session persistence (shortcode or block cart/checkout):**
1. Visit a product page from a location that resolves to a non-default currency (e.g. EUR for Spain)
2. Confirm prices display in EUR (async JS conversion)
3. Add the product to the cart
4. Navigate to the checkout page
5. Confirm the checkout displays prices in EUR (not USD)
6. Navigate back to the shop — confirm prices remain in EUR

**Scenario 2 — Block-based cart quantity update:**
1. With EUR prices displayed, add a product to the cart
2. Navigate to the block-based cart page
3. Update the product quantity
4. Confirm the cart totals and mini-cart remain in EUR (not USD)
5. Proceed to checkout — confirm EUR is retained

**Scenario 3 — Shortcode-based cart/checkout:**
1. Repeat scenarios 1 and 2 using shortcode-based cart and checkout pages
2. Confirm EUR is retained throughout

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.