### PR TITLE
fix: Capital loan list table column visibility is not configurable, inco

### DIFF
--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -47,7 +47,7 @@ const columns = [
 		key: 'amount',
 		label: __( 'Amount', 'woocommerce-payments' ),
 		screenReaderLabel: __( 'Amount', 'woocommerce-payments' ),
-		required: true,
+		required: false,
 		isLeftAligned: false,
 		isNumeric: true,
 	},
@@ -55,7 +55,7 @@ const columns = [
 		key: 'fee_amount',
 		label: __( 'Fixed fee', 'woocommerce-payments' ),
 		screenReaderLabel: __( 'Fixed fee', 'woocommerce-payments' ),
-		required: true,
+		required: false,
 		isLeftAligned: false,
 		isNumeric: true,
 	},
@@ -63,7 +63,7 @@ const columns = [
 		key: 'withhold_rate',
 		label: __( 'Withhold rate', 'woocommerce-payments' ),
 		screenReaderLabel: __( 'Withhold rate', 'woocommerce-payments' ),
-		required: true,
+		required: false,
 		isLeftAligned: false,
 		isNumeric: true,
 	},
@@ -71,7 +71,7 @@ const columns = [
 		key: 'first_paydown_at',
 		label: __( 'First paydown', 'woocommerce-payments' ),
 		screenReaderLabel: __( 'First paydown', 'woocommerce-payments' ),
-		required: true,
+		required: false,
 		isLeftAligned: false,
 		isNumeric: true, // Hack: this is not a numeric field, but "isNumeric" is needed for it to be right-aligned
 	},
@@ -229,8 +229,7 @@ const CapitalPage = (): JSX.Element => {
 				rows={ getRowsData( loans ) }
 				rowsPerPage={ loans.length }
 				summary={ getSummary( loans ) }
-				// The Capital Loan table does not have column configuration enabled, see issue #10106.
-				showMenu={ false }
+				showMenu={ true }
 			/>
 		</Page>
 	);


### PR DESCRIPTION
Fixes #10106

The capital loan list table in `client/capital/index.tsx` had column visibility configuration disabled, making it inconsistent with other reporting tables. The `Amount`, `Fixed fee`, `Withhold rate`, and `First paydown` columns were all marked `required: true`, and `showMenu` was hardcoded to `false`, preventing users from toggling column visibility. Changes `required` to `false` on those four columns and sets `showMenu={ true }` in `CapitalPage` to enable the standard column configuration menu.