### PR TITLE
chore: Bump WC tested up to version to 10.7.0

### DIFF
--- a/changelog/dev-bump-wc-tested-up-to-10.7.0
+++ b/changelog/dev-bump-wc-tested-up-to-10.7.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 10.7.0

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 10.6.0
+ * WC tested up to: 10.7.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 10.6.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Bumps the "WC tested up to" header from 10.6.0 to 10.7.0, ahead of the WooCommerce 10.7.0 release.

#### Testing instructions

* Verify `woocommerce-payments.php` header shows `WC tested up to: 10.7.0`
* Changelog entry present

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description — no logic changes, header-only bump)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)