### PR TITLE
fix: action scheduler hook name

### DIFF
--- a/changelog/fix-e2e-tests-action-scheduler-hook-name
+++ b/changelog/fix-e2e-tests-action-scheduler-hook-name
@@ -1,5 +1,5 @@
 Significance: patch
-Type: fix
-Comment: fix: action scheduler hook name in e2e tests
+Type: dev
+Comment: dev: stabilize Action Scheduler E2E test row/link selection
 
 

--- a/changelog/fix-e2e-tests-action-scheduler-hook-name
+++ b/changelog/fix-e2e-tests-action-scheduler-hook-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix: action scheduler hook name in e2e tests
+
+

--- a/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts
+++ b/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts
@@ -29,6 +29,8 @@ describeif( shouldRunSubscriptionsTests && shouldRunActionSchedulerTests )(
 		const customerBillingConfig =
 			config.addresses[ 'subscriptions-customer' ].billing;
 
+		let subscriptionId: string;
+
 		test.beforeAll( async ( { browser }, { project } ) => {
 			const { shopperPage } = await getShopper(
 				browser,
@@ -46,6 +48,17 @@ describeif( shouldRunSubscriptionsTests && shouldRunActionSchedulerTests )(
 			await expect(
 				shopperPage.getByRole( 'heading', { name: 'Order received' } )
 			).toBeVisible();
+
+			// Capture the subscription ID for the Action Scheduler lookup.
+			subscriptionId = (
+				await shopperPage
+					.getByRole( 'link', {
+						name: 'View subscription number',
+					} )
+					.textContent()
+			 )
+				.trim()
+				.replace( '#', '' );
 		} );
 
 		test( 'should renew a subscription with action scheduler', async ( {
@@ -65,9 +78,10 @@ describeif( shouldRunSubscriptionsTests && shouldRunActionSchedulerTests )(
 				} )
 				.click();
 
+			// Find the action row matching our subscription ID in the args column.
 			const actionRow = merchantPage
 				.locator( 'tr' )
-				.filter( { hasText: actionSchedulerHook } )
+				.filter( { hasText: subscriptionId } )
 				.first();
 			await actionRow.getByRole( 'link', { name: 'Run' } ).click();
 

--- a/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts
+++ b/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts
@@ -65,8 +65,11 @@ describeif( shouldRunSubscriptionsTests && shouldRunActionSchedulerTests )(
 				} )
 				.click();
 
-			await merchantPage.getByRole( 'link', { name: 'Run' } ).focus();
-			await merchantPage.getByRole( 'link', { name: 'Run' } ).click();
+			const actionRow = merchantPage
+				.locator( 'tr' )
+				.filter( { hasText: actionSchedulerHook } )
+				.first();
+			await actionRow.getByRole( 'link', { name: 'Run' } ).click();
 
 			await expect(
 				merchantPage.getByText( actionSchedulerHook, { exact: true } )


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->


I noticed that _sometimes_ the e2e tests fail: https://github.com/Automattic/woocommerce-payments/actions/runs/23540495865/job/68526542046 / https://github.com/Automattic/woocommerce-payments/actions/runs/23547218149/job/68550848547

```
 1) [chromium] › tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts:51:7 › Subscriptions > Renew a subscription via Action Scheduler › should renew a subscription with action scheduler @critical 

    Error: locator.focus: Error: strict mode violation: getByRole('link', { name: 'Run' }) resolved to 2 elements:
        1) <a title="Process the action now as if it were run as part of a queue" href="/wp-admin/tools.php?page=action-scheduler&status=pending&s=woocommerce_scheduled_subscription_payment&action=-1&paged=1&action2=-1&row_action=run&row_id=42&nonce=8a0914af56">Run</a> aka getByRole('link', { name: 'Run' }).first()
        2) <a title="Process the action now as if it were run as part of a queue" href="/wp-admin/tools.php?page=action-scheduler&status=pending&s=woocommerce_scheduled_subscription_payment&action=-1&paged=1&action2=-1&row_action=run&row_id=57&nonce=5307c946c7">Run</a> aka getByRole('link', { name: 'Run' }).nth(1)

    Call log:
      - waiting for getByRole('link', { name: 'Run' })


      66 | 				.click();
      67 |
    > 68 | 			await merchantPage.getByRole( 'link', { name: 'Run' } ).focus();
         | 			                                                        ^
      69 | 			await merchantPage.getByRole( 'link', { name: 'Run' } ).click();
      70 |
      71 | 			await expect(
        at /home/runner/work/woocommerce-payments/woocommerce-payments/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts:68:60

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    tests/e2e/test-results/subscriptions-merchant-mer-7082b-ption-with-action-scheduler-chromium/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #2: screenshot (image/png) ──────────────────────────────────────────────────────────
    tests/e2e/test-results/subscriptions-merchant-mer-7082b-ption-with-action-scheduler-chromium/test-failed-2.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    attachment #4: trace (application/zip) ─────────────────────────────────────────────────────────
    tests/e2e/test-results/subscriptions-merchant-mer-7082b-ption-with-action-scheduler-chromium/trace.zip
    Usage:

        npx playwright show-trace tests/e2e/test-results/subscriptions-merchant-mer-7082b-ption-with-action-scheduler-chromium/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

  1 failed
    [chromium] › tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-renew-action-scheduler.spec.ts:51:7 › Subscriptions > Renew a subscription via Action Scheduler › should renew a subscription with action scheduler @critical 
```

Tweaking the test so that we're trying to get the correct AS job by getting the AS job for the specific subscription, in case there are multiple AS jobs.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Tests should no longer fail on that test case: https://github.com/Automattic/woocommerce-payments/actions/runs/23636684065

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
