### PR TITLE
fix: check database container is running in Docker preflight

### DIFF
--- a/bin/docker-preflight.sh
+++ b/bin/docker-preflight.sh
@@ -21,6 +21,13 @@ if [[ "$infra_needed" == "false" ]]; then
     done
 fi
 
+# Check if the database container is running (network/volumes can persist after container removal)
+if [[ "$infra_needed" == "false" ]]; then
+    if ! docker ps --filter name=wcpay_db --filter status=running --format '{{.Names}}' | grep -q wcpay_db; then
+        infra_needed=true
+    fi
+fi
+
 # Auto-start infrastructure if needed
 if [[ "$infra_needed" == "true" ]]; then
     echo "Shared infrastructure not running. Starting it now..."

--- a/changelog/fix-docker-preflight-check-db
+++ b/changelog/fix-docker-preflight-check-db
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Docker preflight skipping infrastructure startup when database container is missing

--- a/default.env
+++ b/default.env
@@ -20,6 +20,10 @@ PMA_PASSWORD=wordpress
 # Increase uploads limit
 UPLOAD_LIMIT=2G
 
+# Docker Compose: suppress orphan warnings for infra containers (wcpay_db, wcpay_phpmyadmin)
+# that run from docker-compose.infra.yml but share the same network
+COMPOSE_IGNORE_ORPHANS=true
+
 # WCPay
 WCPAY_DIR=/var/www/html/wp-content/plugins/woocommerce-payments
 


### PR DESCRIPTION
Fixes WOOPMNT-6007

#### Changes proposed in this Pull Request

The Docker preflight script (`bin/docker-preflight.sh`) only checked for the `wcpay-network` and shared volumes to decide whether infrastructure needed starting. These resources can persist after the `wcpay_db` container is removed, causing `npm run up:recreate` to skip `infra:up` and leave WordPress unable to connect to the database.

This PR:
- Adds a check that the `wcpay_db` container is actually running before skipping infrastructure startup
- Adds `COMPOSE_IGNORE_ORPHANS=true` to `default.env` to suppress expected orphan container warnings from the split compose file setup (`wcpay_db` and `wcpay_phpmyadmin` run from `docker-compose.infra.yml`)

#### Testing instructions

* Remove the `wcpay_db` container while leaving the network and volumes intact: `docker rm -f wcpay_db`
* Run `npm run up:recreate` — verify it auto-starts infrastructure and the database comes up without errors
* Run `npm run up:recreate` again with everything already running — verify it doesn't redundantly restart infrastructure
* Verify no orphan container warnings appear in the output

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.