### PR TITLE
Send woocommerce_store_id to server in onboarding and account requests

### DIFF
--- a/changelog/add-traplat-3829-send-wc-store-id-to-server
+++ b/changelog/add-traplat-3829-send-wc-store-id-to-server
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Send WooCommerce store ID to the server with onboarding and account requests for Tracks event attribution

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2304,7 +2304,11 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					delete_transient( self::ONBOARDING_DISABLED_TRANSIENT );
 
 					$request = Get_Account::create();
-					$request->set_woocommerce_store_id( get_option( 'woocommerce_store_id', '' ) );
+					$request->set_woocommerce_store_id(
+						( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) )
+							? get_option( \WC_Install::STORE_ID_OPTION, '' )
+							: ''
+					);
 					$response = $request->send();
 					$account  = $response->to_array();
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2303,12 +2303,11 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					// We can let the code below re-create it if the server tells us onboarding is still disabled.
 					delete_transient( self::ONBOARDING_DISABLED_TRANSIENT );
 
-					$request = Get_Account::create();
-					$request->set_woocommerce_store_id(
-						( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) )
-							? get_option( \WC_Install::STORE_ID_OPTION, '' )
-							: ''
-					);
+					$request      = Get_Account::create();
+					$store_id_key = ( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) )
+						? \WC_Install::STORE_ID_OPTION
+						: 'woocommerce_store_id';
+					$request->set_woocommerce_store_id( get_option( $store_id_key, '' ) );
 					$response = $request->send();
 					$account  = $response->to_array();
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2303,7 +2303,8 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 					// We can let the code below re-create it if the server tells us onboarding is still disabled.
 					delete_transient( self::ONBOARDING_DISABLED_TRANSIENT );
 
-					$request  = Get_Account::create();
+					$request = Get_Account::create();
+					$request->set_woocommerce_store_id( get_option( 'woocommerce_store_id', '' ) );
 					$response = $request->send();
 					$account  = $response->to_array();
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1426,7 +1426,9 @@ class WC_Payments_Onboarding_Service {
 	 * @return array
 	 */
 	public function add_woocommerce_store_id_to_request( array $args ): array {
-		$args['woocommerce_store_id'] = get_option( 'woocommerce_store_id', '' );
+		$args['woocommerce_store_id'] = ( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) )
+			? get_option( \WC_Install::STORE_ID_OPTION, '' )
+			: '';
 		return $args;
 	}
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -116,6 +116,7 @@ class WC_Payments_Onboarding_Service {
 	public function init_hooks() {
 		add_filter( 'admin_body_class', [ $this, 'add_admin_body_classes' ] );
 		add_filter( 'wc_payments_get_onboarding_data_args', [ $this, 'maybe_add_test_drive_settings_to_new_account_request' ] );
+		add_filter( 'wc_payments_get_onboarding_data_args', [ $this, 'add_woocommerce_store_id_to_request' ] );
 	}
 
 	/**
@@ -1414,6 +1415,18 @@ class WC_Payments_Onboarding_Service {
 			delete_transient( WC_Payments_Account::ONBOARDING_TEST_DRIVE_SETTINGS_FOR_LIVE_ACCOUNT );
 		}
 
+		return $args;
+	}
+
+	/**
+	 * Add the WooCommerce store ID to outgoing onboarding request args.
+	 *
+	 * @param array $args The request args.
+	 *
+	 * @return array
+	 */
+	public function add_woocommerce_store_id_to_request( array $args ): array {
+		$args['woocommerce_store_id'] = get_option( 'woocommerce_store_id', '' );
 		return $args;
 	}
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1426,9 +1426,10 @@ class WC_Payments_Onboarding_Service {
 	 * @return array
 	 */
 	public function add_woocommerce_store_id_to_request( array $args ): array {
-		$args['woocommerce_store_id'] = ( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) )
-			? get_option( \WC_Install::STORE_ID_OPTION, '' )
-			: '';
+		$store_id_key                 = ( class_exists( '\WC_Install' ) && defined( '\WC_Install::STORE_ID_OPTION' ) )
+			? \WC_Install::STORE_ID_OPTION
+			: 'woocommerce_store_id';
+		$args['woocommerce_store_id'] = get_option( $store_id_key, '' );
 		return $args;
 	}
 

--- a/includes/core/server/request/class-get-account.php
+++ b/includes/core/server/request/class-get-account.php
@@ -38,4 +38,13 @@ class Get_Account extends Request {
 	public function get_method(): string {
 		return 'GET';
 	}
+
+	/**
+	 * Set the WooCommerce store ID to send with the account request.
+	 *
+	 * @param string $woocommerce_store_id The WooCommerce store ID (UUID).
+	 */
+	public function set_woocommerce_store_id( string $woocommerce_store_id ): void {
+		$this->set_param( 'woocommerce_store_id', $woocommerce_store_id );
+	}
 }

--- a/tests/unit/core/server/request/test-class-core-get-account-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-request.php
@@ -45,6 +45,25 @@ class Get_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( WC_Payments_API_Client::ACCOUNTS_API, $request->get_api() );
 		$this->assertSame( 'GET', $request->get_method() );
 	}
