### PR TITLE
fix: QIT schema for tests

### DIFF
--- a/changelog/fix-qit-schema-tests
+++ b/changelog/fix-qit-schema-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: QIT schema
+
+

--- a/tests/qit/qit.json
+++ b/tests/qit/qit.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://qit.woo.com/json-schema/qit",
+    "$schema": "https://raw.githubusercontent.com/woocommerce/qit-cli/trunk/src/src/PreCommand/Schemas/qit-schema.json",
     "sut": {
         "type": "plugin",
         "slug": "woocommerce-payments",

--- a/tests/qit/test-package/qit-test.json
+++ b/tests/qit/test-package/qit-test.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://qit.woo.com/json-schema/test-package",
+    "$schema": "https://raw.githubusercontent.com/woocommerce/qit-cli/trunk/src/src/PreCommand/Schemas/test-package-manifest-schema.json",
     "package": "woocommerce-payments/woopayments-e2e-tests",
     "package_type": "test",
     "test_type": "e2e",


### PR DESCRIPTION
Fixes WOOPMNT-6004

Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

[QIT CLI v1.1.0](https://github.com/woocommerce/qit-cli/releases/tag/1.1.1) (released recently) changed the `$schema` URLs from `https://qit.woo.com/json-schema/...` to raw GitHub URLs (commit). Since the schema validates $schema as an exact const match, the old URLs now fail validation immediately.

Because our CI installs `qit-cli:dev-trunk` (test packages aren't available in stable releases yet), all QIT E2E jobs started failing across every PR once trunk picked up this change.

Fixing.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test runs should work again.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
