### PR TITLE
fix: terminal payment notifications logic

### DIFF
--- a/changelog/fix-WOOPMNT-5958
+++ b/changelog/fix-WOOPMNT-5958
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: dev
 
-fix: Send terminal payment failure notifications on first failure instead of on repeated failures
+dev: Clarify terminal payment failure notification logic and add tests

--- a/changelog/fix-WOOPMNT-5958
+++ b/changelog/fix-WOOPMNT-5958
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: Send terminal payment failure notifications on first failure instead of on repeated failures

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -524,8 +524,8 @@ class WC_Payments_Order_Service {
 
 		$order->add_order_note( $note );
 		$this->complete_order_processing( $order, $intent_status );
-		// Trigger the failed order status hook to send notifications etc only if the order status was not already failed to avoid duplicate notifications.
-		if ( Order_Status::FAILED !== $order_status_before_update ) {
+		// When the order is already in 'failed' status, WC core won't fire notification hooks (status didn't change). Manually trigger them so the merchant is notified on every terminal payment failure.
+		if ( Order_Status::FAILED === $order_status_before_update ) {
 			do_action( 'woocommerce_order_status_pending_to_failed_notification', $order->get_id(), $order );
 			do_action( 'woocommerce_order_status_failed_notification', $order->get_id(), $order );
 		}

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -525,7 +525,7 @@ class WC_Payments_Order_Service {
 		$order->add_order_note( $note );
 		$this->complete_order_processing( $order, $intent_status );
 		// Trigger the failed order status hook to send notifications etc only if the order status was not already failed to avoid duplicate notifications.
-		if ( Order_Status::FAILED === $order_status_before_update ) {
+		if ( Order_Status::FAILED !== $order_status_before_update ) {
 			do_action( 'woocommerce_order_status_pending_to_failed_notification', $order->get_id(), $order );
 			do_action( 'woocommerce_order_status_failed_notification', $order->get_id(), $order );
 		}

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1197,21 +1197,13 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->order->set_status( Order_Status::PENDING );
 		$this->order->save();
 
-		$notification_fired = false;
-		add_action(
-			'woocommerce_order_status_failed_notification',
-			function () use ( &$notification_fired ) {
-				$notification_fired = true;
-			}
-		);
+		$action_count_before = did_action( 'woocommerce_order_status_failed_notification' );
 
 		// Act: Mark the terminal payment as failed.
 		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test123', 'Card declined' );
 
 		// Assert: Notification should fire on first failure.
-		$this->assertTrue( $notification_fired, 'Failed notification should fire when order was not already failed.' );
-
-		remove_all_actions( 'woocommerce_order_status_failed_notification' );
+		$this->assertGreaterThan( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Failed notification should fire when order was not already failed.' );
 	}
 
 	public function test_mark_terminal_payment_failed_skips_notification_when_already_failed() {
@@ -1220,21 +1212,13 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->order->set_status( Order_Status::FAILED );
 		$this->order->save();
 
-		$notification_fired = false;
-		add_action(
-			'woocommerce_order_status_failed_notification',
-			function () use ( &$notification_fired ) {
-				$notification_fired = true;
-			}
-		);
+		$action_count_before = did_action( 'woocommerce_order_status_failed_notification' );
 
 		// Act: Mark the terminal payment as failed again.
 		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test456', 'Card declined' );
 
 		// Assert: Notification should NOT fire when order was already failed.
-		$this->assertFalse( $notification_fired, 'Failed notification should not fire when order was already failed.' );
-
-		remove_all_actions( 'woocommerce_order_status_failed_notification' );
+		$this->assertSame( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Failed notification should not fire when order was already failed.' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1191,19 +1191,20 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		remove_all_filters( 'wcpay_terminal_payment_completed_order_status' );
 	}
 
-	public function test_mark_terminal_payment_failed_fires_notification_via_wc_core_on_first_failure() {
+	public function test_mark_terminal_payment_failed_triggers_status_transition_on_first_failure() {
 		// Arrange: Create the intent and ensure order is in pending status.
 		$intent = WC_Helper_Intention::create_intention( [ 'status' => Intent_Status::REQUIRES_PAYMENT_METHOD ] );
 		$this->order->set_status( Order_Status::PENDING );
 		$this->order->save();
 
-		$action_count_before = did_action( 'woocommerce_order_status_failed_notification' );
+		$action_count_before = did_action( 'woocommerce_order_status_pending_to_failed' );
 
 		// Act: Mark the terminal payment as failed.
 		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test123', 'Card declined' );
 
-		// Assert: WC core fires the notification on status transition (pending → failed).
-		$this->assertGreaterThan( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Notification should fire via WC core on first failure.' );
+		// Assert: WC core fires the status transition hook (pending → failed), which
+		// triggers notifications via WC_Emails when the email system is initialized.
+		$this->assertGreaterThan( $action_count_before, did_action( 'woocommerce_order_status_pending_to_failed' ), 'Status transition hook should fire on first failure.' );
 	}
 
 	public function test_mark_terminal_payment_failed_fires_notification_manually_on_repeated_failure() {

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1191,7 +1191,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		remove_all_filters( 'wcpay_terminal_payment_completed_order_status' );
 	}
 
-	public function test_mark_terminal_payment_failed_sends_notification_on_first_failure() {
+	public function test_mark_terminal_payment_failed_fires_notification_via_wc_core_on_first_failure() {
 		// Arrange: Create the intent and ensure order is in pending status.
 		$intent = WC_Helper_Intention::create_intention( [ 'status' => Intent_Status::REQUIRES_PAYMENT_METHOD ] );
 		$this->order->set_status( Order_Status::PENDING );
@@ -1202,11 +1202,11 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Act: Mark the terminal payment as failed.
 		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test123', 'Card declined' );
 
-		// Assert: Notification should fire on first failure.
-		$this->assertGreaterThan( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Failed notification should fire when order was not already failed.' );
+		// Assert: WC core fires the notification on status transition (pending → failed).
+		$this->assertGreaterThan( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Notification should fire via WC core on first failure.' );
 	}
 
-	public function test_mark_terminal_payment_failed_skips_notification_when_already_failed() {
+	public function test_mark_terminal_payment_failed_fires_notification_manually_on_repeated_failure() {
 		// Arrange: Create the intent and set order to already failed.
 		$intent = WC_Helper_Intention::create_intention( [ 'status' => Intent_Status::REQUIRES_PAYMENT_METHOD ] );
 		$this->order->set_status( Order_Status::FAILED );
@@ -1217,8 +1217,8 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Act: Mark the terminal payment as failed again.
 		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test456', 'Card declined' );
 
-		// Assert: Notification should NOT fire when order was already failed.
-		$this->assertSame( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Failed notification should not fire when order was already failed.' );
+		// Assert: WC core won't fire hooks (status didn't change), so our code manually triggers the notification.
+		$this->assertGreaterThan( $action_count_before, did_action( 'woocommerce_order_status_failed_notification' ), 'Notification should fire manually when order was already failed.' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1191,6 +1191,52 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		remove_all_filters( 'wcpay_terminal_payment_completed_order_status' );
 	}
 
+	public function test_mark_terminal_payment_failed_sends_notification_on_first_failure() {
+		// Arrange: Create the intent and ensure order is in pending status.
+		$intent = WC_Helper_Intention::create_intention( [ 'status' => Intent_Status::REQUIRES_PAYMENT_METHOD ] );
+		$this->order->set_status( Order_Status::PENDING );
+		$this->order->save();
+
+		$notification_fired = false;
+		add_action(
+			'woocommerce_order_status_failed_notification',
+			function () use ( &$notification_fired ) {
+				$notification_fired = true;
+			}
+		);
+
+		// Act: Mark the terminal payment as failed.
+		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test123', 'Card declined' );
+
+		// Assert: Notification should fire on first failure.
+		$this->assertTrue( $notification_fired, 'Failed notification should fire when order was not already failed.' );
+
+		remove_all_actions( 'woocommerce_order_status_failed_notification' );
+	}
+
+	public function test_mark_terminal_payment_failed_skips_notification_when_already_failed() {
+		// Arrange: Create the intent and set order to already failed.
+		$intent = WC_Helper_Intention::create_intention( [ 'status' => Intent_Status::REQUIRES_PAYMENT_METHOD ] );
+		$this->order->set_status( Order_Status::FAILED );
+		$this->order->save();
+
+		$notification_fired = false;
+		add_action(
+			'woocommerce_order_status_failed_notification',
+			function () use ( &$notification_fired ) {
+				$notification_fired = true;
+			}
+		);
+
+		// Act: Mark the terminal payment as failed again.
+		$this->order_service->mark_terminal_payment_failed( $this->order, $intent->get_id(), $intent->get_status(), 'ch_test456', 'Card declined' );
+
+		// Assert: Notification should NOT fire when order was already failed.
+		$this->assertFalse( $notification_fired, 'Failed notification should not fire when order was already failed.' );
+
+		remove_all_actions( 'woocommerce_order_status_failed_notification' );
+	}
+
 	/**
 	 * @dataProvider provider_order_note_exists
 	 */


### PR DESCRIPTION
Fixes WOOPMNT-5958

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fixing a ~logic~ comment flaw in the order notification service for in-person payments.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Just changing a comment and adding a test.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
