### PR TITLE
Add noopener,noreferrer to review prompt window.open

### DIFF
--- a/changelog/update-WOOPMNT-5945-review-noopener
+++ b/changelog/update-WOOPMNT-5945-review-noopener
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add noopener,noreferrer to review prompt window.open call

--- a/client/review-prompt/__tests__/index.test.tsx
+++ b/client/review-prompt/__tests__/index.test.tsx
@@ -157,7 +157,8 @@ describe( 'ReviewPrompt', () => {
 		await waitFor( () => {
 			expect( mockWindowOpen ).toHaveBeenCalledWith(
 				'https://wordpress.org/support/plugin/woocommerce-payments/reviews/#new-post',
-				'_blank'
+				'_blank',
+				'noopener,noreferrer'
 			);
 		} );
 	} );
@@ -173,7 +174,8 @@ describe( 'ReviewPrompt', () => {
 		await waitFor( () => {
 			expect( mockWindowOpen ).toHaveBeenCalledWith(
 				'https://woocommerce.com/products/woocommerce-payments/?review',
-				'_blank'
+				'_blank',
+				'noopener,noreferrer'
 			);
 		} );
 	} );
@@ -345,7 +347,8 @@ describe( 'ReviewPrompt', () => {
 			// Should have tried to open in new window
 			expect( mockWindowOpen ).toHaveBeenCalledWith(
 				'https://wordpress.org/support/plugin/woocommerce-payments/reviews/#new-post',
-				'_blank'
+				'_blank',
+				'noopener,noreferrer'
 			);
 
 			// Should fall back to navigating current window

--- a/client/review-prompt/index.tsx
+++ b/client/review-prompt/index.tsx
@@ -94,7 +94,11 @@ const ReviewPrompt: React.FC = () => {
 			eventProps
 		);
 
-		const windowOpened = window.open( reviewUrl, '_blank' );
+		const windowOpened = window.open(
+			reviewUrl,
+			'_blank',
+			'noopener,noreferrer'
+		);
 		if ( ! windowOpened ) {
 			// Make sure the request completes before redirecting away.
 			await dismissPrompt();


### PR DESCRIPTION
Fixes WOOPMNT-5945

#### Changes proposed in this Pull Request

Adds `noopener,noreferrer` to the `window.open()` call in the review prompt component (`client/review-prompt/index.tsx`), preventing reverse tabnabbing.

**Why:** calling `window.open(reviewUrl, '_blank')` without `noopener,noreferrer` allows the opened page to access `window.opener` and potentially navigate the admin tab.

**Risk is very low** — the `reviewUrl` is hardcoded to two trusted, first-party domains (`wordpress.org` and `woocommerce.com`), not user-controlled input. This is a defense-in-depth fix to close the audit finding cleanly.

**How can this code break?** It shouldn't — adding `noopener,noreferrer` is standard practice and doesn't change the user-visible behavior. The review page still opens in a new tab exactly as before; it just can't access `window.opener` anymore.

#### Testing instructions

Nothing should change from a user perspective. To verify:

1. On the server side, add `'eligibility_review_prompt_phase_0' => 'yes'` to the basic account info (same setup as #11287).
2. Refresh account cache.
3. Navigate to **WooCommerce → Settings → Payments** (top-level, no section).
4. The prompt should appear after a few seconds.
5. Click **"Leave review"**.
6. **Expected:** A new tab opens to the review page (WordPress.org for live mode, Marketplace for test mode) — behavior is identical to before this change.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.