### PR TITLE
fix: update E2E expected error for declined-incorrect card

### DIFF
--- a/changelog/fix-e2e-incorrect-card-error-message
+++ b/changelog/fix-e2e-incorrect-card-error-message
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: update E2E expected error message for declined-incorrect card after #11456 localized Stripe errors
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
@@ -30,7 +30,7 @@ const cards: Array< CardType > = [
 	[
 		'declined-incorrect',
 		config.cards[ 'declined-incorrect' ],
-		'Your card number is invalid.',
+		'Error: Your card number is incorrect.',
 	],
 	[
 		'declined-expired',
@@ -83,7 +83,7 @@ test.describe( 'Payment Methods', () => {
 					errorText
 				);
 
-				// Declined incorrect card also puts the errorText under the card number field.
+				// Declined incorrect card also puts a validation error under the card number field.
 				if ( 'declined-incorrect' === cardType ) {
 					await expect(
 						shopperPage
@@ -92,7 +92,7 @@ test.describe( 'Payment Methods', () => {
 							)
 							.first()
 							.getByRole( 'alert' )
-					).toContainText( errorText );
+					).toContainText( 'Your card number is' );
 				}
 
 				// Verify that the card is not added to the list of payment methods.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

PR #11456 ("allow translation of Stripe error messages") added server-side localization for Stripe card errors. For the `incorrect_number` error code, the message changed from Stripe's client-side `"Your card number is invalid."` to the localized server-side `"Error: Your card number is incorrect."`.

The E2E test `shopper-myaccount-payment-methods-add-fail.spec.ts` was asserting the old client-side message and failing on WC 10.6.0-beta.2.

**Changes:**
- Updated the expected page-level alert text from `"Your card number is invalid."` to `"Error: Your card number is incorrect."`
- Updated the Stripe iframe assertion to use a partial match (`"Your card number is"`) since the iframe shows Stripe's client-side message which differs from the server-side one

#### Testing instructions

* E2E test `Payment Methods > when attempting to add a declined-incorrect card > it should not add the card` should pass on all WC versions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.