### PR TITLE
Fix KYC duplicate session handling and plugin list path normalization

### DIFF
--- a/changelog/fix-security-assessment-fixes
+++ b/changelog/fix-security-assessment-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle duplicate KYC session initialization gracefully

--- a/changelog/fix-security-assessment-fixes#2
+++ b/changelog/fix-security-assessment-fixes#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix active plugin list being empty on older WooCommerce versions

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use WCPay\Logger;
+
 /**
  * REST controller for account details and status.
  */
@@ -232,7 +234,8 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 				$mode
 			);
 		} catch ( Exception $e ) {
-			return new WP_Error( self::RESULT_BAD_REQUEST, $e->getMessage(), [ 'status' => 409 ] );
+			Logger::error( 'Failed to create embedded KYC session: ' . $e->getMessage() );
+			return new WP_Error( 'wcpay_onboarding_duplicate_session', $e->getMessage(), [ 'status' => 409 ] );
 		}
 
 		if ( empty( $account_session ) ) {

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -225,11 +225,15 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 		$capabilities         = ! empty( $request->get_param( 'capabilities' ) ) ? wc_clean( wp_unslash( $request->get_param( 'capabilities' ) ) ) : [];
 		$mode                 = ! empty( $request->get_param( 'mode' ) ) ? sanitize_text_field( $request->get_param( 'mode' ) ) : null;
 
-		$account_session = $this->onboarding_service->create_embedded_kyc_session(
-			$self_assessment_data,
-			$capabilities,
-			$mode
-		);
+		try {
+			$account_session = $this->onboarding_service->create_embedded_kyc_session(
+				$self_assessment_data,
+				$capabilities,
+				$mode
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error( self::RESULT_BAD_REQUEST, $e->getMessage(), [ 'status' => 409 ] );
+		}
 
 		if ( empty( $account_session ) ) {
 			WC_Payments_Utils::log_to_wc( 'Failed to create embedded KYC session: Empty response from onboarding service.' );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2849,6 +2849,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 		$active_plugin_ids = ( is_object( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'get_all_active_valid_plugins' ] ) ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
 		foreach ( $active_plugin_ids as $plugin_file ) {
+			// Normalize to relative path since get_plugins() keys are relative
+			// but wp_get_active_and_valid_plugins() returns absolute paths.
+			$plugin_file = plugin_basename( $plugin_file );
 			if ( isset( $all_plugins[ $plugin_file ] ) ) {
 				$plugin_data                  = $all_plugins[ $plugin_file ];
 				$plugins_list[ $plugin_file ] = [


### PR DESCRIPTION
Fixes WOOPMNT-5975, WOOPMNT-5950

#### Changes proposed in this Pull Request

Two bug fixes from a security assessment:

1. **KYC session duplicate handling** — The REST endpoint for creating embedded KYC sessions didn't catch exceptions from concurrent/duplicate requests, resulting in 500 errors. Added try/catch to return a proper 409 Conflict response, consistent with other endpoints in the same controller.

2. **Active plugin list path normalization** — On WooCommerce versions without `PluginUtil`, the fallback to `wp_get_active_and_valid_plugins()` returns absolute paths while `get_plugins()` keys are relative. All lookups failed silently. Added `plugin_basename()` normalization before the lookup.

#### Testing instructions

1. **KYC duplicate init:** Trigger two concurrent KYC session creation requests (e.g., double-click the onboarding button). Verify you get a 409 response instead of a 500 error.
2. **Plugin list fallback:** On an environment where `PluginUtil` is unavailable (older WC), verify that `get_store_active_plugins()` returns the correct list of active plugins during onboarding.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.