### PR TITLE
Fix onboarding flow detection, reset modal steps, and email confirmation

### DIFF
--- a/changelog/fix-security-quick-wins
+++ b/changelog/fix-security-quick-wins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix NOX in-context onboarding flow detection from referer URL

--- a/changelog/fix-security-quick-wins#2
+++ b/changelog/fix-security-quick-wins#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix reset account modal always hiding pre-reset guidance steps

--- a/changelog/fix-security-quick-wins#3
+++ b/changelog/fix-security-quick-wins#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email confirmation field not appearing on first-time email setup

--- a/client/overview/modal/reset-account/index.tsx
+++ b/client/overview/modal/reset-account/index.tsx
@@ -37,7 +37,7 @@ const ResetAccountModal: React.FC< Props > = ( props: Props ) => {
 			<div className="wcpay-reset-account-modal__content">
 				{
 					// Only show the steps involved info if the account has been onboarded in live mode.
-					! isInTestModeOnboarding && (
+					! isInTestModeOnboarding() && (
 						<>
 							<b>{ strings.beforeContinue }</b>
 							<ol>

--- a/client/settings/notification-settings/__tests__/index.test.tsx
+++ b/client/settings/notification-settings/__tests__/index.test.tsx
@@ -12,11 +12,16 @@ import { render, screen } from '@testing-library/react';
 import NotificationSettings, {
 	NotificationSettingsDescription,
 } from '../index';
-import { useAccountCommunicationsEmail, useGetSavingError } from 'wcpay/data';
+import {
+	useAccountCommunicationsEmail,
+	useGetSavingError,
+	useSettings,
+} from 'wcpay/data';
 
 jest.mock( 'wcpay/data', () => ( {
 	useAccountCommunicationsEmail: jest.fn(),
 	useGetSavingError: jest.fn(),
+	useSettings: jest.fn(),
 } ) );
 
 const mockUseAccountCommunicationsEmail = useAccountCommunicationsEmail as jest.MockedFunction<
@@ -33,6 +38,12 @@ describe( 'NotificationSettings', () => {
 			jest.fn(),
 		] );
 		mockUseGetSavingError.mockReturnValue( null );
+		( useSettings as jest.Mock ).mockReturnValue( {
+			isLoading: false,
+			saveSettings: jest.fn(),
+			isSaving: false,
+			isDirty: false,
+		} );
 	} );
 
 	it( 'renders the notification settings section', () => {

--- a/client/settings/notification-settings/__tests__/notifications-email-input.test.tsx
+++ b/client/settings/notification-settings/__tests__/notifications-email-input.test.tsx
@@ -10,12 +10,21 @@ import { fireEvent, render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import NotificationsEmailInput from '../notifications-email-input';
-import { useGetSavingError, useAccountCommunicationsEmail } from 'wcpay/data';
+import {
+	useGetSavingError,
+	useAccountCommunicationsEmail,
+	useSettings,
+} from 'wcpay/data';
 
 jest.mock( 'wcpay/data', () => ( {
 	useAccountCommunicationsEmail: jest.fn(),
 	useGetSavingError: jest.fn(),
+	useSettings: jest.fn(),
 } ) );
+
+const mockUseSettings = useSettings as jest.MockedFunction<
+	typeof useSettings
+>;
 
 const mockUseAccountCommunicationsEmail = useAccountCommunicationsEmail as jest.MockedFunction<
 	typeof useAccountCommunicationsEmail
@@ -31,6 +40,12 @@ describe( 'NotificationsEmailInput', () => {
 			jest.fn(),
 		] );
 		mockUseGetSavingError.mockReturnValue( null );
+		mockUseSettings.mockReturnValue( {
+			isLoading: false,
+			saveSettings: jest.fn(),
+			isSaving: false,
+			isDirty: false,
+		} );
 	} );
 
 	it( 'displays and updates email address', () => {

--- a/client/settings/notification-settings/notifications-email-input.tsx
+++ b/client/settings/notification-settings/notifications-email-input.tsx
@@ -46,8 +46,8 @@ const NotificationsEmailInput: React.FC< NotificationsEmailInputProps > = ( {
 
 	// Capture the initial email value once it loads from the server.
 	useEffect( () => {
-		if ( accountCommunicationsEmail && initialEmail === null ) {
-			setInitialEmail( accountCommunicationsEmail );
+		if ( initialEmail === null ) {
+			setInitialEmail( accountCommunicationsEmail ?? '' );
 		}
 	}, [ accountCommunicationsEmail, initialEmail ] );
 

--- a/client/settings/notification-settings/notifications-email-input.tsx
+++ b/client/settings/notification-settings/notifications-email-input.tsx
@@ -10,7 +10,11 @@ import React, { useState, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { useAccountCommunicationsEmail, useGetSavingError } from 'wcpay/data';
+import {
+	useAccountCommunicationsEmail,
+	useGetSavingError,
+	useSettings,
+} from 'wcpay/data';
 
 /**
  * Validates an email address format.
@@ -38,18 +42,19 @@ const NotificationsEmailInput: React.FC< NotificationsEmailInputProps > = ( {
 		accountCommunicationsEmail,
 		setAccountCommunicationsEmail,
 	] = useAccountCommunicationsEmail();
+	const { isLoading } = useSettings();
 
 	const [ hasBlurred, setHasBlurred ] = useState( false );
 	const [ confirmEmail, setConfirmEmail ] = useState( '' );
 	const [ hasConfirmBlurred, setHasConfirmBlurred ] = useState( false );
 	const [ initialEmail, setInitialEmail ] = useState< string | null >( null );
 
-	// Capture the initial email value once it loads from the server.
+	// Capture the initial email value once settings have loaded from the server.
 	useEffect( () => {
-		if ( initialEmail === null ) {
+		if ( ! isLoading && initialEmail === null ) {
 			setInitialEmail( accountCommunicationsEmail ?? '' );
 		}
-	}, [ accountCommunicationsEmail, initialEmail ] );
+	}, [ isLoading, accountCommunicationsEmail, initialEmail ] );
 
 	const emailHasChanged =
 		initialEmail !== null && accountCommunicationsEmail !== initialEmail;

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -1145,12 +1145,12 @@ class WC_Payments_Onboarding_Service {
 		if ( false !== strpos( $referer, 'page=wc-admin&task=payments' ) ) {
 			return self::FROM_WCADMIN_PAYMENTS_TASK;
 		}
-		if ( false !== strpos( $referer, 'page=wc-settings&tab=checkout' ) ) {
-			return self::FROM_WCADMIN_PAYMENTS_SETTINGS;
-		}
 		if ( false !== strpos( $referer, 'page=wc-settings&tab=checkout' ) &&
 			false !== strpos( $referer, 'path=/woopayments/onboarding' ) ) {
 			return self::FROM_WCADMIN_NOX_IN_CONTEXT;
+		}
+		if ( false !== strpos( $referer, 'page=wc-settings&tab=checkout' ) ) {
+			return self::FROM_WCADMIN_PAYMENTS_SETTINGS;
 		}
 		if ( false !== strpos( $referer, 'path=/wc-pay-welcome-page' ) ) {
 			return self::FROM_WCADMIN_INCENTIVE;

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -472,6 +472,11 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 				'/wp-admin/admin.php?page=wc-settings&tab=checkout',
 				[ 'wcpay-connect' => '1' ],
 			],
+			'Via the referer URL - NOX in-context'         => [
+				'WCADMIN_NOX_IN_CONTEXT',
+				'/wp-admin/admin.php?page=wc-settings&tab=checkout&path=/woopayments/onboarding',
+				[ 'wcpay-connect' => '1' ],
+			],
 			'Via the referer URL - incentive page'         => [
 				'WCADMIN_PAYMENT_INCENTIVE',
 				'/wp-admin/admin.php?page=wc-admin&path=%2Fwc-pay-welcome-page',


### PR DESCRIPTION
Fixes WOOPMNT-5955, WOOPMNT-5961, WOOPMNT-5970

#### Changes proposed in this Pull Request

Three small bug fixes found during a review:

1. **NOX in-context flow detection** — A more specific referer condition was placed after a generic one that always matched first, so the specific path was unreachable. Reordered to check the specific case first.

2. **Reset account modal guidance** — A function reference was checked for truthiness instead of being called, so the pre-reset steps were never displayed. Added the missing call parentheses.

3. **Email confirmation on first setup** — The initial email baseline was only captured when non-empty, so accounts setting up email for the first time could skip the confirmation field. Removed the truthy guard so the baseline is always captured.

#### Testing instructions

1. **NOX in-context detection:** Verify that navigating to onboarding from the WooPayments settings NOX in-context flow correctly identifies the `FROM_WCADMIN_NOX_IN_CONTEXT` source.
2. **Reset account modal:** Open the reset account modal for a live-mode account and verify the "Before you continue" steps are displayed.
3. **Email confirmation:** On a WooPayments account with no stored communications email, go to Settings > Notifications, enter an email, and verify the "Confirm email" field appears.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.