### PR TITLE
fix: Subscriptions: Fix reserved keyword variable names phpcs reports

### DIFF
--- a/tests/unit/helpers/class-wc-helper-subscriptions.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions.php
@@ -215,28 +215,28 @@ class WC_Subscriptions {
 	 */
 	public static $wcs_is_manual_renewal_enabled = null;
 
-	public static function set_wcs_order_contains_subscription( $function ) {
-		self::$wcs_order_contains_subscription = $function;
+	public static function set_wcs_order_contains_subscription( $callback ) {
+		self::$wcs_order_contains_subscription = $callback;
 	}
 
-	public static function set_wcs_get_subscriptions_for_order( $function ) {
-		self::$wcs_get_subscriptions_for_order = $function;
+	public static function set_wcs_get_subscriptions_for_order( $callback ) {
+		self::$wcs_get_subscriptions_for_order = $callback;
 	}
 
-	public static function set_wcs_get_subscriptions_for_renewal_order( $function ) {
-		self::$wcs_get_subscriptions_for_renewal_order = $function;
+	public static function set_wcs_get_subscriptions_for_renewal_order( $callback ) {
+		self::$wcs_get_subscriptions_for_renewal_order = $callback;
 	}
 
-	public static function set_wcs_is_subscription( $function ) {
-		self::$wcs_is_subscription = $function;
+	public static function set_wcs_is_subscription( $callback ) {
+		self::$wcs_is_subscription = $callback;
 	}
 
-	public static function set_wcs_get_subscription( $function ) {
-		self::$wcs_get_subscription = $function;
+	public static function set_wcs_get_subscription( $callback ) {
+		self::$wcs_get_subscription = $callback;
 	}
 
-	public static function set_wcs_get_subscriptions( $function ) {
-		self::$wcs_get_subscriptions = $function;
+	public static function set_wcs_get_subscriptions( $callback ) {
+		self::$wcs_get_subscriptions = $callback;
 	}
 
 	public static function wcs_cart_contains_renewal( $function ) {


### PR DESCRIPTION
Fixes #8540

PHPCS reported `Universal.NamingConventions.NoReservedKeywordParameterNames.functionFound` violations in `tests/unit/helpers/class-wc-helper-subscriptions.php` because setter methods used `$function` as a parameter name, which is a reserved keyword in PHP. Renames the `$function` parameter to `$callback` in six setter methods of the `WC_Subscriptions` test helper class.