### PR TITLE
fix: avoid MCCY fatal on orphaned currency

### DIFF
--- a/changelog/fix-WOOPMNT-4103-mccy-orphaned-data
+++ b/changelog/fix-WOOPMNT-4103-mccy-orphaned-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: avoid fatal error on invalid currency option in DB

--- a/includes/multi-currency/Currency.php
+++ b/includes/multi-currency/Currency.php
@@ -160,7 +160,7 @@ class Currency implements \JsonSerializable {
 	 */
 	public function get_name(): string {
 		$wc_currencies = get_woocommerce_currencies();
-		return $wc_currencies[ $this->code ];
+		return $wc_currencies[ $this->code ] ?? $this->code;
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -278,6 +278,13 @@ class MultiCurrency {
 		// (e.g. a custom currency was removed), bail out to avoid fatal errors.
 		// Multi-Currency cannot function without a valid base currency.
 		if ( ! array_key_exists( get_woocommerce_currency(), get_woocommerce_currencies() ) ) {
+			Logger::error(
+				sprintf(
+					'Multi-Currency disabled: store currency "%s" is not a recognized WooCommerce currency. '
+					. 'A custom currency may have been removed. Update the currency at WooCommerce → Settings → General.',
+					get_woocommerce_currency()
+				)
+			);
 			// Initialize properties to safe defaults so lazy-init getters and
 			// later init-hook callbacks don't re-trigger init() or fatal.
 			$this->available_currencies = [];

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -274,6 +274,13 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function init() {
+		// If the store currency is not in the list of available WooCommerce currencies
+		// (e.g. a custom currency was removed), bail out to avoid fatal errors.
+		// Multi-Currency cannot function without a valid base currency.
+		if ( ! array_key_exists( get_woocommerce_currency(), get_woocommerce_currencies() ) ) {
+			return;
+		}
+
 		$store_currency_updated = $this->check_store_currency_for_change();
 
 		$this->initialize_available_currencies();

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -278,6 +278,10 @@ class MultiCurrency {
 		// (e.g. a custom currency was removed), bail out to avoid fatal errors.
 		// Multi-Currency cannot function without a valid base currency.
 		if ( ! array_key_exists( get_woocommerce_currency(), get_woocommerce_currencies() ) ) {
+			// Initialize properties to safe defaults so lazy-init getters and
+			// later init-hook callbacks don't re-trigger init() or fatal.
+			$this->available_currencies = [];
+			$this->enabled_currencies   = [];
 			return;
 		}
 

--- a/tests/unit/multi-currency/test-class-currency.php
+++ b/tests/unit/multi-currency/test-class-currency.php
@@ -66,4 +66,13 @@ class WCPay_Multi_Currency_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertFalse( $decimal_currency->get_is_zero_decimal() );
 		$this->assertTrue( $zero_decimal_currency->get_is_zero_decimal() );
 	}
+
+	public function test_get_name_returns_currency_code_when_currency_not_in_woocommerce_list() {
+		$currency = new Currency( $this->localization_service, 'CUSTOM' );
+		$this->assertSame( 'CUSTOM', $currency->get_name() );
+	}
+
+	public function test_get_name_returns_currency_name_for_valid_currency() {
+		$this->assertSame( 'United States (US) dollar', $this->currency->get_name() );
+	}
 }

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -213,19 +213,20 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_get_available_currencies_adds_store_currency() {
+		// Use a real WooCommerce currency that is not in the mock Stripe account currencies.
 		add_filter(
 			'woocommerce_currency',
 			function () {
-				return 'DEFAULT';
+				return 'JPY';
 			},
 			901
 		);
 
 		$this->init_multi_currency();
 
-		$default_currency = $this->multi_currency->get_available_currencies()['DEFAULT'];
+		$default_currency = $this->multi_currency->get_available_currencies()['JPY'];
 
-		$this->assertSame( 'DEFAULT', $default_currency->get_code() );
+		$this->assertSame( 'JPY', $default_currency->get_code() );
 		$this->assertSame( 1.0, $default_currency->get_rate() );
 	}
 
@@ -1602,6 +1603,22 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		update_post_meta( $order_id, '_order_currency', $currency );
 
 		return $order_id;
+	}
+
+	public function test_init_returns_early_when_store_currency_not_in_available_wc_currencies() {
+		// Remove lingering woocommerce_currency filters from previous init (e.g. FrontendCurrencies at priority 900).
+		remove_all_filters( 'woocommerce_currency' );
+
+		// Simulate a removed custom currency by setting the store currency to a non-existent code.
+		update_option( 'woocommerce_currency', 'CUSTOM' );
+
+		$this->init_multi_currency();
+
+		// After init with an invalid store currency, enabled currencies should be empty
+		// because init() returned early before initializing them.
+		$this->assertEmpty( $this->multi_currency->get_enabled_currencies() );
+
+		update_option( 'woocommerce_currency', 'USD' );
 	}
 
 	private function mock_theme( $theme ) {


### PR DESCRIPTION
Fixes WOOPMNT-4103
Fixes #8879

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Merchants have the ability to add custom currencies via the `woocommerce_currencies` filter.
If a merchant registers a custom currency, sets it as default, and then removes the filter, the `woocommerce_currency` option in the DB still holds the now-invalid currency code.
WC core's `get_woocommerce_currency()` returns the stale value, and WooPayments' MCCY code crashes with a fatal `TypeError` in `Currency::get_name()`, because the currency code no longer exists in the array returned by `get_woocommerce_currencies()`.

I am making the least amount of changes possible by returning early if the currency is invalid, giving the merchant the option to change the DB/option value. The site continues to work in single currency mode.

I considered updating the DB option with a "safe" value (e.g.: `USD`), but I don't think it's WooPayments' job to update the DB.

This issue shouldn't happen very often, so I don't think it's worth it to add additional notices/logic to detect it.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Add the following snippet to your site - you can use [Code Snippets](https://wordpress.org/plugins/code-snippets/) or create a custom mu-plugin:
```php
add_filter( 'woocommerce_currencies', function( $currencies ) {
    $currencies['SING'] = 'Singa Custom';
    return $currencies;
} );
```
2. Go to WooCommerce > Settings > General
3. Set the currency to "Singa Custom (SING)", Save
<img width="708" height="189" alt="Screenshot 2026-03-23 at 10 17 21 AM" src="https://github.com/user-attachments/assets/05690574-d205-40c5-a0d3-a0011141dfa5" />

4. Ensure you have MCCY enabled is Payments > Settings
5. Navigate to WooCommerce > Settings > Multi-Currency, ensure you have at least one additional currency
<img width="1058" height="389" alt="Screenshot 2026-03-23 at 10 22 14 AM" src="https://github.com/user-attachments/assets/530f26a5-8452-4400-adda-68405608df8e" />

6. Remove the custom code added in step 1
7. **Before this fix:** Visit any page → fatal `TypeError` in `Currency::get_name()`.
<img width="820" height="636" alt="Screenshot 2026-03-23 at 10 20 51 AM" src="https://github.com/user-attachments/assets/be89549c-d67a-459a-93b6-0f0145892fcf" />

8. **After this fix:** The site loads normally. Multi-Currency features are temporarily disabled.
9. Go to **WooCommerce → Settings → General** and select a standard currency (e.g. USD). Save.
10. Multi-Currency features are restored and work as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
