### PR TITLE
Fix the missing null condition check in for fee currency

### DIFF
--- a/changelog/woopmnt-5947-security-dispute-timeline-may-crash-when-fee-currency-is
+++ b/changelog/woopmnt-5947-security-dispute-timeline-may-crash-when-fee-currency-is
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix the missing null-condition check for the timeline fee. No change in functionality.
+
+

--- a/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
+++ b/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
@@ -1020,6 +1020,52 @@ exports[`mapTimelineEvents single currency events formats dispute_lost events wi
 ]
 `;
 
+exports[`mapTimelineEvents single currency events formats dispute_lost events with network cost but missing fee currency 1`] = `
+[
+  {
+    "body": [
+      "Network cost for the dispute.",
+    ],
+    "date": 2020-04-05T02:56:10.000Z,
+    "headline": <React.Fragment>
+      $5.00 USD was deducted from your 
+      <Link
+        href="admin.php?page=wc-admin&path=%2Fpayments%2Fpayouts%2Fdetails&id=dummy_po_5eaada696b2ef"
+      >
+        Apr 5, 2020 payout
+      </Link>
+      .
+    </React.Fragment>,
+    "icon": <MinusIcon />,
+  },
+  {
+    "body": [],
+    "date": 2020-04-05T02:56:10.000Z,
+    "headline": <React.Fragment>
+      Payment status changed to 
+      <strong>
+        Disputed: Lost
+      </strong>
+      .
+    </React.Fragment>,
+    "icon": <SyncIcon />,
+  },
+  {
+    "body": [],
+    "date": 2020-04-05T02:56:10.000Z,
+    "headline": <React.Fragment>
+      <strong>
+        Dispute lost.
+      </strong>
+       Your customer's bank reviewed the evidence and decided in the customer's favor.
+    </React.Fragment>,
+    "icon": <CrossIcon
+      className="is-error"
+    />,
+  },
+]
+`;
+
 exports[`mapTimelineEvents single currency events formats dispute_needs_response events 1`] = `
 [
   {

--- a/client/payment-details/timeline/__tests__/map-events.test.js
+++ b/client/payment-details/timeline/__tests__/map-events.test.js
@@ -454,6 +454,28 @@ describe( 'mapTimelineEvents', () => {
 			).toMatchSnapshot();
 		} );
 
+		test( 'formats dispute_lost events with network cost but missing fee currency', () => {
+			expect(
+				mapTimelineEvents( [
+					{
+						amount: 10000,
+						currency: 'USD',
+						datetime: 1586055370,
+						deposit: {
+							arrival_date: 1586141770,
+							id: 'dummy_po_5eaada696b2ef',
+						},
+						fee: 1500,
+						network_cost: {
+							amount: 500,
+							currency: 'usd',
+						},
+						type: 'dispute_lost',
+					},
+				] )
+			).toMatchSnapshot();
+		} );
+
 		test( 'formats dispute_lost events with cross-currency network cost', () => {
 			expect(
 				mapTimelineEvents( [

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -1061,7 +1061,7 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 							networkCost.amount,
 							networkCost.currency.toUpperCase(),
 							false,
-							event?.fee?.currency.toUpperCase()
+							event?.fee?.currency?.toUpperCase()
 					  )
 					: '';
 			const isCrossCurrencyNetworkCost =


### PR DESCRIPTION
Fixes WOOPMNT-5947
#### Changes proposed in this Pull Request

 - Fix the missing null-condition check for the fee currency in the timeline.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Covered by the automated tests.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