+	public function test_set_woocommerce_store_id() {
+		$request  = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$store_id = 'test-store-uuid-1234';
+
+		$request->set_woocommerce_store_id( $store_id );
+
+		$params = $request->get_params();
+		$this->assertSame( $store_id, $params['woocommerce_store_id'] );
+	}
+
+	public function test_set_woocommerce_store_id_empty_string() {
+		$request = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
+
+		$request->set_woocommerce_store_id( '' );
+
+		$params = $request->get_params();
+		$this->assertSame( '', $params['woocommerce_store_id'] );
+	}
+
 	public function test_get_account_will_be_requested_as_test_mode_only_in_test_mode_onboarding() {
 		// enable test mode.
 		WC_Payments::mode()->test();

--- a/tests/unit/core/server/request/test-class-core-get-account-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-request.php
@@ -45,6 +45,7 @@ class Get_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( WC_Payments_API_Client::ACCOUNTS_API, $request->get_api() );
 		$this->assertSame( 'GET', $request->get_method() );
 	}
+
 	public function test_set_woocommerce_store_id() {
 		$request  = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$store_id = 'test-store-uuid-1234';

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3923,4 +3923,65 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		// Assert.
 		$this->assertSame( $expected, $result );
 	}
+
+	public function test_get_cached_account_data_sends_woocommerce_store_id() {
+		$store_id = 'test-store-uuid-5678';
+		update_option( 'woocommerce_store_id', $store_id );
+
+		$this->mock_jetpack_connection();
+		$this->mock_empty_cache();
+
+		$request_mock = $this->mock_wcpay_request( Get_Account::class );
+		$request_mock
+			->expects( $this->once() )
+			->method( 'set_woocommerce_store_id' )
+			->with( $store_id );
+		$request_mock
+			->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				new Response(
+					[
+						'account_id'               => 'acc_test',
+						'live_publishable_key'     => 'pk_test_',
+						'test_publishable_key'     => 'pk_live_',
+						'has_pending_requirements' => false,
+						'current_deadline'         => 0,
+						'is_live'                  => true,
+					]
+				)
+			);
+
+		$this->wcpay_account->get_cached_account_data();
+	}
+
+	public function test_get_cached_account_data_sends_empty_store_id_when_option_missing() {
+		delete_option( 'woocommerce_store_id' );
+
+		$this->mock_jetpack_connection();
+		$this->mock_empty_cache();
+
+		$request_mock = $this->mock_wcpay_request( Get_Account::class );
+		$request_mock
+			->expects( $this->once() )
+			->method( 'set_woocommerce_store_id' )
+			->with( '' );
+		$request_mock
+			->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				new Response(
+					[
+						'account_id'               => 'acc_test',
+						'live_publishable_key'     => 'pk_test_',
+						'test_publishable_key'     => 'pk_live_',
+						'has_pending_requirements' => false,
+						'current_deadline'         => 0,
+						'is_live'                  => true,
+					]
+				)
+			);
+
+		$this->wcpay_account->get_cached_account_data();
+	}
 }

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -147,6 +147,7 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 
 	public function test_filters_registered_properly() {
 		$this->assertNotFalse( has_filter( 'admin_body_class', [ $this->onboarding_service, 'add_admin_body_classes' ] ) );
+		$this->assertNotFalse( has_filter( 'wc_payments_get_onboarding_data_args', [ $this->onboarding_service, 'add_woocommerce_store_id_to_request' ] ) );
 	}
 
 	public function test_create_embedded_kyc_session() {
@@ -755,5 +756,24 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 
 		// Assert.
 		$this->assertNotEmpty( $result );
+	}
+
+	public function test_add_woocommerce_store_id_to_request_adds_store_id() {
+		$store_id = 'test-store-uuid-1234';
+		update_option( 'woocommerce_store_id', $store_id );
+
+		$args   = [ 'existing_key' => 'value' ];
+		$result = $this->onboarding_service->add_woocommerce_store_id_to_request( $args );
+
+		$this->assertSame( $store_id, $result['woocommerce_store_id'] );
+		$this->assertSame( 'value', $result['existing_key'] );
+	}
+
+	public function test_add_woocommerce_store_id_to_request_returns_empty_string_when_option_missing() {
+		delete_option( 'woocommerce_store_id' );
+
+		$result = $this->onboarding_service->add_woocommerce_store_id_to_request( [] );
+
+		$this->assertSame( '', $result['woocommerce_store_id'] );
 	}
 }

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -302,6 +302,7 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 						'actioned_notes'              => $actioned_notes,
 						'create_live_account'         => true,
 						'collect_payout_requirements' => false,
