### PR TITLE
chore: add key validation to failed order received message

### DIFF
--- a/changelog/refactor-order-success-page-messaging
+++ b/changelog/refactor-order-success-page-messaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+chore: add key validation to failed order received message

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -392,8 +392,16 @@ class WC_Payments_Order_Success_Page {
 	public function replace_order_received_text_for_failed_orders( $text ) {
 		global $wp;
 
-		$order_id = absint( $wp->query_vars['order-received'] );
-		$order    = wc_get_order( $order_id );
+		$order_id  = apply_filters( 'woocommerce_thankyou_order_id', absint( $wp->query_vars['order-received'] ?? 0 ) );
+		$order_key = apply_filters( 'woocommerce_thankyou_order_key', empty( $_GET['key'] ) ? '' : wc_clean( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$order = false;
+		if ( $order_id > 0 ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+				$order = false;
+			}
+		}
 
 		if ( ! $order ||
 			! $order->needs_payment() ||

--- a/tests/unit/test-class-wc-payments-order-success-page.php
+++ b/tests/unit/test-class-wc-payments-order-success-page.php
@@ -26,6 +26,13 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$this->payments_order_success_page = new WC_Payments_Order_Success_Page();
 	}
 
+	public function tear_down() {
+		global $wp;
+		unset( $_GET['key'] );
+		unset( $wp->query_vars['order-received'] );
+		parent::tear_down();
+	}
+
 	public function test_show_card_payment_method_name_without_card_brand() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
@@ -153,9 +160,10 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$order->set_total( 50 ); // Ensure order needs payment.
 		$order->save();
 
-		// Set up global wp query vars.
+		// Set up global wp query vars and valid order key.
 		global $wp;
 		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = $order->get_order_key();
 
 		$original_text = 'Thank you. Your order has been received.';
 		$result        = $this->payments_order_success_page->replace_order_received_text_for_failed_orders( $original_text );
@@ -171,9 +179,10 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$order->add_meta_data( '_intent_id', 'pi_123' );
 		$order->save();
 
-		// Set up global wp query vars.
+		// Set up global wp query vars and valid order key.
 		global $wp;
 		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = $order->get_order_key();
 
 		// Mock the Get_Intention request.
 		$mock_intent = WC_Helper_Intention::create_intention(
@@ -201,9 +210,10 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		$order->set_status( 'processing' );
 		$order->save();
 
-		// Set up global wp query vars.
+		// Set up global wp query vars and valid order key.
 		global $wp;
 		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = $order->get_order_key();
 
 		$original_text = 'Thank you. Your order has been received.';
 		$result        = $this->payments_order_success_page->replace_order_received_text_for_failed_orders( $original_text );
@@ -215,6 +225,42 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 		// Set up global wp query vars with invalid order ID.
 		global $wp;
 		$wp->query_vars['order-received'] = 999999;
+
+		$original_text = 'Thank you. Your order has been received.';
+		$result        = $this->payments_order_success_page->replace_order_received_text_for_failed_orders( $original_text );
+
+		$this->assertEquals( $original_text, $result );
+	}
+
+	public function test_replace_order_received_text_for_failed_orders_with_invalid_order_key() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'failed' );
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->set_total( 50 );
+		$order->save();
+
+		// Set up global wp query vars with invalid order key.
+		global $wp;
+		$wp->query_vars['order-received'] = $order->get_id();
+		$_GET['key']                      = 'wc_order_INVALID';
+
+		$original_text = 'Thank you. Your order has been received.';
+		$result        = $this->payments_order_success_page->replace_order_received_text_for_failed_orders( $original_text );
+
+		$this->assertEquals( $original_text, $result );
+	}
+
+	public function test_replace_order_received_text_for_failed_orders_with_missing_order_key() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'failed' );
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->set_total( 50 );
+		$order->save();
+
+		// Set up global wp query vars without order key.
+		global $wp;
+		$wp->query_vars['order-received'] = $order->get_id();
+		unset( $_GET['key'] );
 
 		$original_text = 'Thank you. Your order has been received.';
 		$result        = $this->payments_order_success_page->replace_order_received_text_for_failed_orders( $original_text );


### PR DESCRIPTION
Fixes WOOPMNT-5944

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed internally, merging.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
