### PR TITLE
fix: transactions page possible crash when wallet is missing

### DIFF
--- a/changelog/fix-WOOPMNT-5949-wallet-icon-possibly-missing
+++ b/changelog/fix-WOOPMNT-5949-wallet-icon-possibly-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: ensure that page doesn't crash if wallet icon is missing

--- a/client/components/payment-method-details/__tests__/__snapshots__/index.test.js.snap
+++ b/client/components/payment-method-details/__tests__/__snapshots__/index.test.js.snap
@@ -31,3 +31,25 @@ exports[`PaymentMethodDetails renders a valid card brand and last 4 digits 1`] =
   </span>
 </div>
 `;
+
+exports[`PaymentMethodDetails renders without error when payment type object is undefined (e.g. Link) 1`] = `
+<div>
+  <span
+    class="payment-method-details"
+  >
+    <button
+      class="wcpay-tooltip__content-wrapper"
+      type="button"
+    >
+      <div
+        class="wcpay-tooltip__content-wrapper"
+      >
+        <span
+          aria-label="link"
+          class="payment-method__brand payment-method__brand--link account-country--us"
+        />
+      </div>
+    </button>
+  </span>
+</div>
+`;

--- a/client/components/payment-method-details/__tests__/index.test.js
+++ b/client/components/payment-method-details/__tests__/index.test.js
@@ -29,6 +29,13 @@ describe( 'PaymentMethodDetails', () => {
 		expect( paymentMethodDetails ).toMatchSnapshot();
 	} );
 
+	test( 'renders without error when payment type object is undefined (e.g. Link)', () => {
+		const { container } = render(
+			<PaymentMethodDetails payment={ { type: 'link' } } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
 	function renderCard( card ) {
 		return render(
 			<PaymentMethodDetails payment={ { card: card, type: 'card' } } />

--- a/client/components/payment-method-details/index.tsx
+++ b/client/components/payment-method-details/index.tsx
@@ -69,7 +69,7 @@ const formatDetails = ( payment: Payment ): ReactNode => {
 };
 
 const WalletIcon = ( { payment }: PaymentMethodDetailsProps ) => {
-	const { wallet } = payment[ payment.type ];
+	const wallet = payment[ payment.type ]?.wallet;
 	if ( ! wallet ) return null;
 
 	if ( ! wallet.type ) return null;


### PR DESCRIPTION
Fixes WOOPMNT-5949

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

It hasn't been verified as a possibility, but there's a chance that the transactions page could crash if `payment['some_type']` is not present on the payment object.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to Payments > Transactions
- Click on any of the transactions details, focusing on existing Link transactions
- The page should load with no issues

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
