### PR TITLE
Ensure isVisaCompliance is using the current dispute data.

### DIFF
--- a/changelog/woopmnt-5971-security-visa-compliance-cover-letter-uses-stale-dispute
+++ b/changelog/woopmnt-5971-security-visa-compliance-cover-letter-uses-stale-dispute
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Minor change to ensure isVisaCompliance check always uses the current dispute data.
+Comment: Wnsure isVisaCompliance check always uses the current dispute data.
 
 

--- a/changelog/woopmnt-5971-security-visa-compliance-cover-letter-uses-stale-dispute
+++ b/changelog/woopmnt-5971-security-visa-compliance-cover-letter-uses-stale-dispute
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor change to ensure isVisaCompliance check always uses the current dispute data.
+
+

--- a/changelog/woopmnt-5971-security-visa-compliance-cover-letter-uses-stale-dispute
+++ b/changelog/woopmnt-5971-security-visa-compliance-cover-letter-uses-stale-dispute
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Wnsure isVisaCompliance check always uses the current dispute data.
+Comment: Ensure isVisaCompliance check always uses the current dispute data.
 
 

--- a/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
+++ b/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
@@ -65,6 +65,7 @@ import { getRecommendedDocumentFields } from '../recommended-document-fields';
 import { generateAttachments } from '../cover-letter-generator';
 import { getMatrixFields } from '../evidence-matrix';
 import { DOCUMENT_FIELD_KEYS } from '../document-field-keys';
+import type { DisputeReason } from 'wcpay/types/disputes';
 
 // Mock wcpaySettings with feature flag enabled
 declare const global: {
@@ -85,7 +86,7 @@ declare const global: {
  * - labels: Expected labels for UI display
  */
 interface CombinationSpec {
-	reason: string;
+	reason: DisputeReason;
 	productType: string;
 	status?: string; // For duplicate disputes
 	refundStatus?: string; // For credit_not_processed disputes

--- a/client/disputes/new-evidence/__tests__/recommended-document-fields.test.ts
+++ b/client/disputes/new-evidence/__tests__/recommended-document-fields.test.ts
@@ -721,6 +721,22 @@ describe( 'Recommended Documents', () => {
 					'Any other relevant documents that will support your case.'
 				);
 			} );
+
+			it( 'should return Visa Compliance fields when enhanced_eligibility_types includes visa_compliance', () => {
+				global.wcpaySettings.featureFlags.isDisputeAdditionalEvidenceTypesEnabled = true;
+				const result = getRecommendedDocumentFields(
+					'fraudulent',
+					undefined,
+					undefined,
+					undefined,
+					[ 'visa_compliance' ]
+				);
+				expect( result ).toHaveLength( 2 );
+				expect( result[ 0 ].key ).toBe( 'customer_communication' );
+				expect( result[ 0 ].label ).toBe( 'Upload evidence' );
+				expect( result[ 1 ].key ).toBe( 'uncategorized_file' );
+				expect( result[ 1 ].label ).toBe( 'Other documents' );
+			} );
 		} );
 	} );
 

--- a/client/disputes/new-evidence/__tests__/recommended-document-fields.test.ts
+++ b/client/disputes/new-evidence/__tests__/recommended-document-fields.test.ts
@@ -10,6 +10,7 @@ import {
 	getRecommendedShippingDocumentFields,
 } from '../recommended-document-fields';
 import { RecommendedDocument } from '../types';
