### PR TITLE
update: on-session `authentication_required` error message

### DIFF
--- a/changelog/update-WOOPMNT-6001-better-on-session-error-message
+++ b/changelog/update-WOOPMNT-6001-better-on-session-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+update: add better on-session error message for `authentication_required` decline

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -748,6 +748,7 @@ class WC_Payments_Utils {
 				'tax_id_invalid'                        => __( 'Invalid Tax ID, please try again with a valid tax ID.', 'woocommerce-payments' ),
 				'invalid_wallet_type'                   => __( 'Invalid wallet payment type, please try again or use an alternative method.', 'woocommerce-payments' ),
 				'payment_intent_authentication_failure' => __( 'We are unable to authenticate your payment method. Please choose a different payment method and try again.', 'woocommerce-payments' ),
+				'authentication_required'               => __( 'Your card was declined because additional authentication is required. Please contact your card issuer or try a different payment method.', 'woocommerce-payments' ),
 				'insufficient_funds'                    => __( 'Your card has insufficient funds.', 'woocommerce-payments' ),
 			]
 		);

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -1308,6 +1308,23 @@ class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Test that a card_declined error with authentication_required decline_code returns a specific message.
+	 */
+	public function test_get_filtered_error_message_card_declined_with_authentication_required_returns_localized() {
+		$exception = new API_Exception(
+			'Error: Your card was declined.',
+			'card_declined',
+			400,
+			'card_error',
+			'authentication_required'
+		);
+
+		$result = WC_Payments_Utils::get_filtered_error_message( $exception );
+
+		$this->assertEquals( 'Error: Your card was declined because additional authentication is required. Please contact your card issuer or try a different payment method.', $result );
+	}
+
+	/**
 	 * Test that a card_declined error with an unknown decline_code returns the card_declined localized message.
 	 */
 	public function test_get_filtered_error_message_card_declined_with_unknown_decline_code_returns_card_declined() {


### PR DESCRIPTION
Partially fixes WOOPMNT-6001

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There is no test card that can simulate the `authentication_required` failure code.
The only way I could find to simulate is with a custom filter:
```php
add_filter( 'wcpay_api_request_response', function ( $response, $method, $url, $api ) {
	// Only intercept payment intent creation.
	if ( 'POST' !== $method || false === strpos( $api, 'intentions' ) ) {
		return $response;
	}

	return [
		'response' => [ 'code' => 402 ],
		'body'     => wp_json_encode( [
			'error' => [
				'type'           => 'card_error',
				'code'           => 'card_declined',
				'decline_code'   => 'authentication_required',
				'message'        => 'Your card was declined.',
				'payment_intent' => [
					'id'                 => 'pi_simulated_auth_required',
					'status'             => 'requires_payment_method',
					'charges'            => [
						'data' => [
							[
								'outcome' => [
									'seller_message' => 'The bank returned the decline code `authentication_required`.',
								],
							],
						],
					],
					'last_payment_error' => [
						'code'         => 'authentication_required',
						'decline_code' => 'authentication_required',
						'message'      => 'Your card was declined.',
					],
				],
			],
		] ),
	];
}, 10, 4 );
```

1. Ensure you have the filter above on your site
2. Add a product to the cart
3. Navigate to the checkout page
4. Use any test card (e.g.: `4242424242424242`)
5. Notice the error message displayed to the customer
<img width="881" height="206" alt="Screenshot 2026-03-23 at 12 53 15 PM" src="https://github.com/user-attachments/assets/b70627b0-8ef2-41e1-885b-f81ce9bef367" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
