### PR TITLE
fix: avoid payment error string in order meta

### DIFF
--- a/changelog/fix-WOOPMNT-6003-payment-error-order-meta
+++ b/changelog/fix-WOOPMNT-6003-payment-error-order-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: prevent payment error string being written in the order meta

--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -288,7 +288,9 @@ class Payment_Information {
 		$payment_information = new Payment_Information( $payment_method, $order, $payment_type, $token, $payment_initiated_by, $manual_capture, $cvc_confirmation, $fingerprint, $payment_method_stripe_id );
 
 		if ( self::PAYMENT_METHOD_ERROR === $payment_method ) {
-			$error_message = $request['wcpay-payment-method-error-message'] ?? __( "We're not able to process this payment. Please try again later.", 'woocommerce-payments' );
+			$error_message = empty( $request['wcpay-payment-method-error-message'] )
+				? __( "We're not able to process this payment. Please try again later.", 'woocommerce-payments' )
+				: $request['wcpay-payment-method-error-message'];
 			$error_code    = $request['wcpay-payment-method-error-code'] ?? 'unknown-error';
 			$error         = new \WP_Error( $error_code, $error_message );
 			$payment_information->set_error( $error );

--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -291,7 +291,7 @@ class Payment_Information {
 			$error_message = empty( $request['wcpay-payment-method-error-message'] )
 				? __( "We're not able to process this payment. Please try again later.", 'woocommerce-payments' )
 				: $request['wcpay-payment-method-error-message'];
-			$error_code    = $request['wcpay-payment-method-error-code'] ?? 'unknown-error';
+			$error_code    = empty( $request['wcpay-payment-method-error-code'] ) ? 'unknown-error' : $request['wcpay-payment-method-error-code'];
 			$error         = new \WP_Error( $error_code, $error_message );
 			$payment_information->set_error( $error );
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1540,6 +1540,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$intent_failed  = false;
 		$payment_needed = $amount > 0;
 
+		// If an error happened during the payment setup in the client it will be saved in the payment information so we can throw
+		// the error here and follow the standard failed order flow. This must happen before writing to order meta to avoid
+		// persisting the error sentinel string as _payment_method_id.
+		$error = $payment_information->get_error();
+		if ( ! is_null( $error ) ) {
+			throw new \Exception( $error->get_error_message() );
+		}
+
 		// Make sure that we attach the payment method and the customer ID to the order meta data.
 		// Note: For confirmation tokens (ctoken_*), we don't store them here as they are not valid
 		// payment method IDs. The real payment method ID will be stored after intent creation.
@@ -1549,13 +1557,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 		$this->order_service->set_customer_id_for_order( $order, $customer_id );
 		$order->update_meta_data( WC_Payments_Order_Service::WCPAY_MODE_META_KEY, WC_Payments::mode()->is_test() ? Order_Mode::TEST : Order_Mode::PRODUCTION );
-
-		// If an error happened during the payment setup in the client it will be saved in the payment information so we can throw
-		// the error here and follow the standard failed order flow.
-		$error = $payment_information->get_error();
-		if ( ! is_null( $error ) ) {
-			throw new \Exception( $error->get_error_message() );
-		}
 
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
 		if ( apply_filters( 'wcpay_confirm_without_payment_intent', ! $payment_needed && ! $save_payment_method_to_store ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3499,7 +3499,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return $actions;
 		}
 
-		if ( $this->id !== $theorder->get_payment_method() ) {
+		if ( strpos( $theorder->get_payment_method(), self::GATEWAY_ID ) !== 0 ) {
 			return $actions;
 		}
 

--- a/tests/unit/test-class-payment-information.php
+++ b/tests/unit/test-class-payment-information.php
@@ -280,6 +280,21 @@ class Payment_Information_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'unknown-error', $error->get_error_code() );
 	}
 
+	public function test_from_payment_request_with_error_empty_message() {
+		$payment_information = Payment_Information::from_payment_request(
+			[
+				'payment_method'                     => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+				self::PAYMENT_METHOD_REQUEST_KEY     => Payment_Information::PAYMENT_METHOD_ERROR,
+				'wcpay-payment-method-error-message' => '',
+				'wcpay-payment-method-error-code'    => 'unknown-error',
+			]
+		);
+
+		$error = $payment_information->get_error();
+		$this->assertInstanceOf( \WP_Error::class, $error );
+		$this->assertEquals( "We're not able to process this payment. Please try again later.", $error->get_error_message() );
+	}
+
 	public function test_get_cvc_confirmation_from_request_returns_null_if_payment_method_is_empty() {
 		$cvc_confirmation = Payment_Information::get_cvc_confirmation_from_request( [ 'payment_method' => null ] );
 		$this->assertEquals( null, $cvc_confirmation );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2892,7 +2892,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		set_transient( 'wcpay_minimum_amount_usd', '50', DAY_IN_SECONDS );
 
 		$order = WC_Helper_Order::create_order();
-		$pi    = new Payment_Information( 'pm_test', $order, null, null, null, null, null, '', 'card' );
+		$pi    = new Payment_Information( Payment_Information::PAYMENT_METHOD_ERROR, $order, null, null, null, null, null, '', 'card' );
 		$pi->set_error( new \WP_Error( 'invalid_card', 'Invalid Card' ) );
 
 		try {
@@ -2903,7 +2903,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		}
 
 		// Ensure the error sentinel was not persisted as the payment method ID on the order.
-		$this->assertEmpty( $order->get_meta( '_payment_method_id', true ) );
+		$this->assertNotEquals( Payment_Information::PAYMENT_METHOD_ERROR, $order->get_meta( '_payment_method_id', true ) );
 	}
 
 	public function test_process_payment_for_order_rejects_with_order_id_mismatch() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2895,9 +2895,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$pi    = new Payment_Information( 'pm_test', $order, null, null, null, null, null, '', 'card' );
 		$pi->set_error( new \WP_Error( 'invalid_card', 'Invalid Card' ) );
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Invalid Card' );
-		$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
+		try {
+			$this->card_gateway->process_payment_for_order( WC()->cart, $pi );
+			$this->fail( 'Expected exception was not thrown.' );
+		} catch ( \Exception $e ) {
+			$this->assertSame( 'Invalid Card', $e->getMessage() );
+		}
+
+		// Ensure the error sentinel was not persisted as the payment method ID on the order.
+		$this->assertEmpty( $order->get_meta( '_payment_method_id', true ) );
 	}
 
 	public function test_process_payment_for_order_rejects_with_order_id_mismatch() {


### PR DESCRIPTION
Fixes WOOPMNT-6003

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The payment method id was saved in the order meta with value `woocommerce_payments_payment_method_error` when a Stripe error occurred.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Add a product to the cart
- Navigate to the checkout page
- With your browser's dev tools, block any `POST api.stripe.com/v1/payment_methods` request
<img width="491" height="93" alt="Screenshot 2026-03-23 at 2 52 46 PM" src="https://github.com/user-attachments/assets/5043bbaf-8123-466b-a37b-04fe9c55c0c3" />

- As a customer, attempt to checkout using any card (e.g.: `4242424242424242`)
<img width="1300" height="122" alt="Screenshot 2026-03-23 at 3 06 06 PM" src="https://github.com/user-attachments/assets/aaa73f9f-57e9-433f-8f51-762420765322" />

- You should see the request blocked in the network tab
<img width="921" height="88" alt="Screenshot 2026-03-23 at 2 54 00 PM" src="https://github.com/user-attachments/assets/5d718aaf-f78a-415c-aabe-fc2b8e3462e7" />

- As a merchant, navigate to WooCommerce > Orders
- Take note of the last failed order ID
- Check the `wp_wc_orders_meta` table's DB values for the latest order ID
- There should _not_ be a meta key `_payment_method_id` entry with `woocommerce_payments_payment_method_error`

This is what I am seeing in `develop`, instead:
<img width="900" height="48" alt="Screenshot 2026-03-23 at 2 55 56 PM" src="https://github.com/user-attachments/assets/a87be051-1092-4c16-a895-f9c1be57d5c9" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
