### PR TITLE
fix: include test orders in QIT analytics

### DIFF
--- a/changelog/fix-wc-nightly-analytics-data-exclusions
+++ b/changelog/fix-wc-nightly-analytics-data-exclusions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: include test orders in QIT analytics so WC 10.7+ test order exclusion does not break E2E tests
+
+

--- a/tests/qit/test-package/bootstrap/setup.sh
+++ b/tests/qit/test-package/bootstrap/setup.sh
@@ -203,7 +203,7 @@ wp option set wcpay_session_rate_limiter_disabled_wcpay_card_declined_registry y
 wp option set wcpaydev_force_card_testing_protection_on 0 --quiet 2>/dev/null || true
 
 # Include test orders in analytics data (WC 10.7+ excludes _wcpay_mode=test orders by default).
-wp eval 'file_put_contents( WPMU_PLUGIN_DIR . "/qit-include-test-orders-in-analytics.php", "<?php\nadd_filter( \"woocommerce_analytics_is_test_order\", \"__return_false\" );\n" );' 2>/dev/null || true
+wp eval 'wp_mkdir_p( WPMU_PLUGIN_DIR ); file_put_contents( WPMU_PLUGIN_DIR . "/qit-include-test-orders-in-analytics.php", "<?php\nadd_filter( \"woocommerce_analytics_is_test_order\", \"__return_false\" );\n" );' 2>/dev/null || true
 
 # Disable WooCommerce tour dialogs that interfere with tests.
 wp option set woocommerce_orders_report_date_tour_shown yes --quiet 2>/dev/null || true

--- a/tests/qit/test-package/bootstrap/setup.sh
+++ b/tests/qit/test-package/bootstrap/setup.sh
@@ -202,6 +202,9 @@ wp option set wcpay_session_rate_limiter_disabled_wcpay_card_declined_registry y
 # This is also handled in test specs, but pre-setting it ensures consistency.
 wp option set wcpaydev_force_card_testing_protection_on 0 --quiet 2>/dev/null || true
 
+# Include test orders in analytics data (WC 10.7+ excludes _wcpay_mode=test orders by default).
+wp eval 'file_put_contents( WPMU_PLUGIN_DIR . "/qit-include-test-orders-in-analytics.php", "<?php\nadd_filter( \"woocommerce_analytics_is_test_order\", \"__return_false\" );\n" );' 2>/dev/null || true
+
 # Disable WooCommerce tour dialogs that interfere with tests.
 wp option set woocommerce_orders_report_date_tour_shown yes --quiet 2>/dev/null || true
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

WC nightly [includes a change](https://github.com/woocommerce/woocommerce/pull/63550) that excludes orders with `_wcpay_mode = 'test'` from analytics. Since all QIT E2E orders are placed in test mode, the analytics page shows "No data to display" and the multi-currency columns don't appear (no multi-currency orders exist in analytics).

Adding a new mu-plugin for QIT tests that adds this filter:
```
add_filter('woocommerce_analytics_is_test_order', '__return_false');
```

Without this change, `WC nightly` e2e tests are failing: https://github.com/Automattic/woocommerce-payments/actions/runs/23501753327

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
