### PR TITLE
Fix the mistaken `$token` reference to use existing `$payment_token`

### DIFF
--- a/changelog/woopmnt-5957-security-undefined-token-in-subscription-update-all-path
+++ b/changelog/woopmnt-5957-security-undefined-token-in-subscription-update-all-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Refactor the update subscriptions token flow and improve test coverage.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3838,17 +3838,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$return_url = $this->get_return_url( $order );
 
 				if ( $is_changing_payment ) {
-					$payment_token = $this->get_payment_token( $order );
-					if ( class_exists( 'WC_Subscriptions_Change_Payment_Gateway' ) ) {
-						WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $order, $payment_token->get_gateway_id() );
-						$notice = __( 'Payment method updated.', 'woocommerce-payments' );
-
-						if ( WC_Subscriptions_Change_Payment_Gateway::will_subscription_update_all_payment_methods( $order ) && WC_Subscriptions_Change_Payment_Gateway::update_all_payment_methods_from_subscription( $order, $token->get_gateway_id() ) ) {
-							$notice = __( 'Payment method updated for all your current subscriptions.', 'woocommerce-payments' );
-						}
-
-						wc_add_notice( $notice );
-					}
+					$this->maybe_update_subscription_payment_method( $order );
 					$return_url = method_exists( $order, 'get_view_order_url' ) ? $order->get_view_order_url() : $this->get_return_url( $order );
 				}
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -1267,4 +1267,26 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			)
 		);
 	}
+
+	/**
+	 * When a customer changes the payment method for a subscription order, updates the
+	 * payment method via WC_Subscriptions_Change_Payment_Gateway and adds a notice.
+	 *
+	 * @param WC_Order $order The order whose payment method was changed.
+	 */
+	public function maybe_update_subscription_payment_method( WC_Order $order ) {
+		if ( ! class_exists( 'WC_Subscriptions_Change_Payment_Gateway' ) ) {
+			return;
+		}
+
+		$payment_token = $this->get_payment_token( $order );
+		WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $order, $payment_token->get_gateway_id() );
+		$notice = __( 'Payment method updated.', 'woocommerce-payments' );
+
+		if ( WC_Subscriptions_Change_Payment_Gateway::will_subscription_update_all_payment_methods( $order ) && WC_Subscriptions_Change_Payment_Gateway::update_all_payment_methods_from_subscription( $order, $payment_token->get_gateway_id() ) ) {
+			$notice = __( 'Payment method updated for all your current subscriptions.', 'woocommerce-payments' );
+		}
+
+		wc_add_notice( $notice );
+	}
 }

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -138,6 +138,7 @@ if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID >= 70400 ) {
 function wcpay_init_subscriptions_core() {
 	require_once __DIR__ . '/helpers/class-wcs-helper-background-repairer.php';
 	require_once __DIR__ . '/helpers/class-wc-helper-subscriptions.php';
+	require_once __DIR__ . '/helpers/class-wc-subscriptions-change-payment-gateway.php';
 }
 
 // Placeholder for the test container.

--- a/tests/unit/helpers/class-wc-subscriptions-change-payment-gateway.php
+++ b/tests/unit/helpers/class-wc-subscriptions-change-payment-gateway.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Stub for WC_Subscriptions_Change_Payment_Gateway.
+ *
+ * This class ships with WooCommerce Subscriptions and is not available in the
+ * unit test environment. The stub exposes static call-tracking properties so
+ * tests can assert which arguments were passed.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+if ( ! class_exists( 'WC_Subscriptions_Change_Payment_Gateway' ) ) {
+	/**
+	 * Stub class for WC_Subscriptions_Change_Payment_Gateway.
+	 */
+	class WC_Subscriptions_Change_Payment_Gateway {
+		/** @var array */
+		public static $update_payment_method_calls = [];
+		/** @var array */
+		public static $update_all_calls = [];
+		/** @var bool */
+		public static $will_update_all_return = false;
+		/** @var bool */
+		public static $update_all_return = false;
+
+		/**
+		 * Stub for update_payment_method.
+		 *
+		 * @param WC_Order $order      The order.
+		 * @param string   $gateway_id The gateway ID.
+		 */
+		public static function update_payment_method( $order, $gateway_id ) {
+			self::$update_payment_method_calls[] = [
+				'order'      => $order,
+				'gateway_id' => $gateway_id,
+			];
+		}
+
+		/**
+		 * Stub for will_subscription_update_all_payment_methods.
+		 *
+		 * @param WC_Order $order The order.
+		 * @return bool
+		 */
+		public static function will_subscription_update_all_payment_methods( $order ) {
+			return self::$will_update_all_return;
+		}
+
+		/**
+		 * Stub for update_all_payment_methods_from_subscription.
+		 *
+		 * @param WC_Order $order      The order.
+		 * @param string   $gateway_id The gateway ID.
+		 * @return bool
+		 */
+		public static function update_all_payment_methods_from_subscription( $order, $gateway_id ) {
+			self::$update_all_calls[] = [
+				'order'      => $order,
+				'gateway_id' => $gateway_id,
+			];
+			return self::$update_all_return;
+		}
+	}
+}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-trait.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-trait.php
@@ -108,6 +108,50 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Trait_Test extends WCPAY_UnitTestCa
 		delete_option( '_wcpay_feature_stripe_billing' );
 	}
 