+						'woocommerce_store_id'        => get_option( 'woocommerce_store_id', '' ),
 						'compatibility_data'          => $this->get_mock_compatibility_data(),
 						'referral_code'               => null,
 					]

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -254,6 +254,8 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	 * @throws API_Exception
 	 */
 	public function test_get_onboarding_data() {
+		update_option( 'woocommerce_store_id', 'test-store-id-12345' );
+
 		$site_data = [
 			'site_username' => 'admin',
 			'site_locale'   => 'en_US',
@@ -302,7 +304,7 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 						'actioned_notes'              => $actioned_notes,
 						'create_live_account'         => true,
 						'collect_payout_requirements' => false,
-						'woocommerce_store_id'        => get_option( 'woocommerce_store_id', '' ),
+						'woocommerce_store_id'        => 'test-store-id-12345',
 						'compatibility_data'          => $this->get_mock_compatibility_data(),
 						'referral_code'               => null,
 					]


### PR DESCRIPTION
Fixes TRAPLAT-3829

#### Changes proposed in this Pull Request

Sends the WooCommerce store ID (`woocommerce_store_id` option, a UUID available since WC 8.4) to the server on all onboarding and account requests so the server can attach `wc_store_id` to Tracks events.

**Onboarding requests** (init, embedded KYC, test-drive): A single `wc_payments_get_onboarding_data_args` filter in `WC_Payments_Onboarding_Service` adds `woocommerce_store_id` as a top-level request arg, covering all three call sites.

**Account GET request**: A new `set_woocommerce_store_id()` setter on the `Get_Account` request class passes the store ID as a query parameter when fetching account data.

Falls back to an empty string when the option doesn't exist (WC < 8.4). The server PR ([wpcom#203384](https://github.a8c.com/Automattic/wpcom/pull/203384)) deploys first and safely handles empty values.

#### Testing instructions

Should be tested with the server PR.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.