### PR TITLE
E2E: Install composer dependencies when needed

### DIFF
--- a/changelog/fix-e2e-dev-tools-dependencies
+++ b/changelog/fix-e2e-dev-tools-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Internal E2E change.
+
+

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -129,6 +129,12 @@ if [[ ! -d "$DEV_TOOLS_PATH" ]]; then
 	git clone --depth=1 --branch "${WCP_DEV_TOOLS_BRANCH-trunk}" "$WCP_DEV_TOOLS_REPO" "$DEV_TOOLS_PATH"
 fi
 
+# Ensure dev tools dependencies are installed (required before WordPress loads the plugin).
+if [[ -d "$DEV_TOOLS_PATH" && ! -f "$DEV_TOOLS_PATH/vendor/autoload.php" ]]; then
+	step "Installing dev tools dependencies"
+	composer install --no-dev --no-interaction --working-dir="$DEV_TOOLS_PATH"
+fi
+
 step "Starting CLIENT containers"
 redirect_output docker compose -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d wordpress
 if [[ -z $CI ]]; then


### PR DESCRIPTION
Fixes p1773999364621089-slack-C01BPL3ALGP

#### Changes proposed in this Pull Request

Run `composer install` to make dev tools work in E2E tests.

#### Testing instructions

Not sure. In my case, I had an otherwise working local E2E setup.

Without this branch, `npm run test:e2e-setup` was failing with:

```
Warning: require_once(/var/www/html/wp-content/plugins/wcp-dev-tools-e2e/vendor/autoload.php): Failed to open stream: No such file or directory in                                                  
/var/www/html/wp-content/plugins/wcp-dev-tools-e2e/woocommerce-payments-dev-tools.php on line 1868                                                                                                  
Fatal error: Uncaught Error: Failed opening required '/var/www/html/wp-content/plugins/wcp-dev-tools-e2e/vendor/autoload.php' (include_path='.:/usr/local/lib/php') in                              
/var/www/html/wp-content/plugins/wcp-dev-tools-e2e/woocommerce-payments-dev-tools.php:1868     
```

With this change, `npm run test:e2e-down; npm run test:e2e-cleanup; npm run test:e2e-setup` worked.