### PR TITLE
fix: blocks e2e tests

### DIFF
--- a/.github/actions/e2e/run-log-tests/action.yml
+++ b/.github/actions/e2e/run-log-tests/action.yml
@@ -56,8 +56,13 @@ runs:
           echo " - $f"
         done
 
-        # Re-run only the failed spec files.
-        npm run test:e2e-ci "${FAILED_SPECS[@]}"
+        # Include the setup file so Playwright runs auth setup before retrying.
+        # Without this, passing spec files as positional args bypasses project
+        # dependency resolution and auth state files may not exist.
+        SETUP_FILE="tests/e2e/specs/auth.setup.ts"
+
+        # Re-run only the failed spec files (plus setup).
+        npm run test:e2e-ci "$SETUP_FILE" "${FAILED_SPECS[@]}"
 
     # Archive screenshots if any
     - name: Archive e2e test screenshots & logs

--- a/changelog/fix-block-e2e-tests
+++ b/changelog/fix-block-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+fix: failures in e2e PW tests for blocks

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -99,8 +99,8 @@ export default defineConfig( {
 			name: 'basic',
 			use: { ...devices[ 'Desktop Chrome' ] },
 			testMatch: /basic.spec.ts/,
-			// When running blocks tests, filter by @blocks tag (project-level
-			// so it doesn't exclude setup tests from the setup project).
+			// When running blocks tests, filter by @blocks tag (project-level).
+			// This ensures it doesn't exclude setup tests from the setup project.
 			grep: E2E_GROUP === 'blocks' ? /@blocks/ : undefined,
 			dependencies: [ 'setup' ],
 		},

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -93,20 +93,21 @@ export default defineConfig( {
 	testMatch: getTestMatch( E2E_GROUP, E2E_BRANCH ),
 	testIgnore: /specs\/performance/,
 
-	// When running blocks tests, filter by @blocks tag
-	grep: E2E_GROUP === 'blocks' ? /@blocks/ : undefined,
-
 	/* Configure projects for major browsers */
 	projects: [
 		{
 			name: 'basic',
 			use: { ...devices[ 'Desktop Chrome' ] },
 			testMatch: /basic.spec.ts/,
+			// When running blocks tests, filter by @blocks tag (project-level
+			// so it doesn't exclude setup tests from the setup project).
+			grep: E2E_GROUP === 'blocks' ? /@blocks/ : undefined,
 			dependencies: [ 'setup' ],
 		},
 		{
 			name: 'chromium',
 			use: { ...devices[ 'Desktop Chrome' ] },
+			grep: E2E_GROUP === 'blocks' ? /@blocks/ : undefined,
 			dependencies: [ 'setup' ],
 		},
 		// Setup project


### PR DESCRIPTION
Fixes WOOPMNT-5994

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The `[blocks - shopper](https://github.com/Automattic/woocommerce-payments/actions/runs/23331526536/job/67863939051#logs)` e2e tests have been consistently silently failing on every PR on first try.
<img width="1036" height="1600" alt="Screenshot 2026-03-20 at 8 53 20 AM" src="https://github.com/user-attachments/assets/6702a3de-542c-405a-8edf-30cdcae6a175" />


`tests/e2e/playwright.config.ts` — Move grep from config level to project level

The `grep: /@blocks/` filter was set at the config level, which meant it applied to all projects including the setup project. Since the auth setup tests (authenticate as admin, authenticate as customer, etc.) don't contain `@blocks` in their names, they were all filtered out when running blocks tests. The setup project would "pass" with 0 tests, Playwright considered the dependency satisfied, and the chromium tests would run — but `.auth/customer.json` was never created, causing Error reading storage state crashes.
Moving grep to only the basic and chromium projects ensures auth setup always runs regardless of the test group.

`.github/actions/e2e/run-log-tests/action.yml` — Include setup file in retry pass

The retry strategy passes failed spec files as positional arguments to Playwright (`npm run test:e2e-ci "${FAILED_SPECS[@]}"`). When Playwright receives positional file arguments, it bypasses project dependency resolution — the setup project is never re-run. If auth failed in pass 1 (so `.auth/customer.json` doesn't exist), pass 2 would crash with the same storage state error. Adding `auth.setup.ts` to the retry file list ensures auth setup runs before retrying failed specs.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There should not be an error logged for these failures on the `blocks - shopper` group anymore:
- https://github.com/Automattic/woocommerce-payments/actions/runs/23334128441/job/67871762129?pr=11471
- https://github.com/Automattic/woocommerce-payments/actions/runs/23334128441/job/67871762124?pr=11471

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