+	public function test_maybe_update_subscription_payment_method_updates_single_subscription() {
+		$order         = WC_Helper_Order::create_order();
+		$payment_token = WC_Helper_Token::create_token( 'pm_mock' );
+
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'get_payment_token' )
+			->with( $order )
+			->willReturn( $payment_token );
+
+		WC_Subscriptions_Change_Payment_Gateway::$update_payment_method_calls = [];
+		WC_Subscriptions_Change_Payment_Gateway::$update_all_calls            = [];
+		WC_Subscriptions_Change_Payment_Gateway::$will_update_all_return      = false;
+
+		wc_clear_notices();
+		$this->mock_wcpay_subscriptions_trait->maybe_update_subscription_payment_method( $order );
+
+		$this->assertCount( 1, WC_Subscriptions_Change_Payment_Gateway::$update_payment_method_calls );
+		$this->assertSame( $payment_token->get_gateway_id(), WC_Subscriptions_Change_Payment_Gateway::$update_payment_method_calls[0]['gateway_id'] );
+		$this->assertCount( 0, WC_Subscriptions_Change_Payment_Gateway::$update_all_calls );
+		$this->assertContains( 'Payment method updated.', array_column( wc_get_notices( 'success' ), 'notice' ) );
+	}
+
+	public function test_maybe_update_subscription_payment_method_updates_all_subscriptions() {
+		$order         = WC_Helper_Order::create_order();
+		$payment_token = WC_Helper_Token::create_token( 'pm_mock' );
+
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'get_payment_token' )
+			->with( $order )
+			->willReturn( $payment_token );
+
+		WC_Subscriptions_Change_Payment_Gateway::$update_payment_method_calls = [];
+		WC_Subscriptions_Change_Payment_Gateway::$update_all_calls            = [];
+		WC_Subscriptions_Change_Payment_Gateway::$will_update_all_return      = true;
+		WC_Subscriptions_Change_Payment_Gateway::$update_all_return           = true;
+
+		wc_clear_notices();
+		$this->mock_wcpay_subscriptions_trait->maybe_update_subscription_payment_method( $order );
+
+		$this->assertCount( 1, WC_Subscriptions_Change_Payment_Gateway::$update_all_calls );
+		$this->assertSame( $payment_token->get_gateway_id(), WC_Subscriptions_Change_Payment_Gateway::$update_all_calls[0]['gateway_id'] );
+		$this->assertContains( 'Payment method updated for all your current subscriptions.', array_column( wc_get_notices( 'success' ), 'notice' ) );
+	}
+
 	/**
 	 * Test that Amazon Pay subscription hooks are registered.
 	 */


### PR DESCRIPTION
Fixes WOOPMNT-5957

#### Changes proposed in this Pull Request

In the `update_order_status` flow use the in-scope `$payment_token` variable instead of possibly undefined `$token`.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Automated tests shall pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