+import type { DisputeReason } from 'wcpay/types/disputes';
 
 declare const global: {
 	wcpaySettings: {
@@ -35,7 +36,7 @@ describe( 'Recommended Documents', () => {
 	} );
 	describe( 'getRecommendedDocumentFields', () => {
 		it( 'should return default fields when no specific reason is provided', () => {
-			const result = getRecommendedDocumentFields( '' );
+			const result = getRecommendedDocumentFields( '' as DisputeReason );
 			expect( result ).toHaveLength( 6 ); // Default fields + fields for the "general" reason
 			expect( result[ 0 ].key ).toBe( 'receipt' );
 			expect( result[ 1 ].key ).toBe( 'customer_communication' );

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -158,7 +158,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				setIsInitialLoading( true );
 				const d: any = await apiFetch( { path } );
 				setDispute( d );
-				const isVisaCompliance = isVisaComplianceDispute( d );
+				const isVisaComplianceFetched = isVisaComplianceDispute( d );
 				// Prefer the saved metadata value for product type, as it will be empty on the merchant's first visit.
 				// After the merchant saves the dispute challenge, this metadata will be populated and should be used.
 				const suggestedProductType =
@@ -206,7 +206,7 @@ export default ( { query }: { query: { id: string } } ) => {
 				const savedCoverLetter = d.evidence?.uncategorized_text;
 				if ( savedCoverLetter ) {
 					setCoverLetter( savedCoverLetter );
-					if ( isVisaCompliance && isFeatureFlagEnabled ) {
+					if ( isVisaComplianceFetched && isFeatureFlagEnabled ) {
 						// For Visa Compliance disputes, always consider the cover letter as manually edited
 						setIsCoverLetterManuallyEdited( true );
 					} else {
@@ -261,7 +261,7 @@ export default ( { query }: { query: { id: string } } ) => {
 							savedCoverLetter !== generatedContent
 						);
 					}
-				} else if ( isVisaCompliance && isFeatureFlagEnabled ) {
+				} else if ( isVisaComplianceFetched && isFeatureFlagEnabled ) {
 					setCoverLetter( '' );
 					// For Visa Compliance disputes, always consider the cover letter as manually edited
 					setIsCoverLetterManuallyEdited( true );

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -150,12 +150,12 @@ export default ( { query }: { query: { id: string } } ) => {
 	const isFeatureFlagEnabled =
 		wcpaySettings?.featureFlags?.isDisputeAdditionalEvidenceTypesEnabled ||
 		false;
-	const isVisaCompliance = isVisaComplianceDispute( dispute );
 
 	// --- Data loading ---
 	useEffect( () => {
 		const fetchDispute = async () => {
 			try {
+				const isVisaCompliance = isVisaComplianceDispute( dispute );
 				setIsInitialLoading( true );
 				const d: any = await apiFetch( { path } );
 				setDispute( d );
@@ -461,6 +461,7 @@ export default ( { query }: { query: { id: string } } ) => {
 	const disputeReason = dispute?.reason;
 	const hasShipping = needsShipping( disputeReason, productType );
 	let panelHeadings = [ 'Purchase info', 'Review' ];
+	const isVisaCompliance = isVisaComplianceDispute( dispute );
 	if ( isVisaCompliance && isFeatureFlagEnabled ) {
 		panelHeadings = [ 'Dispute information' ];
 	} else if ( hasShipping ) {

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -155,10 +155,10 @@ export default ( { query }: { query: { id: string } } ) => {
 	useEffect( () => {
 		const fetchDispute = async () => {
 			try {
-				const isVisaCompliance = isVisaComplianceDispute( dispute );
 				setIsInitialLoading( true );
 				const d: any = await apiFetch( { path } );
 				setDispute( d );
+				const isVisaCompliance = isVisaComplianceDispute( d );
 				// Prefer the saved metadata value for product type, as it will be empty on the merchant's first visit.
 				// After the merchant saves the dispute challenge, this metadata will be populated and should be used.
 				const suggestedProductType =

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -358,7 +358,8 @@ export default ( { query }: { query: { id: string } } ) => {
 				? refundStatus
 				: undefined,
 			dispute.reason === 'duplicate' ? duplicateStatus : undefined,
-			productType
+			productType,
+			dispute.enhanced_eligibility_types
 		);
 		const applicableFieldKeys = new Set(
 			applicableDocumentFields.map( ( field ) => field.key )
@@ -961,7 +962,8 @@ export default ( { query }: { query: { id: string } } ) => {
 		disputeReason,
 		disputeReason === 'credit_not_processed' ? refundStatus : undefined,
 		disputeReason === 'duplicate' ? duplicateStatus : undefined,
-		productType
+		productType,
+		dispute?.enhanced_eligibility_types
 	);
 
 	const recommendedShippingDocumentFields = getRecommendedShippingDocumentFields(

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -158,7 +158,9 @@ export default ( { query }: { query: { id: string } } ) => {
 				setIsInitialLoading( true );
 				const d: any = await apiFetch( { path } );
 				setDispute( d );
-				const isVisaComplianceFetched = isVisaComplianceDispute( d );
+				const isFetchedDisputeVisaCompliance = isVisaComplianceDispute(
+					d
+				);
 				// Prefer the saved metadata value for product type, as it will be empty on the merchant's first visit.
 				// After the merchant saves the dispute challenge, this metadata will be populated and should be used.
 				const suggestedProductType =
@@ -206,7 +208,10 @@ export default ( { query }: { query: { id: string } } ) => {
 				const savedCoverLetter = d.evidence?.uncategorized_text;
 				if ( savedCoverLetter ) {
 					setCoverLetter( savedCoverLetter );
-					if ( isVisaComplianceFetched && isFeatureFlagEnabled ) {
+					if (
+						isFetchedDisputeVisaCompliance &&
+						isFeatureFlagEnabled
+					) {
 						// For Visa Compliance disputes, always consider the cover letter as manually edited
 						setIsCoverLetterManuallyEdited( true );
 					} else {
@@ -261,7 +266,10 @@ export default ( { query }: { query: { id: string } } ) => {
 							savedCoverLetter !== generatedContent
 						);
 					}
-				} else if ( isVisaComplianceFetched && isFeatureFlagEnabled ) {
+				} else if (
+					isFetchedDisputeVisaCompliance &&
+					isFeatureFlagEnabled
+				) {
 					setCoverLetter( '' );
 					// For Visa Compliance disputes, always consider the cover letter as manually edited
 					setIsCoverLetterManuallyEdited( true );

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -9,6 +9,8 @@ import { __ } from '@wordpress/i18n';
 import { RecommendedDocument } from './types';
 import { getMatrixFields } from './evidence-matrix';
 import { DOCUMENT_FIELD_KEYS } from './document-field-keys';
+import { isVisaComplianceDispute } from 'wcpay/disputes/utils';
+import type { DisputeReason } from 'wcpay/types/disputes';
 
 // Re-export for backward compatibility
 export { DOCUMENT_FIELD_KEYS };
@@ -24,7 +26,7 @@ export { DOCUMENT_FIELD_KEYS };
  * @return {Array<{key: string, label: string}>} Array of recommended document fields
  */
 const getRecommendedDocumentFields = (
-	reason: string,
+	reason: DisputeReason,
 	refundStatus?: string,
 	duplicateStatus?: string,
 	productType?: string,
@@ -38,8 +40,10 @@ const getRecommendedDocumentFields = (
 	if ( isFeatureFlagEnabled ) {
 		// Handle Visa Compliance disputes: reason is 'noncompliant' OR enhanced_eligibility_types includes 'visa_compliance'
 		if (
-			reason === 'noncompliant' ||
-			( enhancedEligibilityTypes || [] ).includes( 'visa_compliance' )
+			isVisaComplianceDispute( {
+				reason,
+				enhanced_eligibility_types: enhancedEligibilityTypes,
+			} )
 		) {
 			return [
 				{

--- a/client/disputes/new-evidence/recommended-document-fields.ts
+++ b/client/disputes/new-evidence/recommended-document-fields.ts
@@ -20,13 +20,15 @@ export { DOCUMENT_FIELD_KEYS };
  * @param {string} refundStatus - The refund status (for credit_not_processed disputes)
  * @param {string} duplicateStatus - The duplicate status (for duplicate disputes)
  * @param {string} productType - The product type (for subscription_canceled disputes)
+ * @param {string[]} enhancedEligibilityTypes - The enhanced eligibility types (e.g. ['visa_compliance'])
  * @return {Array<{key: string, label: string}>} Array of recommended document fields
  */
 const getRecommendedDocumentFields = (
 	reason: string,
 	refundStatus?: string,
 	duplicateStatus?: string,
-	productType?: string
+	productType?: string,
+	enhancedEligibilityTypes?: string[]
 ): Array< RecommendedDocument > => {
 	// Feature flag gated: Check evidence matrix for reason + product type combinations
 	const isFeatureFlagEnabled =
@@ -34,8 +36,11 @@ const getRecommendedDocumentFields = (
 		false;
 
 	if ( isFeatureFlagEnabled ) {
-		// Handle Visa Compliance (noncompliant) disputes
-		if ( reason === 'noncompliant' ) {
+		// Handle Visa Compliance disputes: reason is 'noncompliant' OR enhanced_eligibility_types includes 'visa_compliance'
+		if (
+			reason === 'noncompliant' ||
+			( enhancedEligibilityTypes || [] ).includes( 'visa_compliance' )
+		) {
 			return [
 				{
 					key: DOCUMENT_FIELD_KEYS.CUSTOMER_COMMUNICATION,


### PR DESCRIPTION
Fixes WOOPMNT-5971

#### Changes proposed in this Pull Request


 - Ensure that `isVisaCompliance` constant is updated with the dispute data before using it to decide on the cover letter contents.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Already covered by the tests.
* Manually create an order and pay with the `4000008400000779` card to trigger the dispute.
* Open the disputes page and challenge the dispute (it requires accepting the fee).
* There should be a single-step form to challenge. The cover letter should be empty.

<img width="965" height="1111" alt="image" src="https://github.com/user-attachments/assets/63a72a53-8d8c-44c9-9409-7607c6987f00" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
