### PR TITLE
fix: some failing e2e tests

### DIFF
--- a/changelog/fix-failing-e2e-tests
+++ b/changelog/fix-failing-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: some failing e2e tests
+
+

--- a/changelog/fix-failing-e2e-tests
+++ b/changelog/fix-failing-e2e-tests
@@ -1,5 +1,5 @@
 Significance: patch
-Type: fix
+Type: dev
 Comment: fix: some failing e2e tests
 
 

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -210,18 +210,17 @@ export const disableAllEnabledCurrencies = async ( page: Page ) => {
 	}
 
 	for ( let i = 0; i < deleteButtons.length; i++ ) {
-		await page
-			.locator( '.enabled-currency .enabled-currency__action.delete' )
-			.first()
-			.click();
-
-		const snackbar = page.locator( '.components-snackbar__content', {
-			hasText: 'Enabled currencies updated.',
-		} );
-
-		await expect( snackbar ).toBeVisible( { timeout: 10000 } );
-		await snackbar.click();
-		await expect( snackbar ).toBeHidden( { timeout: 10000 } );
+		await Promise.all( [
+			page.waitForResponse(
+				( resp ) =>
+					resp.url().includes( 'update-enabled-currencies' ) &&
+					resp.status() === 200
+			),
+			page
+				.locator( '.enabled-currency .enabled-currency__action.delete' )
+				.first()
+				.click(),
+		] );
 	}
 };
 
@@ -369,7 +368,6 @@ export const disablePaymentMethods = async (
 		if ( await checkbox.isChecked() ) {
 			await checkbox.click();
 			atLeastOnePaymentMethodDisabled = true;
-			await page.getByRole( 'button', { name: 'Remove' } ).click();
 		}
 	}
 

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -63,9 +63,11 @@ const expectSnackbarWithText = async (
 	expectedText: string,
 	timeout = 10000
 ) => {
-	const snackbar = page.locator( '.components-snackbar__content', {
-		hasText: expectedText,
-	} );
+	const snackbar = page
+		.locator( '.components-snackbar__content', {
+			hasText: expectedText,
+		} )
+		.first();
 
 	await expect( snackbar ).toBeVisible( { timeout } );
 	await page.waitForTimeout( 2000 );

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -216,6 +216,7 @@ export const disableAllEnabledCurrencies = async ( page: Page ) => {
 			page.waitForResponse(
 				( resp ) =>
 					resp.url().includes( 'update-enabled-currencies' ) &&
+					resp.request().method() === 'POST' &&
 					resp.status() === 200
 			),
 			page

--- a/tests/qit/test-package/utils/merchant.ts
+++ b/tests/qit/test-package/utils/merchant.ts
@@ -746,10 +746,6 @@ export const disablePaymentMethods = async (
 		if ( await checkbox.isChecked() ) {
 			await checkbox.click();
 			atLeastOnePaymentMethodDisabled = true;
-			const removeButton = page.getByRole( 'button', { name: 'Remove' } );
-			if ( await removeButton.isVisible() ) {
-				await removeButton.click();
-			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes three E2E test infrastructure issues in `tests/e2e/utils/merchant.ts` that were causing consistent failures across all recent CI runs.

**1. `disableAllEnabledCurrencies` — snackbar race condition**

The function deleted currencies one by one and waited for the "Enabled currencies updated." snackbar after each deletion. This was flaky because the snackbar could appear and auto-dismiss before the assertion evaluated, or the API call could be slow in CI causing a 10s timeout.

**Fix:** Replaced the snackbar-based synchronization with `page.waitForResponse()` on the `update-enabled-currencies` API endpoint. The API response is the reliable, deterministic signal that the operation completed.

**2. `disablePaymentMethods` — clicking a removed "Remove" button**

PR #11477 removed the confirmation modal when disabling payment methods, but the E2E helper was never updated. It still called `page.getByRole('button', { name: 'Remove' })` after unchecking a payment method, hanging forever waiting for a button that no longer exists.

**Fix:** Removed the `getByRole('button', { name: 'Remove' })` click. Same cleanup in QIT utils.

**3. `expectSnackbarWithText` — strict mode violation with stacked snackbars**

After fix no.1 stopped dismissing snackbars from delete operations, multiple "Enabled currencies updated." snackbars could accumulate on the page. When `restoreCurrencies` triggered another one, the locator matched multiple elements and Playwright's strict mode rejected it.

**Fix:** Added `.first()` to the snackbar locator, matching what QIT utils already do.

**Tests affected:**
- `multi-currency-checkout.spec.ts` — checkout with USD, available payment methods
- `shopper-multi-currency-widget.spec.ts` — currency switcher widget
- `merchant-orders-multi-currency.spec.ts` — refund display
- `merchant-orders-partial-refund.spec.ts` — partial refund
- `multi-currency-on-boarding.spec.ts` — currency switcher widget with unsupported theme
- `multi-currency-setup.spec.ts` — GBP decimal points
- `multi-currency.spec.ts` — currency switcher in post/page
- `alipay-checkout-purchase.spec.ts`, `klarna-checkout-purchase.spec.ts` — afterAll cleanup
- `shopper-checkout-purchase-with-upe-methods.spec.ts` — Bancontact beforeAll

#### Testing instructions

* E2E tests should pass on CI — the fixes address the root causes of all snackbar-related and Remove button failures.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.