### PR TITLE
fix: trim whitespace for postcode at checkout

### DIFF
--- a/changelog/fix-postcode-trim-at-checkout
+++ b/changelog/fix-postcode-trim-at-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: trim whitespace for postcode at checkout

--- a/client/checkout/blocks/__tests__/payment-processor.test.js
+++ b/client/checkout/blocks/__tests__/payment-processor.test.js
@@ -209,6 +209,61 @@ describe( 'PaymentProcessor', () => {
 		expect( mockCreatePaymentMethod ).toHaveBeenCalled();
 	} );
 
+	it( 'should trim whitespace from postal code', async () => {
+		const { useCustomerData } = require( '../utils' );
+		useCustomerData.mockReturnValue( {
+			first_name: 'John',
+			last_name: 'Doe',
+			email: 'john@example.com',
+			phone: '555-1234',
+			city: 'Nottingham',
+			country: 'GB',
+			address_1: '1 High St',
+			address_2: '',
+			postcode: ' NG8 4GP ',
+			state: '',
+		} );
+
+		let onPaymentSetupCallback;
+		mockCreatePaymentMethod = jest.fn().mockResolvedValue( {
+			paymentMethod: { id: 'paymentMethodId' },
+		} );
+
+		act( () => {
+			render(
+				<PaymentProcessor
+					activePaymentMethod="woocommerce_payments"
+					api={ mockApi }
+					paymentMethodId="card"
+					emitResponse={ {} }
+					eventRegistration={ {
+						onPaymentSetup: ( callback ) =>
+							( onPaymentSetupCallback = callback ),
+					} }
+					fingerprint=""
+					shouldSavePayment={ false }
+					upeMethods={ {
+						card: { gatewayId: 'woocommerce_payments' },
+					} }
+				/>
+			);
+		} );
+
+		await onPaymentSetupCallback();
+
+		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				params: expect.objectContaining( {
+					billing_details: expect.objectContaining( {
+						address: expect.objectContaining( {
+							postal_code: 'NG8 4GP',
+						} ),
+					} ),
+				} ),
+			} )
+		);
+	} );
+
 	it( 'should return success when there are no failures', async () => {
 		let onPaymentSetupCallback;
 		mockCreatePaymentMethod = jest.fn().mockResolvedValue( {

--- a/client/checkout/blocks/payment-processor.js
+++ b/client/checkout/blocks/payment-processor.js
@@ -32,7 +32,8 @@ const getBillingDetails = ( billingData ) => {
 
 			line1: billingData.address_1,
 			line2: billingData.address_2,
-			postal_code: billingData.postcode,
+			// Trim to avoid Stripe AVS mismatches on leading/trailing whitespace.
+			postal_code: billingData.postcode?.trim(),
 			state: billingData.state,
 		},
 	};

--- a/client/checkout/classic/__tests__/payment-processing.test.js
+++ b/client/checkout/classic/__tests__/payment-processing.test.js
@@ -736,6 +736,50 @@ describe( 'Payment processing', () => {
 		document.body.appendChild( postcodeInput );
 		document.body.appendChild( stateInput );
 	}
+
+	test( 'Payment processing trims whitespace from postal code', async () => {
+		setupBillingDetailsFields();
+		document.getElementById( 'billing_postcode' ).value = ' NG8 4GP ';
+		getFingerprint.mockImplementation( () => {
+			return { visitorId: 'fingerprint' };
+		} );
+
+		const mockDomElement = document.createElement( 'div' );
+		mockDomElement.dataset.paymentMethodType = 'card';
+
+		await mountStripePaymentElement( apiMock, mockDomElement );
+
+		const checkoutForm = {
+			submit: jest.fn(),
+			addClass: jest.fn( () => ( {
+				block: jest.fn(),
+			} ) ),
+			removeClass: jest.fn( () => ( {
+				unblock: jest.fn(),
+				submit: checkoutForm.submit,
+			} ) ),
+			attr: jest.fn().mockReturnValue( 'checkout' ),
+		};
+
+		mockCreatePaymentMethod.mockReturnValue( {
+			paymentMethod: { id: 'paymentMethodId' },
+		} );
+
+		await processPayment( apiMock, checkoutForm, 'card' );
+		await new Promise( ( resolve ) => setImmediate( resolve ) );
+
+		expect( mockCreatePaymentMethod ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				params: expect.objectContaining( {
+					billing_details: expect.objectContaining( {
+						address: expect.objectContaining( {
+							postal_code: 'NG8 4GP',
+						} ),
+					} ),
+				} ),
+			} )
+		);
+	} );
 } );
 
 describe( 'Setup intent creation and confirmation', () => {

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -207,9 +207,12 @@ async function createStripePaymentMethod(
 					line2: document.querySelector(
 						`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.address_2 }`
 					)?.value,
-					postal_code: document.querySelector(
-						`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.postcode }`
-					)?.value,
+					// Trim to avoid Stripe AVS mismatches on leading/trailing whitespace.
+					postal_code: document
+						.querySelector(
+							`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.postcode }`
+						)
+						?.value?.trim(),
 					state: document.querySelector(
 						`#${ SHORTCODE_BILLING_ADDRESS_FIELDS.state }`
 					)?.value,


### PR DESCRIPTION
Fixes WOOPMNT-5983

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

It seems that the AVS checks might fail if the postcode contains some whitespace.
So the AVS checks for ` N1C 4AG ` might fail.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I haven't been able to test this behavior in test mode.
However, we can manually inspect the `POST /v1/payment_methods` call made during checkout.

The tests below should be repeated for both classic and blocks checkout.

- Add a product to the cart
- Navigate to the checkout page
  - On shortcode, you should be able to add whitespace before and after the postcode
  - On block-based checkout, it seems that it's possible to add whitespace only after the postcode
- Insert a GB billing address
  - Ensure you keep the network tab open
- Place the order
- Inspect the call made to `POST /v1/payment_methods`
  - Alternative: go to the Stripe dashboard and inspect the network call on the workbench
- The postcode should no longer contain whitespace


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
